### PR TITLE
allow cross domain AJAX requests for the stats URL

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -31,6 +31,7 @@ def send_banned_email(attendee):
 class Root:
     
     def stats(self):
+        cherrypy.response.headers["Access-Control-Allow-Origin"] = "*"
         return json.dumps({
             'remaining badges': max(0,(MAX_BADGE_SALES - state.BADGES_SOLD)),
             'badges_sold': state.BADGES_SOLD


### PR DESCRIPTION
see http://stackoverflow.com/questions/19821753/jquery-xml-error-no-access-control-allow-origin-header-is-present-on-the-req for more info

nick was getting  XMLHttpRequest cannot load /preregistration/stats. No 'Access-Control-Allow-Origin' header is present on the requested resource. 
