### PR TITLE
Column overriding

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -749,9 +749,16 @@ class Session(SessionManager):
             else:
                 raise ValueError('No existing model with name {}'.format(model.__name__))
 
-        for attr in dir(model):
-            if not attr.startswith('_'):
-                setattr(target, attr, getattr(model, attr))
+        for name in dir(model):
+            if not name.startswith('_'):
+                attr = getattr(model, name)
+                if name in target.__table__.c:
+                    attr.key = attr.key or name
+                    attr.name = attr.name or name
+                    attr.table = target.__table__
+                    target.__table__.c.replace(attr)
+                else:
+                    setattr(target, name, attr)
         return target
 
 


### PR DESCRIPTION
Plugins were previously able to add new columns, but until now they couldn't change existing columns.  I never tested that out, since I never needed to do it for MAGStock, and it turns out that there's a special method you need to call to replace a column rather than adding it:
http://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.expression.ColumnCollection.replace