### PR TITLE
Fix transferable_badge_types list

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -188,6 +188,7 @@ for _badge_type, _range in _config['badge_ranges'].items():
 
 SHIFTLESS_DEPTS = {globals()[dept.upper()] for dept in SHIFTLESS_DEPTS}
 PREASSIGNED_BADGE_TYPES = [globals()[badge_type.upper()] for badge_type in PREASSIGNED_BADGE_TYPES]
+TRANSFERABLE_BADGE_TYPES = [globals()[badge_type.upper()] for badge_type in TRANSFERABLE_BADGE_TYPES]
 
 SEASON_EVENTS = _config['season_events']
 

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -106,7 +106,7 @@ preassigned_badge_types = string_list(default=list('staff_badge', 'supporter_bad
 
 # Some badge types should not be transferable because of privilege (Guest badges) or
 # access level (Staff badges). This lists which badge types can be transferred, if any.
-transferable_badge_types = string_list(default=list(''))
+transferable_badge_types = string_list(default=list())
 
 # Some departments don't use our shift system, so we don't want to email
 # volunteers in those departments asking them to sign up for shifts.  Make this


### PR DESCRIPTION
Fixes the default so it's actually an empty list, and converts it to the actual badge types instead of a list of strings.
