### PR TITLE
Alternate fix (that works) for attendee pagination

### DIFF
--- a/uber/templates/registration/index.html
+++ b/uber/templates/registration/index.html
@@ -136,7 +136,7 @@
         {% endif %}
     {% endfor %}
 
-<table class="table footable" data-page-size="0">
+<table class="table footable" data-page-size="9999999">
 <thead><tr>
     <th> <a href="index?order={{ order.last_first }}">Name</a> </th>
     <th data-hide="phone"> <a href="index?order={{ order.badge_num }}">Badge</a> </th>


### PR DESCRIPTION
Turns out 0 doesn't work right. Setting the pagination size to way more than we ever send to the client inside. I know, not the most elegant solution.
