### PR TITLE
initialize_db() now happens on post-init, ignore any other times it's called

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -61,7 +61,7 @@ from sqlalchemy.schema import Column, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import Query, relationship, joinedload, backref
 from sqlalchemy.types import Boolean, Integer, Float, TypeDecorator, Date
 
-from sideboard.lib import log, parse_config, entry_point, listify, DaemonTask, serializer, cached_property
+from sideboard.lib import log, parse_config, entry_point, listify, DaemonTask, serializer, cached_property, stopped, on_startup
 from sideboard.lib.sa import declarative_base, SessionManager, UTCDateTime, UUID, CoerceUTF8 as UnicodeText
 
 import uber

--- a/uber/models.py
+++ b/uber/models.py
@@ -1,6 +1,7 @@
 from uber.common import *
 from sideboard.lib import stopped, on_startup
 
+
 def _get_defaults(func):
     spec = inspect.getfullargspec(func)
     return dict(zip(reversed(spec.args), reversed(spec.defaults)))
@@ -1893,6 +1894,7 @@ if this fails, keep trying until we're able to connect.
 This should be the ONLY spot (except for maintenance tools) in all of core ubersystem or any plugins
 that attempts to create tables by passing modify_tables=True to Session.initialize_db()
 """
+
 def initialize_db():
     num_tries_remaining = 10
     while not stopped.is_set():

--- a/uber/models.py
+++ b/uber/models.py
@@ -1895,6 +1895,7 @@ This should be the ONLY spot (except for maintenance tools) in all of core ubers
 that attempts to create tables by passing modify_tables=True to Session.initialize_db()
 """
 
+
 def initialize_db():
     num_tries_remaining = 10
     while not stopped.is_set():

--- a/uber/models.py
+++ b/uber/models.py
@@ -1,5 +1,4 @@
 from uber.common import *
-from sideboard.lib import stopped, on_startup
 
 
 def _get_defaults(func):
@@ -417,22 +416,28 @@ class NightsMixin(object):
 class Session(SessionManager):
     engine = sqlalchemy.create_engine(c.SQLALCHEMY_URL, pool_size=50, max_overflow=100)
 
-    """
-    Initializes the database connection for use, and attempt to create any
-    tables registered in our metadata which do not actually exist yet in the
-    database.
-
-    This calls the underlying sideboard function, HOWEVER, in order to actually create
-    any tables, you must specify modify_tables=True.  The reason is, we need to wait for
-    all models from all plugins to insert their mixin data, so we wait until one spot
-    in order to create the database tables.
-
-    Any calls to initialize_db() that do not specify modify_tables=True are ignored.
-
-    drop: USE WITH CAUTION: If True, then we will drop any tables in the database.
-    """
     @classmethod
     def initialize_db(cls, modify_tables=False, drop=False):
+        """
+        Initialize the database and optionally create/drop tables
+
+        Initializes the database connection for use, and attempt to create any
+        tables registered in our metadata which do not actually exist yet in the
+        database.
+
+        This calls the underlying sideboard function, HOWEVER, in order to actually create
+        any tables, you must specify modify_tables=True.  The reason is, we need to wait for
+        all models from all plugins to insert their mixin data, so we wait until one spot
+        in order to create the database tables.
+
+        Any calls to initialize_db() that do not specify modify_tables=True are ignored.
+        i.e. anywhere in Sideboard that calls initialize_db() will be ignored
+        i.e. ubersystem is forcing all calls that don't specify modify_tables=True to be ignored
+
+        Keyword Arguments:
+        modify_tables -- If False, this function does nothing.
+        drop -- USE WITH CAUTION: If True, then we will drop any tables in the database
+        """
         if modify_tables:
             super(Session, cls).initialize_db(drop=drop)
 
@@ -1889,34 +1894,33 @@ def register_session_listeners():
 register_session_listeners()
 
 
-"""
-Initialize the database on startup
-
-We want to do this only after all other plugins have had a chance to initialize
-and add their 'mixin' data (i.e. extra colums) into the models.
-
-Also, it's possible that the DB is still initializing and isn't ready to accept connections, so,
-if this fails, keep trying until we're able to connect.
-
-This should be the ONLY spot (except for maintenance tools) in all of core ubersystem or any plugins
-that attempts to create tables by passing modify_tables=True to Session.initialize_db()
-"""
-
-
 def initialize_db():
+    """
+    Initialize the database on startup
+
+    We want to do this only after all other plugins have had a chance to initialize
+    and add their 'mixin' data (i.e. extra colums) into the models.
+
+    Also, it's possible that the DB is still initializing and isn't ready to accept connections, so,
+    if this fails, keep trying until we're able to connect.
+
+    This should be the ONLY spot (except for maintenance tools) in all of core ubersystem or any plugins
+    that attempts to create tables by passing modify_tables=True to Session.initialize_db()
+    """
     num_tries_remaining = 10
     while not stopped.is_set():
         try:
             Session.initialize_db(modify_tables=True)
         except KeyboardInterrupt:
-            log.critical("DB initialize: Someone hit Ctrl+C while we were starting up")
+            log.critical('DB initialize: Someone hit Ctrl+C while we were starting up')
         except:
             num_tries_remaining -= 1
             if num_tries_remaining == 0:
                 log.error("DB initialize: couldn't connect to DB, we're giving up")
                 raise
-            log.error("DB initialize: can't connect to + initialize DB, will try again in 5 seconds", exc_info=True)
+            log.error("DB initialize: can't connect to / initialize DB, will try again in 5 seconds", exc_info=True)
             stopped.wait(5)
         else:
             break
+
 on_startup(initialize_db, priority=1)

--- a/uber/sep_commands.py
+++ b/uber/sep_commands.py
@@ -32,5 +32,5 @@ def insert_admin():
 @entry_point
 def reset_uber_db():
     assert c.DEV_BOX, 'reset_uber_db is only available on development boxes'
-    Session.initialize_db(drop=True)
+    Session.initialize_db(drop=True, modify_tables=True)
     insert_admin()


### PR DESCRIPTION
per Eli's suggestion

1) initialize the DB in a task that runs only on actual startup after all classes have registered themselves.  any other calls that omit modify_tables=True are basically ignored.

2) this also tries to initialize the DB, and if it fails, retries 10 times with a 5 second delay, to deal with the database not being ready to accept connections (this happens with docker containers starting up for the first time, and out of order)

--

These changes accomplish the following:
1) Fixes broken behavior where ubersystem didn't create all it's DB tables at startup automatically
2) Makes this startup in our current docker setup where uber tries to connect to the DB before the DB is ready to accept connections

Probably should remove Session.initialize_db() from magstock plugins, and any other plugins where that's being used.

@EliAndrewC check on this for me, this change makes it so the following two things in SessionManager don't happen until much later in the startup process (from SessionManager.initialize_db()):

```
configure_mappers()
cls.BaseClass.metadata.bind = cls.engine
```

Also incorporates Eli's fix for overriding DB columns in plugins