### PR TITLE
fixed issues with deleting a group badge

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -381,7 +381,7 @@ class Root:
         except:
             log.error('unable to send group unset email', exc_info=True)
 
-        session.assign_badges(attendee.group, attendee.group.badges + 1)
+        session.assign_badges(attendee.group, attendee.group.badges + 1, registered=attendee.registered)
         session.delete_from_group(attendee, attendee.group)
         raise HTTPRedirect('group_members?id={}&message={}', attendee.group_id, 'Attendee unset; you may now assign their badge to someone else')
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -162,7 +162,6 @@ class Root:
                 ]}))
                 session.assign_badges(attendee.group, attendee.group.badges + 1, attendee.badge_type)
                 session.delete_from_group(attendee, attendee.group)
-                attendee.group.attendees.remove(attendee)
                 message = 'Attendee deleted, but this badge is still available to be assigned to someone else in the same group'
         else:
             session.delete(attendee)

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -160,7 +160,6 @@ class Root:
                 session.add(Attendee(**{attr: getattr(attendee, attr) for attr in [
                     'group', 'registered', 'badge_type', 'badge_num', 'paid', 'amount_paid', 'amount_extra'
                 ]}))
-                session.assign_badges(attendee.group, attendee.group.badges + 1, attendee.badge_type)
                 session.delete_from_group(attendee, attendee.group)
                 message = 'Attendee deleted, but this badge is still available to be assigned to someone else in the same group'
         else:


### PR DESCRIPTION
Brent noticed that we get an error if we tried to "delete" a group badge (which actually just unassigns the badge so someone else can take it).

This was a one-line fix which I'll explain inline, but there were two other fixes which went along with it, which are also explained inline.