### PR TITLE
group edit page allows assignment of ribbons to new badges

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -700,11 +700,11 @@ class Session(SessionManager):
             self.delete(attendee)
             group.attendees.remove(attendee)
 
-        def assign_badges(self, group, new_badge_count, new_badge_type=c.ATTENDEE_BADGE, new_ribbon_type=c.NO_RIBBON, **extra_create_args):
+        def assign_badges(self, group, new_badge_count, new_badge_type=c.ATTENDEE_BADGE, new_ribbon_type=None, **extra_create_args):
             diff = int(new_badge_count) - group.badges
             sorted_unassigned = sorted(group.floating, key=lambda a: a.registered, reverse=True)
 
-            ribbon_to_use = group.new_ribbon if group.new_ribbon is not c.NO_RIBBON else new_ribbon_type
+            ribbon_to_use = new_ribbon_type or group.new_ribbon
 
             if diff > 0:
                 for i in range(diff):

--- a/uber/models.py
+++ b/uber/models.py
@@ -700,13 +700,15 @@ class Session(SessionManager):
             self.delete(attendee)
             group.attendees.remove(attendee)
 
-        def assign_badges(self, group, new_badge_count, new_badge_type=None, **extra_create_args):
-            new_badge_type = new_badge_type or c.ATTENDEE_BADGE
+        def assign_badges(self, group, new_badge_count, new_badge_type=c.ATTENDEE_BADGE, new_ribbon_type=c.NO_RIBBON, **extra_create_args):
             diff = int(new_badge_count) - group.badges
             sorted_unassigned = sorted(group.floating, key=lambda a: a.registered, reverse=True)
+
+            ribbon_to_use = group.new_ribbon if group.new_ribbon is not c.NO_RIBBON else new_ribbon_type
+
             if diff > 0:
                 for i in range(diff):
-                    group.attendees.append(Attendee(badge_type=new_badge_type, ribbon=group.new_ribbon, paid=c.PAID_BY_GROUP, **extra_create_args))
+                    group.attendees.append(Attendee(badge_type=new_badge_type, ribbon=ribbon_to_use, paid=c.PAID_BY_GROUP, **extra_create_args))
             elif diff < 0:
                 if len(group.floating) < abs(diff):
                     return 'You cannot reduce the number of badges for a group to below the number of assigned badges'

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -37,7 +37,8 @@ class Root:
             message = check(group)
             if not message:
                 session.add(group)
-                message = session.assign_badges(group, params['badges'], params['badge_type'])
+                ribbon_to_use = c.NO_RIBBON if not 'ribbon' in params else params['ribbon']
+                message = session.assign_badges(group, params['badges'], params['badge_type'], ribbon_to_use)
                 if not message and new_dealer and not (first_name and last_name and email and group.badges):
                     message = 'When registering a new Dealer, you must enter the name and email address of the group leader and must allocate at least one badge'
                 if not message:

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -37,7 +37,7 @@ class Root:
             message = check(group)
             if not message:
                 session.add(group)
-                ribbon_to_use = c.NO_RIBBON if not 'ribbon' in params else params['ribbon']
+                ribbon_to_use = c.NO_RIBBON if 'ribbon' not in params else params['ribbon']
                 message = session.assign_badges(group, params['badges'], params['badge_type'], ribbon_to_use)
                 if not message and new_dealer and not (first_name and last_name and email and group.badges):
                     message = 'When registering a new Dealer, you must enter the name and email address of the group leader and must allocate at least one badge'

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -37,7 +37,7 @@ class Root:
             message = check(group)
             if not message:
                 session.add(group)
-                ribbon_to_use = c.NO_RIBBON if 'ribbon' not in params else params['ribbon']
+                ribbon_to_use = None if 'ribbon' not in params else params['ribbon']
                 message = session.assign_badges(group, params['badges'], params['badge_type'], ribbon_to_use)
                 if not message and new_dealer and not (first_name and last_name and email and group.badges):
                     message = 'When registering a new Dealer, you must enter the name and email address of the group leader and must allocate at least one badge'

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -95,8 +95,21 @@
         <select name="badge_type">
             {% options c.BADGE_OPTS group.leader.badge_type %}
         </select>
+        Does not change existing badges in this group, only affects newly added badges.
     </div>
 </div>
+
+{% if not new_dealer and not group.is_dealer %}
+<div class="form-group">
+    <label class="col-sm-2 control-label">Ribbon Type</label>
+    <div class="col-sm-6">
+        <select name="ribbon">
+            {% options c.RIBBON_OPTS group.leader.ribbon %}
+        </select>
+         Does not change existing badges in this group, only affects newly added badges.
+    </div>
+</div>
+{% endif %}
 
 <div class="form-group">
     <label class="col-sm-2 control-label">Amount Paid</label>

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -104,7 +104,7 @@
     <label class="col-sm-2 control-label">Ribbon Type</label>
     <div class="col-sm-6">
         <select name="ribbon">
-            {% options c.RIBBON_OPTS group.leader.ribbon %}
+            {% options c.RIBBON_OPTS group.new_ribbon %}
         </select>
          Does not change existing badges in this group, only affects newly added badges.
     </div>


### PR DESCRIPTION
ribbon selection dropdown doesn't show when group is a dealer, only shows when it's a normal group

plus, minor UI fixes to make the buttons slightly less confusing than before

fixes https://github.com/magfest/ubersystem/issues/1354 and probably at least makes https://github.com/magfest/ubersystem/issues/1345 not be so confusing.