### PR TITLE
age discounts now actually work

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -194,8 +194,11 @@ class MagModel:
 
     @property
     def default_cost(self):
-        """Returns the sum of all @cost_property values for this model instance."""
-        return sum([getattr(self, name) for name in self.cost_property_names], 0)
+        """
+        Returns the sum of all @cost_property values for this model instance.
+        Because things like discounts exist, we ensure cost can never be negative.
+        """
+        return max(0, sum([getattr(self, name) for name in self.cost_property_names], 0))
 
     @class_property
     def unrestricted(cls):
@@ -1145,6 +1148,10 @@ class Attendee(MagModel, TakesPaymentMixin):
             return c.get_oneday_price(registered)
         else:
             return c.get_attendee_price(registered)
+
+    @cost_property
+    def discount(self):
+        return -self.age_group_conf['discount']
 
     @property
     def age_group_conf(self):

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -57,6 +57,11 @@
         <td>
             <ul style="padding-left:15px">
                 <li>Membership for {{ c.EVENT_NAME }}</li>
+                {% if not attendee.default_cost %}
+                    <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free!</li>
+                {% elif attendee.discount %}
+                    <li>${{ attendee.age_group_conf.discount }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>
+                {% endif %}
                 {% for swag in attendee.donation_swag|add:attendee.addons %}
                     <li>{{ swag }}</li>
                 {% endfor %}


### PR DESCRIPTION
We took the time to configure discounts for our various age groups... and then we never actually implemented our cost code to look at those discounts!  And then we never noticed - whoops!

Anyway, this is fairly straightforward, but I'll explain my changes inline.  I also wrote unit tests for the new functionality, since those are working again.