### PR TITLE
Fix page caching

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -159,7 +159,7 @@ def cached_page(func):
                 if not os.path.exists(fpath) or datetime.now().timestamp() - os.stat(fpath).st_mtime > 60 * 15:
                     contents = func(*args, **kwargs)
                     with open(fpath, 'wb') as f:
-                        f.write(contents)
+                        f.write(bytes(contents, 'UTF-8'))
                 with open(fpath, 'rb') as f:
                     return f.read()
         else:

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -159,7 +159,11 @@ def cached_page(func):
                 if not os.path.exists(fpath) or datetime.now().timestamp() - os.stat(fpath).st_mtime > 60 * 15:
                     contents = func(*args, **kwargs)
                     with open(fpath, 'wb') as f:
-                        f.write(bytes(contents, 'UTF-8'))
+                        # Try to write assuming content is a byte first, then try it as a string
+                        try:
+                            f.write(contents)
+                        except:
+                            f.write(bytes(contents, 'UTF-8'))
                 with open(fpath, 'rb') as f:
                     return f.read()
         else:


### PR DESCRIPTION
Python 3 no longer accepts strings when writing in byte-mode, so this encodes the contents first.

This is an emergency fix, but we'll refrain from merging and just switch the production server's git branch. After we merge this we need to checkout master again.