### PR TITLE
Hide comments field

### DIFF
--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -237,12 +237,14 @@ function setBadge(badgeType) {
     </div>
   </div>
 
+{% if COLLECT_INTERESTS %}
   <div class="form-group">
     <label for="comments" class="col-sm-2 control-label">Comments</label>
     <div class="col-sm-6">
       <input type="textarea" name="comments" id="comments" value="{{ attendee.comments }}" class="form-control" placeholder="Comments">
     </div>
   </div>
+{% endif %}
 
   <div class="form-group">
     <label for="email_optin" class="col-sm-2 control-label">Keep Me Updated</label>


### PR DESCRIPTION
Hides the comments field behind COLLECT_INTERESTS, because it's a
temporary measure and we don't need ten config options to rip out later.
