### PR TITLE
added report on volunteers who are owed refunds

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -91,12 +91,18 @@ untransferable_attrs = string_list(default=list('first_name','last_name','email'
 # a list of department constants you want to be excluded from the shift system.
 shiftless_depts = string_list(default=list())
 
+# Many events refund badges for volunteers who work a certain number of hours.  This
+# setting indicates how many weighted hours are necessary for a refund.  Refunds do
+# NOT happen automatically, but this number will be displayed and used on various
+# informational pages and reports.
+hours_for_refund = integer(default=24)
+
 # There are two separate deadlines for custom badges; the one after which it's
 # too late for attendees to edit their custom badge submissions, and the one
 # where it's too late for an admin to shift badge numbers on the backend.  The
 # former is controlled by the PRINTED_BADGE_DEADLINE field, which is what we
 # advertise in our emails and such.
-
+#
 # Once the shift option is set to False, custom badge numbers are never changed
 # automatically.  This is a bool instead of a date since we don't usually
 # know the cutoff in advance.

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -251,3 +251,16 @@ class Root:
                 ('Teardown', [job for job in session.query(Job).all() if job.is_teardown and job.slots_untaken])
             ]
         }
+
+    def volunteers_owed_refunds(self, session):
+        attendees = session.query(Attendee).filter(Attendee.paid.in_([c.HAS_PAID, c.PAID_BY_GROUP, c.REFUNDED])).all()
+        return {
+            'attendees': [(
+                'Volunteers Owed Refunds',
+                [a for a in attendees if a.worked_hours >= c.HOURS_FOR_REFUND
+                                     and (a.paid == c.HAS_PAID or c.paid == c.PAID_BY_GROUP and a.group.amount_paid)]
+            ), (
+                'Volunteers Already Refunded',
+                [a for a in attendees if a.paid == c.REFUNDED and a.staffing]
+            )]
+        }

--- a/uber/templates/static_views/stafferComps.html
+++ b/uber/templates/static_views/stafferComps.html
@@ -11,7 +11,7 @@ The more hours you work, the more you get (don't forget about <a href="weightDes
     <li> Working at least 6 hours gets you a {{ c.EVENT_NAME }} t-shirt. <br/><br/> </li>
     <li> Working at least 12 hours gets you food in addition to the shirt.  We have professional chefs preparing 3 meals per day throughout the event. <br/><br/> </li>
     <li> Working at least 18 hours gets you a complementary Staff badge for next year's {{ c.EVENT_NAME }}, which will make you eligible for space in one of our staff hotel rooms. <br/><br/> </li>
-    <li> Working at least 24 hours gets you a refund on your badge for this year. <br/><br/> </li>
+    <li> Working at least {{ c.HOURS_FOR_REFUND }} hours gets you a refund on your badge for this year. <br/><br/> </li>
     <li> Working at least 30 hours <b>ONLY IF</b> you're a returning Staffer gets you space in one of our staff hotel rooms. <br/><br/> </li>
 </ul>
 

--- a/uber/templates/summary/volunteers_owed_refunds.html
+++ b/uber/templates/summary/volunteers_owed_refunds.html
@@ -1,0 +1,27 @@
+{% extends "base-admin.html" %}
+{% block title %}Volunteers Owed Refunds{% endblock %}
+{% block content %}
+
+{% for title, matching in attendees %}
+    <h2>{{ title }}</h2>
+    <table style="width:100%">
+    <thead>
+        <tr>
+            <th>Volunteer</th>
+            <th>Departments</th>
+            <th>Hours Worked / Hours Taken</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for attendee in matching %}
+            <tr>
+                <td>{{ attendee|form_link }}</td>
+                <td>{{ attendee.assigned_depts_labels|join:' / ' }}</td>
+                <td>{{ attendee.worked_hours }} / {{ attendee.weighted_hours }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+    </table>
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
In the past we generally waited for someone to come to Stops and ask for a refund.  This used to be sensible since most of the time their hours wouldn't be marked until they brought us their sheet anyway.

Nowadays with people having smartphones and network access being more prevalent, we can refund volunteer registrations as soon as their hours are marked off, so it's nice to have a report so we can start doing that during quiet time on Saturday night.