### PR TITLE
Remove "dealer approved" emails

### DIFF
--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -155,7 +155,7 @@ MarketplaceReminder(EVENT_NAME +' Dealer waitlist has been exhausted', 'dealer_w
 
 MarketplaceReminder('Your '+ EVENT_NAME +' Dealer registration has been approved', 'dealer_approved.html',
                     lambda g: g.status == APPROVED,
-                    category='marketplace_registration_confirmation')
+                    category='dealer_approved_confirmation')
 
 
 Reminder(Attendee, EVENT_NAME +' Badge Confirmation', 'badge_confirmation.txt',


### PR DESCRIPTION
Changes the category on "dealer approved" emails so new dealers for 8.5
won't get them (they're redundant). Fixes #526 in a roundabout way.
