### PR TITLE
fixed two minor issues on confirm page

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -126,6 +126,10 @@ class Config:
         return cherrypy.request.path_info.split('/')[-1]
 
     @property
+    def HTTP_METHOD(self):
+        return cherrypy.request.method
+
+    @property
     def SUPPORTER_COUNT(self):
         with sa.Session() as session:
             attendees = session.query(sa.Attendee)

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -29,7 +29,7 @@
 <input type="hidden" name="return_to" value="{{ return_to }}" />
 <input type="hidden" name="undoing_extra" value="{{ undoing_extra }}" />
 
-{% if attendee.amount_unpaid %}
+{% if attendee.amount_unpaid and c.HTTP_METHOD == 'GET' %}
     <br/>
     <div class="form-group">
         <div class="col-sm-6 col-sm-offset-2 warning">

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -82,7 +82,7 @@
     </div>
 {% endif %}
 
-{% if c.DONATIONS_ENABLED and c.PREREG_DONATION_OPTS and not attendee.is_dealer and c.PAGE_PATH != '/registration/form' %}
+{% if c.DONATIONS_ENABLED and c.PREREG_DONATION_OPTS and c.PAGE_PATH != '/registration/form' %}
     <script type="text/javascript">
         var donationChanged = function () {
             setVisible('.affiliate-row', $.val('amount_extra') > 0);


### PR DESCRIPTION
Two issues here:

1) Dealers were breaking the confirm page because they didn't have ``amount_extra`` and a lot of our Javascript code relies on them having it.  I'll note that we don't expect dealers to ever end up on this page (though it's theoretically possible, e.g. if we link them to it, or if they volunteer, etc).

2) There's a price warning which shows up on this page if you have an unpaid balance... but this was showing up even if the form failed validation and hadn't been saved yet.