### PR TITLE
add unit test to make sure staffing=true when volunteer ribbon set

### DIFF
--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -321,6 +321,13 @@ class TestStaffingAdjustments:
             assert unset_volunteering.called
 
 
+def test_ensure_staffing_set_if_volunteer_ribbon_attendee_badge(monkeypatch):
+    a = Attendee(first_name='Danny', last_name='Boiiiii')
+    a.ribbon = c.VOLUNTEER_RIBBON
+    a._staffing_adjustments()
+    assert a.staffing
+
+
 class TestBadgeAdjustments:
     @pytest.fixture(autouse=True)
     def mock_attendee_session(self, monkeypatch):


### PR DESCRIPTION
see https://github.com/magfest/ubersystem/issues/1404 for discussion.

this is just the unit test, not the fix.  safe to merge, but does not contain the fix yet which is yet to be written.

I don't have time to look at this tonight unfortunately.