### PR TITLE
Add zipfile decorator

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -17,7 +17,7 @@ import threading
 import traceback
 from glob import glob
 from uuid import uuid4
-from io import StringIO
+from io import StringIO, BytesIO
 from pprint import pprint
 from copy import deepcopy
 from pprint import pformat

--- a/uber/common.py
+++ b/uber/common.py
@@ -7,6 +7,7 @@ import math
 import string
 import socket
 import random
+import zipfile
 import inspect
 import binascii
 import warnings

--- a/uber/common.py
+++ b/uber/common.py
@@ -17,7 +17,6 @@ import threading
 import traceback
 from glob import glob
 from uuid import uuid4
-from io import StringIO, BytesIO
 from pprint import pprint
 from copy import deepcopy
 from pprint import pformat
@@ -28,6 +27,7 @@ from random import randrange
 from contextlib import closing
 from time import sleep, mktime
 from urllib.parse import quote
+from io import StringIO, BytesIO
 from urllib.parse import urlparse
 from urllib.parse import parse_qsl
 from itertools import chain, count

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -87,6 +87,20 @@ def ajax_gettable(func):
     return returns_json
 
 
+def multifile_zipfile(func):
+    @wraps(func)
+    def zipfile_out(self, session):
+        cherrypy.response.headers['Content-Type'] = 'application/zip'
+        cherrypy.response.headers['Content-Disposition'] = 'attachment; filename=' + func.__name__ + '.zip'
+
+        zipfile_writer = StringIO()
+        with zipfile.ZipFile(zipfile_writer) as zip_file:
+            func(self, zip_file, session)
+
+        return zipfile_writer.getvalue().encode('utf-8')
+    return zipfile_out
+
+
 def csv_file(func):
     @wraps(func)
     def csvout(self, session):

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -112,8 +112,11 @@ class Root:
 
     @multifile_zipfile
     def personalized_badges_zip(self, zip_file, session):
-        zip_file.writestr("test1.txt", "test1")
-        zip_file.writestr("test2.txt", "test2")
+        # todo: add other CSV files in here that we can export in bulk
+        # here are some examples of what you can do:
+        zip_file.writestr("personalized_badges.csv", self.personalized_badges())
+        zip_file.writestr("personalized_badges - TXT COPY.txt", self.personalized_badges())
+        zip_file.writestr("bestfile-evar.txt", "This is the best test ever. for reals. testtesttest")
 
     def food_eligible(self, session):
         cherrypy.response.headers['Content-Type'] = 'application/xml'

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -110,6 +110,11 @@ class Root:
                                                 Attendee.amount_extra >= c.SUPPORTER_LEVEL).order_by(Attendee.full_name).all():
             out.writerow(['', 'Supporter', a.badge_printed_name or a.full_name])
 
+    @multifile_zipfile
+    def personalized_badges_zip(self, zip_file, session):
+        zip_file.writestr("test1.txt", "test1")
+        zip_file.writestr("test2.txt", "test2")
+
     def food_eligible(self, session):
         cherrypy.response.headers['Content-Type'] = 'application/xml'
         eligible = {


### PR DESCRIPTION
Huh. turns out this was actually really easy to do. part of #1397 

I wanted to the ability to take a bunch of our existing CSV reports and stick them into a .zip file.  If you stick the ```@multifile_zipfile``` decorator on a function, it'll pass you a ```ZipFile``` object which you can use to easily create a bunch of files inside a zipfile.

result from the test data in here:
![image](https://cloud.githubusercontent.com/assets/5413064/9523156/9eaa841c-4ca6-11e5-834a-6b16ce9f530e.png)

I'll be updating the stuff in summary.py to have real data in it in the next PR.