### PR TITLE
Improves error for invalid age group.

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -71,6 +71,9 @@ def attendee_misc(attendee):
     if COLLECT_EXACT_BIRTHDATE and attendee.birthdate > date.today():
         return 'You cannot be born in the future.'
 
+    if not attendee.age_group:
+        return 'Invalid age group. Please contact us about this error at ' + ADMIN_EMAIL + '.'
+
     if COLLECT_FULL_ADDRESS:
         if not attendee.address1:
             return 'Enter your street address.'


### PR DESCRIPTION
If age groups haven't been added to the database, the attendee's age
group is set to None, which causes 500 errors. Prevents these errors by
displaying a more user-friendly error message.
