### PR TITLE
refactor badge capping (max_badge_sales) logic slightly

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -137,6 +137,10 @@ class Config:
             return individual_supporters + group_supporters
 
     @property
+    def REMAINING_BADGES(self):
+        return max(0, self.MAX_BADGE_SALES - self.BADGES_SOLD)
+
+    @property
     def SQLALCHEMY_URL(self):
         """
         support reading the DB connection info from an environment var (used with Docker containers)

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -86,7 +86,7 @@ class Root:
         cherrypy.response.headers["Access-Control-Allow-Origin"] = "*"
         return json.dumps({
             'badges_sold': c.BADGES_SOLD,
-            'remaining_badges': max(0, c.MAX_BADGE_SALES - c.BADGES_SOLD),
+            'remaining_badges': c.REMAINING_BADGES,
 
             'server_current_timestamp': int(datetime.utcnow().timestamp()),
             'warn_if_server_browser_time_mismatch': c.WARN_IF_SERVER_BROWSER_TIME_MISMATCH

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -76,8 +76,7 @@ class Root:
             'order':          Order(order),
             'attendee_count': total_count,
             'checkin_count':  session.query(Attendee).filter(Attendee.checked_in != None).count(),
-            'attendee':       session.attendee(uploaded_id) if uploaded_id else None,
-            'remaining_badges': max(0, c.MAX_BADGE_SALES - c.BADGES_SOLD)
+            'attendee':       session.attendee(uploaded_id) if uploaded_id else None
         }
 
     @log_pageview
@@ -503,8 +502,7 @@ class Root:
             'checked_in': checked_in,
             'groups':     sorted(groups, key=lambda tup: tup[1]),
             'recent':     session.query(Attendee).filter(Attendee.checked_in == None, Attendee.first_name != '', *restrict_to)
-                                                 .order_by(Attendee.registered).all(),
-            'remaining_badges': max(0, c.MAX_BADGE_SALES - c.BADGES_SOLD)
+                                                 .order_by(Attendee.registered).all()
         }
 
     def new_reg_station(self, reg_station='', message=''):

--- a/uber/templates/registration/new.html
+++ b/uber/templates/registration/new.html
@@ -98,8 +98,8 @@
     <br/> <a href="arbitrary_charge_form">Click Here</a> to create arbitrary credit card charges if Square stops working
 </div>
 
-<div style="text-align:center; font-weight:bold; {% if remaining_badges < 50 %} font-size:18pt; {% endif %}">
-    <br/> Badges remaining: <font color="red">{{ remaining_badges }}</font>
+<div style="text-align:center; font-weight:bold; {% if c.REMAINING_BADGES < 50 %} font-size:18pt; {% endif %}">
+    <br/> Badges remaining: <font color="red">{{ c.REMAINING_BADGES }}</font>
 </div>
 
 <div id="transactions" style="text-align:center ; margin-top:5px ; padding:10px ; background:lightgray ; width:100%">

--- a/uber/templates/summary/index.html
+++ b/uber/templates/summary/index.html
@@ -8,6 +8,8 @@
 <br/>
 <b>Attendees who paid and didn't show up:</b> {{ paid_noshows }}
 <br/>
+<b>Number of remaining badges (before event is sold out):</b> {{ c.REMAINING_BADGES }}
+<br/>
 <b>Total Registrations:</b> {{ total_count }}
 <table style="width:auto ; border-spacing:0px">
 <tr>


### PR DESCRIPTION
- mostly trivial, replaced a few copy+paste instances of badge capping formula with c.REMAINING_BADGES
- since that's a config property now, we don't need to explicitly pass it into templates, they can access c.REMAINING_BADGES directly
- feature: display the # of remaining badges on the summary page