### PR TITLE
Fix confirmation page for invalid badges

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -453,6 +453,9 @@ class Root:
     def confirm(self, session, message='', return_to='confirm', **params):
         attendee = session.attendee(params, bools=_checkboxes, restricted=True)
 
+        if attendee.status == INVALID_STATUS:
+            return render('static_views/invalid_badge.html')
+
         placeholder = attendee.placeholder
         if 'email' in params:
             attendee.placeholder = False

--- a/uber/templates/static_views/invalid_badge.html
+++ b/uber/templates/static_views/invalid_badge.html
@@ -1,0 +1,13 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Confirm Your Details{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+<div class="masthead">
+</div>
+
+<div class="panel panel-default">
+    <h3>Invalid Badge</h3>
+    <p>The badge you are trying to access is no longer valid. This may be because it was a duplicate of another badge, because it was canceled before payment went through, or because you asked to no longer receive emails from us.</p>
+    <p>If you think you should have a valid badge, don't panic! You are probably just on the wrong page. If you can't find your confirmation email, please contact us at {{ REGDESK_EMAIL }}.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
Redirects attendees to a static view to prevent them from viewing or paying for an invalid badge.