### PR TITLE
fixed wording to no longer refer to MAGFest 13 explicitly

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -505,10 +505,10 @@ if POST_CON:
         def default(self, *args, **kwargs):
             return """
                 <html><head></head><body style='text-align:center'>
-                    <h2 style='color:red'>Hope you had a great MAGFest!</h2>
-                    Preregistration for MAGFest 13 will open in the summer.
+                    <h2 style='color:red'>Hope you had a great {event}!</h2>
+                    Preregistration for {event} {year} will open in a few months.
                 </body></html>
-            """
+            """.format(event=EVENT_NAME, year=(1 + int(YEAR)) if YEAR else '')
 
         # TODO: figure out if this is the best way to handle the issue of people not getting shirts
         def shirt_reorder(self, session, message = '', **params):


### PR DESCRIPTION
The "MAGFest is over" message should be generic and use our snazzy config options.