### PR TITLE
added support for preregistering at the door and also being able to print schedules from at-the-con mode

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -7,7 +7,7 @@ def check_if_can_reg(func):
             return render('static_views/prereg_soldout.html')
         elif state.BEFORE_PREREG_OPEN:
             return render('static_views/prereg_not_yet_open.html')
-        elif state.AFTER_PREREG_TAKEDOWN:
+        elif state.AFTER_PREREG_TAKEDOWN and not AT_THE_CON:
             return render('static_views/prereg_closed.html')
         return func(*args,**kwargs)
     return with_check
@@ -85,7 +85,7 @@ def csv_file(func):
 def check_shutdown(func):
     @wraps(func)
     def with_check(self, *args, **kwargs):
-        if UBER_SHUT_DOWN:
+        if UBER_SHUT_DOWN or AT_THE_CON:
             raise HTTPRedirect('index?message={}', 'The page you requested is only available pre-event.')
         else:
             return func(self, *args, **kwargs)

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -3,7 +3,7 @@ from uber.common import *
 @all_renderable(SIGNUPS)
 class Root:
     def index(self, session, message=''):
-        if UBER_SHUT_DOWN:
+        if UBER_SHUT_DOWN or AT_THE_CON:
             return render('signups/printable.html', {'attendee': session.logged_in_volunteer()})
         else:
             return {

--- a/uber/templates/preregistration/attendee_badge_description.html
+++ b/uber/templates/preregistration/attendee_badge_description.html
@@ -1,4 +1,4 @@
 <ul>
     <li>All-access, four-day pass</li>
-    {% if PRICE_BUMPS_ENABLED %}<li style="color:red">{% attendee_price_notice %}</li>{% endif %}
+    {% if PRICE_BUMPS_ENABLED and not AT_THE_CON %}<li style="color:red">{% attendee_price_notice %}</li>{% endif %}
 </ul>

--- a/uber/templates/preregistration/badge_choice.html
+++ b/uber/templates/preregistration/badge_choice.html
@@ -81,7 +81,7 @@
         <td> {% popup_link "../static_views/seasonPasses.html" "Details" %} </td>
     </tr>
 {% endif %}
-{% if GROUPS_ENABLED %}
+{% if GROUPS_ENABLED and not AT_THE_CON %}
     <tr>
     {% if BEFORE_GROUP_PREREG_TAKEDOWN %}
             <td class="nobr">

--- a/uber/templates/preregistration/extra.html
+++ b/uber/templates/preregistration/extra.html
@@ -1,82 +1,95 @@
 {% if DONATIONS_ENABLED %}
-    <script type="text/javascript">
-        var donationChanged = function() {
-            setVisible(".affiliate-row", $.val("amount_extra") > 0);
-            setVisible(".shirt-row", $.val("amount_extra") >= {{ SHIRT_LEVEL }});
-            {% if attendee.badge_type == STAFF_BADGE %}
-                setVisible(".badge-row", true);
-            {% else %}
-                setVisible(".badge-row", $.val("amount_extra") >= {{ SUPPORTER_LEVEL }});
-            {% endif %}
-        };
-        $(function(){
-            if ($.field("amount_extra")) {
-                donationChanged();
-                var format = function(opt) {
-                    if (opt.id == {{ SUPPORTER_LEVEL }} || opt.id == {{ SEASON_LEVEL }}) {
-                        return '<span class="select2-bolded">' + opt.text + '</span>';
-                    } else {
-                        return opt.text;
+    {% if not AT_THE_CON %}
+        <script type="text/javascript">
+            var donationChanged = function() {
+                setVisible(".affiliate-row", $.val("amount_extra") > 0);
+                setVisible(".shirt-row", $.val("amount_extra") >= {{ SHIRT_LEVEL }});
+                {% if attendee.badge_type == STAFF_BADGE %}
+                    setVisible(".badge-row", true);
+                {% else %}
+                    setVisible(".badge-row", $.val("amount_extra") >= {{ SUPPORTER_LEVEL }});
+                {% endif %}
+            };
+            $(function(){
+                if ($.field("amount_extra")) {
+                    donationChanged();
+                    var format = function(opt) {
+                        if (opt.id == {{ SUPPORTER_LEVEL }} || opt.id == {{ SEASON_LEVEL }}) {
+                            return '<span class="select2-bolded">' + opt.text + '</span>';
+                        } else {
+                            return opt.text;
+                        }
+                    };
+                    if ($.field('amount_extra').is('select')) {
+                        $.field("amount_extra").select2({
+                            formatResult: format,
+                            formatSelection: function(opt) { return opt.text; },
+                            minimumResultsForSearch: 99,
+                            escapeMarkup: function(m) { return m; }
+                        });
                     }
-                };
-                if ($.field('amount_extra').is('select')) {
-                    $.field("amount_extra").select2({
-                        formatResult: format,
-                        formatSelection: function(opt) { return opt.text; },
-                        minimumResultsForSearch: 99,
-                        escapeMarkup: function(m) { return m; }
+                    $.field("affiliate").select2({
+                        placeholder: "I don't care about this",
+                        createSearchChoice: function(term) {
+                            return {id: term, text: term};
+                        },
+                        data: {{ affiliates|jsonize }}
+                    }).select2("val", {{ attendee.affiliate|default:""|jsonize }});
+                    $("form").submit(function(){
+                        $(":submit").attr("value", "Uploading Preregistration...").attr("disabled", true);
                     });
                 }
-                $.field("affiliate").select2({
-                    placeholder: "I don't care about this",
-                    createSearchChoice: function(term) {
-                        return {id: term, text: term};
-                    },
-                    data: {{ affiliates|jsonize }}
-                }).select2("val", {{ attendee.affiliate|default:""|jsonize }});
-                $("form").submit(function(){
-                    $(":submit").attr("value", "Uploading Preregistration...").attr("disabled", true);
-                });
-            }
-        });
-    </script>
-
-    {% if attendee.badge_type != PSEUDO_DEALER_BADGE %}
-        <tr class="extra-row">
-            <td valign="top" style="padding-top:15px"><b>Want to kick in extra?</b></td>
+            });
+        </script>
+        {% if attendee.badge_type != PSEUDO_DEALER_BADGE %}
+            <tr class="extra-row">
+                <td valign="top" style="padding-top:15px"><b>Want to kick in extra?</b></td>
+                <td>
+                    {% if AFTER_SUPPORTER_DEADLINE and attendee.amount_extra >= SUPPORTER_LEVEL %}
+                        {{ attendee.amount_extra_label }}
+                        <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" />
+                    {% else %}
+                        <select name="amount_extra" style="width:50%" onChange="donationChanged()" >
+                            {% options PREREG_DONATION_OPTS attendee.amount_extra %}
+                        </select>
+                    {% endif %}
+                    &nbsp;
+                    <nobr>{% popup_link "../static_views/givingExtra.html" "Why do this?" %}</nobr>
+                    <br/>
+                    <font size="-2">Each level includes all lower levels.</font> <br/>
+                    <font size="-2" color="red">Supporter level and higher {% if BEFORE_SUPPORTER_DEADLINE %}are{% else %}were{% endif %} only available until {{ SUPPORTER_DEADLINE|datetime }}.</font> 
+                </td>
+            </tr>
+        {% endif %}
+        <tr class="badge-row extra-row" style="display:none">
+            <td> <b>Name Printed on Badge:</b> </td>
             <td>
-                {% if AFTER_SUPPORTER_DEADLINE and attendee.amount_extra >= SUPPORTER_LEVEL %}
-                    {{ attendee.amount_extra_label }}
-                    <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" />
-                {% else %}
-                    <select name="amount_extra" style="width:50%" onChange="donationChanged()" >
-                        {% options PREREG_DONATION_OPTS attendee.amount_extra %}
-                    </select>
+                <input type="text" name="badge_printed_name" value="{{ attendee.badge_printed_name }}" {% if AFTER_PRINTED_BADGE_DEADLINE %}readonly{% endif %} />
+                {% if AFTER_PRINTED_BADGE_DEADLINE %}
+                    <br/> <i>(custom badges have already been ordered, so you can no longer set this)</i>
                 {% endif %}
-                &nbsp;
-                <nobr>{% popup_link "../static_views/givingExtra.html" "Why do this?" %}</nobr>
-                <br/>
-                <font size="-2">Each level includes all lower levels.</font> <br/>
-                <font size="-2" color="red">Supporter level and higher {% if BEFORE_SUPPORTER_DEADLINE %}are{% else %}were{% endif %} only available until {{ SUPPORTER_DEADLINE|datetime }}.</font> 
+            </td>
+        </tr>
+        <tr class="affiliate-row extra-row" style="display:none">
+            <td valign="top"> <b>Affiliate:</b> </td>
+            <td>
+                <input type="hidden" name="affiliate" style="width:30ex" />
+                &nbsp; <span class="popup">{% popup_link "../static_views/affiliates.html" "What's an affiliate?" %}</span>
+            </td>
+        </tr>
+    {% elif not attendee.is_new and attendee.amount_extra %}
+        <tr class="affiliate-row extra-row">
+            <td valign="top"> Donation: </td>
+            <td>
+                Thanks for kicking in ${{ attendee.amount_extra }}, you can pick up the following at our merch booth:
+                <ul>
+                {% for item in attendee.donation_swag %}
+                    <li>{{ item }}</li>
+                {% endfor %}
+                </ul>
             </td>
         </tr>
     {% endif %}
-    <tr class="badge-row extra-row" style="display:none">
-        <td> <b>Name Printed on Badge:</b> </td>
-        <td>
-            <input type="text" name="badge_printed_name" value="{{ attendee.badge_printed_name }}" {% if AFTER_PRINTED_BADGE_DEADLINE %}readonly{% endif %} />
-            {% if AFTER_PRINTED_BADGE_DEADLINE %}
-                <br/> <i>(custom badges have already been ordered, so you can no longer set this)</i>
-            {% endif %}
-        </td>
-    </tr>
-    <tr class="affiliate-row extra-row" style="display:none">
-        <td valign="top"> <b>Affiliate:</b> </td>
-        <td>
-            <input type="hidden" name="affiliate" style="width:30ex" />
-            &nbsp; <span class="popup">{% popup_link "../static_views/affiliates.html" "What's an affiliate?" %}</span>
-        </td>
-    </tr>
 {% endif %}
 
 {% include "preregistration/shirt_selection.html" %}


### PR DESCRIPTION
Talked to @kitsuta and we decided that we definitely want people to be able to preregister on our website for full weekend passes.  We also want people to be able to log in and print out their shift schedules.