### PR TITLE
Enumerate single day badge options

### DIFF
--- a/uber/constants.py
+++ b/uber/constants.py
@@ -34,6 +34,13 @@ class State:
             if dt >= day:
                 price = bumped_price
         return price
+    
+    def get_specific_oneday_badge(self, day):
+        for n in DAYS:
+                current_day = datetime.strptime(n[0], "%Y-%m-%d")
+                if day == current_day.strftime("%A"):
+                    return state.get_oneday_price(current_day)
+        return None
 
     def get_group_price(self, dt):
         return self.get_attendee_price(dt) - conf['badge_prices']['group_discount']
@@ -165,22 +172,29 @@ BADGE_OPTS = enum(
     SUPPORTER_BADGE = 'Supporter',
     STAFF_BADGE     = 'Staff',
     GUEST_BADGE     = 'Guest',
-    ONE_DAY_BADGE   = 'One Day'
+    FRIDAY_BADGE    = 'Friday',
+    SATURDAY_BADGE  = 'Saturday',
+    SUNDAY_BADGE    = 'Sunday'
 )
 NORMAL_AT_THE_DOOR_BADGE_OPTS = enum(
+    sort_by_declaration = True,
     ATTENDEE_BADGE = 'Full Weekend Pass (${})'.format(state.BADGE_PRICE),
-    ONE_DAY_BADGE = 'Single Day Pass (${})'.format(state.ONEDAY_BADGE_PRICE)
+    FRIDAY_BADGE   = 'Friday Pass (${})'.format(state.get_specific_oneday_badge(day="Friday")),
+    SATURDAY_BADGE = 'Saturday Pass (${})'.format(state.get_specific_oneday_badge(day="Saturday")),
+    SUNDAY_BADGE   = 'Sunday Pass (${})'.format(state.get_specific_oneday_badge(day="Sunday"))
 )
 AT_THE_DOOR_BADGE_OPTS = NORMAL_AT_THE_DOOR_BADGE_OPTS
 
 PSEUDO_GROUP_BADGE  = 1  # people registering in groups will get attendee badges
 PSEUDO_DEALER_BADGE = 2  # dealers get attendee badges with a ribbon
 BADGE_RANGES = {         # these may overlap, but shouldn't
-    STAFF_BADGE:     [1, 200],
-    SUPPORTER_BADGE: [201, 700],
-    GUEST_BADGE:     [701, 750],
-    ATTENDEE_BADGE:  [751, 3000],
-    ONE_DAY_BADGE:   [0, 0],
+    STAFF_BADGE:     [1, 199],
+    SUPPORTER_BADGE: [200, 799],
+    GUEST_BADGE:     [800, 999],
+    ATTENDEE_BADGE:  [1000, 2999],
+    FRIDAY_BADGE:    [5000, 5499],
+    SATURDAY_BADGE:  [5000, 5499],
+    SUNDAY_BADGE:    [5000, 5499],
 }
 MAX_BADGE = max(xs[1] for xs in BADGE_RANGES.values())
 

--- a/uber/defaults.conf
+++ b/uber/defaults.conf
@@ -17,6 +17,7 @@ MAGFest Panels Department'''
 
 [[single_day]]
 Friday = 35
+Saturday = 35
 Sunday = 25
 
 [[attendee]]

--- a/uber/models.py
+++ b/uber/models.py
@@ -553,8 +553,12 @@ class Attendee(MagModel, TakesPaymentMixin):
             return 0
         elif self.overridden_price is not None:
             return self.overridden_price
-        elif self.badge_type == ONE_DAY_BADGE:
-            return state.get_oneday_price(registered)
+        elif self.badge_type == FRIDAY_BADGE:
+            return state.get_specific_oneday_badge(day="Friday")
+        elif self.badge_type == SATURDAY_BADGE:
+            return state.get_specific_oneday_badge(day="Saturday")
+        elif self.badge_type == SUNDAY_BADGE:
+            return state.get_specific_oneday_badge(day="Sunday")
         else:
             return state.get_attendee_price(registered)
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -355,7 +355,7 @@ class Root:
                     message = 'Please select an age category'
                 elif attendee.payment_method == MANUAL and not attendee.email:
                     message = 'Email address is required to pay with a credit card at our registration desk'
-                elif attendee.badge_type not in [ATTENDEE_BADGE, ONE_DAY_BADGE]:
+                elif attendee.badge_type not in [ATTENDEE_BADGE, FRIDAY_BADGE, SATURDAY_BADGE, SUNDAY_BADGE]:
                     message = 'No hacking allowed!'
                 else:
                     attendee.badge_num = 0

--- a/uber/siteconfig/magfest85/constants.py
+++ b/uber/siteconfig/magfest85/constants.py
@@ -79,19 +79,24 @@ DONATION_TIERS = {
 DEALER_BADGE_PRICE = 30
 
 BADGE_OPTS = enum(
+    sort_by_declaration = True,
     ATTENDEE_BADGE  = 'Attendee',
     SUPPORTER_BADGE = 'Supporter',
     STAFF_BADGE     = 'Staff',
     GUEST_BADGE     = 'Guest',
-    ONE_DAY_BADGE   = 'One Day'
+    FRIDAY_BADGE    = 'Friday',
+    SATURDAY_BADGE  = 'Saturday',
+    SUNDAY_BADGE    = 'Sunday'
 )
 
 BADGE_RANGES = {         # these may overlap, but shouldn't
-    STAFF_BADGE:     [1, 299],
-    SUPPORTER_BADGE: [300, 599],
+    STAFF_BADGE:     [1, 199],
+    SUPPORTER_BADGE: [200, 799],
     GUEST_BADGE:     [800, 999],
     ATTENDEE_BADGE:  [1000, 2999],
-    ONE_DAY_BADGE:   [5000, 5499],
+    FRIDAY_BADGE:    [5000, 5499],
+    SATURDAY_BADGE:  [5000, 5499],
+    SUNDAY_BADGE:    [5000, 5499],
 }
 
 STORE_PRICES = (                # start as a tuple to preserve order for STORE_ITEMS


### PR DESCRIPTION
Splits one_day_badge out into Friday, Saturday, and Sunday badges so that attendees can buy any day at-the-door. Fixes #533.
