### PR TITLE
run stripe form generation through django

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -382,7 +382,6 @@ class stripe_form(template.Node):
             'regtext': regtext,
             'email': email,
             'payment_id': payment_id,
-            # 'key': STRIPE_PUBLIC_KEY,
             'charge': charge
         }
 

--- a/uber/templates/preregistration/stripeForm.html
+++ b/uber/templates/preregistration/stripeForm.html
@@ -3,7 +3,7 @@
     <script
         src="https://checkout.stripe.com/v2/checkout.js" class="stripe-button"
         data-key="{{ STRIPE_PUBLIC_KEY }}"
-        {% if email != "" %}data-email="{{ email }}"{% endif %}
+        {% if email %}data-email="{{ email }}"{% endif %}
         data-amount="{{charge.amount}}"
         data-name="{{ EVENT_NAME_AND_YEAR }} {{regtext}}"
         data-description="{{charge.description}}"


### PR DESCRIPTION
this is so we sanitize inputs automatically, which we should be doing here but weren't. security thing

@EliAndrewC  could you look this one over very carefully.  I tested it out a bunch and it looks like it should be sane for everything.

We should make a mental note to test all the various ways in which we do Stripe forms in ubersystem to make sure this works there.

I think this fixes #283
