### PR TITLE
fixes #1192 and fixes #1194

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -414,7 +414,7 @@ class stripe_form(template.Node):
         charge = self.charge.resolve(context)
         cherrypy.session[payment_id] = charge.to_dict()
 
-        email = ""
+        email = ''
         if charge.targets and charge.models[0].email:
             email = charge.models[0].email[:255]
 

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -98,13 +98,17 @@
             });
             $('.focus:first').focus();
             if (window.DISABLE_STRIPE_BUTTONS_ON_CLICK) {
-                $('form.stripe').on('click', 'button', function() {
-                    $('a > .stripe-button-el').unwrap().attr('disabled', true).unwrap()
+                // we can't intercept the Javascript form submit, so once someone has clicked the Stripe
+                // submit button, listen for us leaving the page and disable the buttons then
+                $(document).on('click', 'form > .stripe-button-el', function () {
+                    $(window).on('beforeunload', function () {
+                        $('a > .stripe-button-el').unwrap().prop('disabled', true).unwrap();
+                    });
                 });
             }
             // prevent people from paying after prereg closes
             {% if c.PRE_CON %}
-                if ($('form.stripe').length) {
+                if ($('form.stripe').size()) {
                     var prevHour = new Date().getHours();
                     var checkHour = function() {
                         var currHour = new Date().getHours();

--- a/uber/templates/common.js
+++ b/uber/templates/common.js
@@ -97,18 +97,18 @@ var $undoForm = function (path, params, linkText) {
 };
 
 function showTop (message) {
-    $("#top").show("fast").find("td:first").html(message);
+    $('#top').show('fast').find('td:first').html(message);
 }
 function hideTop () {
-    $("#top").hide("fast");
+    $('#top').hide('fast');
 }
 
 $(function () {
-    $(".datepicker").datepicker({
+    $('.datepicker').datepicker({
         changeMonth: true,
         changeYear: true,
-        yearRange: "-100:+0",
-        defaultDate: "-20y",
-        dateFormat: "yy-mm-dd"
+        yearRange: '-100:+0',
+        defaultDate: '-20y',
+        dateFormat: 'yy-mm-dd'
     });
 });

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -241,7 +241,7 @@
         {% if attendee.is_dealer %}
             <button type="submit" class="btn btn-primary" value="Submit Application">Submit Application</button>
         {% else %}
-            <button type="submit" class="btn btn-primary" value="Preregister">Preregister</button>
+            <button type="submit" class="btn btn-primary" value="Add to Cart">Add to Cart</button>
         {% endif %}
     </div>
 </div>

--- a/uber/templates/preregistration/stripeForm.html
+++ b/uber/templates/preregistration/stripeForm.html
@@ -5,7 +5,8 @@
         data-key="{{ c.STRIPE_PUBLIC_KEY }}"
         {% if email %}data-email="{{ email }}"{% endif %}
         data-zip-code="true"
-        data-amount="{{charge.amount}}"
+        data-allow-remember-me="false"
+        data-amount="{{ charge.amount }}"
         data-name="{{ c.EVENT_NAME_AND_YEAR }} {{ regtext }}"
         data-description="{{ charge.description }}"
         data-image="../static/theme/stripe-logo.png">


### PR DESCRIPTION
This has two fixes:

1) We change "Preregister" to "Add to Cart" on the prereg form, since people will be less likely to think they're preregistering when the fill out the form and then don't pay.  That was a simple one-line change.

2) When someone opens the Stripe form and then cancels out of it, the other Stripe buttons are no longer disabled.  This took me 4 hours to figure out how to accomplish!  Relevant XKCD: http://xkcd.com/1425/ though arguably it's not the same thing because the answer did turn out to be relatively simple in the end :/

