### PR TITLE
Price notices and Volunteer options

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -206,22 +206,6 @@ pathfinder = "Pathfinder"
 concerts = "Concerts"
 chiptunes = "Chipspace"
 
-[[job_interest]]
-registration = "Registration"
-music        = "Music"
-food         = "Food"
-slip_slide   = "Slip 'n Slide"
-cat_herding  = "Cat Herding"
-misc         = "Standby/Misc"
-
-[[job_location]]
-registration = "Registration"
-music        = "Music"
-food         = "Food"
-slip_slide   = "Slip 'n Slide"
-cat_herding  = "Cat Herding"
-misc         = "Standby/Misc"
-
 [[dept_head_overrides]]
 staff_support = "Jack Boyd"
 security = "The Dorsai Irregulars"

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -105,14 +105,6 @@ def join_and(xs):
         return ', '.join(xs)
 
 
-@register.filter
-def price_or_extra(amount_extra):
-    if c.PAGE_PATH == '/preregistration/form':
-        return '${}'.format(c.BADGE_PRICE + amount_extra)
-    else:
-        return '+${}'.format(amount_extra)
-
-
 @tag
 class maybe_anchor(template.Node):
     def __init__(self, name):

--- a/uber/static/theme/prereg.css
+++ b/uber/static/theme/prereg.css
@@ -64,3 +64,10 @@ body {
 .panel.panel-default {
     padding-top: 15px;
 }
+
+.prereg-price-notice {
+    color: red;
+}
+.active .prereg-price-notice {
+    color: rgb(255, 125, 125);
+}

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -2,12 +2,6 @@
 {% block title %}Preregistration{% endblock %}
 {% block content %}
 
-<script>
-    $(function () {
-        $('#bold-field-message').prependTo('form.form-horizontal');
-    });
-</script>
-
 <div class="masthead"></div>
 
 <div class="panel panel-default">

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -61,29 +61,22 @@
             selector: '.badge-type-selector',
             options: [{
                 title: 'Attending{% if c.PAGE_PATH == "/preregistration/form" %}: ${{ c.BADGE_PRICE }}{% endif %}',
-                description: 'Allows access to the convention for its duration.',
+                description: 'Allows access to the convention for its duration. {% price_notice "Preregistration" c.PREREG_TAKEDOWN %}',
                 extra: 0
             }]
         };
         {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS %}
             BADGE_TYPES.options.push({
                 title: 'Add a tshirt: {{ c.SHIRT_LEVEL|price_or_extra }}',
-                description: 'Attendee level plus a {{ c.EVENT_NAME }} themed t-shirt.',
+                description: 'Attendee level plus a {{ c.EVENT_NAME }} themed t-shirt. {% price_notice "Preregistration" c.PREREG_TAKEDOWN c.SHIRT_LEVEL %}',
                 extra: {{ c.SHIRT_LEVEL }}
             });
         {% endif %}
         {% if c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
             BADGE_TYPES.options.push({
                 title: 'Supporter: {{ c.SUPPORTER_LEVEL|price_or_extra }}',
-                description: 'Donate extra and get more swag with your membership.',
+                description: 'Donate extra and get more swag with your membership. {% price_notice "Supporter registration" c.SUPPORTER_DEADLINE c.SUPPORTER_LEVEL %}',
                 extra: {{ c.SUPPORTER_LEVEL }}
-            });
-        {% endif %}
-        {% if c.SEASON_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
-            BADGE_TYPES.options.push({
-                title: 'Season Supporter: ${{ c.SEASON_LEVEL|price_or_extra }}',
-                description: 'Access to all {{ c.ORGANIZATION_NAME }} events for the year.',
-                extra: {{ c.SEASON_LEVEL }}
             });
         {% endif %}
 

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -39,6 +39,8 @@
                 onClick: function () {
                     $('.group_fields').addClass('hide');
                     $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
+                    $('#bold-field-message').insertBefore($.field('first_name').parents('.form-group'));
+                    togglePrices();
                 }
             }]
         };
@@ -53,6 +55,8 @@
                 onClick: function () {
                     $('.group_fields').removeClass('hide');
                     $('input[name="badge_type"]').val('{{ c.PSEUDO_GROUP_BADGE }}');
+                    $('#bold-field-message').insertBefore($.field('name').parents('.form-group'));
+                    togglePrices();
                 }
             });
         {% endif %}
