### PR TITLE
Attendees trusted per-department

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1348,9 +1348,6 @@ class Attendee(MagModel, TakesPaymentMixin):
     def trusted_in(self, department):
         return int(department or 0) in self.trusted_depts_ints
 
-    def assigned_and_trusted_in(self, department):
-        return self.assigned_to(department) and self.trusted_in(department)
-
     @property
     def trusted_in_any_depts(self):
         return len(self.trusted_depts_ints) > 0

--- a/uber/models.py
+++ b/uber/models.py
@@ -1092,7 +1092,7 @@ class Attendee(MagModel, TakesPaymentMixin):
             self.staffing = True
 
         # remove trusted status from any dept we are not assigned to
-        self.trusted_depts = ','.join([str(td) for td in self.trusted_depts_ints if td in self.assigned_depts_ints])
+        self.trusted_depts = ','.join(str(td) for td in self.trusted_depts_ints if td in self.assigned_depts_ints)
 
     def unset_volunteering(self):
         self.staffing = False

--- a/uber/models.py
+++ b/uber/models.py
@@ -630,7 +630,6 @@ class Session(SessionManager):
                                         .order_by(Attendee.full_name).all()
                          if c.AT_THE_CON or not location or int(location) in a.assigned_depts_ints]
             for job in jobs:
-                # TODO: update
                 job._available_staffers = [a for a in attendees if not job.restricted or a.trusted_in(job.location)]
             return jobs, shifts, attendees
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -1050,9 +1050,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     def _staffing_adjustments(self):
         if self.ribbon == c.DEPT_HEAD_RIBBON:
             self.staffing = True
-            # question: do we have info about what this person is a dept head of? or is that not something
-            # we know explicitly?  if so, we can either make them trusted in every dept, or trusted in no departments.
-            # self.trusted_depts = self.assigned_depts # this might be a reasonable thing to do. or not.
+            self.trusted_depts = self.assigned_depts
             self.badge_type = c.STAFF_BADGE
             if self.paid == c.NOT_PAID:
                 self.paid = c.NEED_NOT_PAY
@@ -1343,13 +1341,14 @@ class Attendee(MagModel, TakesPaymentMixin):
         return int(department or 0) in self.assigned_depts_ints
 
     def trusted_in(self, department):
-        return int(department or 0) in self.trusted_in_ints
+        return int(department or 0) in self.trusted_depts_ints
 
     def assigned_and_trusted_in(self, department):
         return self.assigned_to(department) and self.trusted_in(department)
 
+    @property
     def trusted_in_any_depts(self):
-        return len(self.trusted_depts) > 0
+        return len(self.trusted_depts_ints) > 0
 
     def has_shifts_in(self, department):
         return any(shift.job.location == department for shift in self.shifts)

--- a/uber/models.py
+++ b/uber/models.py
@@ -1217,7 +1217,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def is_transferable(self):
-        return not self.is_new and not self.trusted_in_any_depts and not self.checked_in \
+        return not self.is_new and not self.trusted_somewhere and not self.checked_in \
            and self.paid in [c.HAS_PAID, c.PAID_BY_GROUP] \
            and self.badge_type in c.TRANSFERABLE_BADGE_TYPES
 
@@ -1352,7 +1352,10 @@ class Attendee(MagModel, TakesPaymentMixin):
         return int(department or 0) in self.trusted_depts_ints
 
     @property
-    def trusted_in_any_depts(self):
+    def trusted_somewhere(self):
+        """
+        :return: True if this Attendee is trusted in at least 1 department
+        """
         return len(self.trusted_depts_ints) > 0
 
     def has_shifts_in(self, department):

--- a/uber/models.py
+++ b/uber/models.py
@@ -689,6 +689,12 @@ class Session(SessionManager):
                         self.delete_from_group(attendee, group)
 
         def assign(self, attendee_id, job_id):
+            '''
+            assign an Attendee to a Job by creating a Shift
+
+            :return: 'None' on success, error message on failure
+            '''
+
             job = self.job(job_id)
             attendee = self.attendee(attendee_id)
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -1078,6 +1078,9 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.badge_type == c.STAFF_BADGE:
             self.staffing = True
 
+        # remove trusted status from any dept we are not assigned to
+        self.trusted_depts = ','.join([str(td) for td in self.trusted_depts_ints if td in self.assigned_depts_ints])
+
     def unset_volunteering(self):
         self.staffing = False
         self.trusted_depts = self.requested_depts = self.assigned_depts = ''

--- a/uber/models.py
+++ b/uber/models.py
@@ -629,6 +629,7 @@ class Session(SessionManager):
                                         .options(joinedload(Attendee.shifts), joinedload(Attendee.group))
                                         .order_by(Attendee.full_name).all()
                          if c.AT_THE_CON or not location or int(location) in a.assigned_depts_ints]
+            # this ._available_staffers doesn't appear to be used anywhere anymore, and should probably be removed
             for job in jobs:
                 job._available_staffers = [a for a in attendees if not job.restricted or a.trusted_in(job.location)]
             return jobs, shifts, attendees

