### PR TITLE
set printed badge deadline to yesterday instead of unsetting it completely

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -278,7 +278,7 @@ supporter_deadline = string(default="")
 # empty list), this is the date by which attendees must enter what they want printed
 # on their badge; after this date we lock in whatever they entered or their full name
 # if they didn't provide anything.
-printed_badge_deadline = string(default="")
+printed_badge_deadline = string(default="2014-12-26")
 
 # Even after preregistration goes offline, we still allow groups to allocate their
 # unassigned badges until this date.


### PR DESCRIPTION
I realized that it would be useful to set this in the past instead of unsetting it completely since there's some other functionality which uses this deadline.
