### PR TITLE
re-added missing message div for merch

### DIFF
--- a/uber/templates/registration/merch.html
+++ b/uber/templates/registration/merch.html
@@ -146,6 +146,8 @@
     });
 </script>
 
+<div id="message" style="color:red ; margin-bottom:10px">&nbsp;</div>
+
 <div class="center" style="margin-bottom:10px ; font-style:italic">
     Square not working?  In a pinch, you can create arbitrary charges <a href="arbitrary_charge_form">here</a>.
     <br/>See outstanding t-shirt counts <a href="../summary/shirt_counts">here</a>.


### PR DESCRIPTION
Ryan noticed that doing certain things on the merch page would just not show anything.  This was always things where we would have just expected no action to take place, but a message should have still been shown.

There used to be a ``<div id="message></div>`` on every page, and the merch page relied on that.  The bootstrap refactor replaced that with ``toastr``, which meant that a lot of messages on this page just weren't being shown.