### PR TITLE
Switch price display depending on # of kick-in levels

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -158,6 +158,12 @@ max_badge_sales = integer(default=20000)
 # If this is False, we won't display the "Want to Kick in Extra" stuff.
 donations_enabled = boolean(default=True)
 
+# This controls how badges and kick-in levels are displayed on the pre-
+# registration form. If it's true, the badge prices are displayed
+# separately from the badge add-ons and there is a slider to select
+# extra kick-in levels beyond what is shown in the badge level boxes.
+donation_slider_display = boolean(default=True)
+
 # Attendees kicking in extra can enter their own new "affiliate" or select
 # from a list of all affiliates which have already been entered.  This is
 # the list of the top affiliates from last year which we use to prepopulate
@@ -306,7 +312,7 @@ group_prereg_takedown = string(default="2016-01-11")
 # registrations to fill out the form to claim their badge until this date, after which
 # we usually just delete the unclaimed badges (as our emails warn that we'll do),
 # although this is a manual process.
-placeholder_deadline  = string(default="2016-01-18")
+placeholder_deadline  = string(default="2016-01-18")f
 
 # New preregistrations can no longer be made after this date, but all other features will
 # continue to work, such as badge transfers, group management, and shift signup.

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -498,13 +498,11 @@ def price_notice(parser, token):
 
 
 class PriceNotice(template.Node):
-    def __init__(self, label, takedown, amount_extra='0'):
+    def __init__(self, label, takedown, amount_extra='0', discount='0'):
         self.label = label.strip('"').strip("'")
-        self.takedown, self.amount_extra = Variable(takedown), Variable(amount_extra)
+        self.takedown, self.amount_extra, self.discount = Variable(takedown), Variable(amount_extra), Variable(discount)
 
-    def _notice(self, label, takedown, amount_extra):
-        discount = c.GROUP_DISCOUNT if takedown == c.GROUP_PREREG_TAKEDOWN else 0
-
+    def _notice(self, label, takedown, amount_extra, discount):
         if c.PAGE_PATH not in ['/preregistration/form', '/preregistration/register_group_member']:
             return ''  # we only display notices for new attendees
         else:
@@ -516,7 +514,7 @@ class PriceNotice(template.Node):
             return '<div class="prereg-type-closing">{} closes at 11:59pm EST on {}</div>'.format(label, takedown.strftime('%A, %b %e'))
 
     def render(self, context):
-        return self._notice(self.label, self.takedown.resolve(context), self.amount_extra.resolve(context))
+        return self._notice(self.label, self.takedown.resolve(context), self.amount_extra.resolve(context), self.discount.resolve(context))
 
 
 @tag

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -503,12 +503,14 @@ class PriceNotice(template.Node):
         self.takedown, self.amount_extra = Variable(takedown), Variable(amount_extra)
 
     def _notice(self, label, takedown, amount_extra):
+        discount = c.GROUP_DISCOUNT if takedown == c.GROUP_PREREG_TAKEDOWN else 0
+
         if c.PAGE_PATH not in ['/preregistration/form', '/preregistration/register_group_member']:
             return ''  # we only display notices for new attendees
         else:
             for day, price in sorted(c.PRICE_BUMPS.items()):
                 if day < takedown and localized_now() < day:
