### PR TITLE
add more helpful message when volunteers try to login before shifts are created

### DIFF
--- a/uber/templates/signups/login.html
+++ b/uber/templates/signups/login.html
@@ -18,7 +18,8 @@
     {% else %}
         <div class="well">
             Shifts are not yet available. If you are signed up as a volunteer, you will 
-            be emailed when shifts become available.  Thanks so much for volunteering!
+            be emailed when shifts become available.  We anticipate that volunteer shifts and the volunteer checklist will go live on 11/26/15.
+            You should receive an email with more information at that time, thanks so much for volunteering!
         </div>
     {% endif %}
 </div>

--- a/uber/templates/signups/login.html
+++ b/uber/templates/signups/login.html
@@ -18,7 +18,7 @@
     {% else %}
         <div class="well">
             Shifts are not yet available. If you are signed up as a volunteer, you will 
-            be emailed when shifts become available.  We anticipate that volunteer shifts and the volunteer checklist will go live on 11/26/15.
+            be emailed when shifts become available.  We anticipate that volunteer shifts and the volunteer checklist will go live on {{ c.SHIFTS_CREATED }}.
             You should receive an email with more information at that time, thanks so much for volunteering!
         </div>
     {% endif %}


### PR DESCRIPTION
Sets dates for Shift Signups to be live on 11/26/15, for MAGFest 2016.
This should update: https://prime.uber.magfest.org/uber/signups/login

I'm not sure if there is a more specific MAGFest 2016 branch that this should be in?