### PR TITLE
Correct tracking for invalidating groups

### DIFF
--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -82,7 +82,7 @@ class Root:
         if group.badges - group.unregistered_badges and not confirmed:
             raise HTTPRedirect('deletion_confirmation?id={}', id)
         else:
-            Tracking.track(DELETED, group)
+            Tracking.track(INVALIDATED, group)
             #for attendee in group.attendees:
                 #session.delete(attendee)
             #session.delete(group)


### PR DESCRIPTION
Changing the tracking message to be invalidate, not delete, so that
"deleted" always means "actually factually deleted"