-                    return '<div class="prereg-price-notice">Price goes up to ${} at 11:59pm EST on {}</div>'.format(price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
+                    return '<div class="prereg-price-notice">Price goes up to ${} at 11:59pm EST on {}</div>'.format(price - discount + int(amount_extra), (day - timedelta(days=1)).strftime('%A, %b %e'))
                 elif localized_now() < day and takedown == c.PREREG_TAKEDOWN:
                     return '<div class="prereg-type-closing">{} closes at 11:59pm EST on {}. Price goes up to ${} at-door.</div>'.format(label, takedown.strftime('%A, %b %e'), price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
             return '<div class="prereg-type-closing">{} closes at 11:59pm EST on {}</div>'.format(label, takedown.strftime('%A, %b %e'))

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -87,7 +87,7 @@
         {% endif %}
 
         var togglePrices = function () {
-            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' %}(($.field('amount_extra') && $.field('amount_extra').is(":visible") && $.val('badge_type') === {{ c.ATTENDEE_BADGE }}) ? false : true){% else %}false{% endif %};
+            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' and c.DONATION_SLIDER_DISPLAY %}($.val('badge_type') === {{ c.ATTENDEE_BADGE }}){% else %}false{% endif %};
             $.each(BADGE_TYPES.options, function (i, type) {
                 var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
                 var $price_notice = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price_notice').empty();
@@ -162,7 +162,11 @@
                 setBadge(REG_TYPES, $.field('name') && $.val('name') ? 1 : 0);  // default to attendee or group
                 makeBadgeMatchExtra();
                 if ($.field('amount_extra')) {
-                    $.field('amount_extra').on('change', makeBadgeMatchExtra);
+                    {% if c.DONATION_SLIDER_DISPLAY %}
+                        $.field('amount_extra').parents('.form-group').hide();
+                    {% else %}
+                        $.field('amount_extra').on('change', makeBadgeMatchExtra);
+                    {% endif %}
                 }
             }
         });

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -23,9 +23,9 @@
                 } else {
                     $('input[name="international"]').prop('checked', true);
                 }
-            }
+            };
             $(function() {
-                $('#international').hide()
+                $('#international').hide();
                 setInternational()
             });
         {% endif %}
