### PR TITLE
fix at-door unassigned group badges not allowing you to click the submit button

### DIFF
--- a/uber/templates/registration/new.html
+++ b/uber/templates/registration/new.html
@@ -21,6 +21,7 @@
             $link.hide();
         } else {
             $link.show().attr("href", "../groups/form?id=" + $group.val());
+            $group.parents("tr").find(":submit").removeAttr("disabled");
         }
         $badgeNum.focus();
     };


### PR DESCRIPTION
This was something Eli and I fixed on-site at 8.5, being ported over to 'master'
