### PR TITLE
Change the order of the badge status alterations

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -893,13 +893,14 @@ class Root:
     def temp_fix_badge_status(self, session, message=''):
         attendees, groups = session.everyone()
         for attendee in attendees:
-            if attendee.status == NEW_STATUS and not attendee.placeholder and attendee.first_name:
-                if (attendee.paid == HAS_PAID or attendee.paid == NEED_NOT_PAY) or (attendee.paid == PAID_BY_GROUP and not attendee.group.amount_unpaid):
-                    attendee.status = COMPLETED_STATUS
-            elif attendee.paid == PAID_BY_GROUP and not attendee.group:
+            if attendee.paid == PAID_BY_GROUP and not attendee.group:
                 attendee.paid = NOT_PAID
                 attendee.status = INVALID_STATUS
-                session.add(attendee)
+            elif attendee.status == NEW_STATUS and not attendee.placeholder and attendee.first_name:
+                if (attendee.paid == HAS_PAID or attendee.paid == NEED_NOT_PAY) or (attendee.paid == PAID_BY_GROUP and not attendee.group.amount_unpaid):
+                    attendee.status = COMPLETED_STATUS
+            session.add(attendee)
+            
         try:
             session.commit()
         except:


### PR DESCRIPTION
Adding the paid by group attendees breaks if you haven't already fixed
the attendees with no group, so this changes around the order. Hopefully
that's the last of the fixes needed.