### PR TITLE
added ratings from the current year to the poor ratings report

### DIFF
--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -87,8 +87,15 @@ class Root:
         }
 
     def ratings(self, session):
-        return {'attendees': [a for a in session.query(Attendee).filter_by(staffing=True).order_by(Attendee.full_name).all()
-                                if 'poorly' in a.past_years]}
+        return {
+            'prev_years': [a for a in session.query(Attendee)
+                                             .filter_by(staffing=True)
+                                             .order_by(Attendee.full_name).all()
+                             if 'poorly' in a.past_years],
+            'current': [a for a in session.query(Attendee)
+                                          .options(joinedload(Attendee.shifts)).all()
+                          if any(shift.rating == c.RATED_BAD for shift in a.shifts)]
+        }
 
     def staffing_overview(self, session):
         jobs, shifts, attendees = session.everything()

--- a/uber/templates/summary/ratings.html
+++ b/uber/templates/summary/ratings.html
@@ -2,8 +2,38 @@
 {% block title %}Negative Ratings{% endblock %}
 {% block content %}
 
-{% for attendee in attendees %}
-    <h2>{{ attendee.full_name }}</h2>
+<h2>Poor Ratings From This Year</h2>
+{% for attendee in current %}
+    <h3>{{ attendee.full_name }}</h3>  
+    <b>{{ attendee.worked_hours }}</b> hours worked ({{ attendee.nonshift_hours }} of them were nonshift hours) <br/>
+    <b>{{ attendee.weighted_hours }}</b> hours signed up for <br/>
+    {% if attendee.admin_notes %}<br/><b>Admin Notes:</b><br/><pre>{{ attendee.admin_notes }}</pre>{% endif %}
+    <table width="95%" align="center">
+    <tr style="font-weight:bold">
+        <td>Job</td>
+        <td>When</td>
+        <td>Weight</td>
+        <td>Status</td>
+        <td>Rating</td>
+    </tr>
+    {% for shift in attendee.shifts %}
+        <tr>
+            <td><nobr>{{ shift.job.name }} ({{ shift.job.location_label }})</nobr></td>
+            <td>{% timespan shift.job %}</td>
+            <td><nobr>x{{ shift.job.weight }} ({{ shift.job.total_hours }} hours total)</nobr></td>
+            <td>{{ shift.worked_label }}</td>
+            <td>
+                {{ shift.rating_label }}
+                {% if shift.comment %}<br/>{{ shift.comment }}{% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </table>
+{% endfor %}
+
+<h2>Poor Ratings From Previous Years</h2>
+{% for attendee in prev_years %}
+    <h3>{{ attendee.full_name }}</h3>
     {% for year in attendee.past_years_json %}
         <h3>{{ year.year }}</h3>
         <b>{{ year.worked_hours }}</b> hours worked ({{ year.nonshift_hours }} of them were nonshift hours) <br/>


### PR DESCRIPTION
Brent and I were looking at the report of poorly-performing staffers and we noticed that it only had ratings from previous years.  Whoops - this made sense the very first time we used this report but obviously it needs to include both past and current ratings.