--- a/uber/models.py
+++ b/uber/models.py
@@ -640,13 +640,10 @@ class Session(SessionManager):
             return [(a.id, a.full_name) for a in self.staffers_by_job(job)]
 
         def staffers_by_job(self, job):
-            q = self.query(Attendee)
-
-            if job.restricted:
-                q = q.filter(Attendee.trusted_depts.contains(str(job.location)))
-
-            return q.filter_by(staffing=True)\
+            return self.query(Attendee)\
+                .filter_by(staffing=True)\
                 .filter(Attendee.assigned_depts.contains(str(job.location)))\
+                .filter(*(Attendee.trusted_depts.contains(str(job.location)),) if job.restricted else ())\
                 .order_by(Attendee.full_name).all()
 
         def search(self, text, *filters):

--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -171,7 +171,7 @@ class Root:
         return {
             'job':       job,
             'message':   message,
-            'attendees': job.capable_staff_opts
+            'attendees': job.capable_volunteers_opts
         }
 
     @csrf_protected

--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -171,7 +171,7 @@ class Root:
         return {
             'job':       job,
             'message':   message,
-            'attendees': session.staffers_by_job_options(job)
+            'attendees': job.capable_staff_opts
         }
 
     @csrf_protected

--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -127,7 +127,7 @@ class Root:
             hours_here[shift.attendee] += shift.job.weighted_hours
         for attendee in attendees:
             attendee.hours_here = hours_here[attendee]
-            attendee.trusted_here = attendee.trusted_in(location) if location else attendee.trusted_in_any_depts
+            attendee.trusted_here = attendee.trusted_in(location) if location else attendee.trusted_somewhere
         return {
             'location':           location,
             'attendees':          attendees,

--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -170,10 +170,7 @@ class Root:
         return {
             'job':       job,
             'message':   message,
-            'attendees': session.query(Attendee.id, Attendee.full_name)  # TODO
-                                .filter_by(staffing=True, **({'trusted': True} if job.restricted else {}))
-                                .filter(Attendee.assigned_depts.contains(str(job.location)))
-                                .order_by(Attendee.full_name).all()
+            'attendees': session.staffers_by_job_options(job)
         }
 
     @csrf_protected

--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -127,6 +127,7 @@ class Root:
             hours_here[shift.attendee] += shift.job.weighted_hours
         for attendee in attendees:
             attendee.hours_here = hours_here[attendee]
+            attendee.trusted_here = attendee.trusted_in(location) if location else attendee.trusted_in_any_depts
         return {
             'location':           location,
             'attendees':          attendees,

--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -170,7 +170,7 @@ class Root:
         return {
             'job':       job,
             'message':   message,
-            'attendees': session.query(Attendee.id, Attendee.full_name)
+            'attendees': session.query(Attendee.id, Attendee.full_name)  # TODO
                                 .filter_by(staffing=True, **({'trusted': True} if job.restricted else {}))
                                 .filter(Attendee.assigned_depts.contains(str(job.location)))
                                 .order_by(Attendee.full_name).all()

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -715,13 +715,13 @@ class Root:
             'shifts':   Shift.dump(attendee.shifts),
             'jobs':     [(job.id, '({}) [{}] {}'.format(custom_tags.timespan.pretty(job), job.location_label, job.name))
                          for job in session.query(Job)
-                                           .outerjoin(Job.shifts)
-                                           .filter(Job.start_time > localized_now() - timedelta(hours=2),
-                                                   Job.location.in_(attendee.assigned_depts_ints),
-                                                   *([] if Job.location.in_(attendee.trusted_depts) else [Job.restricted == False]))
-                                           .group_by(Job.id)
-                                           .having(func.count(Shift.id) < Job.slots)
-                                           .order_by(Job.start_time, Job.location).all()]
+                           .outerjoin(Job.shifts)
+                           .filter(Job.start_time > localized_now() - timedelta(hours=2),
+                                   Job.location.in_(attendee.assigned_depts_ints))
+                           .filter(or_(Job.restricted == False, Job.location.in_(attendee.trusted_depts_ints)))
+                           .group_by(Job.id)
+                           .having(func.count(Shift.id) < Job.slots)
+                           .order_by(Job.start_time, Job.location).all()]
         }
 
     @csrf_protected

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -719,7 +719,7 @@ class Root:
                                            .outerjoin(Job.shifts)
                                            .filter(Job.start_time > localized_now() - timedelta(hours=2),
                                                    Job.location.in_(attendee.assigned_depts_ints),
-                                                   *([] if attendee.trusted else [Job.restricted == False]))
+                                                   *([] if Job.location.in_(attendee.trusted_depts) else [Job.restricted == False]))
                                            .group_by(Job.id)
                                            .having(func.count(Shift.id) < Job.slots)
                                            .order_by(Job.start_time, Job.location).all()]

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -225,13 +225,13 @@ class Root:
                     untaken[job.location][hour].append(job)
         flagged = []
         for attendee in attendees:
-            if attendee.trusted and not attendee.is_dept_head:
+            if not attendee.is_dept_head:
                 overlapping = defaultdict(set)
                 for shift in attendee.shifts:
                     if not shift.job.restricted:
                         for dept in attendee.assigned_depts_ints:
                             for hour in shift.job.hours:
