### PR TITLE
turned off reminder emails for printed badge reminders

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -278,7 +278,7 @@ supporter_deadline = string(default="")
 # empty list), this is the date by which attendees must enter what they want printed
 # on their badge; after this date we lock in whatever they entered or their full name
 # if they didn't provide anything.
-printed_badge_deadline = string(default="2015-01-04")
+printed_badge_deadline = string(default="")
 
 # Even after preregistration goes offline, we still allow groups to allocate their
 # unassigned badges until this date.


### PR DESCRIPTION
From an email earlier today:

BTW, as a side note, one thing I didn't realize until literally just now is that there's usually an automated email which goes out saying what the last day is for people to enter their customized badge name.  However, months ago I set this date to Jan 4th, thinking that was probably around when we'd place the order.  It sounds like we're doing it sooner, and that email hasn't even hone out yet, so I can just turn it off and we can skip that step this year.
