### PR TITLE
Tempfix dealer reg

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -288,6 +288,7 @@ dealer_reg_deadline    = string(default="")
 dealer_reg_shutdown    = string(default="")
 dealer_payment_due     = string(default="")
 dealer_waitlist_closed = string(default="")
+dealer_reg_public      = string(default="")
 
 # This is ignored if Supporter registrations are turned off (which happens implicitly if
 # the SUPPORTER_LEVEL value is higher than any of the donation tiers), but if Supporter

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -39,14 +39,14 @@
         <label class="col-sm-2 control-label" style="white-space:nowrap">Registration Type</label>
     </div>
 
-    {% if c.DEALER_REG_START %}
+    {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC != '' %}
         <div class="form-group">
             <p class="help-block col-sm-8 col-sm-offset-2">
                 <strong>Dealers:</strong>
                 {% if c.BEFORE_DEALER_REG_PUBLIC %}
                     Registrations for dealer memberships begin {{ c.DEALER_REG_START|datetime }}.
                 {% else %}
-                    Please register <a href="{{ c.URL_BASE }}/preregistration/dealer_registration">here</a>.
+                    Please register <a href="dealer_registration">here</a>.
                 {% endif %}
             </p>
         </div>

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -39,7 +39,7 @@
         <label class="col-sm-2 control-label" style="white-space:nowrap">Registration Type</label>
     </div>
 
-    {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC != '' %}
+    {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC %}
         <div class="form-group">
             <p class="help-block col-sm-8 col-sm-offset-2">
                 <strong>Dealers:</strong>


### PR DESCRIPTION
1) ability to have dealer reg be open, but not on the public form (so you can send stuff to dealers before announcing it publicly)
2) add dealer_reg_public to configspec.ini, by default it's none which disables all references to dealer stuff on the prereg form
3) unrelated: remove unneeded/bad c.BASE_URL in form.html template

In its default configuration (as it is now) it won't show any dealer stuff.  This will need to be changed in order to open dealer registration for magclassic.  

For how to fix, see https://github.com/magfest/ubersystem/issues/1244