-                                if hour in untaken[dept]:
+                                if attendee.trusted_in(dept) and hour in untaken[dept]:
                                     overlapping[shift.job].update(untaken[dept][hour])
                 if overlapping:
                     flagged.append([attendee, sorted(overlapping.items(), key=lambda tup: tup[0].start_time)])

--- a/uber/templates/jobs/signups.html
+++ b/uber/templates/jobs/signups.html
@@ -31,13 +31,13 @@
         <td> <a href="form?id={{ job.id }}"><b>{{ job.name }}{% if job.restricted %}*{% endif %}</b></a> </td>
         <td> <nobr>({{ job.shifts|length }}/{{ job.slots }} slots filled)</nobr> </td>
         {% if job.shifts|length < job.slots %}
-            {% if job.available_staffers %}
+            {% if job.available_staff %}
                 <form method="post" action="assign_from_list">
                 {% csrf_token %}
                 <td>
                     <input type="hidden" name="job_id" value="{{ job.id }}" />
                     <select name="staffer_id">
-                        {% for attendee in job.available_staffers %}
+                        {% for attendee in job.available_staff %}
                             <option value="{{ attendee.id }}">{{ attendee.full_name }}</option>
                         {% endfor %}
                     </select>

--- a/uber/templates/jobs/signups.html
+++ b/uber/templates/jobs/signups.html
@@ -31,13 +31,13 @@
         <td> <a href="form?id={{ job.id }}"><b>{{ job.name }}{% if job.restricted %}*{% endif %}</b></a> </td>
         <td> <nobr>({{ job.shifts|length }}/{{ job.slots }} slots filled)</nobr> </td>
         {% if job.shifts|length < job.slots %}
-            {% if job.available_staff %}
+            {% if job.available_volunteers %}
                 <form method="post" action="assign_from_list">
                 {% csrf_token %}
                 <td>
                     <input type="hidden" name="job_id" value="{{ job.id }}" />
                     <select name="staffer_id">
-                        {% for attendee in job.available_staff %}
+                        {% for attendee in job.available_volunteers %}
                             <option value="{{ attendee.id }}">{{ attendee.full_name }}</option>
                         {% endfor %}
                     </select>

--- a/uber/templates/jobs/staffers.html
+++ b/uber/templates/jobs/staffers.html
@@ -55,7 +55,7 @@
         <td width="20%" data-order="{{ attendee.full_name }}" data-search="{{ attendee.full_name }}"> <a href="../registration/shifts?id={{ attendee.id }}">{{ attendee.full_name }}</a>        </td>
         <td width="10">{{ attendee.badge_num }}</a></td>
         <td width="10">{% if attendee.is_dept_head %}<font size="-1">[D]</font>{% endif %}</td>
-        <td width="10">{% if attendee.trusted %}<font size="-1">[T]</font>{% endif %}</td>
+        <td width="10">{% if attendee.trusted_in_any_depts %}<font size="-1">[T]</font>{% endif %}</td>
         <td width="10">{% if attendee.multiply_assigned %}<font size="-1">[M]</font>{% endif %}</td>
         <td width="10">{% if attendee.can_work_setup or attendee.can_work_teardown %}<font size="-1">[L]</font>{% endif %}</td>
         <td width="10">{{ attendee.placeholder }}</td>
@@ -70,7 +70,7 @@
 <div style="margin-left:10px">
     [D]: <i>Staffers marked with a "D" are department heads.</i> <br/>
     [M]: <i>Staffers marked with a "M" are assigned to multiple locations</i> <br/>
-    [T]: <i>Staffers marked with a "T" are trusted</i> <br/>
+    [T]: <i>Staffers marked with a "T" are trusted in at least one department</i> <br/>
     [L]: <i>Staffers marked with a "L" are working load-in and/or load-out</i>
 </div>
 

--- a/uber/templates/jobs/staffers.html
+++ b/uber/templates/jobs/staffers.html
@@ -55,7 +55,7 @@
         <td width="20%" data-order="{{ attendee.full_name }}" data-search="{{ attendee.full_name }}"> <a href="../registration/shifts?id={{ attendee.id }}">{{ attendee.full_name }}</a>        </td>
         <td width="10">{{ attendee.badge_num }}</a></td>
         <td width="10">{% if attendee.is_dept_head %}<font size="-1">[D]</font>{% endif %}</td>
-        <td width="10">{% if attendee.trusted_in_any_depts %}<font size="-1">[T]</font>{% endif %}</td>
+        <td width="10">{% if attendee.trusted_here %}<font size="-1">[T]</font>{% endif %}</td>
         <td width="10">{% if attendee.multiply_assigned %}<font size="-1">[M]</font>{% endif %}</td>
         <td width="10">{% if attendee.can_work_setup or attendee.can_work_teardown %}<font size="-1">[L]</font>{% endif %}</td>
         <td width="10">{{ attendee.placeholder }}</td>
@@ -70,7 +70,9 @@
 <div style="margin-left:10px">
     [D]: <i>Staffers marked with a "D" are department heads.</i> <br/>
     [M]: <i>Staffers marked with a "M" are assigned to multiple locations</i> <br/>
