### PR TITLE
datetime filter no longer hard-codes 11:59pm EST

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -2,8 +2,8 @@ from uber.common import *
 
 
 @register.filter
-def datetime(dt, fmt='11:59pm EST on %A, %b %e'):
-    return ' '.join(dt.astimezone(c.EVENT_TIMEZONE).strftime(fmt).split())
+def datetime(dt, fmt='%-I:%M%p %Z on %A, %b %e'):
+    return ' '.join(dt.astimezone(c.EVENT_TIMEZONE).strftime(fmt).split()).replace('AM', 'am').replace('PM', 'pm')
 
 from datetime import datetime  # noqa: now that we've registered our filter, re-import the "datetime" class to avoid conflicts
 


### PR DESCRIPTION
We were previously always saying ``11:59pm EST" for all of our deadlines and such even if those were set to some other time of day.