### PR TITLE
Call the correct method

### DIFF
--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -24,7 +24,7 @@ class Root:
             location = cherrypy.session.get('prev_location') or ARCADE  # TODO: make this configurable
         cherrypy.session['prev_location'] = location
 
-        jobs, shifts, attendees = Job.everything(location)
+        jobs, shifts, attendees = session.everything(location)
         return {
             'location': location,
             'jobs':     jobs,


### PR DESCRIPTION
**Disclaimer**: I do not know the codebase.

When trying to look at Jobs with the signups view, the following 500
error is given:

```
Traceback (most recent call last):
  File "/usr/local/uber13/env/lib/python3.4/site-packages/CherryPy-3.5.0-py3.4.egg/cherrypy/_cprequest.py", line 670, in respond
    response.body = self.handler()
  File "/usr/local/uber13/env/lib/python3.4/site-packages/CherryPy-3.5.0-py3.4.egg/cherrypy/lib/encoding.py", line 217, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/usr/local/uber13/env/lib/python3.4/site-packages/CherryPy-3.5.0-py3.4.egg/cherrypy/_cpdispatch.py", line 61, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/usr/local/uber13/plugins/uber/uber/decorators.py", line 128, in with_session
    retval = func(*args, session=session, **kwargs)
  File "/usr/local/uber13/plugins/uber/uber/decorators.py", line 239, in with_restrictions
    return func(*args, **kwargs)
  File "/usr/local/uber13/plugins/uber/uber/decorators.py", line 209, in with_rendering
    result = func(*args, **kwargs)
  File "/usr/local/uber13/plugins/uber/uber/site_sections/jobs.py", line 27, in signups
    jobs, shifts, attendees = Job.everything(location)
AttributeError: type object 'Job' has no attribute 'everything'
```

A quick look at jobs.py shows session.everything() being called in other places,
so that's probably what we want to be calling here too.
