### PR TITLE
added shirt reminder email

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -212,6 +212,11 @@ StopsEmail('Still want to volunteer at {EVENT_NAME}?', 'shifts/volunteer_check.t
               lambda a: SHIFTS_CREATED and days_before(5, UBER_TAKEDOWN)
                                        and a.ribbon == VOLUNTEER_RIBBON and a.takes_shifts and a.weighted_hours == 0)
 
+StopsEmail('Please tell us your {EVENT_NAME} shirt size', 'shifts/shirt_reminder.txt',
+           lambda a: SHIFTS_CREATED and a.shirt == NO_SHIRT and a.gets_shirt
+                                    and days_before(30, UBER_TAKEDOWN) and days_after(1, a.registered),
+           needs_approval=True)
+
 
 # MAGFest provides staff rooms for returning volunteers; leave ROOM_DEADLINE blank to keep these emails turned off.
 

--- a/uber/templates/emails/shifts/shirt_reminder.txt
+++ b/uber/templates/emails/shifts/shirt_reminder.txt
@@ -1,0 +1,7 @@
+{{ attendee.first_name }},
+
+Thanks again for volunteering to help at {{ EVENT_NAME }}.  You're eligible for a tshirt as thanks for your help, but we need your shirt size to set aside a shirt for you at our merch booth.
+
+You can tell us your shirt size by filling out the volunteer checklist at {{ URL_BASE }}/signups/login
+
+{{ STOPS_EMAIL_SIGNATURE }}


### PR DESCRIPTION
As per Ryan's request, a reminder email for people to fill out their tshirt size.

This is especially useful since most of our reminder emails are for people who need shifts, so this will be a good reminder for people without shifts to fill out the checklist.