@@ -60,26 +64,37 @@
             row: '#badge-types',
             selector: '.badge-type-selector',
             options: [{
-                title: 'Attending{% if c.PAGE_PATH == "/preregistration/form" %}: ${{ c.BADGE_PRICE }}{% endif %}',
+                title: 'Attending',
                 description: 'Allows access to the convention for its duration. {% price_notice "Preregistration" c.PREREG_TAKEDOWN %}',
                 extra: 0
             }]
         };
         {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS %}
             BADGE_TYPES.options.push({
-                title: 'Add a tshirt: {{ c.SHIRT_LEVEL|price_or_extra }}',
+                title: 'Add a tshirt',
                 description: 'Attendee level plus a {{ c.EVENT_NAME }} themed t-shirt. {% price_notice "Preregistration" c.PREREG_TAKEDOWN c.SHIRT_LEVEL %}',
                 extra: {{ c.SHIRT_LEVEL }}
             });
         {% endif %}
         {% if c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
             BADGE_TYPES.options.push({
-                title: 'Supporter: {{ c.SUPPORTER_LEVEL|price_or_extra }}',
+                title: 'Supporter',
                 description: 'Donate extra and get more swag with your membership. {% price_notice "Supporter registration" c.SUPPORTER_DEADLINE c.SUPPORTER_LEVEL %}',
                 extra: {{ c.SUPPORTER_LEVEL }}
             });
         {% endif %}
 
+        var togglePrices = function () {
+            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' %}$.val('badge_type') === {{ c.ATTENDEE_BADGE }}{% else %}false{% endif %};
+            $.each(BADGE_TYPES.options, function (i, type) {
+                var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
+                if (showTotalPrices) {
+                    $price.append(': $').append(type.extra + {{ c.BADGE_PRICE }});
+                } else if (type.extra) {
+                    $price.append(': +$').append(type.extra);
+                }
+            });
+        };
         var setBadge = function (types, index) {
             var type = types.options[index];
             $(types.selector)
@@ -105,23 +120,27 @@
             }
         };
         $(function () {
-            $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
-                $.each(types.options, function (index, type) {
-                    $(types.row).append(
-                        $('<div class="col-sm-3"></div>').append(
-                            $('<a class="list-group-item"></a>').addClass(types.selector.substring(1)).click(function () {
-                                setBadge(types, index);
-                            }).append(
-                                $('<h4 class="list-group-item-heading"></h4>').html(type.title)
-                            ).append(
-                                $('<p class="list-group-item-text"></p>').html(type.description))));
+            if ($(BADGE_TYPES.row).size()) {
+                $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
+                    $.each(types.options, function (index, type) {
+                        $(types.row).append(
+                            $('<div class="col-sm-3"></div>').append(
+                                $('<a class="list-group-item"></a>').addClass(types.selector.substring(1)).click(function () {
+                                    setBadge(types, index);
+                                }).append(
+                                    $('<h4 class="list-group-item-heading"></h4>')
+                                        .append(type.title)
+                                        .append('<span class="price"></span>')
+                                ).append(
+                                    $('<p class="list-group-item-text"></p>').html(type.description))));
+                    });
+                    $(types.row).append('<div style="clear:both">&nbsp;</div>');
                 });
-                $(types.row).append('<div style="clear:both">&nbsp;</div>');
-            });
-            setBadge(REG_TYPES, $.field('name') && $.val('name') ? 1 : 0);  // default to attendee or group
-            makeBadgeMatchExtra();
-            if ($.field('amount_extra')) {
-                $.field('amount_extra').on('change', makeBadgeMatchExtra);
+                setBadge(REG_TYPES, $.field('name') && $.val('name') ? 1 : 0);  // default to attendee or group
+                makeBadgeMatchExtra();
+                if ($.field('amount_extra')) {
+                    $.field('amount_extra').on('change', makeBadgeMatchExtra);
+                }
             }
         });
     </script>


### PR DESCRIPTION
This has four main changes:

1) The actual contents of the ticket: for each badge type, we display a warning indicating when and to what the price will be raised.  As before, this warning changes to a warning about when preregistration closes when we reach that point.

2) I was testing out the group stuff and found myself unhappy with the way the prices displayed.  If you selected the "Group Leader" option, it would still tell you that your Attendee badge cost $50 even though that's no longer true.  So I added some Javascript code to check the group selection; if you're making a single registration it shows the overall price (e.g. $70 for a shirt) but if you're making a group registraton it only shows the amounts added (e.g. +$20 for a shirt).  The other forms all just work the same way they did before.

3) As a result of moving the group fields, the "Bold fields are required" message was showing up between the Registration Type and the Badge Type rows.  That's fine when the group fields are displayed, but when they're not it just looks awkward.  Now we move it to the correct place based on whether or not it's a group registration.

4) I removed the Magstock options from ``development-defaults.ini`` since that's managed by puppet data anyway.