### PR TITLE
Change logic for display single-day prices

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -46,6 +46,8 @@ magcon = ""
 
 [[single_day]]
 Friday = 35
+Saturday = 40
+Sunday = 40
 Monday = 30
 
 [[attendee]]

--- a/uber/config.py
+++ b/uber/config.py
@@ -103,8 +103,8 @@ class State:
         return opts
 
     @property
-    def DISPLAY_ONSITE_BADGES(self):
-        return days_before(30, EPOCH)
+    def DISPLAY_ONEDAY_BADGES(self):
+        return ONE_DAYS_ENABLED and days_before(30, EPOCH)
 
     def __getattr__(self, name):
         if name.split('_')[0] in ['BEFORE', 'AFTER']:

--- a/uber/config.py
+++ b/uber/config.py
@@ -102,6 +102,10 @@ class State:
             opts.append((ONE_DAY_BADGE,  'Single Day Pass (${})'.format(self.ONEDAY_BADGE_PRICE)))
         return opts
 
+    @property
+    def DISPLAY_ONSITE_BADGES(self):
+        return days_before(30, EPOCH)
+
     def __getattr__(self, name):
         if name.split('_')[0] in ['BEFORE', 'AFTER']:
             date_setting = globals()[name.split('_', 1)[1]]

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -439,8 +439,12 @@ class single_day_prices(template.Node):
     def render(self, context):
         prices = ''
         for day, price in BADGE_PRICES['single_day'].items():
-            prices += '${} for {}, '.format(price, day)
-        return prices + 'and ${} for other days'.format(BADGE_PRICES['default_single_day'])
+            if day == datetime.strftime(ESCHATON, "%A"):
+                prices += 'and ${} for {}'.format(price, day)
+            else:
+                prices += '${} for {}, '.format(price, day)
+        #prices += 'and ${} for other days'.format(BADGE_PRICES['default_single_day'])
+        return prices
 
 class Notice(template.Node):
     def notice(self, label, takedown, discount=0, amount_extra=0):

--- a/uber/templates/preregistration/badge_choice.html
+++ b/uber/templates/preregistration/badge_choice.html
@@ -57,12 +57,6 @@
         </td>
         <td> {% popup_link "../static_views/attendees.html" "Details" %} </td>
     </tr>
-{% if AFTER_PREREG_TAKEDOWN and ONE_DAYS_ENABLED %}
-    <tr>
-        <td> <b>Single Day Passes:</b> </td>
-        <td><ul><li>Single days passes available for sale at the door for {% single_day_prices %}.</li></ul></td>
-    </tr>
-{% endif %}
 {% if SUPPORTERS_ENABLED %}
     <tr>
         <td class="nobr">
@@ -104,6 +98,12 @@
                 <ul><li>The deadline for Group registration has passed, but you can still register as a regular attendee.</li></ul>
             </td>
     {% endif %}
+    </tr>
+{% endif %}
+{% if ONE_DAYS_ENABLED and DISPLAY_ONSITE_BADGES %}
+    <tr>
+        <td> <b>Single Day Passes:</b> </td>
+        <td><ul><li>Single days passes available for sale at the door for {% single_day_prices %}.</li></ul></td>
     </tr>
 {% endif %}
 </table>

--- a/uber/templates/preregistration/badge_choice.html
+++ b/uber/templates/preregistration/badge_choice.html
@@ -103,7 +103,7 @@
 {% if DISPLAY_ONEDAY_BADGES %}
     <tr>
         <td> <b>Single Day Passes:</b> </td>
-        <td><ul><li>Single days passes available for sale at the door for {% single_day_prices %}.</li></ul></td>
+        <td><ul><li>Single day passes available for sale at the door for {% single_day_prices %}.</li></ul></td>
     </tr>
 {% endif %}
 </table>

--- a/uber/templates/preregistration/badge_choice.html
+++ b/uber/templates/preregistration/badge_choice.html
@@ -100,7 +100,7 @@
     {% endif %}
     </tr>
 {% endif %}
-{% if ONE_DAYS_ENABLED and DISPLAY_ONSITE_BADGES %}
+{% if DISPLAY_ONEDAY_BADGES %}
     <tr>
         <td> <b>Single Day Passes:</b> </td>
         <td><ul><li>Single days passes available for sale at the door for {% single_day_prices %}.</li></ul></td>

--- a/uber/templates/static_views/prereg_closed.html
+++ b/uber/templates/static_views/prereg_closed.html
@@ -2,7 +2,7 @@
     <h2 style='color:red'>{{ EVENT_NAME_AND_YEAR }} pre-registration has closed.</h2>
     We'll see everyone {{ EVENT_MONTH }} {{ EVENT_START_DAY }} - {{ EVENT_END_DAY }}.<br/>
     <br/>
-    Full weekend passes will be available at the door for ${{ BADGE_PRICE }}.<br/>
+    Full weekend passes will be available at the door for ${{ BADGE_PRICE }}. Single days passes will be available for {% single_day_prices %}.<br/>
     <br/>
     Please <a href="http://magfest.org/contact">contact us</a> if you have any questions.<br/>
 </body></html>


### PR DESCRIPTION
Adds DISPLAY_ONSITE_BADGES to control when to display the at-door badges, which is currently configured to be 30 days before the start of the event. Also adds them to prereg_closed.html.

Fixes #305.