### PR TITLE
Typo fix

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -18,7 +18,7 @@ def check_dealer(group):
     if not group.address and COLLECT_INTERESTS:
         return 'Dealers are required to provide an address for tax purposes'
     elif not group.wares:
-        return 'You must provide a detail explanation of what you sell for us to evaluate your submission'
+        return 'You must provide a detailed explanation of what you sell for us to evaluate your submission'
     elif not group.website:
         if COLLECT_INTERESTS:
             return "Please enter your business' website address"

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -121,7 +121,7 @@ $(document).ready(function(){
     <input type="hidden" name="edit_id" value="{{ edit_id }}" />
 {% endif %}
 {% if attendee.is_dealer %}
-<span><h2>Dealer Application</h2></span>
+<span><center><h2>Dealer Application</h2></center></span>
 {% endif %}
 {% include "preregistration/badge_choice.html" %}
 {% if not attendee.is_dealer %}


### PR DESCRIPTION
Fixes a typo in one of the validation messages, and centers the "dealer
application" heading.
