### PR TITLE
Add ability to convert dealer badges to regular badges when declined

### DIFF
--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -66,7 +66,7 @@ class Root:
         }
 
     @ajax
-    def unapprove(self, session, id, action, email):
+    def unapprove(self, session, id, action, email, convert=None):
         assert action in ['waitlisted', 'declined']
         group = session.group(id)
         subject = 'Your {EVENT_NAME} Dealer registration has been ' + action
@@ -75,11 +75,26 @@ class Root:
         if action == 'waitlisted':
             group.status = c.WAITLISTED
         else:
+            message = 'Group declined'
             for attendee in group.attendees:
-                session.delete(attendee)
+                if attendee.is_unassigned or not convert:
+                    session.delete(attendee)
+                else:
+                    message = 'Group declined and emails sent to attendees'
+                    attendee.paid = c.NOT_PAID
+                    attendee.badge_status = c.NEW_STATUS
+                    attendee.ribbon = c.NO_RIBBON
+                    send_email(c.REGDESK_EMAIL, attendee.email, 'Do you still want to come to {EVENT_NAME}?',
+                               render('emails/dealers/badge_converted.html', {
+                                   'attendee': attendee,
+                                   'group': group
+                               }), model=attendee)
+                    group.attendees.remove(attendee)
+                    group.leader = None
             session.delete(group)
         session.commit()
-        return {'success': True}
+        return {'success': True,
+                'message': message}
 
     @csrf_protected
     def delete(self, session, id, confirmed=None):

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -84,11 +84,14 @@ class Root:
                     attendee.paid = c.NOT_PAID
                     attendee.badge_status = c.NEW_STATUS
                     attendee.ribbon = c.NO_RIBBON
-                    send_email(c.REGDESK_EMAIL, attendee.email, 'Do you still want to come to {EVENT_NAME}?',
-                               render('emails/dealers/badge_converted.html', {
-                                   'attendee': attendee,
-                                   'group': group
-                               }), model=attendee)
+                    try:
+                        send_email(c.REGDESK_EMAIL, attendee.email, 'Do you still want to come to {EVENT_NAME}?',
+                                   render('emails/dealers/badge_converted.html', {
+                                       'attendee': attendee,
+                                       'group': group
+                                   }), model=attendee)
+                    except:
+                        message = 'Group declined (but the emails could not be sent)'
                     group.attendees.remove(attendee)
                     group.leader = None
             session.delete(group)

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -443,14 +443,19 @@ class Root:
             'message':  message
         }
 
-    def invalid_badge(self, session, id):
-        return {'attendee': session.attendee(id, allow_invalid=True)}
+    def invalid_badge(self, session, id, message=''):
+        return {'attendee': session.attendee(id, allow_invalid=True), 'message': message}
+
+    def invalidate(self, session, id):
+        attendee = session.attendee(id)
+        attendee.badge_status = c.INVALID_STATUS
+        raise HTTPRedirect('invalid_badge?id={}&message={}', attendee.id, 'Sorry you can\'t make it! We hope to see you next year!')
 
     def confirm(self, session, message='', return_to='confirm', undoing_extra='', **params):
         attendee = session.attendee(params, restricted=True)
 
         placeholder = attendee.placeholder
-        if 'email' in params:
+        if 'email' in params and not message:
             attendee.placeholder = False
             message = check(attendee) or check_prereg_reqs(attendee)
             if not message:

--- a/uber/templates/emails/dealers/badge_converted.html
+++ b/uber/templates/emails/dealers/badge_converted.html
@@ -1,0 +1,15 @@
+<html>
+<head></head>
+<body>
+
+{{ attendee.first_name }},
+
+<br/><br/>Although your group ({{ group.name}}) has been declined, we think you may still want to come and enjoy all that {{ c.EVENT_NAME }} has to offer!
+Therefore, we have reserved a badge for you{% if c.PRICE_BUMPS and attendee.badge_cost < c.BADGE_PRICE %} at the price of registration when you first applied{% endif %}.
+
+<br/><br/>Please go ahead and confirm or decline <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">your registration</a>. We hope to see you this year!
+
+{% include "emails/reg_workflow/reg_notes.html" %}
+
+</body>
+</html>

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <script type="text/javascript">
-    var unapprove = function(action) {
+    var unapprove = function(action, convert) {
         if (!$.val("email")) {
             $("#setstatus").prepend('<div style="color:red">You must enter an email message.</div>');
         } else {
@@ -11,11 +11,12 @@
             $.post("unapprove", {
                 id: "{{ group.id }}",
                 action: action,
+                convert: convert,
                 csrf_token: csrf_token,
                 email: $.val("email")
-            }, function() {
-                if (action == "declined") {
-                    window.location = "index?message=Group+declined";
+            }, function(json) {
+                if (json.message) {
+                    window.location = "index?message="+ json.message;
                 } else {
                     $("#status").text("Waitlisted");
                 }
@@ -163,6 +164,8 @@
                         <textarea name="email", rows="5" cols="50"></textarea> <br/>
                         <button onClick="unapprove('waitlisted'); return false;">Waitlist</button>
                         <button onClick="unapprove('declined'); return false;">Reject</button>
+                        <br/><button onClick="unapprove('declined', true); return false;">Reject and Convert Badges</button>
+                        <p class="help-block">(Allows rejected dealers to register at the price they would have paid when they applied.)</p>
                     </div>
                 {% endif %}
             {% endif %}

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -20,6 +20,10 @@
             }, 1);
         {% endif %}
     });
+
+    $(function confirmInvalidate() {
+
+    })
 </script>
 
 <div class="panel panel-default">
@@ -33,8 +37,8 @@
     <br/>
     <div class="form-group">
         <div class="col-sm-6 col-sm-offset-2 warning">
-            You currently have an outstanding balance of ${{ attendee.amount_unpaid }} due to having requested
-            registration add-ons and then not completing the payment form.  Please either 
+            You currently have an outstanding balance of ${{ attendee.amount_unpaid }}{% if attendee.amount_extra %} due to having requested
+            registration add-ons and then not completing the payment form{% endif %}.  Please either
             <a href="attendee_donation_form?id={{ attendee.id }}">click here</a> to pay, or alter your registration below to
             eliminate whichever addons you've decided not to select.
         </div>
@@ -55,10 +59,19 @@
         {% if attendee.is_transferable %}
             <button type="button" class="btn btn-primary" onClick='location.href="transfer_badge?id={{ attendee.id }}"'>Transfer my Badge</button>
         {% endif %}
+        {% if not attendee.amount_paid or not attendee.paid == c.NEED_NOT_PAY %}
+            <button type="submit" form="invalidate" class="btn btn-danger" onClick="return confirm('Are you sure you want to delete your badge? This can\'t be undone!');">I'm not coming</button>
+        {% endif %}
     </div>
 </div>
 
 </form>
+
+    {% if not attendee.amount_paid or not attendee.paid == c.NEED_NOT_PAY %}
+    <form method="post" action="invalidate" id="invalidate">
+        <input type="hidden" name="id" value="{{ attendee.id }}"/>
+    </form>
+    {% endif %}
 </div>
 
 {% endblock %}

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -20,10 +20,6 @@
             }, 1);
         {% endif %}
     });
-
-    $(function confirmInvalidate() {
-
-    })
 </script>
 
 <div class="panel panel-default">


### PR DESCRIPTION
Adds a "Reject and Convert" button to allow admins to save assigned badges when declining dealers. The system will automatically email each badge holder offering them a chance to finish their registration.