### PR TITLE
fixed badge update code to work on non-preassigned badges

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -576,7 +576,8 @@ class Session(SessionManager):
                 return out_of_range
 
             # Keeps non-preassigned badges numberless unless they've already been checked in.
-            if badge_type not in c.PREASSIGNED_BADGE_TYPES and not attendee.checked_in:
+            if badge_type not in c.PREASSIGNED_BADGE_TYPES and (not c.NUMBERED_BADGES or not attendee.checked_in):
+                attendee.badge_type = badge_type
                 attendee.badge_num = 0
                 return 'Badge updated'
 

--- a/uber/templates/registration/change_badge.html
+++ b/uber/templates/registration/change_badge.html
@@ -8,7 +8,7 @@
             var badge_type = parseInt($("[name=badge_type]").val());
             var radio = badge_type === {{ attendee.badge_type}} ? "manual" : "auto";
             $("[value=" + radio + "]").attr("checked", true);
-            setVisible("#badge_num_row", {{ c.PREASSIGNED_BADGE_TYPES }}.indexOf(badge_type) >= 0);
+            setVisible("#badge_num_row", !{{ c.NUMBERED_BADGES|jsonize }} && {{ c.PREASSIGNED_BADGE_TYPES }}.indexOf(badge_type) >= 0);
             assignChanged();
         {% endif %}
     }


### PR DESCRIPTION
Two changes here:

1) We no longer ask for badge numbers on the Change Badge form if ``c.NUMBERED_BADGES`` is False.

2) There was a bug where we wouldn't successfully change the badge type for a non-preassigned badge.  I'll point it out inline.