@@ -35,7 +35,7 @@
             selector: '.reg-type-selector',
             options: [{
                 title: 'Single Attendee',
-                description: 'A single registration; you can register more before paying',
+                description: 'A single registration; you can register more before paying.',
                 onClick: function () {
                     $('.group_fields').addClass('hide');
                     $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
@@ -50,7 +50,7 @@
             REG_TYPES.options.push({
                 title: 'Group Leader',
                 {% if c.BEFORE_GROUP_PREREG_TAKEDOWN %}
-                    description: '<p class="list-group-item-text">Register a group of {{ c.MIN_GROUP_SIZE }} or more and save ${{ c.GROUP_DISCOUNT }} per badge.</p>',
+                    description: '<p class="list-group-item-text">Register a group of {{ c.MIN_GROUP_SIZE }} people or more.</p>',
                 {% else %}
                     description: '<p class="list-group-item-text">The deadline for Group registration has passed, but you can still register as a regular attendee.</p>'
                 {% endif %}
@@ -67,35 +67,54 @@
             selector: '.badge-type-selector',
             options: [{
                 title: '{% if c.PAGE_PATH == "/preregistration/form" or c.PAGE_PATH == "/preregistration/dealer_registration" %}Attending{% else %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
-                description: 'Allows access to the convention for its duration. {% price_notice "Preregistration" c.PREREG_TAKEDOWN %}',
+                description: 'Allows access to the convention for its duration.',
                 extra: 0
             }]
         };
         {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS and not attendee.gets_free_shirt %}
             BADGE_TYPES.options.push({
                 title: 'Add a tshirt',
-                description: 'Add a {{ c.EVENT_NAME }} themed t-shirt to your registration. {% price_notice "Preregistration" c.PREREG_TAKEDOWN c.SHIRT_LEVEL %}',
+                description: 'Add a {{ c.EVENT_NAME }} themed t-shirt to your registration.',
                 extra: {{ c.SHIRT_LEVEL }}
             });
         {% endif %}
         {% if c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
             BADGE_TYPES.options.push({
                 title: 'Supporter',
-                description: 'Donate extra and get more swag with your registration. {% price_notice "Supporter registration" c.SUPPORTER_DEADLINE c.SUPPORTER_LEVEL %}',
+                description: 'Donate extra and get more swag with your registration.',
                 extra: {{ c.SUPPORTER_LEVEL }}
             });
         {% endif %}
 
         var togglePrices = function () {
-            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' %}$.val('badge_type') === {{ c.ATTENDEE_BADGE }}{% else %}false{% endif %};
+            var showTotalPrices = (($.field('amount_extra') && $.field('amount_extra').is(":visible")) ? false : true);
             $.each(BADGE_TYPES.options, function (i, type) {
                 var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
+                var $price_notice = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price_notice').empty();
                 if (showTotalPrices) {
-                    $('.prereg-price-notice').show();
                     $price.append(': $').append(type.extra + {{ c.BADGE_PRICE }});
+                    {% for amount_extra, val in c.PREREG_DONATION_OPTS %}
+                        if (type.extra == {{ amount_extra }} && type.extra >= {{c.SUPPORTER_LEVEL }}) {
+                            $price_notice.append('{% price_notice "Supporter registration" c.SUPPORTER_DEADLINE c.SUPPORTER_LEVEL %}')
+                        } else if (type.extra == {{amount_extra }}) {
+                            $price_notice.append('{% price_notice "Preregistration" c.PREREG_TAKEDOWN amount_extra %}')
+                        }
+                    {% endfor %}
                 } else if (type.extra) {
-                    $('.prereg-price-notice').hide();
                     $price.append(': +$').append(type.extra);
+                }
+            });
+            $.each(REG_TYPES.options, function (i, type) {
+                var $price = $(REG_TYPES.selector).slice(i, i + 1).find('.price').empty();
+                var $price_notice = $(REG_TYPES.selector).slice(i, i + 1).find('.price_notice').empty();
+                if (!showTotalPrices) {
+                    if (type.title == 'Single Attendee') {
+                        $price.append(': $').append({{ c.BADGE_PRICE }});
+                        $price_notice.append('{% price_notice "Preregistration" c.PREREG_TAKEDOWN %}')
+                    } else if (type.title == 'Group Leader') {
+                        $price.append(': $').append({{ c.GROUP_PRICE }}).append(' per badge');
+                        $price_notice.append('{% price_notice "Group registration" c.GROUP_PREREG_TAKEDOWN %}')
+                    }
                 }
             });
         };
@@ -114,7 +133,7 @@
             if ($(BADGE_TYPES.row).size()) {
                 var target = 0;
                 $.each(BADGE_TYPES.options, function (i, badgeType) {
-                    if (badgeType.extra && $.field('amount_extra') && badgeType.extra <= $.val('amount_extra')) {
+                    if (badgeType.extra && $.field('amount_extra') && badgeType.extra == $.val('amount_extra')) {
                         target = i;
                     }
                 });
@@ -124,6 +143,7 @@
             }
         };
         $(function () {
+            var showTotalPrices = (($.field('amount_extra') && $.field('amount_extra').is(":visible")) ? true : true);
             if ($(BADGE_TYPES.row).size()) {
                 $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
                     $.each(types.options, function (index, type) {
@@ -136,7 +156,7 @@
                                         .append(type.title)
                                         .append('<span class="price"></span>')
                                 ).append(
-                                    $('<p class="list-group-item-text"></p>').html(type.description))));
+                                    $('<p class="list-group-item-text"></p>').html(type.description).append('<span class="price_notice"></span>'))));
                     });
                     $(types.row).append('<div style="clear:both">&nbsp;</div>');
                 });

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -87,7 +87,7 @@
         {% endif %}
 
         var togglePrices = function () {
-            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' and c.DONATION_SLIDER_DISPLAY %}($.val('badge_type') === {{ c.ATTENDEE_BADGE }}){% else %}false{% endif %};
+            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' and not c.DONATION_SLIDER_DISPLAY %}($.val('badge_type') === {{ c.ATTENDEE_BADGE }}){% else %}false{% endif %};
             $.each(BADGE_TYPES.options, function (i, type) {
                 var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
                 var $price_notice = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price_notice').empty();
@@ -162,7 +162,7 @@
                 setBadge(REG_TYPES, $.field('name') && $.val('name') ? 1 : 0);  // default to attendee or group
                 makeBadgeMatchExtra();
                 if ($.field('amount_extra')) {
-                    {% if c.DONATION_SLIDER_DISPLAY %}
+                    {% if not c.DONATION_SLIDER_DISPLAY %}
                         $.field('amount_extra').parents('.form-group').hide();
                     {% else %}
                         $.field('amount_extra').on('change', makeBadgeMatchExtra);

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -87,7 +87,7 @@
         {% endif %}
 
         var togglePrices = function () {
-            var showTotalPrices = (($.field('amount_extra') && $.field('amount_extra').is(":visible")) ? false : true);
+            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' %}(($.field('amount_extra') && $.field('amount_extra').is(":visible") && $.val('badge_type') === {{ c.ATTENDEE_BADGE }}) ? false : true){% else %}false{% endif %};
             $.each(BADGE_TYPES.options, function (i, type) {
                 var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
                 var $price_notice = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price_notice').empty();
@@ -143,7 +143,6 @@
             }
         };
         $(function () {
-            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' %}(($.field('amount_extra') && $.field('amount_extra').is(":visible") && $.val('badge_type') === {{ c.ATTENDEE_BADGE }}) ? false : true){% else %}false{% endif %};
             if ($(BADGE_TYPES.row).size()) {
                 $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
                     $.each(types.options, function (index, type) {

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -94,9 +94,9 @@
                 if (showTotalPrices) {
                     $price.append(': $').append(type.extra + {{ c.BADGE_PRICE }});
                     {% for amount_extra, val in c.PREREG_DONATION_OPTS %}
-                        if (type.extra == {{ amount_extra }} && type.extra >= {{c.SUPPORTER_LEVEL }}) {
+                        if (type.extra == {{ amount_extra }} && type.extra >= {{ c.SUPPORTER_LEVEL }}) {
                             $price_notice.append('{% price_notice "Supporter registration" c.SUPPORTER_DEADLINE c.SUPPORTER_LEVEL %}')
-                        } else if (type.extra == {{amount_extra }}) {
+                        } else if (type.extra == {{ amount_extra }}) {
                             $price_notice.append('{% price_notice "Preregistration" c.PREREG_TAKEDOWN amount_extra %}')
                         }
                     {% endfor %}
@@ -113,7 +113,7 @@
                         $price_notice.append('{% price_notice "Preregistration" c.PREREG_TAKEDOWN %}')
                     } else if (type.title == 'Group Leader') {
                         $price.append(': $').append({{ c.GROUP_PRICE }}).append(' per badge');
-                        $price_notice.append('{% price_notice "Group registration" c.GROUP_PREREG_TAKEDOWN %}')
+                        $price_notice.append('{% price_notice "Group registration" c.GROUP_PREREG_TAKEDOWN 0 c.GROUP_DISCOUNT %}')
                     }
                 }
             });

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -143,7 +143,7 @@
             }
         };
         $(function () {
-            var showTotalPrices = (($.field('amount_extra') && $.field('amount_extra').is(":visible")) ? true : true);
+            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' %}(($.field('amount_extra') && $.field('amount_extra').is(":visible") && $.val('badge_type') === {{ c.ATTENDEE_BADGE }}) ? false : true){% else %}false{% endif %};
             if ($(BADGE_TYPES.row).size()) {
                 $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
                     $.each(types.options, function (index, type) {


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/1425. This is pretty complex view logic, but in essence we now check to see if the amount_extra field is present and visible. If so, we can assume that the more sensible way to display price information is to attach it to the registration type and show the badge levels as additional prices - otherwise, we display the total on the badge level buttons.

I've also made the badge level buttons only highlight if you select their exact kick-in level, as their prices are misleading otherwise.