### PR TITLE
Change "special requests" label

### DIFF
--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -121,7 +121,7 @@ $(document).ready(function(){
     <input type="hidden" name="edit_id" value="{{ edit_id }}" />
 {% endif %}
 {% if attendee.is_dealer %}
-<span><center><h2>Dealer Application</h2></center></span>
+<span class="text-center"><h2>Dealer Application</h2></span>
 {% endif %}
 {% include "preregistration/badge_choice.html" %}
 {% if not attendee.is_dealer %}
@@ -239,7 +239,7 @@ $(document).ready(function(){
     </div>
 
         <div class="form-group">
-    <label for="special_needs" class="col-sm-2 control-label">Special Requests</label>
+    <label for="special_needs" class="col-sm-2 control-label">Table Requests and Special Requests</label>
     <div class="col-sm-6">
       <textarea class="form-control" name="special_needs" rows="4" placeholder="E.g., specific table, who you would like to sit near, who you would not like to sit near.">{{ group.special_needs }}</textarea>
     </div>


### PR DESCRIPTION
Dealers keep missing the "Special Requests" section because they're
looking for a 'table' keyword. Changes the text on the page to match
that.
