### PR TITLE
Revert "Prevent attendees from registering fewer than the minimum gro…

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -8,13 +8,11 @@ def to_sessionized(attendee, group):
         return Charge.to_sessionized(attendee)
 
 
-def check_prereg_reqs(attendee, group=None):
+def check_prereg_reqs(attendee):
     if attendee.badge_type == c.PSEUDO_DEALER_BADGE and not attendee.cellphone:
         return 'Your phone number is required'
     elif attendee.amount_extra >= c.SHIRT_LEVEL and attendee.shirt == c.NO_SHIRT:
         return 'Your shirt size is required'
-    elif attendee.badge_type == c.PSEUDO_GROUP_BADGE and group.badges < c.MIN_GROUP_SIZE:
-        return "You cannot buy fewer than {} badges at the group rate.".format(c.MIN_GROUP_SIZE)
 
 
 def check_dealer(group):
@@ -152,7 +150,7 @@ class Root:
             return render('static_views/dealer_reg_closed.html') if c.AFTER_DEALER_REG_SHUTDOWN else render('static_views/dealer_reg_not_open.html')
 
         if 'first_name' in params:
-            message = check(attendee) or check_prereg_reqs(attendee, group)
+            message = check(attendee) or check_prereg_reqs(attendee)
             if not message and attendee.badge_type in [c.PSEUDO_DEALER_BADGE, c.PSEUDO_GROUP_BADGE]:
                 message = check(group)
                 if attendee.badge_type == c.PSEUDO_DEALER_BADGE:


### PR DESCRIPTION
Reverts magfest/ubersystem#1448

Bizarrely, (and even though I could swear I tested this use case) the last PR made it so that any time you try to buy any group badge it trips the new validation.

I can't fathom why this would be happening, so I'll revert this for now so I can deploy another fix and we'll figure it out sometime soon.