### PR TITLE
magstock: remove ability for new people to sign up for shirt pre-orders

### DIFF
--- a/uber/templates_themed/magstock/preregistration/shirt_selection.html
+++ b/uber/templates_themed/magstock/preregistration/shirt_selection.html
@@ -27,7 +27,16 @@ this bettter with the rest of the shirt system.
     });
 </script>
 
+{% if attendee.amount_extra %}
 <tr class="extra-row">
+{% else %}
+<tr>
+    <td><b>Shirt:</b></td>
+    <td><i>Shirt pre-orders are closed, but you can still buy them on-site.</i></td>
+</tr>
+
+<tr class="extra-row" style="display:none">
+{% endif %}
     <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" id="amount_extra" />
     <td> <b>I want to buy a shirt (+${{ SHIRT_COST }})</b> </td>
     <td>


### PR DESCRIPTION
if you already have a shirt selected, it'll let you see that.
the entire shirt/merch system in uber needs to be ripped out and redone as a shopping cart or something eventually.  for now, I'm just hacking this in since it only needs to work for another week (famous last words)
