### PR TITLE
Add group explanation

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -41,6 +41,14 @@
         if ($.field('no_cellphone')) {
             $.field('no_cellphone').on('click', noCellphoneClicked);
         }
+
+        if ($.field('address')) {
+            $('#group-explanation').insertAfter($.field('address').parents('.form-group'));
+        } else if ($.field('badges')) {
+            $('#group-explanation').insertAfter($.field('badges').parents('.form-group'));
+        } else {
+            $('#group-explanation').remove();
+        }
     });
 
     {% if not attendee.is_new %}
@@ -56,6 +64,16 @@
         <div class="col-sm-6 heading-label">Bold fields are required</div>
     </div>
 {% endif %}
+
+<div id="group-explanation" class="form-group">
+    <p class="col-sm-8 col-sm-offset-1">
+        {% if attendee.is_dealer %}
+            Please enter your personal information below.  Information for any additional vendors at your table can be filled out once your application is approved.
+        {% else %}
+            Please enter the information for the group leader below (additional group member information will be entered after purchase is complete):
+        {% endif %}
+    </p>
+</div>
 
 {% if c.PAGE == 'confirm' %}
     <div class="form-group">


### PR DESCRIPTION
This functionality already exists in the MAGClassic plugin, but it's a nice bit of explanation text and we want it for all events that use groups or dealers, so it's being moved to core.