### PR TITLE
Fix emails

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -384,7 +384,7 @@ class stripe_form(template.Node):
         cherrypy.session[payment_id] = charge.to_dict()
 
         email = ""
-        if charge.targets and email:
+        if charge.targets and charge.models[0].email:
             email = charge.models[0].email[:255]
 
         if not charge.targets:


### PR DESCRIPTION
A previous commit mistakenly causes emails to always be withheld from
the Stripe form. This fixes that.
