### PR TITLE
added shirt sizes to multi-merch pickup

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -306,7 +306,7 @@ class Root:
     def merch(self, message=''):
         return {'message': message}
 
-    def multi_merch_pickup(self, session, message="", csrf_token=None, picker_upper=None, badges=()):
+    def multi_merch_pickup(self, session, message="", csrf_token=None, picker_upper=None, badges=(), **shirt_sizes):
         picked_up = []
         if csrf_token:
             check_csrf(csrf_token)
@@ -326,6 +326,9 @@ class Root:
                                 picked_up.append('{a.full_name} (badge {a.badge_num}) already got their merch'.format(a=attendee))
                             else:
                                 attendee.got_merch = True
+                                shirt_key = 'shirt_{}'.format(attendee.badge_num)
+                                if shirt_key in shirt_sizes:
+                                    attendee.shirt = int(listify(shirt_sizes.get(shirt_key, c.SIZE_UNKNOWN))[0])
                                 picked_up.append('{a.full_name} (badge {a.badge_num}): {a.merch}'.format(a=attendee))
                                 session.add(MerchPickup(picked_up_by=picker_upper, picked_up_for=attendee))
                 session.commit()

--- a/uber/templates/registration/multi_merch_pickup.html
+++ b/uber/templates/registration/multi_merch_pickup.html
@@ -12,11 +12,33 @@
     }
 </style>
 <script>
+    var $shirtOpts = function (badgeNum) {
+        var $opts = $('<select/>').attr('name', 'shirt_' + badgeNum);
+        $.each({{ c.MERCH_SHIRT_OPTS|jsonize }}, function(i, size) {
+            $opts.append(
+                $('<option/>').val(size[0]).text(size[1]));
+        });
+        return $opts;
+    }
+
     var addMoreBadges = function () {
         for (var i = 0; i < 5; i++) {
-            $('#badges')
-                .append('<input type="number" class="number" name="badges" />')
-                .append('<br/>');
+            $('#badges').append(
+                $('<div class="badge-row"></div>')
+                    .append(
+                        $('<input type="number" class="number" name="badges" />')
+                            .on('blur', function (event) {
+                                var badgeNum = $(event.target).val();
+                                $.post('check_merch', {csrf_token: csrf_token, badge_num: badgeNum}, function (resp) {
+                                    var $message = $(event.target).parents('.badge-row').find('.message');
+                                    $message.html(resp.message);
+                                    if (resp.shirt) {
+                                        $message.append($shirtOpts(badgeNum));
+                                        $message.find('select').val(resp.shirt);
+                                    }
+                                }, 'json');
+                            }))
+                    .append('<span class="message" style="color:red"></span>'));
         }
     };
     $(addMoreBadges);
@@ -24,8 +46,10 @@
 
 <form method="post" action="">
 {% csrf_token %}
-This form is for when someone picks up badges for multiple other people.
+This form is for when someone picks up merch for multiple other people.
 Enter the badge numbers of everyone involved (blank fields will be ignored).
+
+<br/> <br/>
 
 <b> Badge Number of whoever is picking up the merch: </b>
 <input type="number" name="picker_upper" class="number" />


### PR DESCRIPTION
We have a page that merch uses when someone collects merch on behalf of one or more individuals.

That page previously didn't allow merch to select the size of tshirt that was given out.  This adds that ability, which is important for current inventory tracking and future inventory.