### PR TITLE
emails now only send by category

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -69,6 +69,7 @@ current_theme = string(default="magfest")
 
 supporter_badge_type_enabled = boolean(default=True)
 
+email_categories_allowed_to_send = string_list(default=list('all'))
 
 [dates]
 prereg_opening         = string(default="2014-04-15")

--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -3,11 +3,13 @@ from uber.common import *
 class Reminder:
     instances = OrderedDict()
     
-    def __init__(self, model, subject, template, filter, sender=REGDESK_EMAIL, extra_data=None, cc=None, post_con=False):
+    def __init__(self, model, subject, template, filter, sender=REGDESK_EMAIL, extra_data=None, cc=None, post_con=False, category=None):
         self.model, self.subject, self.template, self.sender = model, subject, template, sender
         self.cc = cc or []
         self.extra_data = extra_data or {}
         self.instances[subject] = self
+        self.category = category or 'uncategorized'
+
         if post_con:
             self.filter = lambda x: POST_CON and filter(x)
         else:
@@ -27,7 +29,8 @@ class Reminder:
     
     def should_send(self, x, all_sent = None):
         try:
-            return not self.prev(x, all_sent) and self.filter(x)
+            email_category_allowed = 'all' in EMAIL_CATEGORIES_ALLOWED_TO_SEND or self.category in EMAIL_CATEGORIES_ALLOWED_TO_SEND
+            return not self.prev(x, all_sent) and email_category_allowed and self.filter(x)
         except:
             log.error('unexpected error', exc_info=True)
     
@@ -89,7 +92,30 @@ def days_before(days, dt, until=None):
         return dt - timedelta(days=days) < datetime.now() < until
 
 
+
+
 ### WARNING - changing the email subject line for an email causes ALL of those emails to be re-sent!
+
+Reminder(Attendee, EVENT_NAME +' schedule, maps, and other FAQs', 'precon_faqs.html',
+         lambda a: days_before(7, EPOCH), category='precon_faq')
+
+
+Reminder(Attendee, EVENT_NAME +' payment received', 'attendee_confirmation.html',
+         lambda a: a.paid == HAS_PAID,
+         category='attendee_registration_confirmation')
+
+Reminder(Attendee, EVENT_NAME +' group registration confirmed', 'attendee_confirmation.html',
+         lambda a: a.group and a != a.group.leader and a.registered > datetime(2013, 11, 11),
+         category='attendee_registration_confirmation')
+
+Reminder(Group, EVENT_NAME +' group payment received', 'group_confirmation.html',
+         lambda g: g.amount_paid == g.total_cost,
+         category='attendee_registration_confirmation')
+
+
+
+Reminder(Attendee, EVENT_NAME +' extra payment received', 'group_donation.txt',
+         lambda a: a.paid == PAID_BY_GROUP and a.amount_extra and a.amount_paid == a.amount_extra)
 
 
 MarketplaceReminder('Reminder to pay for your '+ EVENT_NAME +' Dealer registration', 'dealer_payment_reminder.txt',
@@ -108,19 +134,6 @@ MarketplaceReminder(EVENT_NAME +' Dealer waitlist has been exhausted', 'dealer_w
 
 MarketplaceReminder('Your '+ EVENT_NAME +' Dealer registration has been approved', 'dealer_approved.html',
                     lambda g: g.status == APPROVED)
-
-Reminder(Attendee, EVENT_NAME +' payment received', 'attendee_confirmation.html',
-         lambda a: a.paid == HAS_PAID)
-
-Reminder(Attendee, EVENT_NAME +' group registration confirmed', 'attendee_confirmation.html',
-         lambda a: a.group and a != a.group.leader and a.registered > datetime(2013, 11, 11))
-
-Reminder(Group, EVENT_NAME +' group payment received', 'group_confirmation.html',
-         lambda g: g.amount_paid == g.total_cost)
-
-Reminder(Attendee, EVENT_NAME +' extra payment received', 'group_donation.txt',
-         lambda a: a.paid == PAID_BY_GROUP and a.amount_extra and a.amount_paid == a.amount_extra)
-
 
 
 Reminder(Attendee, EVENT_NAME +' Badge Confirmation', 'badge_confirmation.txt',
@@ -256,8 +269,6 @@ Reminder(Attendee, EVENT_NAME +' parental consent form reminder', 'under_18_remi
 GuestReminder(EVENT_NAME +' food for guests', 'guest_food.txt')
 
 GuestReminder(EVENT_NAME +' hospitality suite information', 'guest_food_info.txt')
-
-Reminder(Attendee, EVENT_NAME +' schedule, maps, and other FAQs', 'precon_faqs.html', lambda a: days_before(7, EPOCH))
 
 
 DeptHeadReminder(EVENT_NAME +' staffers need to be marked and rated', 'postcon_hours.txt', post_con=True)


### PR DESCRIPTION
WIP.

default category set in INI is 'all', which is special-cased
all other emails send only if their category is active

 we can use this turn on and off email types per-event

NOTE: did NOT test this out yet, will do that later tonight.  @EliAndrewC  I just wanted to get your eyes on it to see if this is sane looking.
