### PR TITLE
add staff email export (for Madmimi import)

### DIFF
--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -134,7 +134,7 @@ class Root:
     @csv_file
     def staff_emails(self, out, session):
         out.writerow(["fullname", "email", "zipcode"])
-        for a in session.query(Attendee).filter_by(staffing=True).order_by('email').all():
+        for a in session.query(Attendee).filter_by(staffing=True, placeholder=False).order_by('email').all():
             out.writerow([a.full_name, a.email, a.zip_code])
 
     @unrestricted


### PR DESCRIPTION
NOTE: exports all staff emails irregardless of the unrelated can_spam flag
this is for adding staff to a staff-only newsletter, not the public one
