### PR TITLE
changed UBER_SHUT_DOWN message

### DIFF
--- a/uber/server.py
+++ b/uber/server.py
@@ -14,10 +14,8 @@ cherrypy.tools.add_email_to_error_page = cherrypy.Tool('after_error_response', _
 class UberShutDown:
     def default(self, *args, **kwargs):
         return render('closed.html')
-    
-    signups = signups.Root()
+
     schedule = schedule.Root()
-    preregistration = preregistration.Root()
 
 mimetypes.init()
 

--- a/uber/templates/closed.html
+++ b/uber/templates/closed.html
@@ -1,14 +1,10 @@
 {% extends "base-admin.html" %}
-{% block title %}We'll see you at {{ EVENT_NAME }}{% endblock %}
+{% block title %}{{ EVENT_NAME }} server is being moved{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
 
-<h2 style="color:red">The {{ EVENT_NAME }} registration/staffing database is now offline.</h2>
+<h2 style="color:red">The {{ EVENT_NAME }} registration/volunteer wesite is temporarily offline</h2>
 
-We'll see everyone on January 2 - 5.
-<br/> <br/>
-Full weekend passes are available at the door for ${{ DOOR_BADGE_PRICE }}, and single day passes will be $20 for Thursday or Sunday, and $40 for Friday or Saturday.
-<br/> <br/>
-If you're a staffer, you can still view and print out your shift schedule <a href="{{ URL_BASE }}/signups/login">here</a>.
+We'll be back online shortly, at which point you'll again be able to access the page you were trying to load.
 
 {% endblock %}


### PR DESCRIPTION
In previous years we literally shut down public Uber for the entirety of MAGFest.  This year we're just moving to the hotel and then redirecting people to the onsite Uber so people can still preregister, claim group badges, etc.  So instead of saying that we're offline for the weekend, we now instead say that we're temporarily offline and will be back online shortly.