### PR TITLE
Drop unwanted schedule columns

### DIFF
--- a/uber/constants.py
+++ b/uber/constants.py
@@ -148,7 +148,8 @@ EVENT_LOC_OPTS = enum(
     OUTDOORS = 'Outdoor Events',
     JAMSPACE = 'Jamspace',
     CHIPTUNES = 'Chiptunes',
-    REGISTRATION = 'Registration'
+    REGISTRATION = 'Registration',
+    HORIZONS = 'Horizons'
 )
 GROUPED_EVENTS = [PANELS_1, PANELS_2, PANELS_3,
                   CONCERTS, CHIPTUNES, JAMSPACE]

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -5,6 +5,8 @@ from django.utils.text import normalize_newlines
 class Root:
     @unrestricted
     def index(self, message=''):
+        Event.objects.exclude(location__in=[loc for loc,desc in EVENT_LOC_OPTS]).delete()
+        
         if HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
             return "The "+ EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."
         


### PR DESCRIPTION
Added a fix for unwanted schedule columns - anything not listed in constants.py will be removed from the DB.

Also added a Horizons column, at the request of that department.

Fixes #418 - deploy must be done carefully because this will remove some columns from the live database.
