### PR TITLE
dealer table prices now display correctly

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -518,6 +518,21 @@ class PriceNotice(template.Node):
         return '<div class="prereg-price-notice">{}</div>'.format(notice) if notice else ''
 
 
+@tag
+class table_prices(template.Node):
+    def render(self, context):
+        if len(c.TABLE_PRICES) <= 1:
+            return '${} per table'.format(c.TABLE_PRICES['default_price'])
+        else:
+            cost, costs = 0, []
+            for i in range(1, 1 + c.MAX_TABLES):
+                cost += c.TABLE_PRICES[i]
+                table_plural, cost_plural = ('', 's') if i == 1 else ('s', '')
+                costs.append('<nobr>{} table{} cost{} ${}</nobr>'.format(i, table_plural, cost_plural, cost))
+            costs[-1] = 'and ' + costs[-1]
+            return ', '.join(costs)
+
+
 # FIXME this can probably be cleaned up more
 @register.tag(name='random_hash')
 def random_hash(parser, token):

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -84,6 +84,12 @@
         </div>
     </div>
 {% else %}
+    <script>
+        $(function () {
+            $('#bold-field-message').insertBefore($.field('name').parents('.form-group'));
+        });
+    </script>
+
     <div class="form-group">
         <label for="name" class="col-sm-2 control-label">Dealer Table Name</label>
         <div class="col-sm-6">
@@ -97,7 +103,7 @@
             <select class="form-control" name="tables">
                 {% int_options 1 c.MAX_TABLES group.tables %}
             </select>
-            (${{ c.TABLE_PRICES.default_price }} per table)
+            ({% table_prices %})
         </div>
     </div>
     <div class="form-group">
@@ -136,7 +142,7 @@
     </div>
 
     <div class="form-group">
-        <label for="special_needs" class="col-sm-2 control-label">Table Requests and Special Requests</label>
+        <label for="special_needs" class="col-sm-2 control-label optional-field">Table Requests and Special Requests</label>
         <div class="col-sm-6">
             <textarea class="form-control" name="special_needs" rows="4" placeholder="E.g., specific table, who you would like to sit near, who you would not like to sit near.">{{ group.special_needs }}</textarea>
         </div>


### PR DESCRIPTION
Dealer tables were just displaying the "default price" per table.  However, we typically have different prices for each table so we can make them progressively more expensive.  I've implemented a custom tag which does this automatically by using the contents of ``c.TABLE_PRICES``.