### PR TITLE
Fixes badge transfers

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -346,7 +346,6 @@ class Root:
         assert old.is_transferrable, 'This badge is not transferrable'
         attendee = session.attendee(params, bools=_checkboxes, restricted=True)
         attendee.registered = old.registered
-        session.expunge(old)
 
         if 'first_name' in params:
             message = check(attendee) or check_prereg_reqs(attendee)


### PR DESCRIPTION
Quick fix to let badge transfers actually work. Partially addresses #598.

The emails are still weird, though, and the history still isn't saved.
