### PR TITLE
fix major timezone conversion bug

### DIFF
--- a/uber/utils.py
+++ b/uber/utils.py
@@ -11,12 +11,9 @@ class HTTPRedirect(cherrypy.HTTPRedirect):
     def quote(self, s):
         return quote(s) if isinstance(s, str) else str(s)
 
-utc_timezone = pytz.timezone("UTC")
-
 def localized_now():
-    utc_now = datetime.utcnow().replace(tzinfo=utc_timezone)
-    now_dt = utc_now.astimezone(EVENT_TIMEZONE)
-    return now_dt
+    utc_now = datetime.utcnow().replace(tzinfo=UTC)
+    return utc_now.astimezone(EVENT_TIMEZONE)
 
 
 def comma_and(xs):

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -11,9 +11,12 @@ class HTTPRedirect(cherrypy.HTTPRedirect):
     def quote(self, s):
         return quote(s) if isinstance(s, str) else str(s)
 
+utc_timezone = pytz.timezone("UTC")
 
 def localized_now():
-    return EVENT_TIMEZONE.localize(datetime.now())
+    utc_now = datetime.utcnow().replace(tzinfo=utc_timezone)
+    now_dt = utc_now.astimezone(EVENT_TIMEZONE)
+    return now_dt
 
 
 def comma_and(xs):


### PR DESCRIPTION
current code worked when server's time zone == EVENT_TIMEZONE

if it was not (example: server timezone = EST, EVENT_TIMEZONE = PST), then it would take the datetime.now() which was in local timezone, chop off the local timezone, and replace it with the EVENT_TIMZEONE.  however, this replacement is incorrect, as the local time is not converted into the desired timezone.

cherry-picked from Rockage branch