### PR TITLE
Only show at-door price notice for badges without unique deadlines

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -509,7 +509,7 @@ class PriceNotice(template.Node):
             for day, price in sorted(c.PRICE_BUMPS.items()):
                 if day < takedown and localized_now() < day:
                     return '<div class="prereg-price-notice">Price goes up to ${} at 11:59pm EST on {}</div>'.format(price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
-                elif localized_now() < day:
+                elif localized_now() < day and takedown == c.PREREG_TAKEDOWN:
                     return '<div class="prereg-type-closing">{} closes at 11:59pm EST on {}. Price goes up to ${} at-door.</div>'.format(label, takedown.strftime('%A, %b %e'), price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
             return '<div class="prereg-type-closing">{} closes at 11:59pm EST on {}</div>'.format(label, takedown.strftime('%A, %b %e'))
 

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -35,7 +35,7 @@
         </div>
     </div>
 
-    {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC %}
+    {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC and c.BEFORE_DEALER_REG_SHUTDOWN %}
         <div class="form-group row">
             <p class="col-sm-6 col-sm-offset-2">
                 <strong>Dealers:</strong>


### PR DESCRIPTION
Fixes a bug where the Supporter badge is shown with a message about the price going up at-door.