### PR TITLE
Change department head checklist wording

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -267,7 +267,7 @@ url = "https://www.facebook.com/events/589110291195335/"
 
 [[creating_shifts]]
 deadline = "2014-11-02"
-description = "STOPS is happy to create shifts for your department.  So you can sign off on this step without making the shifts yourself, in which case we'll just make the same shifts we made last year.  You can also just email us to let us know about any differences or special requests and we can handle that as well."
+description = "STOPS is happy to assist you in creating shifts, if you aren't making any changes, we can use the shifts from M12.  Please let us know if you need assistance with this step or what changes you have."
 path = "/jobs/index?location={department}"
 
 [[assigned_volunteers]]


### PR DESCRIPTION
Change some wording around creating shifts in the department head
checklist to make it clear that STOPS will help you carry over a
previous shift schedule, but will not create one from scratch for other
departments.
