### PR TITLE
fixes #505

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -124,12 +124,14 @@ class Root:
     @csrf_protected
     def delete(self, session, id, return_to = 'index?'):
         attendee = session.attendee(id)
-        session.delete(attendee)
-        message = 'Attendee deleted'
         if attendee.group:
-            session.add(Attendee(group=attendee.group, paid=attendee.paid,
+            session.delete_from_group(attendee, attendee.group)
+            session.add(Attendee(group=attendee.group, paid=attendee.paid, registered=attendee.registered,
                                  badge_type=attendee.badge_type, badge_num=attendee.badge_num))
             message = 'Attendee deleted, but badge ' + attendee.badge + ' is still available to be assigned to someone else'
+        else:
+            session.delete(attendee)
+            message = 'Attendee deleted'
 
         raise HTTPRedirect(return_to + ('' if return_to[-1] == '?' else '&') + 'message={}', message)
 
@@ -333,7 +335,7 @@ class Root:
         attendee.got_merch = False
         if attendee.no_shirt:
             session.delete(attendee.no_shirt)
-        session.delete()
+        session.commit()
         return '{a.full_name} ({a.badge}) merch handout canceled'.format(a=attendee)
 
     if AT_THE_CON or DEV_BOX:

--- a/uber/tests/models/test_group.py
+++ b/uber/tests/models/test_group.py
@@ -119,6 +119,14 @@ def test_assign_new_badges(session, monkeypatch):
         assert attendee.ribbon == 111
         assert attendee.badge_type == 222
 
+def test_assign_extra_create_arguments(session):
+    group = Group()
+    registered = localized_now()
+    session.assign_badges(group, 2, registered=registered)
+    assert 2 == group.badges == len(group.attendees)
+    for attendee in group.attendees:
+        assert attendee.registered == registered
+
 def test_assign_removing_too_many_badges(session):
     assert not session.assign_badges(Group(attendees=[Attendee(paid=PAID_BY_GROUP)]), 0)
     assert 'You cannot' in session.assign_badges(Group(attendees=[Attendee(paid=HAS_PAID)]), 0)


### PR DESCRIPTION
As mentioned in my previous pull request, this is an extension of the work done there to make it so when we unset a group badge, it keeps the same "registered" date, which matters because of the price bump.
