### PR TITLE
part of the fix for earlier performance issue

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1188,7 +1188,7 @@ Tracking.UNTRACKED = [Tracking, Email]
 
 
 class Session(SessionManager):
-    engine = sqlalchemy.create_engine(SQLALCHEMY_URL)
+    engine = sqlalchemy.create_engine(SQLALCHEMY_URL, pool_size=50, max_overflow=100)
 
     class QuerySubclass(Query):
         @property

--- a/uber/server.py
+++ b/uber/server.py
@@ -86,9 +86,13 @@ class Redirector:
 cherrypy.tree.mount(Root(), PATH, APPCONF)
 
 if SEND_EMAILS or DEV_BOX:
-    DaemonTask(AutomatedEmail.send_all, interval=300)
+    if not AT_THE_CON:
+        DaemonTask(AutomatedEmail.send_all, interval=300)
     if PRE_CON:
         DaemonTask(detect_duplicates, interval=300)
         DaemonTask(check_unassigned, interval=300)
         if CHECK_PLACEHOLDERS:
             DaemonTask(check_placeholders, interval=300)
+
+# this should be replaced by something a little cleaner, but it's a useful debugging tool, so we'll go with it for now
+DaemonTask(lambda: log.error(Session.engine.pool.status()), interval=5)


### PR DESCRIPTION
Earlier today, Uber started slowing WAY down when we hit a high number of users.  I realized that there were three easy things I could do to address this issue:

1) I completely forgot to review our web server settings when we puppetized them, to make sure they matched last year's settings.  MY BAD!  We had our thread pool set to 10, which isn't really enough when people's web browsers have keepalive turned on.  I bumped this up to 150 in the puppet template on mcp.magfest.net so that's not included in this change.

2) Relatedly, our SQLALchemy default connection pool size was laughably low.  I don't think this actually matters much in practice since I think the web server change was the only real issue that mattered, but just to be safe I bumped this up to 50 and increased the queue size to 100.  I doubt this will matter much.

3) I turned off automated emails when in AT_THE_CON mode.  This only applies to background emails such as payment confirmations, so things like badge transfer emails will still go through (which are probably the ones we care about the most at this point).  Were we running Uber on a beefier server like we planned and not a $10/month VPS this wouldn't be as much of an issue but the high CPU usage was causing a slowdown every 5 minutes.  Since we've always turned off these background emails in past years I don't think it's a problem to have them turned off now.