### PR TITLE
Use listify only on the watch_list relationship

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -907,7 +907,7 @@ class Group(MagModel, TakesPaymentMixin):
 
 
 class Attendee(MagModel, TakesPaymentMixin):
-    watchlist_id = Column(UUID, ForeignKey('watch_list.id', ondelete='set null'), unique=True, nullable=True, default=None)
+    watchlist_id = Column(UUID, ForeignKey('watch_list.id', ondelete='set null'), nullable=True, default=None)
 
     group_id = Column(UUID, ForeignKey('group.id', ondelete='SET NULL'), nullable=True)
     group = relationship(Group, backref='attendees', foreign_keys=group_id, cascade='save-update,merge,refresh-expire,expunge')
@@ -1183,13 +1183,13 @@ class Attendee(MagModel, TakesPaymentMixin):
     def watchlist_guess(self):
         try:
             with Session() as session:
-                return session.guess_attendee_watchentry(self)
+                return [u.__dict__ for u in session.guess_attendee_watchentry(self)]
         except:
             return None
 
     @property
     def banned(self):
-        return listify(self.watch_list) or self.watchlist_guess
+        return listify(self.watch_list) if self.watchlist_id else self.watchlist_guess
 
     @property
     def badge(self):

--- a/uber/models.py
+++ b/uber/models.py
@@ -477,7 +477,7 @@ class Session(SessionManager):
                                                          WatchList.email == attendee.email,
                                                          WatchList.birthdate == attendee.birthdate),
                                                      WatchList.last_name == attendee.last_name,
-                                                     WatchList.active == True)).all()
+                                                     WatchList.active == True))
 
         def get_account_by_email(self, email):
             return self.query(AdminAccount).join(Attendee).filter(func.lower(Attendee.email) == func.lower(email)).one()
@@ -1182,14 +1182,14 @@ class Attendee(MagModel, TakesPaymentMixin):
     @property
     def watchlist_guess(self):
         try:
-            with sa.Session() as session:
+            with Session() as session:
                 return session.guess_attendee_watchentry(self)
         except:
             return None
 
     @property
     def banned(self):
-        return self.watch_list or self.watchlist_guess
+        return listify(self.watch_list) or self.watchlist_guess
 
     @property
     def badge(self):

--- a/uber/models.py
+++ b/uber/models.py
@@ -477,7 +477,7 @@ class Session(SessionManager):
                                                          WatchList.email == attendee.email,
                                                          WatchList.birthdate == attendee.birthdate),
                                                      WatchList.last_name == attendee.last_name,
-                                                     WatchList.active == True))
+                                                     WatchList.active == True)).all()
 
         def get_account_by_email(self, email):
             return self.query(AdminAccount).join(Attendee).filter(func.lower(Attendee.email) == func.lower(email)).one()
@@ -1183,13 +1183,13 @@ class Attendee(MagModel, TakesPaymentMixin):
     def watchlist_guess(self):
         try:
             with Session() as session:
-                return [u.__dict__ for u in session.guess_attendee_watchentry(self)]
+                return [w.to_dict() for w in session.guess_attendee_watchentry(self)]
         except:
             return None
 
     @property
     def banned(self):
-        return listify(self.watch_list) if self.watchlist_id else self.watchlist_guess
+        return listify(self.watch_list or self.watchlist_guess)
 
     @property
     def badge(self):

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -167,7 +167,7 @@ class Root:
             message = 'Watchlist entry updated'
         return {
             'attendee': attendee,
-            'watchlist_entries': listify(attendee.banned),
+            'watchlist_entries': attendee.banned,
             'message': message
         }
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -167,7 +167,6 @@ class Root:
             message = 'Watchlist entry updated'
         return {
             'attendee': attendee,
-            'watchlist_entries': attendee.banned,
             'message': message
         }
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -151,7 +151,7 @@ class Root:
         }
 
     def watchlist(self, session, attendee_id, watchlist_id=None, message='', **params):
-        attendee = session.attendee(attendee_id)
+        attendee = session.attendee(attendee_id, allow_invalid=True)
         if watchlist_id:
             watchlist_entry = session.watch_list(watchlist_id)
 

--- a/uber/templates/registration/watchlist.html
+++ b/uber/templates/registration/watchlist.html
@@ -38,10 +38,10 @@
     <form class="form-inline" role="form" method="post" action="watchlist">
         {% csrf_token %}
         <input type="hidden" name="attendee_id" value="{{ attendee.id }}" />
-        <input type="hidden" name="watchlist_id" value="{{ attendee.banned.id }}" />
+        <input type="hidden" name="watchlist_id" value="{{ entry.id }}" />
         <div class="form-group">
             <label class="btn btn-success">
-                <input type="checkbox" name="active" value="{{ attendee.banned.active }}" />
+                <input type="checkbox" name="active" value="{{ entry.active }}" />
                 {% if attendee.banned.active %} Deactivate Watchlist Entry {% else %} Activate Watchlist Entry {% endif %}
             </label>
         </div>

--- a/uber/templates/registration/watchlist.html
+++ b/uber/templates/registration/watchlist.html
@@ -7,7 +7,7 @@
 <h2>{% if not attendee.watchlist_id %}Possible {% endif %}Watchlist Entry for {{ attendee.full_name }} {% if c.AT_THE_CON %}({{ attendee.badge }}){% endif %}</h2>
 
 <div class="panel col-md-4">
-    {% for entry in watchlist_entries %}
+    {% for entry in attendee.banned %}
     {% if not attendee.watchlist_id %}
     <div class="row">
         <label class="col-sm-2 control-label">Watchlist First Names</label>


### PR DESCRIPTION
Using listify on the session object returned by guess_attendee_watchentry was causing a session-related exception, so we use it only on watch_list where it is needed. Also fixes a bug that prevented admins from properly confirming watchlist entries.