### PR TITLE
Fix deadlines display, allow arbitrary discounts

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -470,4 +470,5 @@ class season_price_notice(Notice):
     def render(self, context):
         return self.notice('Season supporter preregistration', SUPPORTER_DEADLINE, amount_extra=SEASON_LEVEL)
 
+        
 template.builtins.append(register)


### PR DESCRIPTION
the setup:

for rockage, supporter deadline was to coincide with Magfest for Dec 26th.  we wanted that message to display on the badge_choice page.

However, there was also a price bump happening on Dec 31st.

Expected: a message like "Supporter preregistration closes at 11:59pm PST on Friday, Dec 26"
Actual: "Price goes up to $95 at 11:59pm PST on Wednesday, Dec 31"

This fixes that issue by ignoring later price bumps.

---

in addition, I restructured the code a little to change the `discount` param from being a boolean to being an integer so we can pass in arbitrary discount amounts.  This was needed for the student discount in Rockage.
