### PR TITLE
Force nonshift hours into INT data type

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -621,7 +621,7 @@ class Root:
         if not re.match('^[0-9]+$', nonshift_hours):
             raise HTTPRedirect('shifts?id={}&message={}', attendee.id, 'Invalid integer')
 
-        attendee.nonshift_hours = nonshift_hours
+        attendee.nonshift_hours = int(nonshift_hours)
         attendee.save()
         raise HTTPRedirect('shifts?id={}&message={}', attendee.id, 'Non-shift hours updated')
 


### PR DESCRIPTION
Basically, models.py was treating something as a string instead of a number. So I made registration.py force the input into an INT before sending it off.

Probably a terrible, hacky way to fix #393. But it DOES fix it.
