### PR TITLE
fixed erroneous warning about wrong nights on hotel assignments page

### DIFF
--- a/uber/site_sections/hotel.py
+++ b/uber/site_sections/hotel.py
@@ -184,7 +184,8 @@ def _attendee_dict(attendee):
         'wanted_roommates': getattr(attendee.hotel_requests, 'wanted_roommates', ''),
         'unwanted_roommates': getattr(attendee.hotel_requests, 'unwanted_roommates', ''),
         'approved': int(getattr(attendee.hotel_requests, 'approved', False)),
-        'departments': ' / '.join(attendee.assigned_depts_labels)
+        'departments': ' / '.join(attendee.assigned_depts_labels),
+        'nights_lookup': {night: getattr(attendee.hotel_requests, night, False) for night in NIGHT_NAMES},
     }
 
 def _room_dict(session, room):

--- a/uber/static/lib/angular/hotel/app.js
+++ b/uber/static/lib/angular/hotel/app.js
@@ -51,7 +51,7 @@ angular.module('hotel', ['ngRoute', 'magfest'])
     })
     .controller('HotelController', function($scope, $http, Hotel, errorHandler) {
         $scope.wrongNights = function (room, attendee) {
-            return room.nights.replace('Tue / ', '') != attendee.nights;    // needs to be configurable
+            return room.nights != attendee.nights;
         };
         $scope.remove = function (attendee_id) {
             $http({
@@ -122,17 +122,17 @@ angular.module('hotel', ['ngRoute', 'magfest'])
             room_id: $scope.room.id,
             attendee_id: $scope.lists.unassigned[0] && $scope.lists.unassigned[0].id
         };
-        $scope.isSetupOrTeardown = function (room) {    // TODO: this would be a one-liner in lodash
+        $scope.isSetupOrTeardown = function (modelWithNights) {    // TODO: this would be a one-liner in lodash
             var nonCore = false;
             angular.forEach($scope.NIGHTS, function (night) {
-                nonCore = nonCore || !night.core;
+                nonCore = nonCore || !night.core && modelWithNights[night.name];
             });
-            return nonCore;
+            return Boolean(nonCore);
         };
         $scope.add = function() {
             var room = Hotel.get('rooms', $scope.assignment.room_id);
             var attendee = Hotel.get('unassigned', $scope.assignment.attendee_id);
-            var autoDecline = $scope.wrongNights(room, attendee) && $scope.isSetupOrTeardown(room);
+            var autoDecline = $scope.isSetupOrTeardown(attendee.nights_lookup) && !$scope.isSetupOrTeardown(room);
             // TODO: replace confirm with an async Angular-driven UI component (for better testability)
             if (!autoDecline || confirm('This attendee has requested setup/teardown and you are assigning them to a regular room, wnich will automatically decline their request to help with setup/teardown.')) {
                 $http({


### PR DESCRIPTION
People kept seeing the warning message, "This attendee has requested setup/teardown and you are assigning them to a regular room, wnich will automatically decline their request to help with setup/teardown."

Which is fine except that they'd see it even when it didn't apply!  The backend did the correct thing, so if you ignored the warning it wouldn't mess anything up, which is good.  This pull request makes the warning only happen when it should.
