### PR TITLE
add laptop "kiosk-mode" landing page

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -100,7 +100,6 @@ class Root:
         """
         raise HTTPRedirect('form')
 
-
     def check_prereg(self):
         return json.dumps({'force_refresh': c.AFTER_PREREG_TAKEDOWN or c.BADGES_SOLD >= c.MAX_BADGE_SALES})
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -92,6 +92,15 @@ class Root:
             'warn_if_server_browser_time_mismatch': c.WARN_IF_SERVER_BROWSER_TIME_MISMATCH
         })
 
+    def kiosk(self):
+        """
+        Landing page for kiosk laptops, this should redirect to whichever page we want at-the-door laptop kiosks
+        to land on.  The reason this is a redirect is that at-the-door laptops might be imaged and hard to change
+        their default landing page.  If sysadmins want to change the landing page, they can do it here.
+        """
+        raise HTTPRedirect('form')
+
+
     def check_prereg(self):
         return json.dumps({'force_refresh': c.AFTER_PREREG_TAKEDOWN or c.BADGES_SOLD >= c.MAX_BADGE_SALES})
 


### PR DESCRIPTION
this is needed because once laptops are imaged, it's really painful to change their homepage
this allows devs to redirect to a different page if needed without having to mess with the laptop config