### PR TITLE
Hide Affiliate form

### DIFF
--- a/uber/templates/preregistration/extra.html
+++ b/uber/templates/preregistration/extra.html
@@ -79,7 +79,7 @@
     </div>
     {% endif %}
     
-
+{% if COLLECT_INTERESTS %}
 <div class="affiliate-row extra-row form-group" style="display:none">
     <label for="affiliate" class="col-sm-2 control-label">Affiliate:</label>
     <div class="col-sm-6">
@@ -89,6 +89,7 @@
 <div class="affiliate-row extra-row form-group" style="display:none">
     <p class="help-block col-sm-6 col-sm-offset-2 popup">{% popup_link "../static_views/affiliates.html" "What's an affiliate?" %}</p>
 </div>
+{% endif %}
 {% endif %}
 
 {% include "preregistration/shirt_selection.html" %}

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -23,9 +23,9 @@ $(document).ready(function(){
     var super_sponsor_badge_price = {{ BADGE_PRICE }} + super_sponsor_addon
     $('#featured2_select').html('<h4 class="list-group-item-heading">Super Sponsor: $'+super_sponsor_badge_price+'</h4><p class="list-group-item-text">The most generous option - get even more great perks!</p>');
 
-    if ($.field("amount_extra").val() == sponsor_addon) {
+    if ($.val('amount_extra') === sponsor_addon) {
         setBadge('Featured1');
-    } else if ($.field("amount_extra").val() == super_sponsor_addon) {
+    } else if ($.val('amount_extra') === super_sponsor_addon) {
         setBadge('Featured2');
     } else {
         setBadge('Attendee');


### PR DESCRIPTION
Hides the affiliate form behind COLLECT_INTERESTS, since AC doesn't want
it.

Also includes a minor improvement to the Javascript in the pre-reg form.