-    [T]: <i>Staffers marked with a "T" are trusted in at least one department</i> <br/>
+    [T]: <i>Staffers marked with a "T" are trusted
+         {% if location %}in this department{% else %}in at least one department{% endif %}
+         </i> <br/>
     [L]: <i>Staffers marked with a "L" are working load-in and/or load-out</i>
 </div>
 

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -213,17 +213,17 @@
 {% include "regform.html" %}
 
 <div class="form-group staffing staffing-checked">
-    <label class="col-sm-2 control-label">Trusted?</label>
+    <label class="col-sm-2 control-label">Assigned Depts</label>
     <div class="col-sm-6">
-        {% checkbox attendee.trusted %} This volunteer can take restricted shifts
-        <span class="popup">{% popup_link "../static_views/trustDesc.html" "What does this mean?" %}</span>
+        {% checkgroup attendee.assigned_depts %}
     </div>
 </div>
 
 <div class="form-group staffing staffing-checked">
-    <label class="col-sm-2 control-label">Assigned Depts</label>
+    <label class="col-sm-2 control-label">Trusted in which depts</label>
     <div class="col-sm-6">
-        {% checkgroup attendee.assigned_depts %}
+        {% checkgroup attendee.trusted_depts %}
+        <span class="popup">{% popup_link "../static_views/trustDesc.html" "What does this mean?" %}</span>
     </div>
 </div>
 

--- a/uber/tests/conftest.py
+++ b/uber/tests/conftest.py
@@ -50,13 +50,34 @@ def init_db(request, sensible_defaults):
             first_name='Regular',
             last_name='Attendee'
         ))
