### PR TITLE
re-added shifts email and removed MAGFest-specific info

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -227,6 +227,9 @@ StopsEmail('Still want to volunteer at {EVENT_NAME}?', 'shifts/volunteer_check.t
               lambda a: c.SHIFTS_CREATED and days_before(5, c.UBER_TAKEDOWN)
                                          and a.ribbon == c.VOLUNTEER_RIBBON and a.takes_shifts and a.weighted_hours == 0)
 
+StopsEmail('Your {EVENT_NAME} shift schedule', 'shifts/schedule.html',
+           lambda a: c.SHIFTS_CREATED and days_before(1, c.UBER_TAKEDOWN) and a.weighted_hours)
+
 
 # For events with customized badges, these emails remind people to let us know what we want on their badges.  We have
 # one email for our volunteers who haven't bothered to confirm they're coming yet (bleh) and one for everyone else.

--- a/uber/templates/emails/shifts/schedule.html
+++ b/uber/templates/emails/shifts/schedule.html
@@ -5,7 +5,7 @@
 {{ attendee.first_name }},
 <br/> <br/>
 
-Sorry for the mix-up, but due to a timezone bug, all of the shift times in the previous email were 5 hours off from their actual times.  Please disregard that email, as this email has the correct times.
+Thanks again for volunteering at {{ c.EVENT_NAME }}!
 <br/> <br/>
 
 {% if attendee.takes_shifts and attendee.shifts %}
@@ -13,7 +13,7 @@ Sorry for the mix-up, but due to a timezone bug, all of the shift times in the p
     mark each shift as worked.
     <br/> <br/>
     If you forget to print out this sheet and would like to pick up a spare copy, or if you want to change your hours,
-    you can drop by Staffing Ops in the Fest Ops room during {{ c.EVENT_NAME }}.
+    you can drop by Staffing Ops during {{ c.EVENT_NAME }}.
 {% endif %}
 
 {% include "signups/printable_schedule.html" %}

--- a/uber/templates/signups/food_info.html
+++ b/uber/templates/signups/food_info.html
@@ -1,0 +1,4 @@
+{% comment %}<!--
+    Events should override this file with information about volunteer food, if applicable.
+    If this template is not overridden, then no food information will be shown to volunteers.
+-->{% endcomment %}

--- a/uber/templates/signups/printable_schedule.html
+++ b/uber/templates/signups/printable_schedule.html
@@ -10,26 +10,7 @@
     get a free badge or free hotel room space next year.
 {% endif %}
 
-<br/> <br/>
-Free food is available in the Hospitality Suite in Room 6176 during the following times:
-<ul>
-    <li>Breakfast: 7:00 am to 11:00 am</li>
-    <li>Lunch: 12:00 pm to 4:00 pm</li>
-    <li>Dinner: 5:00 pm to 9:00 pm</li>
-    <li>Overnight: 9:00 pm to 4:00 am (or until the hot food has run out, whichever occurs first)</li>
-</ul>
-
-{% if attendee.badge_type == c.ATTENDEE_BADGE and attendee.takes_shifts %}
-    You'll become eligible for food after signing up for at least 12 weighted hours <b>AND</b> working at least 6 weighted hours.  Please come to Staffing Ops (in the Fest Ops room) to get your ribbon marked after working your first shift and getting your department head to sign this sheet. <br/>
-{% endif %}
-
-<br/>
-In addition to the Hospitality Suite, you can buy food at the Galaxy Cafe.  To get there, go to the far back of the Maryland Ballroom foyer, then go through the doors and turn left.  Just before you get to the Security desk in the hallway, look to your left and there will be a wide set of stairs going down.  Go down those stairs and then the Galaxy Cafe will be on your right.  You can use the Galaxy Cafe during any of the following times:
-<ul>
-    <li>Breakfast ($12.50): 6:30am - 8:00am</li>
-    <li>Lunch ($14.50): 1:00pm - 2:30pm</li>
-    <li>Dinner ($14.50): 7:00pm - 9:00pm</li>
-</ul>
+{% include "signups/food_info.html" %}
 
 {% if attendee.shifts %}
     <i>You should report to a Department Chair for each department you're working before the start of your first shift:</i>


### PR DESCRIPTION
This was deleted during the big refactor this year, so I'm turning it back on now.