### PR TITLE
bcc marketplace on all waitlist/decline emails

### DIFF
--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -67,7 +67,7 @@ class Root:
         group = session.group(id)
         subject = 'Your {EVENT_NAME} Dealer registration has been ' + action
         if group.email:
-            send_email(c.MARKETPLACE_EMAIL, group.email, subject, email, model=group)
+            send_email(c.MARKETPLACE_EMAIL, group.email, subject, email, bcc=c.MARKETPLACE_EMAIL, model=group)
         if action == 'waitlisted':
             group.status = c.WAITLISTED
         else:


### PR DESCRIPTION
When a dealer application is explicitly waitlisted or declined by an admin, they type out an email into a textarea field on the admin form, which gets sent to that dealer from the marketplace address.  This change also bccs the marketplace mailing list on those emails so that everyone can keep up with what's happening.