### PR TITLE
volunteers now correctly get assigned volunteer ribbons after a badge change

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1109,13 +1109,13 @@ class Attendee(MagModel, TakesPaymentMixin):
             old_staffing = self.orig_value_of('staffing')
             if self.staffing and not old_staffing or self.ribbon == c.VOLUNTEER_RIBBON and old_ribbon != c.VOLUNTEER_RIBBON:
                 self.staffing = True
-                if self.ribbon == c.NO_RIBBON:
-                    self.ribbon = c.VOLUNTEER_RIBBON
             elif old_staffing and not self.staffing or self.ribbon != c.VOLUNTEER_RIBBON and old_ribbon == c.VOLUNTEER_RIBBON:
                 self.unset_volunteering()
 
         if self.badge_type == c.STAFF_BADGE and self.ribbon == c.VOLUNTEER_RIBBON:
             self.ribbon = c.NO_RIBBON
+        elif self.staffing and self.badge_type != c.STAFF_BADGE and self.ribbon == c.NO_RIBBON:
+            self.ribbon = c.VOLUNTEER_RIBBON
 
         if self.badge_type == c.STAFF_BADGE:
             self.staffing = True


### PR DESCRIPTION
Brent noticed that after changing someone from a Staff badge to an Attendee badge, they were still marked as a volunteer (which is correct) but without a volunteer ribbon (which is not correct).

This fixes that, so that doing that change will leave them with the correct ribbon.