### PR TITLE
decorators for timing and caching

### DIFF
--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -4,6 +4,7 @@ from django.utils.text import normalize_newlines
 @all_renderable(STUFF)
 class Root:
     @unrestricted
+    @cached
     def index(self, session, message=''):
         if HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
             return "The " + EVENT_NAME + " schedule is being developed and will be made public when it's closer to being finalized."

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -11,10 +11,10 @@
     var checkCap = function () {
         $.getJSON('check_prereg', function(check) {
             if (check.force_refresh) {
-                location.reload(); // Reload the page to prevent registering after reg is closed
+                location.reload();  // Reload the page to prevent registering after reg is closed
             }
         });
     };
-    setInterval(checkCap, 1000 * 1 * 15);
+    setInterval(checkCap, 1000 * 1 * 90);
 </script>
 {% endblock header %}


### PR DESCRIPTION
This does two things:

1) There's a new ``@cached`` decorator, which will cause a page to be cached.  I'll explain inline.

2) There's a new ``@timed`` decorator, which will cause the time of the page to be logged to syslog.