### PR TITLE
feat(prereg): add badge selector to register group member

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1,4 +1,7 @@
 from uber.common import *
+from string import Template
+from django.utils.safestring import mark_safe
+import json
 
 
 def to_sessionized(attendee, group):
@@ -318,12 +321,41 @@ class Root:
         else:
             attendee.can_spam = True    # only defaults to true for these forms
 
+        badges = [
+            {
+                'type': 'attending',
+                'title': 'Attending: $0',
+                'description': 'Allows access to the convention for its duration'
+            }
+        ]
+        if (c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and
+                c.SUPPORTER_AVAILABLE):
+            title = {'price': '$' + str(c.SUPPORTER_LEVEL)}
+            badges.append({
+                'type': 'supporter',
+                'title': Template('Supporter: $price').substitute(title),
+                'description': 'Donate extra and get more swag with your membership',
+                'extra': c.SUPPORTER_LEVEL
+            })
+
+        if (c.SEASON_LEVEL in c.PREREG_DONATION_TIERS and
+                c.SUPPORTER_AVAIALABLE):
+            title = {'price': '$' + str(c.SEASON_LEVEL)}
+            badges.append({
+                'type': 'season_supporter',
+                'title': Template('Season Supporter: $price')
+                    .substitute(title),
+                'description': 'Fill this in later',
+                'extra': c.SEASON_LEVEL
+            })
+
         return {
             'message':  message,
             'group_id': group_id,
             'group': group,
             'attendee': attendee,
-            'affiliates': session.affiliates()
+            'affiliates': session.affiliates(),
+            'badges': mark_safe(json.dumps(badges))
         }
 
     def group_extra_payment_form(self, session, id):

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -2,87 +2,19 @@
 {% block title %}Preregistration{% endblock %}
 {% block content %}
 
+<style>
+    .bs-wizard {
+      border-bottom: 0;
+    }
+</style>
+
 <div class="masthead"></div>
 
 <div class="panel panel-default">
 {% if attendee.is_dealer %}
     <span class="text-center"><h2>Dealer Application</h2></span>
 {% else %}
