### PR TITLE
Add test email sending

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1442,6 +1442,14 @@ class AdminAccount(MagModel):
             return None
 
     @staticmethod
+    def admin_email():
+        try:
+            with Session() as session:
+                return session.admin_attendee().email
+        except:
+            return None
+
+    @staticmethod
     def access_set(id=None):
         try:
             with Session() as session:

--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -44,6 +44,29 @@ class Root:
             'examples': examples
         }
 
+    def test_email(self, session, subject=None, body=None, from_address=None, to_address=None, **params):
+        """
+        Testing only: send a test email as a system user
+        """
+
+        output_msg = ""
+
+        if subject and body and from_address and to_address:
+            send_email(from_address, to_address, subject, body)
+            output_msg = "RAMS has attempted to send your email."
+
+        right_now = str(datetime.now())
+
+        return {
+            'from_address': from_address or c.STAFF_EMAIL,
+            'to_address': to_address or
+                          ("goldenaxe75t6489@mailinator.com" if c.DEV_BOX else AdminAccount.admin_email())
+                          or "",
+            'subject':  c.EVENT_NAME_AND_YEAR + " test email " + right_now,
+            'body': body or "ignore this email, <b>it is a test</b> of the <u>RAMS email system</u> " + right_now,
+            'message': output_msg,
+        }
+
     @csrf_protected
     def approve(self, session, subject):
         session.add(ApprovedEmail(subject=subject))

--- a/uber/templates/emails/test_email.html
+++ b/uber/templates/emails/test_email.html
@@ -1,0 +1,31 @@
+{% extends "base-admin.html" %}
+{% block title %}Test email sending{% endblock %}
+{% block content %}
+
+<h2>Send a test email from RAMS. Please use with care.</h2>
+
+<form action="test_email" method="POST">
+    <table border="0">
+        <tr>
+            <td>To:</td>
+            <td><input size="50" type="text" name="to_address" value="{{to_address}}" /></td>
+        </tr>
+        <tr>
+            <td>From:</td>
+            <td><input size="50" type="text" name="from_address" value="{{from_address}}" /></td>
+        </tr>
+        <tr>
+            <td>Subject:</td>
+            <td><input size="50" type="text" name="subject" value="{{subject}}" /><br/></td>
+        </tr>
+    </table>
+
+    Body:<br/>
+    <textarea cols=100 rows=20 name="body">{{body}}</textarea>
+
+    <br/><br/>
+    <input type="submit" value="submit" name="submit">
+
+</form>
+
+{% endblock %}

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -321,13 +321,6 @@ class TestStaffingAdjustments:
             assert unset_volunteering.called
 
 
-def test_ensure_staffing_set_if_volunteer_ribbon_attendee_badge(monkeypatch):
-    a = Attendee(first_name='Danny', last_name='Boiiiii')
-    a.ribbon = c.VOLUNTEER_RIBBON
-    a._staffing_adjustments()
-    assert a.staffing
-
-
 class TestBadgeAdjustments:
     @pytest.fixture(autouse=True)
     def mock_attendee_session(self, monkeypatch):

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -321,6 +321,13 @@ class TestStaffingAdjustments:
             assert unset_volunteering.called
 
 
+def test_ensure_staffing_set_if_volunteer_ribbon_attendee_badge(monkeypatch):
+    a = Attendee(first_name='Danny', last_name='Boiiiii')
+    a.ribbon = c.VOLUNTEER_RIBBON
+    a._staffing_adjustments()
+    assert a.staffing
+
+
 class TestBadgeAdjustments:
     @pytest.fixture(autouse=True)
     def mock_attendee_session(self, monkeypatch):


### PR DESCRIPTION
Adds a simple page to test email sending from the web UI.

![image](https://cloud.githubusercontent.com/assets/5413064/9497344/87b1f7b4-4be2-11e5-8a04-3495799bb94c.png)

This just calls ```send_emails()``` with the info.

I was using this to test out a switch of our Amazon AWS key