+
+        d_arcade = str(c.ARCADE)
+        d_console = str(c.CONSOLE)
+        d_arcade_and_console = '{},{}'.format(c.ARCADE, c.CONSOLE)
+        assigned_depts = {
+            'One': d_arcade,
+            'Two': d_console,
+            'Three': d_arcade_and_console,
+            'Four': d_arcade_and_console,
+            'Five': ''
+        }
+        trusted_depts = {
+            'One': '',
+            'Two': '',
+            'Three': '',
+            'Four': d_arcade_and_console,
+            'Five': ''
+        }
+
         for name in ['One', 'Two', 'Three', 'Four', 'Five']:
             session.add(Attendee(
                 placeholder=True,
                 first_name=name,
                 last_name=name,
                 paid=c.NEED_NOT_PAY,
-                badge_type=c.STAFF_BADGE
+                badge_type=c.STAFF_BADGE,
+                assigned_depts=assigned_depts[name],
+                trusted_depts=trusted_depts[name]
             ))
             session.add(Attendee(
                 placeholder=True,

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -273,6 +273,23 @@ class TestStaffingAdjustments:
         assert a.trusted_in_any_depts
         assert a.badge_type == c.STAFF_BADGE
 
+    def test_trust_TrustedInAssignedDept_AfterStaffingAdjustments(self):
+        a = Attendee(staffing=True,
+                     assigned_depts='{},{}'.format(c.CONSOLE, c.CON_OPS),
+                     trusted_depts='{},{}'.format(c.CONSOLE, c.CON_OPS))
+        a._staffing_adjustments()
+        assert a.assigned_to(c.CONSOLE) and a.trusted_in(c.CONSOLE)
+        assert a.assigned_to(c.CON_OPS) and a.trusted_in(c.CON_OPS)
+
+    def test_trust_NotTrustedInAnUnassignedDept_AfterStaffingAdjustments(self):
+        a = Attendee(staffing=True,
+                     assigned_depts='{},{}'.format(c.CONSOLE, c.CON_OPS),
+                     trusted_depts='{},{}'.format(c.ARCADE, c.CON_OPS))
+        a._staffing_adjustments()
+        assert a.assigned_to(c.CONSOLE) and not a.trusted_in(c.CONSOLE)
+        assert not a.assigned_to(c.ARCADE) and not a.trusted_in(c.ARCADE)
+        assert a.assigned_to(c.CON_OPS) and a.trusted_in(c.CON_OPS)
+
     def test_unpaid_dept_head(self):
         a = Attendee(ribbon=c.DEPT_HEAD_RIBBON)
         a._staffing_adjustments()

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -273,7 +273,11 @@ class TestStaffingAdjustments:
         assert a.trusted_in_any_depts
         assert a.badge_type == c.STAFF_BADGE
 
-    def test_trust_TrustedInAssignedDept_AfterStaffingAdjustments(self):
+    def test_staffing_still_trusted_assigned(self):
+        """
+        After applying staffing adjustements:
+        Any depts you are both trusted and assigned to should remain unchanged
+        """
         a = Attendee(staffing=True,
                      assigned_depts='{},{}'.format(c.CONSOLE, c.CON_OPS),
                      trusted_depts='{},{}'.format(c.CONSOLE, c.CON_OPS))
@@ -281,7 +285,12 @@ class TestStaffingAdjustments:
         assert a.assigned_to(c.CONSOLE) and a.trusted_in(c.CONSOLE)
         assert a.assigned_to(c.CON_OPS) and a.trusted_in(c.CON_OPS)
 
-    def test_trust_NotTrustedInAnUnassignedDept_AfterStaffingAdjustments(self):
+    def test_staffing_no_longer_trusted_unassigned(self):
+        """
+        After applying staffing adjustements:
+        1) Any depts you are trusted in but not assigned to, you should not longer remain trusted in
+        2) Any depts you are assigned to but not trusted in, you should remain untrusted in
+        """
         a = Attendee(staffing=True,
                      assigned_depts='{},{}'.format(c.CONSOLE, c.CON_OPS),
                      trusted_depts='{},{}'.format(c.ARCADE, c.CON_OPS))

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -104,7 +104,7 @@ def test_is_transferrable(monkeypatch):
     assert Attendee(paid=c.PAID_BY_GROUP).is_transferable
     assert not Attendee(paid=c.NOT_PAID).is_transferable
 
-    assert not Attendee(paid=c.HAS_PAID, trusted=True).is_transferable
+    assert not Attendee(paid=c.HAS_PAID, trusted=True).is_transferable # TODO
     assert not Attendee(paid=c.HAS_PAID, checked_in=datetime.now(UTC)).is_transferable
     assert not Attendee(paid=c.HAS_PAID, badge_type=c.STAFF_BADGE).is_transferable
     assert not Attendee(paid=c.HAS_PAID, badge_type=c.GUEST_BADGE).is_transferable
@@ -168,8 +168,10 @@ def test_takes_shifts():
 
 class TestUnsetVolunteer:
     def test_basic(self):
+         # TODO
         a = Attendee(staffing=True, trusted=True, requested_depts=c.CONSOLE, assigned_depts=c.CONSOLE, ribbon=c.VOLUNTEER_RIBBON, shifts=[Shift()])
         a.unset_volunteering()
+        # TODO
         assert not a.staffing and not a.trusted and not a.requested_depts and not a.assigned_depts and not a.shifts and a.ribbon == c.NO_RIBBON
 
     def test_different_ribbon(self):
@@ -253,7 +255,7 @@ class TestStaffingAdjustments:
     def test_dept_head_invariants(self):
         a = Attendee(ribbon=c.DEPT_HEAD_RIBBON)
         a._staffing_adjustments()
-        assert a.staffing and a.trusted
+        assert a.staffing and a.trusted  # TODO, update, this is no longer true
         assert a.badge_type == c.STAFF_BADGE
 
     def test_unpaid_dept_head(self):

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -115,7 +115,7 @@ def test_is_not_transferable_trusted(monkeypatch):
 
 
 def test_trusted_in_any_depts():
-    a = Attendee(trusted_depts='{},{}'.format(c.ARCADE, c.CONSOLE) )
+    a = Attendee(trusted_depts='{},{}'.format(c.ARCADE, c.CONSOLE))
     assert a.trusted_in_any_depts
     assert len(a.trusted_depts_ints) == 2
 

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -115,14 +115,9 @@ def test_is_not_transferable_trusted(monkeypatch):
 
 
 def test_trusted_somewhere():
-    a = Attendee(trusted_depts='{},{}'.format(c.ARCADE, c.CONSOLE))
-    assert a.trusted_somewhere
-
-    a.trusted_depts = c.CONSOLE
-    assert a.trusted_somewhere
-
-    a.trusted_depts = ''
-    assert not a.trusted_somewhere
+    assert Attendee(trusted_depts='{},{}'.format(c.ARCADE, c.CONSOLE)).trusted_somewhere
+    assert Attendee(trusted_depts=str(c.CONSOLE)).trusted_somewhere
+    assert not Attendee(trusted_depts='').trusted_somewhere
 
 
 class TestGetsShirt:

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -114,15 +114,15 @@ def test_is_not_transferable_trusted(monkeypatch):
     assert not Attendee(paid=c.HAS_PAID, trusted_depts=c.CONSOLE).is_transferable
 
 
-def test_trusted_in_any_depts():
+def test_trusted_somewhere():
     a = Attendee(trusted_depts='{},{}'.format(c.ARCADE, c.CONSOLE))
-    assert a.trusted_in_any_depts
+    assert a.trusted_somewhere
 
     a.trusted_depts = c.CONSOLE
-    assert a.trusted_in_any_depts
+    assert a.trusted_somewhere
 
     a.trusted_depts = ''
-    assert not a.trusted_in_any_depts
+    assert not a.trusted_somewhere
 
 
 class TestGetsShirt:
@@ -185,7 +185,7 @@ class TestUnsetVolunteer:
     def test_basic(self):
         a = Attendee(staffing=True, trusted_depts=c.CONSOLE, requested_depts=c.CONSOLE, assigned_depts=c.CONSOLE, ribbon=c.VOLUNTEER_RIBBON, shifts=[Shift()])
         a.unset_volunteering()
-        assert not a.staffing and not a.trusted_in_any_depts and not a.requested_depts and not a.assigned_depts and not a.shifts and a.ribbon == c.NO_RIBBON
+        assert not a.staffing and not a.trusted_somewhere and not a.requested_depts and not a.assigned_depts and not a.shifts and a.ribbon == c.NO_RIBBON
 
     def test_different_ribbon(self):
         a = Attendee(ribbon=c.DEALER_RIBBON)
@@ -270,7 +270,7 @@ class TestStaffingAdjustments:
         a._staffing_adjustments()
         assert a.staffing
         assert a.trusted_in(c.CONSOLE)
-        assert a.trusted_in_any_depts
+        assert a.trusted_somewhere
         assert a.badge_type == c.STAFF_BADGE
 
     def test_staffing_still_trusted_assigned(self):

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -117,16 +117,12 @@ def test_is_not_transferable_trusted(monkeypatch):
 def test_trusted_in_any_depts():
     a = Attendee(trusted_depts='{},{}'.format(c.ARCADE, c.CONSOLE))
     assert a.trusted_in_any_depts
-    assert len(a.trusted_depts_ints) == 2
 
     a.trusted_depts = c.CONSOLE
     assert a.trusted_in_any_depts
-    assert len(a.trusted_depts_ints) == 1
 
     a.trusted_depts = ''
-    assert len(a.trusted_depts_ints) == 0
-    not_trusted = not a.trusted_in_any_depts
-    assert not_trusted
+    assert not a.trusted_in_any_depts
 
 
 class TestGetsShirt:

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -46,7 +46,8 @@ class TestAssign:
 
     def test_restricted(self, session):
         assert session.assign(session.staff_two.id, session.job_six.id)
-        session.staff_two.trusted = True
+        session.staff_two.trusted_depts = str(c.CONSOLE)
+        # TODO: update
         session.commit()
         assert not session.assign(session.staff_two.id, session.job_six.id)
 
@@ -71,6 +72,7 @@ class TestAvailableStaffers:
         monkeypatch.setattr(Job, 'all_staffers', [session.staff_one, session.staff_two, session.staff_three, session.staff_four])
         monkeypatch.setattr(Job, 'no_overlap', lambda self, a: True)
 
+        # TODO: update
         session.staff_one.trusted = session.staff_four.trusted = True
 
         session.staff_one.assigned_depts = str(c.ARCADE)

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -126,4 +126,3 @@ class TestAvailableStaffers:
     def test_staffers_by_job_restricted(self, session):
         attendees = session.staffers_by_job(session.job_six)
         assert attendees == [session.staff_four]
-

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -53,6 +53,7 @@ class TestAssign:
         assert session.assign(session.staff_two.id, session.job_six.id)
 
     def test_restricted_in_correct_trusted_dept(self, session):
+        session.staff_two.assigned_depts = '{},{}'.format(str(c.ARCADE), str(c.CONSOLE))
         session.staff_two.trusted_depts = '{},{}'.format(str(c.ARCADE), str(c.CONSOLE))
         session.commit()
         assert not session.assign(session.staff_two.id, session.job_six.id)

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -98,25 +98,25 @@ class TestAvailableStaffers:
 
     def test_by_department(self, session):
         # order of the output is alphabetically sorted and must be tested that way
-        assert session.job_one.available_staff == [session.staff_four, session.staff_one, session.staff_three]
-        assert session.job_four.available_staff == [session.staff_four, session.staff_three, session.staff_two]
+        assert session.job_one.available_volunteers == [session.staff_four, session.staff_one, session.staff_three]
+        assert session.job_four.available_volunteers == [session.staff_four, session.staff_three, session.staff_two]
 
     def test_by_trust(self, session):
-        assert session.job_six.available_staff == [session.staff_four]
+        assert session.job_six.available_volunteers == [session.staff_four]
 
     def test_by_overlap(self, session, monkeypatch):
         monkeypatch.setattr(Job, 'no_overlap', lambda self, a: a in [session.staff_one, session.staff_two])
-        assert session.job_one.available_staff == [session.staff_one]
-        assert session.job_four.available_staff == [session.staff_two]
+        assert session.job_one.available_volunteers == [session.staff_one]
+        assert session.job_four.available_volunteers == [session.staff_two]
 
     def test_staffers_by_job_unrestricted(self, session):
-        attendees = session.job_one.capable_staff
+        attendees = session.job_one.capable_volunteers
         assert attendees == [session.staff_four, session.staff_one, session.staff_three]
 
     def test_staffers_by_job_options_unrestricted(self, session):
-        attendees = session.job_one.capable_staff_opts
+        attendees = session.job_one.capable_volunteers_opts
         assert attendees == [(a.id, a.full_name) for a in [session.staff_four, session.staff_one, session.staff_three]]
 
     def test_staffers_by_job_restricted(self, session):
-        attendees = session.job_six.capable_staff
+        attendees = session.job_six.capable_volunteers
         assert attendees == [session.staff_four]

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -87,25 +87,19 @@ class TestAssign:
 class TestAvailableStaffers:
     @pytest.fixture(autouse=True)
     def extra_setup(self, session, monkeypatch):
-        # note: Jobs for this fixture are defined in uber/tests/conftest.py
-        monkeypatch.setattr(Job, 'all_staffers', [session.staff_one, session.staff_two, session.staff_three, session.staff_four])
+        # note: Assigned Depts, Trusted Depts, and Jobs for this fixture are defined in uber/tests/conftest.py
         monkeypatch.setattr(Job, 'no_overlap', lambda self, a: True)
 
-        session.staff_one.assigned_depts = str(c.ARCADE)
-        session.staff_one.trusted_depts = str(c.CONSOLE)
-
-        session.staff_two.assigned_depts = str(c.CONSOLE)
-
-        session.staff_three.assigned_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
-
-        session.staff_four.assigned_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
-        session.staff_four.trusted_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
-
-        session.commit()
+    def test_testing_environment(self, session):
+        # if this fails, data that our test relies on is not setup correctly.
+        result = session.query(Attendee).filter_by(staffing=True).all()
+        for a in [session.staff_one, session.staff_two, session.staff_three, session.staff_four, session.staff_five]:
+            assert a in result
 
     def test_by_department(self, session):
-        assert session.job_one.available_staff == [session.staff_one, session.staff_three, session.staff_four]
-        assert session.job_four.available_staff == [session.staff_two, session.staff_three, session.staff_four]
+        # order of the output is alphabetically sorted and must be tested that way
+        assert session.job_one.available_staff == [session.staff_four, session.staff_one, session.staff_three]
+        assert session.job_four.available_staff == [session.staff_four, session.staff_three, session.staff_two]
 
     def test_by_trust(self, session):
         assert session.job_six.available_staff == [session.staff_four]

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -38,32 +38,43 @@ def session(request):
 class TestAssign:
     @pytest.fixture(autouse=True)
     def default_assignment(self, session):
-        assert not session.assign(session.staff_one.id, session.job_one.id)
+        error = session.assign(session.staff_one.id, session.job_one.id)
+        assert not error
 
     def test_non_volunteer(self, session):
         attendee = session.query(Attendee).filter_by(staffing=False).first()
-        assert session.assign(attendee.id, session.job_one.id)
+        error = session.assign(attendee.id, session.job_one.id)
+        assert error
 
     def test_restricted_no_trusted_depts(self, session):
-        assert session.assign(session.staff_two.id, session.job_six.id)
+        error = session.assign(session.staff_two.id, session.job_six.id)
+        assert error
 
     def test_restricted_wrong_trusted_dept(self, session):
         session.staff_two.trusted_depts = str(c.ARCADE)
         session.commit()
-        assert session.assign(session.staff_two.id, session.job_six.id)
+        error = session.assign(session.staff_two.id, session.job_six.id)
+        assert error
 
     def test_restricted_in_correct_trusted_dept(self, session):
         session.staff_two.assigned_depts = '{},{}'.format(str(c.ARCADE), str(c.CONSOLE))
         session.staff_two.trusted_depts = '{},{}'.format(str(c.ARCADE), str(c.CONSOLE))
         session.commit()
-        assert not session.assign(session.staff_two.id, session.job_six.id)
+        error = session.assign(session.staff_two.id, session.job_six.id)
+        assert not error
 
     def test_full(self, session):
-        assert session.assign(session.staff_two.id, session.job_one.id)
+        error = session.assign(session.staff_two.id, session.job_one.id)
+        assert error
 
-        assert not session.assign(session.staff_three.id, session.job_four.id)
-        assert not session.assign(session.staff_four.id, session.job_four.id)
-        assert session.assign(session.staff_four.id, session.job_four.id)
+        error = session.assign(session.staff_three.id, session.job_four.id)
+        assert not error
+
+        error = session.assign(session.staff_four.id, session.job_four.id)
+        assert not error
+
+        error = session.assign(session.staff_four.id, session.job_four.id)
+        assert error
 
     # this indirectly tests the .no_overlap() method, though a more direct test would be good as well
     def test_overlap(self, session):
@@ -76,16 +87,21 @@ class TestAssign:
 class TestAvailableStaffers:
     @pytest.fixture(autouse=True)
     def extra_setup(self, session, monkeypatch):
+        # note: Jobs for this fixture are defined in uber/tests/conftest.py
         monkeypatch.setattr(Job, 'all_staffers', [session.staff_one, session.staff_two, session.staff_three, session.staff_four])
         monkeypatch.setattr(Job, 'no_overlap', lambda self, a: True)
 
+        session.staff_one.assigned_depts = str(c.ARCADE)
         session.staff_one.trusted_depts = str(c.CONSOLE)
+
+        session.staff_two.assigned_depts = str(c.CONSOLE)
+
+        session.staff_three.assigned_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
+
+        session.staff_four.assigned_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
         session.staff_four.trusted_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
 
-        session.staff_one.assigned_depts = str(c.ARCADE)
-        session.staff_two.assigned_depts = str(c.CONSOLE)
-        session.staff_three.assigned_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
-        session.staff_four.assigned_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
+        session.commit()
 
     def test_by_department(self, session):
         assert session.job_one.available_staffers == [session.staff_one, session.staff_three, session.staff_four]
@@ -98,3 +114,16 @@ class TestAvailableStaffers:
         monkeypatch.setattr(Job, 'no_overlap', lambda self, a: a in [session.staff_one, session.staff_two])
         assert session.job_one.available_staffers == [session.staff_one]
         assert session.job_four.available_staffers == [session.staff_two]
+
+    def test_staffers_by_job_unrestricted(self, session):
+        attendees = session.staffers_by_job(session.job_one)
+        assert attendees == [session.staff_four, session.staff_one, session.staff_three]
+
+    def test_staffers_by_job_options_unrestricted(self, session):
+        attendees = session.staffers_by_job_options(session.job_one)
+        assert attendees == [(a.id, a.full_name) for a in [session.staff_four, session.staff_one, session.staff_three]]
+
+    def test_staffers_by_job_restricted(self, session):
+        attendees = session.staffers_by_job(session.job_six)
+        assert attendees == [session.staff_four]
+

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -44,10 +44,16 @@ class TestAssign:
         attendee = session.query(Attendee).filter_by(staffing=False).first()
         assert session.assign(attendee.id, session.job_one.id)
 
-    def test_restricted(self, session):
+    def test_restricted_no_trusted_depts(self, session):
         assert session.assign(session.staff_two.id, session.job_six.id)
-        session.staff_two.trusted_depts = str(c.CONSOLE)
-        # TODO: update
+
+    def test_restricted_wrong_trusted_dept(self, session):
+        session.staff_two.trusted_depts = str(c.ARCADE)
+        session.commit()
+        assert session.assign(session.staff_two.id, session.job_six.id)
+
+    def test_restricted_in_correct_trusted_dept(self, session):
+        session.staff_two.trusted_depts = '{},{}'.format(str(c.ARCADE), str(c.CONSOLE))
         session.commit()
         assert not session.assign(session.staff_two.id, session.job_six.id)
 

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -72,8 +72,8 @@ class TestAvailableStaffers:
         monkeypatch.setattr(Job, 'all_staffers', [session.staff_one, session.staff_two, session.staff_three, session.staff_four])
         monkeypatch.setattr(Job, 'no_overlap', lambda self, a: True)
 
-        # TODO: update
-        session.staff_one.trusted = session.staff_four.trusted = True
+        session.staff_one.trusted_depts = str(c.CONSOLE)
+        session.staff_four.trusted_depts = '{},{}'.format(c.ARCADE, c.CONSOLE)
 
         session.staff_one.assigned_depts = str(c.ARCADE)
         session.staff_two.assigned_depts = str(c.CONSOLE)

--- a/uber/tests/models/test_job.py
+++ b/uber/tests/models/test_job.py
@@ -104,25 +104,25 @@ class TestAvailableStaffers:
         session.commit()
 
     def test_by_department(self, session):
-        assert session.job_one.available_staffers == [session.staff_one, session.staff_three, session.staff_four]
-        assert session.job_four.available_staffers == [session.staff_two, session.staff_three, session.staff_four]
+        assert session.job_one.available_staff == [session.staff_one, session.staff_three, session.staff_four]
+        assert session.job_four.available_staff == [session.staff_two, session.staff_three, session.staff_four]
 
     def test_by_trust(self, session):
-        assert session.job_six.available_staffers == [session.staff_four]
+        assert session.job_six.available_staff == [session.staff_four]
 
     def test_by_overlap(self, session, monkeypatch):
         monkeypatch.setattr(Job, 'no_overlap', lambda self, a: a in [session.staff_one, session.staff_two])
-        assert session.job_one.available_staffers == [session.staff_one]
-        assert session.job_four.available_staffers == [session.staff_two]
+        assert session.job_one.available_staff == [session.staff_one]
+        assert session.job_four.available_staff == [session.staff_two]
 
     def test_staffers_by_job_unrestricted(self, session):
-        attendees = session.staffers_by_job(session.job_one)
+        attendees = session.job_one.capable_staff
         assert attendees == [session.staff_four, session.staff_one, session.staff_three]
 
     def test_staffers_by_job_options_unrestricted(self, session):
-        attendees = session.staffers_by_job_options(session.job_one)
+        attendees = session.job_one.capable_staff_opts
         assert attendees == [(a.id, a.full_name) for a in [session.staff_four, session.staff_one, session.staff_three]]
 
     def test_staffers_by_job_restricted(self, session):
-        attendees = session.staffers_by_job(session.job_six)
+        attendees = session.job_six.capable_staff
         assert attendees == [session.staff_four]


### PR DESCRIPTION
Change attendee concept of 'trusted' in RAMS.

Previously we had a concept of an attendee being 'trusted' vs 'not trusted'.  i.e. trustworthy enough to handle money, work security, whatever.

However, someone trusted in one department might not necessarily be trusted in another.  When someone was re-assigned departments, they would show up as being trusted in the new department, even though the department heads didn't know them.

This change allows someone to be set as trusted on a per-department basis.  i.e. trusted in Arcade but not in Treasury/etc.

Goes with another PR for magprime repo https://github.com/magfest/magprime/pull/35 which must be merged at the same time.

This PR contains all the code changes needed for this, and will need to have a database migration to migrate attendee status.