### PR TITLE
Notices now show and hide appropriately

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -508,14 +508,13 @@ class PriceNotice(template.Node):
         else:
             for day, price in sorted(c.PRICE_BUMPS.items()):
                 if day < takedown and localized_now() < day:
-                    return 'Price goes up to ${} at 11:59pm EST on {}'.format(price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
+                    return '<div class="prereg-price-notice">Price goes up to ${} at 11:59pm EST on {}</div>'.format(price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
                 elif localized_now() < day:
-                    return '{} closes at 11:59pm EST on {}. Price goes up to ${} at-door.'.format(label, takedown.strftime('%A, %b %e'), price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
-            return '{} closes at 11:59pm EST on {}'.format(label, takedown.strftime('%A, %b %e'))
+                    return '<div class="prereg-type-closing">{} closes at 11:59pm EST on {}. Price goes up to ${} at-door.</div>'.format(label, takedown.strftime('%A, %b %e'), price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
+            return '<div class="prereg-type-closing">{} closes at 11:59pm EST on {}</div>'.format(label, takedown.strftime('%A, %b %e'))
 
     def render(self, context):
-        notice = self._notice(self.label, self.takedown.resolve(context), self.amount_extra.resolve(context))
-        return '<div class="prereg-price-notice">{}</div>'.format(notice) if notice else ''
+        return self._notice(self.label, self.takedown.resolve(context), self.amount_extra.resolve(context))
 
 
 @tag

--- a/uber/static/theme/prereg.css
+++ b/uber/static/theme/prereg.css
@@ -65,9 +65,9 @@ body {
     padding-top: 15px;
 }
 
-.prereg-price-notice {
+.prereg-price-notice, .prereg-type-closing {
     color: #CC0000;
 }
-.active .prereg-price-notice {
+.active .prereg-price-notice, .active .prereg-type-closing {
     color: #FFCC66;
 }

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -91,8 +91,10 @@
             $.each(BADGE_TYPES.options, function (i, type) {
                 var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
                 if (showTotalPrices) {
+                    $('.prereg-price-notice').show();
                     $price.append(': $').append(type.extra + {{ c.BADGE_PRICE }});
                 } else if (type.extra) {
+                    $('.prereg-price-notice').hide();
                     $price.append(': +$').append(type.extra);
                 }
             });


### PR DESCRIPTION
See #1290 for a more detailed explanation, but basically we want "prereg closes" notices to always show up, but "price goes up" notices to only be shown if someone is paying for the first time (e.g. not claiming a group badge).