### PR TITLE
Fix donation tier migration

### DIFF
--- a/alembic/versions/51e4adb4b60_add_watch_list.py
+++ b/alembic/versions/51e4adb4b60_add_watch_list.py
@@ -28,6 +28,15 @@ def upgrade():
         sa.Column('action', sa.UnicodeText(), nullable=False),
     )
 
+    op.add_column('job', sa.Column('type',sa.Integer(), default=252034462))
+    op.alter_column('job', 'weight', server_default=1)
+    op.add_column('food_restrictions', sa.Column('sandwich_pref',sa.Integer(), nullable=False, default=127073423))
+    op.add_column('food_restrictions', sa.Column('no_cheese',sa.Boolean(), nullable=False, default=False))
+
+    op.drop_table('room_assignment')
+    op.drop_table('room')
+    op.drop_table('checkout')
+
 
 def downgrade():
     op.drop_table('watch_list')

--- a/alembic/versions/54fae9d8798_add_donation_tier.py
+++ b/alembic/versions/54fae9d8798_add_donation_tier.py
@@ -18,7 +18,7 @@ import sqlalchemy as sa
 
 def upgrade():
     op.add_column('attendee',
-        sa.Column('donation_tier', sa.Integer())
+        sa.Column('donation_tier', sa.Integer(), server_default=243383191)
     )
 
 


### PR DESCRIPTION
Fixes the addition of the donation tier column so it actually sets everyone to the real default. Also adds some previously-manual SQL into
the WachList migration.