### PR TITLE
mark "name printed on badge" as optional

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -149,7 +149,7 @@
     </div>
 
     <div class="badge-row extra-row form-group" style="display:none">
-        <label for="badge_printed_name" class="col-sm-2 control-label">Name Printed on Badge</label>
+        <label for="badge_printed_name" class="col-sm-2 control-label optional-field">Name Printed on Badge</label>
         <div class="col-sm-6">
             <input type="text" class="form-control" name="badge_printed_name" maxlength="20" value="{{ attendee.badge_printed_name }}" {% if c.AFTER_PRINTED_BADGE_DEADLINE %}readonly{% endif %} />
         </div>


### PR DESCRIPTION
makes it so it doesn't appear bold to denote required field

not sure if there was an open issue for this one, Brent was asking about it.

example of what it looks like fixed, notice it's no longer bold:
![image](https://cloud.githubusercontent.com/assets/5413064/9556198/f2362334-4da0-11e5-91c0-dd5fc3bced27.png)