-    <script type="text/javascript">
-        var BADGE_TYPES = [{
-            title: 'Attending: ${{ c.BADGE_PRICE }}',
-            description: 'Allows access to the convention for its duration.'
-        }];
-        {% if c.GROUPS_ENABLED and attendee.is_new and not group_id %}
-            BADGE_TYPES.push({
-                title: 'Group Leader',
-                {% if c.BEFORE_GROUP_PREREG_TAKEDOWN %}
-                    description: '<p class="list-group-item-text">Register a group of {{ c.MIN_GROUP_SIZE }} or more and save ${{ c.GROUP_DISCOUNT }} per badge.</p>',
-                {% else %}
-                    description: '<p class="list-group-item-text">The deadline for Group registration has passed, but you can still register as a regular attendee.</p>'
-                {% endif %}
-                onClick: function () {
-                    $('.group_fields').removeClass('hide');
-                    $('input[name="badge_type"]').val('{{ c.PSEUDO_GROUP_BADGE }}');
-                }
-            });
-        {% endif %}
-        {% if c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
-            BADGE_TYPES.push({
-                title: 'Supporter: ${{ c.BADGE_PRICE|add:c.SUPPORTER_LEVEL }}',
-                description: 'Donate extra and get more swag with your membership.',
-                extra: {{ c.SUPPORTER_LEVEL }}
-            });
-        {% endif %}
-        {% if c.SEASON_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
-            BADGE_TYPES.push({
-                title: 'Season Supporter: ${{ c.BADGE_PRICE|add:c.SEASON_LEVEL }}',
-                description: 'Fill this in later',
-                extra: {{ c.SEASON_LEVEL }}
-            });
-        {% endif %}
-
-        var setBadge = function (badgeTypeIndex) {
-            var badgeType = BADGE_TYPES[badgeTypeIndex];
-            $('.group_fields').addClass('hide');
-            $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
-            $('.badge_type_selector').removeClass('active');
-            $('.badge_type_selector').slice(badgeTypeIndex, 1 + badgeTypeIndex).addClass('active');
-            $.field('amount_extra').val(badgeType.extra || 0).trigger('change');
-            (badgeType.onClick || $.noop)();
-        }
-        var makeBadgeMatchExtra = function () {
-            var target = $.val('name') ? 1 : 0;  // default to attendee or group
-            if (target !== 1) {
-                $.each(BADGE_TYPES, function (i, badgeType) {
-                    if (badgeType.extra && badgeType.extra <= $.val('amount_extra')) {
-                        target = i;
-                    }
-                });
-            }
-            if (!$('.badge_type_selector:nth(' + target + ')').is('.active')) {
-                setBadge(target);
-            }
-        };
-        $(function () {
-            $.each(BADGE_TYPES, function (index, badgeType) {
-                $('#badge_types').append(
-                    $('<div class="col-sm-3"></div>').append(
-                        $('<a class="list-group-item badge_type_selector"></a>').click(function () {
-                            setBadge(index);
-                        }).append(
-                            $('<h4 class="list-group-item-heading"></h4>').html(badgeType.title)
-                        ).append(
-                            $('<p class="list-group-item-text"></p>').html(badgeType.description))));
-            });
-            makeBadgeMatchExtra();
-            if ($.field('amount_extra')) {
-                $.field('amount_extra').on('change', makeBadgeMatchExtra);
-            }
-        });
-    </script>
-
-    <div class="row bs-wizard" style="border-bottom:0;border-top:0;">   
+    <div class="row bs-wizard">   
         <div class="col-xs-4 bs-wizard-step active">
             <div class="text-center bs-wizard-stepnum">Step 1</div>
             <div class="progress">
@@ -240,5 +172,81 @@
 </form>
 
 {% include "preregistration/disclaimers.html" %}
+
+{% if attendee.is_dealer != true %}
+    <script>
+        var BADGE_TYPES = [{
+            title: 'Attending: ${{ c.BADGE_PRICE }}',
+            description: 'Allows access to the convention for its duration.'
+        }];
+        {% if c.GROUPS_ENABLED and attendee.is_new and not group_id %}
+            BADGE_TYPES.push({
+                title: 'Group Leader',
+                {% if c.BEFORE_GROUP_PREREG_TAKEDOWN %}
+                    description: '<p class="list-group-item-text">Register a group of {{ c.MIN_GROUP_SIZE }} or more and save ${{ c.GROUP_DISCOUNT }} per badge.</p>',
+                {% else %}
+                    description: '<p class="list-group-item-text">The deadline for Group registration has passed, but you can still register as a regular attendee.</p>'
+                {% endif %}
+                onClick: function () {
+                    $('.group_fields').removeClass('hide');
+                    $('input[name="badge_type"]').val('{{ c.PSEUDO_GROUP_BADGE }}');
+                }
+            });
+        {% endif %}
+        {% if c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
+            BADGE_TYPES.push({
+                title: 'Supporter: ${{ c.BADGE_PRICE|add:c.SUPPORTER_LEVEL }}',
+                description: 'Donate extra and get more swag with your membership.',
+                extra: {{ c.SUPPORTER_LEVEL }}
+            });
+        {% endif %}
+        {% if c.SEASON_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
+            BADGE_TYPES.push({
+                title: 'Season Supporter: ${{ c.BADGE_PRICE|add:c.SEASON_LEVEL }}',
+                description: 'Fill this in later',
+                extra: {{ c.SEASON_LEVEL }}
+            });
+        {% endif %}
+
+        var setBadge = function (badgeTypeIndex) {
+            var badgeType = BADGE_TYPES[badgeTypeIndex];
+            $('.group_fields').addClass('hide');
+            $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
+            $('.badge_type_selector').removeClass('active');
+            $('.badge_type_selector').slice(badgeTypeIndex, 1 + badgeTypeIndex).addClass('active');
+            $.field('amount_extra').val(badgeType.extra || 0).trigger('change');
+            (badgeType.onClick || $.noop)();
+        }
+        var makeBadgeMatchExtra = function () {
+            var target = $.val('name') ? 1 : 0;  // default to attendee or group
+            if (target !== 1) {
+                $.each(BADGE_TYPES, function (i, badgeType) {
+                    if (badgeType.extra && badgeType.extra <= $.val('amount_extra')) {
+                        target = i;
+                    }
+                });
+            }
+            if (!$('.badge_type_selector:nth(' + target + ')').is('.active')) {
+                setBadge(target);
+            }
+        };
+        $(function () {
+            $.each(BADGE_TYPES, function (index, badgeType) {
+                $('#badge_types').append(
+                    $('<div class="col-sm-3"></div>').append(
+                        $('<a class="list-group-item badge_type_selector"></a>').click(function () {
+                            setBadge(index);
+                        }).append(
+                            $('<h4 class="list-group-item-heading"></h4>').html(badgeType.title)
+                        ).append(
+                            $('<p class="list-group-item-text"></p>').html(badgeType.description))));
+            });
+            makeBadgeMatchExtra();
+            if ($.field('amount_extra')) {
+                $.field('amount_extra').on('change', makeBadgeMatchExtra);
+            }
+        });
+    </script>
+{% endif %}
 
 {% endblock %}

--- a/uber/templates/preregistration/register_group_member.html
+++ b/uber/templates/preregistration/register_group_member.html
@@ -3,22 +3,64 @@
 {% block backlink %}{% endblock %}
 {% block content %}
 
+<style>
+    .bs-wizard {
+      border-bottom: 0;
+    }
+</style>
+
 <div class="masthead"></div>
 
 <div class="panel panel-default">
-<form method="post" action="register_group_member" class="form-horizontal">
-{% csrf_token %}
-<input type="hidden" name="id" value="{{ attendee.db_id }}" />
-<input type="hidden" name="group_id" value="{{ group_id }}" />
-
-{% include "regform.html" %}
-
-<div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary" id="updateButton">Register</button>
+    <div class="row bs-wizard">
+        <div class="form-group" id="badge_types">
+            <label for="badge" class="col-sm-2 control-label">&nbsp;</label>
+        </div>
     </div>
+    <form method="post" action="register_group_member" class="form-horizontal">
+        {% csrf_token %}
+        <input type="hidden" name="id" value="{{ attendee.db_id }}" />
+        <input type="hidden" name="group_id" value="{{ group_id }}" />
+
+        {% include "regform.html" %}
+
+        <div class="form-group">
+            <div class="col-sm-6 col-sm-offset-2">
+                <button type="submit" class="btn btn-primary" id="updateButton">Register</button>
+            </div>
+        </div>
+    </form>
 </div>
-</form>
-</div>
+<script>
+    var badges = {{ badges }};
+    var badgesElem = $('#badge_types');
+
+    var setBadge = function (idx) {
+        var badge = badges[idx];
+        $('.group_fields').addClass('hide');
+        $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
+        $('.badge_type_selector').removeClass('active');
+        $('.badge_type_selector').slice(idx, 1 + idx).addClass('active');
+        $.field('amount_extra').val(badge.extra || 0).trigger('change');
+        (badge.onClick || $.noop)();
+    };
+
+    var createBadgeHtml = function (badge, idx) {
+      badgesElem.append(
+          $('<div class="col-sm-3"></div>').append(
+              $('<a class="list-group-item badge_type_selector"></a>').click(function () {
+                  setBadge(idx);
+              }).append(
+                  $('<h4 class="list-group-item-heading"></h4>').html(badge.title)
+              ).append(
+                  $('<p class="list-group-item-text"></p>').html(badge.description)
+              )
+          )
+      );
+    };
+
+    badges.forEach(createBadgeHtml);
+    setBadge(0);
+</script>
 
 {% endblock %}


### PR DESCRIPTION
- Add the badge selector to the register group member view

This addresses #1098

Note: this needs some thought before merging - in particular, whether it makes sense for this calculation to be followed for the cost of supporter badges. This badge logic should probably be abstracted some, but as this calculation is currently scoped to the `register_group_member` method, this should be safe.