### PR TITLE
display badge type of assigned group members

### DIFF
--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -46,6 +46,7 @@
             <td>
                 <a href="mailto:{{ attendee.email }}">{{ attendee.email }}</a>
                 &nbsp;&nbsp;&nbsp;&nbsp;
+                {{ attendee.badge }}
             </td>
             <td>
                 <!-- placeholder group leader registrations won't have a zip code -->


### PR DESCRIPTION
minor UI fix, any reason to not do this?

basically it adds the field highlighted below in red, which shows assigned people what kind of badge+ribbon they have.

![image](https://cloud.githubusercontent.com/assets/5413064/9142266/902cf630-3d0c-11e5-9aa4-a6357620411b.png)
