### PR TITLE
fix typo when trying to unassign all checkboxes on admin attendee edit

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -340,6 +340,11 @@ class MagModel:
         return query.first() if last_only else query.all()
 
     def apply(self, params, *, bools=(), checkgroups=(), restricted=True, ignore_csrf=True):
+        """
+        Args:
+            restricted (bool): if true, restrict any changes only to fields which we allow attendees to set on their own
+                if false, allow changes to any fields.
+        """
         bools = self.regform_bools if restricted else bools
         checkgroups = self.regform_checkgroups if restricted else checkgroups
         for column in self.__table__.columns:

--- a/uber/models.py
+++ b/uber/models.py
@@ -341,7 +341,7 @@ class MagModel:
 
     def apply(self, params, *, bools=(), checkgroups=(), restricted=True, ignore_csrf=True):
         bools = self.regform_bools if restricted else bools
-        checkgroups = self.regform_checkgroups if restricted else bools
+        checkgroups = self.regform_checkgroups if restricted else checkgroups
         for column in self.__table__.columns:
             if (not restricted or column.name in self.unrestricted) and column.name in params and column.name != 'id':
                 if isinstance(params[column.name], list):

--- a/uber/tests/models/test_apply.py
+++ b/uber/tests/models/test_apply.py
@@ -53,7 +53,7 @@ def test_unassign_all_assigned_depts(attendee, post):
     attendee.apply({'assigned_depts': c.ARCADE}, restricted=False, checkgroups={'assigned_depts'})
     assert attendee.assigned_depts == str(c.ARCADE)
 
-    # make sure if we remove all interests by leaving params blank that it sticks
+    # make sure if we remove all assigned_depts by leaving params blank that it sticks
     # note: this only works when submitting data via POST
     attendee.apply({}, restricted=False, checkgroups={'assigned_depts'})
     assert attendee.assigned_depts == ''
@@ -62,13 +62,13 @@ def test_unassign_all_assigned_depts(attendee, post):
 def test_dont_let_restricted_unassign_all_assigned_depts(attendee, post):
     assert attendee.assigned_depts == ''
 
-    # set this up by assigning arcade as an assigned dept
+    # set this up by trying to assign arcade as an assigned dept, which should fail
     attendee.apply({'assigned_depts': c.ARCADE}, restricted=True, checkgroups={'assigned_depts'})
     assert attendee.assigned_depts == ''
 
     attendee.assigned_depts = str(c.ARCADE)
 
-    # make sure if we remove all interests by leaving params blank that it sticks
+    # make sure if we attempt to remove all assigned_depts by leaving params blank that it doens't let us
     attendee.apply({}, restricted=True, checkgroups={'assigned_depts'})
     assert attendee.assigned_depts == str(c.ARCADE)
 

--- a/uber/tests/models/test_apply.py
+++ b/uber/tests/models/test_apply.py
@@ -33,6 +33,45 @@ def test_not_restricted(attendee):
     assert attendee.paid == c.HAS_PAID
 
 
+def test_unassign_all_interests(attendee, post):
+    assert attendee.interests == ''
+
+    # set this up by assigning arcade as an interest
+    attendee.apply({'interests': c.ARCADE}, restricted=False, checkgroups={'interests'})
+    assert attendee.interests == str(c.ARCADE)
+
+    # make sure if we remove all interests by leaving params blank that it sticks
+    # note: this only works when submitting data via POST
+    attendee.apply({}, restricted=False, checkgroups={'interests'})
+    assert attendee.interests == ''
+
+
+def test_unassign_all_assigned_depts(attendee, post):
+    assert attendee.assigned_depts == ''
+
+    # set this up by assigning arcade as an assigned dept
+    attendee.apply({'assigned_depts': c.ARCADE}, restricted=False, checkgroups={'assigned_depts'})
+    assert attendee.assigned_depts == str(c.ARCADE)
+
+    # make sure if we remove all interests by leaving params blank that it sticks
+    # note: this only works when submitting data via POST
+    attendee.apply({}, restricted=False, checkgroups={'assigned_depts'})
+    assert attendee.assigned_depts == ''
+
+
+def test_dont_let_restricted_unassign_all_assigned_depts(attendee, post):
+    assert attendee.assigned_depts == ''
+
+    # set this up by assigning arcade as an assigned dept
+    attendee.apply({'assigned_depts': c.ARCADE}, restricted=True, checkgroups={'assigned_depts'})
+    assert attendee.assigned_depts == ''
+
+    attendee.assigned_depts = str(c.ARCADE)
+
+    # make sure if we remove all interests by leaving params blank that it sticks
+    attendee.apply({}, restricted=True, checkgroups={'assigned_depts'})
+    assert attendee.assigned_depts == str(c.ARCADE)
+
 def test_id(attendee):
     old_id = attendee.id
     attendee.apply({'id': Attendee().id}, restricted=False)

--- a/uber/tests/models/test_apply.py
+++ b/uber/tests/models/test_apply.py
@@ -72,6 +72,7 @@ def test_dont_let_restricted_unassign_all_assigned_depts(attendee, post):
     attendee.apply({}, restricted=True, checkgroups={'assigned_depts'})
     assert attendee.assigned_depts == str(c.ARCADE)
 
+
 def test_id(attendee):
     old_id = attendee.id
     attendee.apply({'id': Attendee().id}, restricted=False)


### PR DESCRIPTION
add some tests that reproduced this bug, and work now that it's fixed.
the bug was a copy+paste error we didn't catch til now

fixes #1381 