### PR TITLE
Restrict attendee count to STATS access

### DIFF
--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -1,6 +1,6 @@
 from uber.common import *
 
-@all_renderable(PEOPLE, STATS)
+@all_renderable(STATS)
 class Root:
     def index(self, session):
         attendees, groups = session.everyone()

--- a/uber/templates/registration/index.html
+++ b/uber/templates/registration/index.html
@@ -114,13 +114,13 @@
     <a class="btn btn-default" {% if not AT_THE_CON %}disabled="disabled"{% endif %} 
     	href="new">View Recent At-the-Door Registrations</a>
 </div>
-
+{% if COLLECT_INTERESTS %}
 <div class="panel col-md-4">
 <div class="col-md-6">{{ attendee_count }} Attendee{{ attendee_count|pluralize }}</div>
         <div class="col-md-6"><span id="checkin_count">{{ checkin_count }}</span> Checked In</div>
 </div>
+{% endif %}
 </div>
-
     {% if search_results %}
     <div class="panel panel-info">
     <a href="index?order={{ order }}">Click here</a> to view full attendee list instead of only search results.


### PR DESCRIPTION
AnthroCon keeps their attendee count under wraps until closing ceremonies - for that reason, we need to be able to hide it from all but certain admin accounts. I removed it from the attendee list and restricted the summary page to only accounts with Analytics access.
