### PR TITLE
Let plugins add to enums instead of overriding them

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -86,7 +86,7 @@ class Config(_Overridable):
     check the booleans returned by c.BEFORE_PLACEHOLDER_DEADLINE or c.AFTER_PLACEHOLDER_DEADLINE
     """
 
-    def __init__ (self):
+    def __init__(self):
         self.config_base = parse_config(__file__)
 
     def get_oneday_price(self, dt):

--- a/uber/config.py
+++ b/uber/config.py
@@ -10,12 +10,12 @@ class _Overridable:
                 setattr(cls, attr, getattr(klass, attr))
         return cls
 
-    def include_plugin_config(self, c, plugin_config):
+    def include_plugin_config(self, plugin_config):
         """Plugins call this method to merge their own config into the global c object."""
 
-        c.config_base.merge(plugin_config)
-        c.make_enums(c.config_base['enums'])
-        c.make_dates(c.config_base['dates'])
+        self.config_base.merge(plugin_config)
+        self.make_enums(self.config_base['enums'])
+        self.make_dates(self.config_base['dates'])
 
     def make_dates(self, config_section):
         """

--- a/uber/config.py
+++ b/uber/config.py
@@ -73,9 +73,19 @@ class _Overridable:
                 lookup[val] = desc
 
         enum_name = enum_name.upper()
-        setattr(self, enum_name + '_OPTS', opts)
-        setattr(self, enum_name + '_VARS', varnames)
-        setattr(self, enum_name + ('' if enum_name.endswith('S') else 'S'), lookup)
+        # When loading plugin's configs, we want to make sure we don't override existing enums
+        if hasattr(self, enum_name + '_OPTS'):
+            for opt in opts:
+                getattr(self, enum_name + '_OPTS').append(opt)
+
+            for varname in varnames:
+                getattr(self, enum_name + '_VARS').append(varname)
+
+            getattr(self, enum_name + ('' if enum_name.endswith('S') else 'S')).update(lookup)
+        else:
+            setattr(self, enum_name + '_OPTS', opts)
+            setattr(self, enum_name + '_VARS', varnames)
+            setattr(self, enum_name + ('' if enum_name.endswith('S') else 'S'), lookup)
 
 
 class Config(_Overridable):


### PR DESCRIPTION
The current behavior of make_enum() meant that plugins could never append new options to enums, only override them. Not only is that generally undesirable, but it potentially lets plugins completely break each other, so we now always append options if the enum in question already exists.