### PR TITLE
Re-enable manual badge number assignments

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -591,7 +591,7 @@ class Session(SessionManager):
 
                 # determine the new badge number now that the badges have shifted
                 next = self.next_badge_num(badge_type, old_badge_num)
-                badge_num = min(badge_num or next, next)
+                badge_num = min(int(badge_num) or next, next)
 
                 # make room for the new number, if applicable
                 if badge_num:

--- a/uber/templates/registration/change_badge.html
+++ b/uber/templates/registration/change_badge.html
@@ -8,7 +8,7 @@
             var badge_type = parseInt($("[name=badge_type]").val());
             var radio = badge_type === {{ attendee.badge_type}} ? "manual" : "auto";
             $("[value=" + radio + "]").attr("checked", true);
-            setVisible("#badge_num_row", !{{ c.NUMBERED_BADGES|jsonize }} && {{ c.PREASSIGNED_BADGE_TYPES }}.indexOf(badge_type) >= 0);
+            setVisible("#badge_num_row", {{ c.NUMBERED_BADGES|jsonize }} && {{ c.PREASSIGNED_BADGE_TYPES }}.indexOf(badge_type) >= 0);
             assignChanged();
         {% endif %}
     }


### PR DESCRIPTION
The JavaScript for the badge change page was checking for the wrong config value, so the box to change the number wasn't showing up. This fixes that plus a 500 error that would have prevented number changes from going through.

Fixes https://github.com/magfest/ubersystem/issues/1395.