### PR TITLE
fix bug in config.py parsing where it doesn't accept negative values

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -170,9 +170,9 @@ def _make_enum(enum_name, section):
     globals()[enum_name + '_VARS'] = varnames
     globals()[enum_name + ('' if enum_name.endswith('S') else 'S')] = lookup
 
-def check_int(s):
-    if s[0] in ('-', '+'):
-    	return s[1:].isdigit()
+def _is_intstr(s):
+    if s and s[0] in ('-', '+'):
+        return s[1:].isdigit()
     return s.isdigit()
 
 for _name, _section in _config['enums'].items():
@@ -186,7 +186,7 @@ for _name, _section in _config['integer_enums'].items():
     if isinstance(_section, dict):
         _interpolated = OrderedDict()
         for _desc, _val in _section.items():
-            if check_int(_val):
+            if _is_intstr(_val):
                 key = int(_val)
             else:
                 key = globals()[_val.upper()]

--- a/uber/config.py
+++ b/uber/config.py
@@ -170,17 +170,29 @@ def _make_enum(enum_name, section):
     globals()[enum_name + '_VARS'] = varnames
     globals()[enum_name + ('' if enum_name.endswith('S') else 'S')] = lookup
 
+def check_int(s):
+    if s[0] in ('-', '+'):
+    	return s[1:].isdigit()
+    return s.isdigit()
+
 for _name, _section in _config['enums'].items():
     _make_enum(_name, _section)
 
 for _name, _val in _config['integer_enums'].items():
     if isinstance(_val, int):
         globals()[_name.upper()] = _val
+
 for _name, _section in _config['integer_enums'].items():
     if isinstance(_section, dict):
         _interpolated = OrderedDict()
         for _desc, _val in _section.items():
-            _interpolated[int(_val) if _val.isdigit() else globals()[_val.upper()]] = _desc
+            if check_int(_val):
+                key = int(_val)
+            else:
+                key = globals()[_val.upper()]
+
+            _interpolated[key] = _desc
+
         _make_enum(_name, _interpolated)
 
 BADGE_RANGES = {}


### PR DESCRIPTION
In the rockage branch, I was trying to do this:

```
[[donation_tier]]
'SJSU Student discount' = -10
'No thanks' = 0
'Supporter Package' = SUPPORTER_LEVEL
```

(note: not necessarily that doing that above is a good idea, just something I was trying out)

This exposed a bug in the underlying config parsing since I guess we've never tried to parse a negative INI value in the history of ubersystem.

This was crashing on '-10' because the previous code was using str.isdigit() which returns false for -10.  That would instead try to resolve it like a variable name doing globals()['-10'] which threw a KeyError.

The fix is that instead of using isdigit() directly, we check for the presence of a +/- first and then do isdigit() after that.