### PR TITLE
Added job locations to placeholder emails

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -26,12 +26,10 @@ from xml.dom import minidom
 from random import randrange
 from contextlib import closing
 from time import sleep, mktime
-from urllib.parse import quote
 from io import StringIO, BytesIO
-from urllib.parse import urlparse
-from urllib.parse import parse_qsl
 from itertools import chain, count
 from collections import defaultdict, OrderedDict
+from urllib.parse import quote, urlparse, parse_qsl
 from datetime import date, time, datetime, timedelta
 from threading import Thread, RLock, local, current_thread
 from os.path import abspath, basename, dirname, exists, join

--- a/uber/templates/emails/daily_checks/placeholders.html
+++ b/uber/templates/emails/daily_checks/placeholders.html
@@ -11,6 +11,9 @@
                 {% if attendee.group %}
                     (<a href="{{ c.URL_BASE }}/groups/form?id={{ attendee.group.id }}">{{ attendee.group.name }}</a>)
                 {% endif %}
+                {% if attendee.assigned_depts %}
+                    => {{ attendee.assigned_depts_labels|join:' / ' }}
+                {% endif %}
             </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
Brent said it would be useful to see which departments our placeholder volunteers are assigned to so that we know which department heads to bug.