### PR TITLE
Add client-side date-of-birth validations

### DIFF
--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -90,7 +90,13 @@
             }
             $('.footable').footable();
             $('.date').datetextentry({
-                field_order: 'MDY'
+                field_order: 'MDY',
+                min_year : '1890',
+                max_date : function() { return this.get_today(); },
+                max_date_message : 'You cannot be born in the future.',
+                show_tooltips : false,
+                errorbox_x    : -135,
+                errorbox_y    : 28
             });
             $('.geolocator').geocomplete({
                 details: '.address_details',


### PR DESCRIPTION
Fixes #1229.

The way we check for people who enter a year too early is hard-coded for right now - I wasn't able to get our date text field to accept a function return for `min_year` like it does for `max_date`. Weird.