### PR TITLE
Add email and zipcode to quick check-in

### DIFF
--- a/uber/templates/registration/checkin.html
+++ b/uber/templates/registration/checkin.html
@@ -118,6 +118,14 @@
                     </tr>
                 {% endif %}
                 <tr>
+                    <td><strong>Email:</strong></td>
+                    <td>{{ attendee.email }}</td>
+                </tr>
+                <tr>
+                    <td><strong>Zipcode:</strong></td>
+                    <td>{{ attendee.zipcode }}</td>
+                </tr>
+                <tr>
                     <td><strong>Emergency Contact:</strong></td>
                     <td>{{ attendee.ec_phone }}</td>
                 </tr>


### PR DESCRIPTION
Lets volunteers more easily verify which badge is duplicate.