### PR TITLE
fixed common.js error

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -196,8 +196,11 @@ class Config(_Overridable):
 
     @property
     def CURRENT_ADMIN(self):
-        with sa.Session() as session:
-            return session.admin_attendee().to_dict()
+        try:
+            with sa.Session() as session:
+                return session.admin_attendee().to_dict()
+        except:
+            return {}
 
     @property
     def HTTP_METHOD(self):


### PR DESCRIPTION
Our ``magfest.js`` file iterates through everything in ``c`` (except stuff in ``[secret]``) and renders it into a Javascript object.  As currently implemented, if anything raises an exception, then ``magfest.js`` results in an HTTP 500 error because of the uncaught exception.