### PR TITLE
price_notice tag: throw a better error message when takedown is None

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -522,6 +522,10 @@ class PriceNotice(template.Node):
         self.takedown, self.amount_extra, self.discount = Variable(takedown), Variable(amount_extra), Variable(discount)
 
     def _notice(self, label, takedown, amount_extra, discount):
+        if not takedown:
+            raise ValueError('price_notice tag error: Takedown date not valid{}'.format(
+                ' for "' + label + '"' if label else ''))
+
         if c.PAGE_PATH not in ['/preregistration/form', '/preregistration/register_group_member']:
             return ''  # we only display notices for new attendees
         else:


### PR DESCRIPTION
I was diagnosing a config error with CoolCon (generic install with no event-specific config), this validation check helps spot which template items are invalid.

instead of 
```python
TypeError: unorderable types: datetime.datetime() < NoneType()
```

it now says
```python
ValueError: price_notice tag error: Takedown date not valid for "Group registration"
```