### PR TITLE
Min group badges addable fix

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -954,12 +954,12 @@ class Group(MagModel, TakesPaymentMixin):
 
     @property
     def min_badges_addable(self):
-        if self.is_dealer and self.badges >= self.dealer_max_badges:
-            return 0
-        elif self.is_dealer or self.can_add:
+        if self.can_add:
             return 1
+        elif self.is_dealer:
+            return 0
         else:
-            return 5
+            return c.MIN_GROUP_ADDITION
 
 
 class Attendee(MagModel, TakesPaymentMixin):

--- a/uber/models.py
+++ b/uber/models.py
@@ -927,7 +927,7 @@ class Group(MagModel, TakesPaymentMixin):
         total = 0
         for attendee in self.attendees:
             if attendee.paid == c.PAID_BY_GROUP:
-                total += c.get_group_price(attendee.registered)
+                total += c.DEALER_BADGE_PRICE if attendee.is_dealer else c.get_group_price(attendee.registered)
         return total
 
     @cost_property


### PR DESCRIPTION
There are two fixes here:

1) I changed the hard-coded value of ``5`` to instead use ``c.MIN_GROUP_ADDITION`` (which is 5 by default).  This is unambiguously a fix.

2) I updated the code to conform to MAGFest's policies; dealers cannot add badges unless explicitly marked as ``can_add``.  This is different than what Anthrocon had in place.  Theoretically any event can just override this property in a ``@Session.model_mixin`` in a plugin, and I think this is a good default behavior.  I considered putting just leaving this code as-is and putting our logic in a plugin, but I didn't for several reasons:
- I wanted to fix the hard-coded issue anyway
- the existing code arguably has a bug in that it checks the dealer max badges but allows more than the max to be added
- I'd have needed to copy/paste the code in two different repos
- this behavior seems like a good and sensible default

If anyone feels uncomfortable about me replacing Anthrocon logic with MAGFest logic, I can always put it in our two plugins, but I think this is fine to be merge as-is for the reasons stated above.