### PR TITLE
remove obsolete config, room deadline

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -41,8 +41,6 @@ supporter_deadline = "2015-12-26"
 
 printed_badge_deadline = "2016-01-04"
 
-room_deadline = "2015-11-30"
-
 
 [badge_prices]
 


### PR DESCRIPTION
these have been replaced by the dept head checklist I THINK.

I DIDNT TEST THIS YET, but I could not find references to these config vars in core anywhere.  @EliAndrewC  lemme know if these are indeed supposed to have been obsoleted by recent dept head checklist config stuff.

there are 2 other PRs associated with this.