### PR TITLE
Change MAGFest to EVENT_NAME

### DIFF
--- a/uber/templates/static_views/legal_name.html
+++ b/uber/templates/static_views/legal_name.html
@@ -4,9 +4,9 @@
 </head>
 <body>
 
-<h3 align="center"> Why Does MAGFest Need My Legal Name? </h3>
+<h3 align="center"> Why Does {{ EVENT_NAME }} Need My Legal Name? </h3>
 
-To help ensure the safety of everyone at MAGFest, registrations are tied to attendees using their photo ID. Attendees present their photo ID upon check-in to claim their badge.
+To help ensure the safety of everyone at {{ EVENT_NAME }}, registrations are tied to attendees using their photo ID. Attendees present their photo ID upon check-in to claim their badge.
 
 <br/> <br/>
 


### PR DESCRIPTION
I overlooked using the EVENT_NAME constant when writing the legal name explanation. Now the page is event-agnostic.

I thought I did this before, but it may have been in master branch. Regardless, we need this before going live.
