### PR TITLE
Add Badge Printed Name and Shirt to Admin page

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -106,12 +106,11 @@
                 if ($.field('affiliate')) {
                     $.field('affiliate').select2({
                         placeholder: "I don't care about this",
-                        createSearchChoice: function(term) {
-                            return {id: term, text: term};
-                        },
+                        allowClear: true,
+                        tags: true,
                         data: {{ affiliates|jsonize }},
                         width: '100%',
-                    }).select2('val', {{ attendee.affiliate|default:''|jsonize }});
+                    }).val({{ attendee.affiliate|default:''|jsonize }});
                 }
                 $('form').submit(function(){
                     $(':submit').attr('value', 'Uploading Preregistration...').attr('disabled', true);
@@ -156,7 +155,9 @@
     <div class="affiliate-row extra-row form-group" style="display:none">
         <label for="affiliate" class="col-sm-2 control-label optional-field">Affiliate</label>
         <div class="col-sm-6">
-            <input type="hidden" name="affiliate" style="width:30ex" />
+            <select name="affiliate">
+                <option value="" selected="selected"></option>
+            </select>
         </div>
         {% popup_link "../static_views/affiliates.html" "What's an affiliate?" %}
     </div>

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -188,6 +188,15 @@
     </div>
 </div>
 
+{% if attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or attendee.amount_extra >= c.SUPPORTER_LEVEL %}
+    <div class="form-group">
+        <label for="badge_printed_name" class="col-sm-2 control-label">Name Printed on Badge</label>
+        <div class="col-sm-6">
+            <input type="text" class="form-control" name="badge_printed_name" maxlength="20" value="{{ attendee.badge_printed_name }}" />
+        </div>
+    </div>
+{% endif %}
+
 {% include "regform.html" %}
 
 <div class="form-group">
@@ -255,6 +264,18 @@
         </nobr>
     </div>
 </div>
+
+{% if attendee.amount_extra >= c.SHIRT_LEVEL %}
+    <div class="form-group">
+        <label for="shirt" class="col-sm-2 control-label">Shirt Size</label>
+        <div class="col-sm-6">
+            <select name="shirt" class="form-control">
+                <option value="{{ c.NO_SHIRT }}">Select a shirt size</option>
+                {% options c.SHIRT_OPTS attendee.shirt %}
+            </select>
+        </div>
+    </div>
+{% endif %}
 
 <div class="form-group">
     <label class="col-sm-2 control-label">Extra Merch</label>


### PR DESCRIPTION
These are hidden from the admin page as part of a larger block, but we should really be able to edit them. Fixes #1183.