### PR TITLE
Separate badge type buttons into different groups

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -105,6 +105,14 @@ def join_and(xs):
         return ', '.join(xs)
 
 
+@register.filter
+def price_or_extra(amount_extra):
+    if c.PAGE_PATH == '/preregistration/form':
+        return '${}'.format(c.BADGE_PRICE + amount_extra)
+    else:
+        return '+${}'.format(amount_extra)
+
+
 @tag
 class maybe_anchor(template.Node):
     def __init__(self, name):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -438,7 +438,10 @@ class Root:
                 if attendee.full_name in c.BANNED_ATTENDEES:
                     send_banned_email(attendee)
 
-                if attendee.group_id:
+                if attendee.amount_unpaid:
+                    cherrypy.session['return_to'] = 'group_members?id={}&'.format(attendee.group_id)
+                    raise HTTPRedirect('attendee_donation_form?id={}', attendee.id)
+                elif attendee.group_id:
                     raise HTTPRedirect('group_members?id={}&message={}', attendee.group_id, 'Registration successfully transferred')
                 else:
                     raise HTTPRedirect('confirm?id={}&message={}', attendee.id, 'Your registration has been transferred')

--- a/uber/static/theme/prereg.css
+++ b/uber/static/theme/prereg.css
@@ -15,10 +15,6 @@ body {
     background-repeat: repeat-x repeat-y;
 }
 
