### PR TITLE
Remove Supporter badge autoassign

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1079,9 +1079,6 @@ class Attendee(MagModel, TakesPaymentMixin):
             if self.is_dealer:
                 self.ribbon = c.DEALER_RIBBON
 
-        if self.amount_extra >= c.SUPPORTER_LEVEL and not self.amount_unpaid and self.badge_type == c.ATTENDEE_BADGE:
-            self.badge_type = c.SUPPORTER_BADGE
-
         if c.PRE_CON:
             if self.paid == c.NOT_PAID or not self.has_personalized_badge or self.is_unassigned:
                 self.badge_num = 0
@@ -1290,6 +1287,8 @@ class Attendee(MagModel, TakesPaymentMixin):
         stuff.append('a {} wristband'.format(c.WRISTBAND_COLORS[self.age_group]))
         if self.regdesk_info:
             stuff.append(self.regdesk_info)
+        if self.amount_extra >= c.SUPPORTER_LEVEL:
+            stuff.append('their Supporter badge')
         return comma_and(stuff)
 
     @property

--- a/uber/models.py
+++ b/uber/models.py
@@ -1248,7 +1248,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def gets_paid_shirt(self):
-        return self.amount_extra >= c.SHIRT_LEVEL or self.badge_type == c.SUPPORTER_BADGE
+        return self.amount_extra >= c.SHIRT_LEVEL
 
     @property
     def gets_shirt(self):
@@ -1264,7 +1264,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def donation_swag(self):
-        extra = c.SUPPORTER_LEVEL if not self.amount_extra and self.badge_type == c.SUPPORTER_BADGE else self.amount_extra
+        extra = self.amount_extra
         return [desc for amount, desc in sorted(c.DONATION_TIERS.items()) if amount and extra >= amount]
 
     @property

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -11,7 +11,7 @@ class Root:
             'shirt_sizes':   [(desc, count(shirt=shirt)) for shirt, desc in c.SHIRT_OPTS],
             'paid_counts':   [(desc, count(paid=status)) for status, desc in c.PAYMENT_OPTS],
             'badge_counts':  [(desc, count(badge_type=bt), count(paid=c.NOT_PAID, badge_type=bt), count(paid=c.HAS_PAID, badge_type=bt)) for bt, desc in c.BADGE_OPTS],
-            'aff_counts':    [(aff['text'], count(badge_type=c.SUPPORTER_BADGE, affiliate=aff['text'], paid=c.HAS_PAID), count(badge_type=c.SUPPORTER_BADGE, affiliate=aff['text'], paid=c.NOT_PAID)) for aff in session.affiliates()],
+            'aff_counts':    [(aff['text'], len([a for a in attendees if a.amount_extra >= c.SUPPORTER_LEVEL and a.affiliate == aff['text']])) for aff in session.affiliates()],
             'checkin_count': count(checked_in=None),
             'paid_noshows':  count(paid=c.HAS_PAID, checked_in=None) + len([a for a in attendees if a.paid == c.PAID_BY_GROUP and a.group.amount_paid and not a.checked_in]),
             'free_noshows':  count(paid=c.NEED_NOT_PAY, checked_in=None),

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -90,7 +90,13 @@
             }
             $('.footable').footable();
             $('.date').datetextentry({
-                field_order: 'MDY'
+                field_order: 'MDY',
+                min_year : '1890',
+                max_date : function() { return this.get_today(); },
+                max_date_message : 'You cannot be born in the future.',
+                show_tooltips : false,
+                errorbox_x    : -135,
+                errorbox_y    : 28
             });
             $('.geolocator').geocomplete({
                 details: '.address_details',

--- a/uber/templates/registration/checkin.html
+++ b/uber/templates/registration/checkin.html
@@ -121,6 +121,10 @@
                     </tr>
                 {% endif %}
                 <tr>
+                    <td><strong>Donation Level:</strong></td>
+                    <td>{{ attendee.amount_extra_label }}</td>
+                </tr>
+                <tr>
                     <td><strong>Email:</strong></td>
                     <td>{{ attendee.email }}</td>
                 </tr>

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -6,7 +6,7 @@
 
 <script type="text/javascript">
     var isPreassignedBadgeType = function (badge_type) {
-        return $.inArray(parseInt(badge_type), [{{ c.STAFF_BADGE }}, {{ c.SUPPORTER_BADGE }}]) >= 0;
+        return $.inArray(parseInt(badge_type), [{{ c.PREASSIGNED_BADGE_TYPES }}]) >= 0;
     };
 
     var setGroupLink = function () {

--- a/uber/templates/static_views/supporters.html
+++ b/uber/templates/static_views/supporters.html
@@ -14,7 +14,7 @@ our <a href="givingExtra.html">donation levels</a>.
 <br/> <br/>
 
 The main thing you get as a Supporter is a special
-swag bag{% if c.SUPPORTER_BADGE in c.PREASSIGNED_BADGE_TYPES %} and a cool customized badge{% endif %}.
+swag bag.
 As with all donation levels, you still get all of the swag from the lower donation levels,
 and if you donate at a higher level, you still get the Supporter package.
 


### PR DESCRIPTION
Fixes #1227.

Unfortunately this includes my last PR because my local copy of master got dirty, but luckily it's a pretty simple change.

I've left a lot of the checks for Supporter badges in because I expect we'll need those later for when we add comped kick-in levels.