### PR TITLE
WIP: Settle a bet between Eli and Vicki

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -904,7 +904,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     last_name     = Column(UnicodeText)
     email         = Column(UnicodeText)
     birthdate     = Column(Date, nullable=True, default=None)
-    age_group     = Column(Choice(c.AGE_GROUPS), default=c.AGE_UNKNOWN, nullable=True)
+    age_group     = Column(Choice(c.AGE_GROUP_OPTS), default=c.AGE_UNKNOWN, nullable=True)
 
     international = Column(Boolean, default=False)
     zip_code      = Column(UnicodeText)


### PR DESCRIPTION
I sincerely do not know how this fixes the problem. It probably has something to do with the difference between dicts and lists.

The problem, on the production server, is that we were finding these errors in the log shortly before our server started hanging:

```
r/plugins/uber/uber/decorators.py", line 72, in returns_json#012    return json.dumps(func(*args, **kwargs), cls=serializer).encode('utf-8')#012  File "/usr/local/uber/plugins/uber/uber/site_sections/registration.py", line 280, in check_in#012    session.commit()#012  File "/usr/local/uber/env/lib/python3.4/site-packages/sqlalchemy/orm/session.py", line 790, in commit#012    self.transaction.commit()#012  File "/usr/local/uber/env/lib/python3.4/site-packages/sqlalchemy/orm/session.py", line 392, in commit#012    self._prepare_impl()#012  File "/usr/local/uber/env/lib/python3.4/site-packages/sqlalchemy/orm/session.py", line 372, in _prepare_impl#012    self.session.flush()#012  File "/usr/local/uber/env/lib/python3.4/site-packages/sqlalchemy/orm/session.py", line 2004, in flush#012    self._flush(objects)#012  File "/usr/local/uber/env/lib/python3.4/site-packages/sqlalchemy/orm/session.py", line 2031, in _flush#012    self.dispatch.before_flush(self, flush_context, objects)#012  File "/usr/local/uber/env/lib/python3.4/site-packages/sqlalchemy/event/attr.py", line 218, in __call__#012    fn(*args, **kw)#012  File "/usr/local/uber/plugins/uber/uber/models.py", line 1747, in _presave_adjustments#012    model.presave_adjustments()#012  File "/usr/local/uber/plugins/uber/uber/models.py", line 163, in presave_adjustments#012    self._invoke_adjustment_callbacks('presave_adjustment')#012  File "/usr/local/uber/plugins/uber/uber/models.py", line 160, in _invoke_adjustment_callbacks#012    func()#012  File "/usr/local/uber/plugins/uber/uber/models.py", line 999, in _misc_adjustments#012    self.age_group = self.age_group_conf['val']#012  File "/usr/local/uber/plugins/uber/uber/models.py", line 1102, in age_group_conf#012    return c.AGE_GROUP_CONFIGS[self.age_group or c.AGE_UNKNOWN]#012KeyError: '216660930'
```

The KeyError, 216660930, is the integer value of `c.UNDER_21`. In all honesty, this code should never be run - it should be running https://github.com/magfest/ubersystem/blob/fix-age-group-error/uber/models.py#L1099 instead. On my local server, I wasn't able to reproduce this error, but I _did_ find that when you try to save an attendee with a certain birthdate (test birthdate was 09/08/1995), their age group doesn't change. This is the line that started making that work, so I'm hoping it will also fix the server-crashing error.
