### PR TITLE
added [D] to staffer list on jobs section

### DIFF
--- a/uber/templates/jobs/staffers.html
+++ b/uber/templates/jobs/staffers.html
@@ -42,6 +42,7 @@
         <td> <ul><li></li></ul> </td>
         <td>
             <a href="../registration/shifts?id={{ attendee.id }}">{{ attendee.full_name }}</a>
+            {% if attendee.is_dept_head %}<font size="-1">[D]</font>{% endif %}
             {% if attendee.trusted %}<font size="-1">[T]</font>{% endif %}
             {% if attendee.multiply_assigned %}<font size="-1">[M]</font>{% endif %}
             {% if attendee.hotel_requests.approved and attendee.hotel_requests.setup_teardown %}<font size="-1">[L]</font>{% endif %}
@@ -53,6 +54,7 @@
 
 <br/> <br/>
 <div style="margin-left:10px">
+    [D]: <i>Staffers marked with a "D" are department heads.</i> <br/>
     [M]: <i>Staffers marked with a "M" are assigned to multiple locations</i> <br/>
     [T]: <i>Staffers marked with a "T" are trusted</i> <br/>
     [L]: <i>Staffers marked with a "L" are working load-in and/or load-out</i>


### PR DESCRIPTION
Brent asked to add a marked on the "staffers" page on the jobs section indicating whether the staffer was a department head.  This seems like a good idea in general, and it's especially useful for events where 3-5 people all have that title (though it seems like it would be useful in any case).