### PR TITLE
modified new dealer admin workflow

### DIFF
--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -47,7 +47,10 @@ class Root:
                         leader.first_name, leader.last_name, leader.email = first_name, last_name, email
                         leader.placeholder = True
                         if group.status == c.APPROVED:
-                            raise HTTPRedirect('../preregistration/group_members?id={}', group.id)
+                            if group.amount_unpaid:
+                                raise HTTPRedirect('../preregistration/group_members?id={}', group.id)
+                            else:
+                                raise HTTPRedirect('index?message={}', group.name + ' has been uploaded, approved, and marked as paid')
                         else:
                             raise HTTPRedirect('index?message={}', group.name + ' is uploaded and ' + group.status_label)
                     else:


### PR DESCRIPTION
Here's how it works now:
- when you enter a group on the admin form with the "New Dealer" button, the system will check whether or not you've marked the group as paid
- if you've marked the group as paid in full, it'll just direct you back to the main group list, where you can click the "Add a Dealer" button again if you want
- if the group has an unpaid balance, it'll do what it did before, and direct you to the page where the payment can be made

This was asked for by Danielle in an email thread today.