### PR TITLE
Paginate the printed badges page

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -548,7 +548,7 @@ class Root:
 
         raise HTTPRedirect('form?id={}&message={}', attendee_id, message)
 
-    def printed_badges(self, session, message='', id=None, pending=None, reprint_reason=''):
+    def printed_badges(self, session, page='1', message='', id=None, pending=None, reprint_reason=''):
         if id:
             attendee = session.attendee(id)
             attendee.status = COMPLETED_STATUS
@@ -563,7 +563,14 @@ class Root:
         else:
             badges = session.query(Attendee).filter(Attendee.status == PRINTED_STATUS).order_by(Attendee.badge_num).all()
 
+        page = int(page)
+        count = len(badges)
+        pages = range(1, int(math.ceil(count / 100)) + 1)
+        badges = badges[-100 + 100*page : 100*page] if page else []
+
         return {
+            'page':           page,
+            'pages':          pages,
             'message':    message,
             'badges':     badges,
             'pending': pending

--- a/uber/templates/registration/printed_badges.html
+++ b/uber/templates/registration/printed_badges.html
@@ -13,7 +13,15 @@
 </div>
 
 <br/>
-
+<div class="panel panel-default">
+    {% for pagenum in pages %}
+        {% if pagenum == page %}
+            {{ pagenum }}
+        {% else %}
+            <a href="index?page={{ pagenum }}">{{ pagenum }}</a>
+        {% endif %}
+    {% endfor %}
+{% if page %}
 <table class="table footable" data-page-size="9999999">
 <thead><tr>
     <th>Legal Name</th>
@@ -52,5 +60,6 @@
     </tr>
 {% endfor %}
 </table>
+    {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This avoids the slow-loading problem that crops up when you have 5000 badges.