### PR TITLE
daemon tasks now actually run continuously

### DIFF
--- a/uber/utils.py
+++ b/uber/utils.py
@@ -268,7 +268,7 @@ class DaemonTask:
     def start(self):
         assert not self.threads, '{} was already started and has not yet stopped'.format(self.name)
         for i in range(self.thread_count):
-            t = Thread(target = self.func, name = self.name)
+            t = Thread(target = self.run, name = self.name)
             t.daemon = True
             t.start()
             self.threads.append(t)


### PR DESCRIPTION
before, each daemon task was called only on startup and never again
not sure how we never noticed this before, or perhaps I was hallucinating that it worked before?

issue was that the new thread should have run DaemonTask.run()
.run() runs in a loop every X seconds, and calls the correct callback function

what was happening instead was we had the thread call the callback function ONCE and then exit,
resulting in the daemon task only running when you first started cherrypy,
and never running again (not very daemon-like).

I think this is the right fix except HOW DID WE NEVER NOTICE THIS BEFORE? 

Eli, could definitely use a careful code review here

fixes #336 
