### PR TITLE
dealer badge prices are now correctly calculated

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -927,7 +927,7 @@ class Group(MagModel, TakesPaymentMixin):
         total = 0
         for attendee in self.attendees:
             if attendee.paid == c.PAID_BY_GROUP:
-                total += c.get_group_price(attendee.registered)
+                total += c.DEALER_BADGE_PRICE if attendee.is_dealer else c.get_group_price(attendee.registered)
         return total
 
     @cost_property


### PR DESCRIPTION
As some people have noticed in their own testing, the prices for dealer registrations weren't adding up properly.  It turns out that we were using the group badge price instead of the dealer badge price.  This fixes that to use the correct price when computing group badges based on whether or not each attendee is a dealer.