### PR TITLE
Fix multi-line text in CSV exporting and importing

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -861,6 +861,10 @@ class Root:
                         val = datetime.strptime(val, date_format).date()
                     elif isinstance(col.type, Integer):
                         val = int(val)
+                    elif isinstance(col.type, UnicodeText):
+                        # Replace "\n" with newlines
+                        val = val.split(r"\n")
+                        val = '\n'.join(val)
 
                     # now that we've converted val to whatever it actually needs to be, we
                     # can just set it on the attendee

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -186,6 +186,10 @@ class Root:
                     # Also you should fill in whatever actual format you want.
                     val = getattr(attendee, col.name)
                     row.append(val.strftime('%Y-%m-%d %H:%M:%S') if val else '')
+                elif isinstance(col.type, UnicodeText):
+                    # Remove newlines and replace them with \r\n to prevent issues with multiline fields
+                    val = getattr(attendee, col.name).splitlines()
+                    row.append(r"\n".join(val))
                 else:
                     # For everything else we'll just dump the value, although we might
                     # consider adding more special cases for things like foreign keys.


### PR DESCRIPTION
CSV files generally can't handle newlines, so we convert back and forth to/from \n
