### PR TITLE
fixed utc bug with oneday badge prices

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -525,7 +525,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def badge_cost(self):
-        registered = self.registered or localized_now()
+        registered = self.registered_local or localized_now()
         if self.paid in [PAID_BY_GROUP, NEED_NOT_PAY]:
             return 0
         elif self.overridden_price is not None:


### PR DESCRIPTION
Derp, I grepped the codebase for all cases of ``start_time`` to find any remaining issues like this, but forgot to do the same thing with ``registered`` so this one slipped through.  Derp.