### PR TITLE
fix schedule crash when adding panelists

### DIFF
--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -137,7 +137,8 @@ class Root:
                         session.delete(ap)
                 for attendee_id in new_panelist_ids:
                     if attendee_id not in old_panelist_ids:
-                        session.add(AssignedPanelist(event=event, attendee_id=attendee_id))
+                        attendee = session.attendee(id=attendee_id)
+                        session.add(AssignedPanelist(event=event, attendee=attendee))
                 raise HTTPRedirect('edit#{}', event.start_slot and (event.start_slot - 1))
 
         return {


### PR DESCRIPTION
fixes https://github.com/magfest/ubersystem/issues/1376

NOTE: the original error was, after it bombed out, causing a subsequent search on the reg page to crash.  I suspect maybe the session wasn't being cleaned up and that was affecting the next thing trying to use the session.

Or something.

@EliAndrewC @kitsuta please look and let me know if i'm doing anything silly here.

What was happening was we were passing in just attendee.id and not attendee itself to the AssignedPanelist() class, which when it tried to add itself to the db it would not pull up its Attendee object.

I'm not super-sure what's going on here, only that the other sections of code that access this type of lookup passed in the attendee object, so I made this one do it too.  Seems to work.