### PR TITLE
Remove check for SUPPORTERS_ENABLED

### DIFF
--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -136,7 +136,6 @@ function setInternational() {
     </div>
   {% endif %}
 
-  {% if SUPPORTERS_ENABLED %}
     <div class="col-sm-3">
     <a id="featured1_select" onclick="setBadge('Featured1')" class="list-group-item badge_type_selector">
       <h4 class="list-group-item-heading">Sponsor: $</h4>
@@ -150,7 +149,6 @@ function setInternational() {
       <p class="list-group-item-text">The most generous option - get even more great perks!</p>
     </a>
     </div>
-  {% endif %}
 
   </div>
   </div>


### PR DESCRIPTION
Since we've decoupled the kick-in levels from the supporter_level, the
options were hidden (or didn't work). This should reinstate them.
