### PR TITLE
Add a lost badge report button

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -418,6 +418,7 @@ has_paid      = string(default="yes")
 need_not_pay  = string(default="doesn't need to")
 refunded      = string(default="paid and refunded")
 paid_by_group = string(default="paid by group")
+lost_badge    = string(default="lost badge")
 __many__ = string
 
 [[access]]

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -274,6 +274,14 @@ class Root:
     def merch(self, message=''):
         return {'message': message}
 
+    def lost_badge(self, session, id):
+        a = session.attendee(id)
+        a.for_review += "Automated message: Badge reported lost on {}. Previous payment type: {}.".format(localized_now().strftime('%m/%d, %H:%M'),a.paid_label)
+        a.paid = LOST_BADGE
+        session.add(a)
+        session.commit()
+        raise HTTPRedirect('index?message={}', 'Badge has been recorded as lost.')
+
     @ajax
     def check_merch(self, session, badge_num):
         id = shirt = None

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -316,6 +316,16 @@
             <br/><input type="submit" value="{% if attendee.group %}Unassign this group badge{% else %}Delete Attendee{% endif %}" />
         </form>
     </div>
+
+    {% if attendee.paid != LOST_BADGE %}
+        <br/>
+        <div style="margin-left:25%">
+            <form method="post" action="lost_badge">
+                <input type="hidden" name="id" value="{{ attendee.id }}" />
+                <input type="submit" value="Report Lost Badge">
+            </form>
+        </div>
+    {% endif %}
 {% endif %}
 
 {% endblock %}

--- a/uber/templates/registration/index.html
+++ b/uber/templates/registration/index.html
@@ -233,7 +233,17 @@
         {% if attendee.checked_in or not AT_THE_CON %}
             <td> <nobr>{{ attendee.age_group_label }}</nobr> </td>
             {% if AT_THE_CON %}
-                <td> {{ attendee.checked_in|time:"fA"|lower }} {{ attendee.checked_in|date:"D" }} </td>
+                <td>
+                    {% if attendee.paid == LOST_BADGE %}
+                    <strong>Badge reported as lost!</strong>
+                    {% else %}
+                    {{ attendee.checked_in|time:"fA"|lower }} {{ attendee.checked_in|date:"D" }} <br/>
+                    <form method="post" action="lost_badge">
+                        <input type="hidden" name="id" value="{{ attendee.id }}" />
+                        <input type="submit" value="Report Lost Badge">
+                    </form>
+                    {% endif %}
+                </td>
             {% endif %}
         {% elif attendee.paid == NOT_PAID %}
             <td colspan="2">


### PR DESCRIPTION
Fix #847. Helps reg quickly handle lost badges by adding a button to attendee list
and details pages.

Volunteers will have to manually restore lost badges using the
information in the admin notes.