### PR TITLE
Add offline mode

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -22,6 +22,12 @@ def check_if_can_reg(func):
             return render('static_views/prereg_not_yet_open.html')
         elif state.AFTER_PREREG_TAKEDOWN and not AT_THE_CON:
             return render('static_views/prereg_closed.html')
+        elif OFFLINE_MODE:
+            with Session() as session:
+                try:
+                    attendee = session.admin_account(cherrypy.session['account_id'])
+                except:
+                    return render('static_views/prereg_offline.html')
         return func(*args,**kwargs)
     return with_check
 

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -240,7 +240,6 @@ $(document).ready(function() {
 <link rel="stylesheet" href="../static/lib/jquery-cluetip/jquery.cluetip.css" type="text/css" />
 <link rel="stylesheet" href="../static/lib/jquery-contextMenu/jquery.contextMenu.css" type="text/css" />
 <link rel="stylesheet" href="../static/lib/jquery-ui/ui-lightness/jquery-ui-1.9.0.custom.css" type="text/css" />
-<link rel="icon" href="https://www.anthrocon.org/sites/all/themes/anthrocon-2015/images/anthrocon-2015/favicon.gif" type="image/x-icon" />
 
 <script src="../static/lib/toastr/toastr.min.js"></script>
 <link href="../static/lib/toastr/toastr.min.css" rel="stylesheet">
@@ -258,15 +257,18 @@ $(document).ready(function() {
 <script src="../static/lib/jquery-datetextentry/jquery.datetextentry.js" type="text/javascript"></script>
 <link href="../static/lib/jquery-datetextentry/jquery.datetextentry.css" rel="stylesheet">
 
-<script src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
 <script src="../static/lib/ubilabs-geocomplete/jquery.geocomplete.js"></script>
 
+{% if not OFFLINE_MODE %}
+<script src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
+<link rel="icon" href="https://www.anthrocon.org/sites/all/themes/anthrocon-2015/images/anthrocon-2015/favicon.gif" type="image/x-icon" />
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
 <!--[if lt IE 9]>
 	<script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 	<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
+{% endif %}
 {% endblock %}
 </body>
 </html>

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -112,7 +112,7 @@ $(document).ready(function() {
     {% block head_additional %}{% endblock %}
 </head>
 <body>
-<div class="loader"><a class="loader_link" href="../static_views/slow_load.html" target="_blank"></a></div>
+{% if not OFFLINE_MODE %}<div class="loader"><a class="loader_link" href="../static_views/slow_load.html" target="_blank"></a></div>{% endif %}
 {% block top_of_body_additional %}{%  endblock %}
 <div id="mainContainer" class="container-fluid">
 {% block top %}

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -106,7 +106,7 @@ $(".buttonsView").children().click(function(){ window.onbeforeunload = UnPopIt; 
     <div class="text-center">
         {% if AT_THE_CON %}
             <a href="index?payment_method={{ CASH }}"><button class="btn btn-success">Pay with Cash</button></a>
-            {% stripe_form take_payment charge %}
+            {% if not OFFLINE_MODE %}{% stripe_form take_payment charge %}{% endif %}
             <a href="index?payment_method={{ SQUARE }}"><button class="btn btn-info">Pay with Card at the Desk</button></a>
         {% else %}
             {% stripe_form take_payment charge %}

--- a/uber/templates/static_views/prereg_offline.html
+++ b/uber/templates/static_views/prereg_offline.html
@@ -1,0 +1,13 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Preregistration{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+
+<div class="masthead">
+</div>
+
+<div class="panel text-center">
+    <h4>Online Registration is Currently Unavailable!</h4>
+    <p>Registration has been taken offline. Please proceed to the registration desk to register. We apologize for any inconvenience.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
Fixes #1131.

This adds a new configuration option called "Offline Mode." The idea behind this option is that if an event loses its internet (or just can't acquire it in the first place), we want an easy way to turn off internet-dependent features, particularly Stripe. 

This is also disables online at-door reg, since there's no more syncing between the cloud server and the local server while the system is offline.

Requires config option `offline_mode = True`