### PR TITLE
Add new donation_tier column to track donation levels separate from amount_extra

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -543,6 +543,7 @@ teardown = string(default="Teardown")
 [[__many__]]
 __many__ = string
 
+[donation_tiers]
 
 [dept_checklist]
 [[__many__]]

--- a/uber/models.py
+++ b/uber/models.py
@@ -1242,7 +1242,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         return self.badge_type in c.PREASSIGNED_BADGE_TYPES
 
     @property
-    def donation_swag(self): #TODO: Convert this
+    def donation_swag(self):  # TODO: Convert this
         extra = self.amount_extra
         return [desc for amount, desc in sorted(c.DONATION_TIERS.items()) if amount and extra >= amount]
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -11,7 +11,7 @@ def to_sessionized(attendee, group):
 def check_prereg_reqs(attendee):
     if attendee.badge_type == c.PSEUDO_DEALER_BADGE and not attendee.cellphone:
         return 'Your phone number is required'
-    elif attendee.amount_extra >= c.SHIRT_LEVEL and attendee.shirt == c.NO_SHIRT:
+    elif attendee.donation_tier in c.SHIRT_TIERS and attendee.shirt == c.NO_SHIRT:
         return 'Your shirt size is required'
 
 
@@ -238,7 +238,7 @@ class Root:
             attendee.amount_paid = attendee.total_cost
             session.add(attendee)
 
-        for group in charge.groups:
+        for group in charge.groups:  # TODO: Look at this
             group.amount_paid = group.default_cost - group.amount_extra
             for attendee in group.attendees:
                 if attendee.amount_extra:
@@ -542,3 +542,7 @@ class Root:
             'message': message,
             'attendee': attendee
         }
+
+    @ajax
+    def get_donation_price(self, val, dt):
+        return c.get_donation_tier_price(c.DONATION_TIER_CONFIGS[int(val)], dt)

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -49,7 +49,7 @@ class Root:
             'counts': sorted(counts.items(), key=lambda tup: -tup[-1].total),
             'registrations': session.query(Attendee).filter_by(paid=c.NEED_NOT_PAY).count(),
             'quantities': [(desc, session.query(Attendee).filter(Attendee.amount_extra >= amount).count())
-                           for amount, desc in sorted(c.DONATION_TIERS.items()) if amount] # TODO: Look at this
+                           for amount, desc in sorted(c.DONATION_TIERS.items()) if amount]  # TODO: Look at this
         }
 
     def departments(self, session):

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -13,7 +13,7 @@ class Root:
             'shirt_sizes':   [(desc, count(shirt=shirt)) for shirt, desc in c.SHIRT_OPTS],
             'paid_counts':   [(desc, count(paid=status)) for status, desc in c.PAYMENT_OPTS],
             'badge_counts':  [(desc, count(badge_type=bt), count(paid=c.NOT_PAID, badge_type=bt), count(paid=c.HAS_PAID, badge_type=bt)) for bt, desc in c.BADGE_OPTS],
-            'aff_counts':    [(aff['text'], len([a for a in attendees if a.amount_extra >= c.SUPPORTER_LEVEL and a.affiliate == aff['text']])) for aff in session.affiliates()],
+            'aff_counts':    [(aff['text'], len([a for a in attendees if a.donation_tier in c.SUPPORTER_TIERS and a.affiliate == aff['text']])) for aff in session.affiliates()],
             'checkin_count': count(lambda a: a.checked_in),
             'paid_noshows':  count(paid=c.HAS_PAID, checked_in=None) + len([a for a in attendees if a.paid == c.PAID_BY_GROUP and a.group and a.group.amount_paid and not a.checked_in]),
             'free_noshows':  count(paid=c.NEED_NOT_PAY, checked_in=None),
@@ -49,7 +49,7 @@ class Root:
             'counts': sorted(counts.items(), key=lambda tup: -tup[-1].total),
             'registrations': session.query(Attendee).filter_by(paid=c.NEED_NOT_PAY).count(),
             'quantities': [(desc, session.query(Attendee).filter(Attendee.amount_extra >= amount).count())
-                           for amount, desc in sorted(c.DONATION_TIERS.items()) if amount]
+                           for amount, desc in sorted(c.DONATION_TIERS.items()) if amount] # TODO: Look at this
         }
 
     def departments(self, session):
@@ -135,7 +135,7 @@ class Root:
     def printed_badges_supporters(self, out, session):
         uber.reports.personalized_badge_report_type(include_badge_nums=False)\
             .run(out, session,
-                 sa.Attendee.amount_extra >= c.SUPPORTER_LEVEL,
+                 sa.Attendee.donation_tier in c.SUPPORTER_TIERS,
                  order_by=sa.Attendee.full_name,
                  badge_type_override='supporter')
 

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -52,15 +52,15 @@
 
     {% if not attendee.is_new %}
         // This removes any badge levels lower than the attendee has purchased already
