### PR TITLE
fixes #856

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -218,7 +218,7 @@ developer_email = string(default="eli@courtwright.org")
 # In some of our pages and emails relating to hotel room nights, it makes sense
 # to list the nights in order based on the start of the event rather than the
 # first day of the week.
-night_display_order = string_list(default=list("wednesday", "thursday", "friday", "saturday", "sunday", "monday", "tuesday"))
+night_display_order = string_list(default=list("tuesday", "wednesday", "thursday", "friday", "saturday", "sunday", "monday"))
 
 # These are all just constants which we happen to define here.  You can ignore
 # these options and should probably never change or override them.

--- a/uber/site_sections/hotel.py
+++ b/uber/site_sections/hotel.py
@@ -100,6 +100,7 @@ class Root:
             }, indent=4, cls=serializer)
         else:
             attendee = session.admin_attendee()
+            three_days_before = (EPOCH - timedelta(days=3)).strftime('%A')
             two_days_before = (EPOCH - timedelta(days=2)).strftime('%A')
             day_before = (EPOCH - timedelta(days=1)).strftime('%A')
             last_day = ESCHATON.strftime('%A')
@@ -109,6 +110,11 @@ class Root:
                 'dump': _hotel_dump(session, department),
                 'department_name': dict(JOB_LOCATION_OPTS)[int(department)],
                 'nights': [{
+                    'core': False,
+                    'name': three_days_before.lower(),
+                    'val': globals()[three_days_before.upper()],
+                    'desc': three_days_before + ' night (for setup volunteers)'
+                }, {
                     'core': False,
                     'name': two_days_before.lower(),
                     'val': globals()[two_days_before.upper()],


### PR DESCRIPTION
Note that we'll still display warning messages for people without Tuesday night, so we should probably add that to the Volunteer checklist as well.
