### PR TITLE
turned on notes for later review precon

### DIFF
--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -292,12 +292,10 @@
     <td> Receive Newsletter: </td>
     <td> {% checkbox attendee.can_spam %} Yes </td>
 </tr>
-{% if AT_OR_POST_CON %}
-    <tr>
-        <td valign="top"> Notes for Later Review: </td>
-        <td> <textarea name="for_review" rows="3" style="width:66%">{{ attendee.for_review }}</textarea> </td>
-    </tr>
-{% endif %}
+<tr>
+    <td valign="top"> Notes for Later Review: </td>
+    <td> <textarea name="for_review" rows="3" style="width:66%">{{ attendee.for_review }}</textarea> </td>
+</tr>
 <tr>
     <td valign="top"> Admin Notes: </td>
     <td> <textarea name="admin_notes" rows="3" style="width:66%">{{ attendee.admin_notes }}</textarea> </td>

--- a/uber/templates/registration/shifts.html
+++ b/uber/templates/registration/shifts.html
@@ -99,10 +99,8 @@
 <form method="post" action="update_notes">
 {% csrf_token %}
 <input type="hidden" name="id" value="{{ attendee.id }}" />
-{% if AT_OR_POST_CON %}
-    <br/> <b>Notes For Later Review:</b> <br/>
-    <textarea name="for_review" rows="4" style="margin-left:10px ; margin-top:5px ; width:80%">{{ attendee.for_review }}</textarea>
-{% endif %}
+<br/> <b>Notes For Later Review:</b> <br/>
+<textarea name="for_review" rows="4" style="margin-left:10px ; margin-top:5px ; width:80%">{{ attendee.for_review }}</textarea>
 <br/> <br/> <b>Admin Notes:</b> <br/>
 <textarea name="admin_notes" rows="4" style="margin-left:10px ; margin-top:5px ; width:80%">{{ attendee.admin_notes }}</textarea>
 <br/> <input style="margin-left:10px ; margin-top:5px" type="submit" value="Update Admin Notes" />


### PR DESCRIPTION
I realized while talking to Brent that there wasn't any good reason not to always have the Notes for Later Review field.  It used to only show up at or after the event.