-        while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].extra < {{ attendee.amount_extra }}) {
+        while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].extra < {{ attendee.donation_tier }}) {
             BADGE_TYPES.options.splice(0, 1);
         }
 
         // This is the same idea, except it disables the kick-in buttons and then hides them
         $(function () {
-            if($('input:radio[name=amount_extra]').size()) {
-                $('input:radio[name=amount_extra]').each( function() {
-                    if (!isNaN($(this).val()) && Number($(this).val()) < {{ attendee.amount_extra }}) {
+            if($('input:radio[name=donation_tier]').size()) {
+                $('input:radio[name=donation_tier]').each( function() {
+                    if (!isNaN($(this).val()) && Number($(this).val()) < {{ attendee.donation_tier }}) {
                         $(this).prop('disabled', true);
                         $(this).parent().hide();
                     }
@@ -114,41 +114,47 @@
     </div>
 {% endif %}
 
-{% if c.DONATIONS_ENABLED and c.PREREG_DONATION_OPTS and c.PAGE_PATH != '/registration/form' %}
+{% if c.DONATIONS_ENABLED and c.PAGE_PATH != '/registration/form' %}
     <script type="text/javascript">
         var donationChanged = function () {
-            setVisible('.affiliate-row', $.val('amount_extra') > 0);
+            updateAmountExtra();
+            setVisible('.affiliate-row', $.val('donation_tier') != {{ c.NO_DONATION }});
             {% if attendee.gets_shirt %}
                 setVisible('.shirt-row', true);
             {% else %}
-                setVisible('.shirt-row', $.val('amount_extra') >= {{ c.SHIRT_LEVEL }});
+                setVisible('.shirt-row', $.inArray($.val('donation_tier'), {{ c.SHIRT_TIERS }}) != -1);
             {% endif %}
             {% if attendee.badge_type in c.PREASSIGNED_BADGE_TYPES %}
                 setVisible('.badge-row', true);
             {% else %}
-                setVisible('.badge-row', $.val('amount_extra') >= {{ c.SUPPORTER_LEVEL }});
+                setVisible('.badge-row', $.inArray($.val('donation_tier'), {{ c.SUPPORTER_TIERS }}) != -1);
             {% endif %}
-            $.each($("input:radio[name='amount_extra']"), function() {
-                $(this).parents('.btn').removeClass('active btn-primary');
-                $(this).parents('.btn').addClass('btn-default');
-                if ($(this).val() <= $.val('amount_extra')) {
-                    $(this).parents('.btn').removeClass('btn-default');
-                    $(this).parents('.btn').addClass('active btn-primary');
-                }
-            });
+            $('input[name=donation_tier]:checked').parents('.btn').removeClass('btn-default');
+            $('input[name=donation_tier]:checked').parents('.btn').addClass('active btn-primary');
+            $('input[name=donation_tier]:checked').parents('.btn').prevAll().removeClass('btn-default').addClass('active btn-primary');
+            $('input[name=donation_tier]:checked').parents('.btn').nextAll().addClass('btn-default').removeClass('active btn-primary');
             };
+        function updateAmountExtra() {
+            $.post("get_donation_price", {
+                        val:  $.val('donation_tier'),
+                        dt: $.now(),
+                        csrf_token: csrf_token
+                    }, function(json) {
+                        $.field("amount_extra").val(json);
+                    }, "json");
+        }
         $(function(){
-            if ($.field('amount_extra')) {
+            if ($.field('donation_tier')) {
                 donationChanged();
                 {% if c.PAGE_PATH != '/registration/form' %}
-                    if ($.field('amount_extra').is('select')) {
-                        $.field('amount_extra').select2({
+                    if ($.field('donation_tier').is('select')) {
+                        $.field('donation_tier').select2({
                             formatResult: function (opt) { return opt.text; },
                             formatSelection: function (opt) { return opt.text; },
                             minimumResultsForSearch: 99,
                             escapeMarkup: function (m) { return m; },
                             width: '100%',
-                        }).select2('val', {{ attendee.amount_extra }});
+                        }).select2('val', {{ attendee.donation_tier }});
                     }
                 {% endif %}
                 if ($.field('affiliate')) {
@@ -168,14 +174,15 @@
     </script>
 
     <div class="extra-row form-group">
-        <label for="amount_extra" class="col-sm-2 control-label">Want to kick in extra?</label>
+        <label for="donation_tier" class="col-sm-2 control-label">Want to kick in extra?</label>
         <div class="col-sm-6">
-            {% if c.AFTER_PRINTED_BADGE_DEADLINE and attendee.amount_extra >= c.SUPPORTER_LEVEL %}
-                {{ attendee.amount_extra_label }}
-                <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" />
+            <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" />
+            {% if c.AFTER_PRINTED_BADGE_DEADLINE and attendee.donation_tier in c.SUPPORTER_TIERS %}
+                {{ attendee.donation_tier_label }}
+                <input type="hidden" name="donation_tier" value="{{ attendee.donation_tier }}" />
             {% else %}
                 <div class="btn-group btn-group-vertical" data-toggle="buttons">
-                    {% radiogroup c.PREREG_DONATION_OPTS attendee.amount_extra %}
+                    {% radiogroup c.PREREG_DONATION_OPTS attendee.donation_tier %}
                 </div>
             {% endif %}
         </div>

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -279,8 +279,8 @@
         {% endif %}
         <nobr>
             Kicked In Extra:
-            <select name="amount_extra">
-                {% options c.DONATION_TIER_OPTS attendee.amount_extra %}
+            <select name="donation_tier">
+                {% options c.DONATION_TIER_OPTS attendee.donation_tier %}
             </select>
         </nobr>
     </div>


### PR DESCRIPTION
In some cases, we want an attendee to have a donation level without having to pay extra for it. This extends donation tiers to be tracked in their own column separate from amount_extra so we can do so.

Left to do:
- Right now, attendee's amount_extra is always set to their donation tier - we need to let admins override this.
- There's a few places in the code that refer to amount_extra when they possibly shouldn't. I've marked a few of them out, and there's a bunch in templates.
- I need to add a pre-reg only check to make sure that attendees don't try to edit their hidden amount_extra field to be cheaper than their donation level.