-.bs-wizard {
-    margin-top: 40px;
-}
-
 /*Form Wizard*/
 .bs-wizard {border-bottom: solid 1px #e0e0e0; padding: 0 0 10px 0;}
 .bs-wizard > .bs-wizard-step {padding: 0; position: relative;}
@@ -45,7 +41,10 @@ body {
     margin: 0 auto;
 }
 
-.badge_type_selector {
+#badge-types {
+    margin-bottom: 0px;
+}
+.reg-type-selector, .badge-type-selector {
     cursor: pointer;
 }
 
@@ -60,4 +59,8 @@ body {
 .warning {
     font-weight: bold;
     background-color: pink;
+}
+
+.panel.panel-default {
+    padding-top: 15px;
 }

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -170,7 +170,6 @@
                 <br/><br/>
             </div>
         {% endblock %}
-        {% block message %}<span id="message" style="float:left ; color:red">{{ message }}</span>{% endblock %}
         {% block backlink %}
             <nav class="navbar navbar-default navbar-static-top" role="navigation">
                 <!-- Brand and toggle get grouped for better mobile display -->

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -41,6 +41,10 @@
     </div>
 {% endif %}
 
+<div class="form-group" id="badge-types">
+    <label class="col-sm-2 control-label">Badge Level</label>
+</div>
+
 {% include "regform.html" %}
 
 <div class="form-group">

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -4,8 +4,7 @@
 
 <script>
     $(function () {
-        $('#form-begin-spacer').prependTo('form.form-horizontal');
-        $('#bold-field-message').insertAfter('#form-begin-spacer');
+        $('#bold-field-message').prependTo('form.form-horizontal');
     });
 </script>
 
@@ -15,83 +14,6 @@
 {% if attendee.is_dealer %}
     <span class="text-center"><h2>Dealer Application</h2></span>
 {% else %}
-    <script type="text/javascript">
-        var BADGE_TYPES = [{
-            title: 'Attending: ${{ c.BADGE_PRICE }}',
-            description: 'Allows access to the convention for its duration.'
-        }];
-        {% if c.GROUPS_ENABLED and attendee.is_new and not group_id %}
-            BADGE_TYPES.push({
-                title: 'Group Leader',
-                {% if c.BEFORE_GROUP_PREREG_TAKEDOWN %}
-                    description: '<p class="list-group-item-text">Register a group of {{ c.MIN_GROUP_SIZE }} or more and save ${{ c.GROUP_DISCOUNT }} per badge.</p>',
-                {% else %}
-                    description: '<p class="list-group-item-text">The deadline for Group registration has passed, but you can still register as a regular attendee.</p>'
-                {% endif %}
-                extra: null,  // indicates that we shouldn't change the amount_extra dropdown
-                onClick: function () {
-                    $('.group_fields').removeClass('hide');
-                    $('input[name="badge_type"]').val('{{ c.PSEUDO_GROUP_BADGE }}');
-                }
-            });
-        {% endif %}
-        {% if c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
-            BADGE_TYPES.push({
-                title: 'Supporter: ${{ c.BADGE_PRICE|add:c.SUPPORTER_LEVEL }}',
-                description: 'Donate extra and get more swag with your membership.',
-                extra: {{ c.SUPPORTER_LEVEL }}
-            });
-        {% endif %}
-        {% if c.SEASON_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
-            BADGE_TYPES.push({
-                title: 'Season Supporter: ${{ c.BADGE_PRICE|add:c.SEASON_LEVEL }}',
-                description: 'Fill this in later',
-                extra: {{ c.SEASON_LEVEL }}
-            });
-        {% endif %}
-
-        var setBadge = function (badgeTypeIndex) {
-            var badgeType = BADGE_TYPES[badgeTypeIndex];
-            $('.group_fields').addClass('hide');
-            $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
-            $('.badge_type_selector').removeClass('active');
-            $('.badge_type_selector').slice(badgeTypeIndex, 1 + badgeTypeIndex).addClass('active');
-            (badgeType.onClick || $.noop)();
-            if (badgeType.extra !== null) {
-                $.field('amount_extra').val(badgeType.extra || 0).trigger('change');
-            }
-        }
-        var makeBadgeMatchExtra = function () {
-            var target = $.val('name') ? 1 : 0;  // default to attendee or group
-            if (target !== 1) {
-                $.each(BADGE_TYPES, function (i, badgeType) {
-                    if (badgeType.extra && badgeType.extra <= $.val('amount_extra')) {
-                        target = i;
-                    }
-                });
-            }
-            if (!$('.badge_type_selector:nth(' + target + ')').is('.active')) {
-                setBadge(target);
-            }
-        };
-        $(function () {
-            $.each(BADGE_TYPES, function (index, badgeType) {
-                $('#badge_types').append(
-                    $('<div class="col-sm-3"></div>').append(
-                        $('<a class="list-group-item badge_type_selector"></a>').click(function () {
-                            setBadge(index);
-                        }).append(
-                            $('<h4 class="list-group-item-heading"></h4>').html(badgeType.title)
-                        ).append(
-                            $('<p class="list-group-item-text"></p>').html(badgeType.description))));
-            });
-            makeBadgeMatchExtra();
-            if ($.field('amount_extra')) {
-                $.field('amount_extra').on('change', makeBadgeMatchExtra);
-            }
-        });
-    </script>
-
     <div class="row bs-wizard" style="border-bottom:0;border-top:0;">   
         <div class="col-xs-4 bs-wizard-step active">
             <div class="text-center bs-wizard-stepnum">Step 1</div>
@@ -119,8 +41,12 @@
         </div>
     </div>
 
-    <div class="form-group" id="badge_types">
-        <label for="badge" class="col-sm-2 control-label">&nbsp;</label>
+    <div class="form-group" id="reg-types">
+        <label class="col-sm-2 control-label" style="white-space:nowrap">Registration Type</label>
+    </div>
+
+    <div class="form-group" id="badge-types">
+        <label class="col-sm-2 control-label">Badge Level</label>
     </div>
 
     {% if c.DEALER_REG_START %}

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -1,35 +1,135 @@
 {% extends "base.html" %}
-{% block backlink %}
-
-
-{% endblock %}
+{% block backlink %}{% endblock %}
 {% block header %}
-<link href="../static/theme/prereg.css" rel="stylesheet">
-<script type="text/javascript">
-    var checkCap = function () {
-        $.getJSON('../preregistration/check_prereg', function(check) {
-            if (check.force_refresh) {
-                location.reload();  // Reload the page to prevent registering after reg is closed
+    <link href="../static/theme/prereg.css" rel="stylesheet">
+    <script type="text/javascript">
+        var PREREG_CHECK_INTERVAL = 15 * 60 * 1000;
+        var checkCap = function () {
+            $.getJSON('../preregistration/check_prereg', function (check) {
+                if (check.force_refresh) {
+                    location.reload();  // Reload the page to prevent registering after reg is closed
+                } else {
+                    setTimeout(checkCap, PREREG_CHECK_INTERVAL);
+                }
+            });
+        };
+        setTimeout(checkCap, PREREG_CHECK_INTERVAL);
+
+        {% if c.COLLECT_FULL_ADDRESS %}
+            var setInternational = function () {
+                countryName = $('input[name="country"]').val();
+                if(countryName == 'USA' || countryName == 'US' || countryName == 'United States') {
+                    $('input[name="international"]').prop('checked', false);
+                } else {
+                    $('input[name="international"]').prop('checked', true);
+                }
+            }
+            $(function() {
+                $('#international').hide()
+                setInternational()
+            });
+        {% endif %}
+
+        var REG_TYPES = {
+            row: '#reg-types',
+            selector: '.reg-type-selector',
+            options: [{
+                title: 'Single Attendee',
+                description: 'A single registration; you can register more before paying',
+                onClick: function () {
+                    $('.group_fields').addClass('hide');
+                    $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
+                }
+            }]
+        };
+        {% if c.GROUPS_ENABLED and attendee.is_new and not group_id %}
+            REG_TYPES.options.push({
+                title: 'Group Leader',
+                {% if c.BEFORE_GROUP_PREREG_TAKEDOWN %}
+                    description: '<p class="list-group-item-text">Register a group of {{ c.MIN_GROUP_SIZE }} or more and save ${{ c.GROUP_DISCOUNT }} per badge.</p>',
+                {% else %}
+                    description: '<p class="list-group-item-text">The deadline for Group registration has passed, but you can still register as a regular attendee.</p>'
+                {% endif %}
+                onClick: function () {
+                    $('.group_fields').removeClass('hide');
+                    $('input[name="badge_type"]').val('{{ c.PSEUDO_GROUP_BADGE }}');
+                }
+            });
+        {% endif %}
+        var BADGE_TYPES = {
+            row: '#badge-types',
+            selector: '.badge-type-selector',
+            options: [{
+                title: 'Attending{% if c.PAGE_PATH == "/preregistration/form" %}: ${{ c.BADGE_PRICE }}{% endif %}',
+                description: 'Allows access to the convention for its duration.',
+                extra: 0
+            }]
+        };
+        {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS %}
+            BADGE_TYPES.options.push({
+                title: 'Add a tshirt: {{ c.SHIRT_LEVEL|price_or_extra }}',
+                description: 'Attendee level plus a {{ c.EVENT_NAME }} themed t-shirt.',
+                extra: {{ c.SHIRT_LEVEL }}
+            });
+        {% endif %}
+        {% if c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
+            BADGE_TYPES.options.push({
+                title: 'Supporter: {{ c.SUPPORTER_LEVEL|price_or_extra }}',
+                description: 'Donate extra and get more swag with your membership.',
+                extra: {{ c.SUPPORTER_LEVEL }}
+            });
+        {% endif %}
+        {% if c.SEASON_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
+            BADGE_TYPES.options.push({
+                title: 'Season Supporter: ${{ c.SEASON_LEVEL|price_or_extra }}',
+                description: 'Access to all {{ c.ORGANIZATION_NAME }} events for the year.',
+                extra: {{ c.SEASON_LEVEL }}
+            });
+        {% endif %}
+
+        var setBadge = function (types, index) {
+            var type = types.options[index];
+            $(types.selector)
+                .removeClass('active')
+                .slice(index, 1 + index)
+                .addClass('active');
+            (type.onClick || $.noop)();
+            if (type.extra !== undefined && type.extra !== null) {
+                $.field('amount_extra').val(type.extra || 0).trigger('change');
+            }
+        }
+        var makeBadgeMatchExtra = function () {
+            if ($(BADGE_TYPES.row).size()) {
+                var target = 0;
+                $.each(BADGE_TYPES.options, function (i, badgeType) {
+                    if (badgeType.extra && badgeType.extra <= $.val('amount_extra')) {
+                        target = i;
+                    }
+                });
+                if (!$(BADGE_TYPES.selector).slice(target, 1 + target).is('.active')) {
+                    setBadge(BADGE_TYPES, target);
+                }
+            }
+        };
+        $(function () {
+            $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
+                $.each(types.options, function (index, type) {
+                    $(types.row).append(
+                        $('<div class="col-sm-3"></div>').append(
+                            $('<a class="list-group-item"></a>').addClass(types.selector.substring(1)).click(function () {
+                                setBadge(types, index);
+                            }).append(
+                                $('<h4 class="list-group-item-heading"></h4>').html(type.title)
+                            ).append(
+                                $('<p class="list-group-item-text"></p>').html(type.description))));
+                });
+                $(types.row).append('<div style="clear:both">&nbsp;</div>');
+            });
+            setBadge(REG_TYPES, $.field('name') && $.val('name') ? 1 : 0);  // default to attendee or group
+            makeBadgeMatchExtra();
+            if ($.field('amount_extra')) {
+                $.field('amount_extra').on('change', makeBadgeMatchExtra);
             }
         });
-    };
-    setInterval(checkCap, 1000 * 1 * 90);
-
-{% if c.COLLECT_FULL_ADDRESS %}
-$(document).ready(function() {
-    $("#international").hide()
-    setInternational()
-});
-
-function setInternational() {
-    countryName = $("input[name='country']").val();
-
-    if(countryName == "USA" || countryName == "US" || countryName == "United States") {
-        $("input[name='international']").prop('checked', false);
-    } else {
-        $("input[name='international']").prop('checked', true);
-    }
-}
-{% endif %}
-</script>
+    </script>
 {% endblock header %}

--- a/uber/templates/preregistration/register_group_member.html
+++ b/uber/templates/preregistration/register_group_member.html
@@ -11,6 +11,10 @@
 <input type="hidden" name="id" value="{{ attendee.db_id }}" />
 <input type="hidden" name="group_id" value="{{ group_id }}" />
 
+<div class="form-group" id="badge-types">
+    <label class="col-sm-2 control-label">Badge Level</label>
+</div>
+
 {% include "regform.html" %}
 
 <div class="form-group">

--- a/uber/templates/preregistration/transfer_badge.html
+++ b/uber/templates/preregistration/transfer_badge.html
@@ -15,6 +15,10 @@ our Registration Desk; that will belong to whomever the badge is transferred.
 {% csrf_token %}
 <input type="hidden" name="id" value="{{ attendee.id }}" />
 
+<div class="form-group" id="badge-types">
+    <label class="col-sm-2 control-label">Badge Level</label>
+</div>
+
 {% include "regform.html" %}
 
 <div class="form-group">

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -32,9 +32,13 @@
         noCellphoneClicked();
         $.field('no_cellphone').on('click', noCellphoneClicked);
     });
-</script>
 
-<div id="form-begin-spacer" class="form-group"></div>
+    {% if not attendee.is_new %}
+        while (window.BADGE_TYPES && BADGE_TYPES.options[0].extra < {{ attendee.amount_extra }}) {
+            BADGE_TYPES.options.splice(0, 1);
+        }
+    {% endif %}
+</script>
 
 {% if c.PAGE_PATH != '/registration/form' %}
     <div id="bold-field-message" class="form-group">

--- a/uber/templates/registration/index.html
+++ b/uber/templates/registration/index.html
@@ -1,16 +1,5 @@
 {% extends "base-admin.html" %}
 {% block title %}Attendee Admin{% endblock %}
-{% block message %}
-
-<span id="message" style="float:left ; color:red ; margin-top:4px ; margin-left:4px">
-{% if attendee %}
-    <a href="form?id={{ attendee.id }}">{{ attendee.full_name }}</a> {{ message }}
-{% else %}
-    {{ message }}
-{% endif %}
-</span>
-
-{% endblock %}
 {% block content %}
 <script type="text/javascript">
     var $highlit = null;

--- a/uber/templates/registration/register.html
+++ b/uber/templates/registration/register.html
@@ -1,7 +1,6 @@
 {% extends "./preregistration/preregbase.html" %}
 {% block title %}At the Door Registration{% endblock %}
 {% block backlink %}{% endblock %}
-{% block message %}{% endblock %}
 {% block content %}
 
 <div class="masthead"></div>

--- a/uber/templates/static_views/stafferComps.html
+++ b/uber/templates/static_views/stafferComps.html
@@ -10,7 +10,7 @@ The more hours you work, the more you get (don't forget about <a href="weightDes
 <ul>
     <li> Working at least 6 hours gets you a {{ c.EVENT_NAME }} t-shirt. <br/><br/> </li>
     <li> Working at least 12 hours gets you food in addition to the shirt.  We have professional chefs preparing 3 meals per day throughout the event. <br/><br/> </li>
-    <li> Working at least 18 hours gets you a complementary Staff badge for next year's {{ c.EVENT_NAME }}, which will make you eligible for space in one of our staff hotel rools. <br/><br/> </li>
+    <li> Working at least 18 hours gets you a complementary Staff badge for next year's {{ c.EVENT_NAME }}, which will make you eligible for space in one of our staff hotel rooms. <br/><br/> </li>
     <li> Working at least 24 hours gets you a refund on your badge for this year. <br/><br/> </li>
     <li> Working at least 30 hours <b>ONLY IF</b> you're a returning Staffer gets you space in one of our staff hotel rooms. <br/><br/> </li>
 </ul>


### PR DESCRIPTION
We now have two rows of badge selection:
- The first row is for selecting between a single or a group registration.  This row ONLY appears on the main prereg form.
- The second row is for selecting badge level (regular, tshirt, supporter, etc).  It shows up on all the prereg forms (main prereg form, badge confirmation page, badge transfer page, and group badge claiming page).

As discussed in #1217 we don't show any of badge levels lower than what's already selected.

I made a couple of other fixes/improvements, which I'll explain with inline code comments.