### PR TITLE
more robust email regex

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -48,7 +48,7 @@ max_badge_sales = integer(default=13000)
 show_affiliates_and_extras = boolean(default=True)
 default_affiliates = string_list(default=list("Metroid Metal", "Protomen", "Game Grumps", "The Megas", "OC ReMix", "JonTron", "Steam Train", "ScrewAttack", "Retroware"))
 
-email_re = string(default="^\w+@\w+(\.\w+){1,}$")
+email_re = string(default="^[a-zA-Z0-9_\-+.]+@[a-zA-Z0-9_\-+.]+(\.[a-zA-Z0-9_\-+.]+){1,}$")
 
 developer_email = string(default="eli@courtwright.org")
 admin_email = string(default="Eli Courtwright <eli@courtwright.org>")


### PR DESCRIPTION
matches an email address like asdf-asdf+asdf3@asdf.asdf.com
fixes #259
