### PR TITLE
Change consent form email date

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -244,7 +244,7 @@ AutomatedEmail(Attendee, 'Personalized {EVENT_NAME} badges will be ordered next 
 # MAGFest requires signed and notarized parental consent forms for anyone under 18.  This automated email reminder to
 # bring the consent form only happens if this feature is turned on by setting the CONSENT_FORM_URL config option.
 AutomatedEmail(Attendee, '{EVENT_NAME} parental consent form reminder', 'reg_workflow/under_18_reminder.txt',
-               lambda a: c.CONSENT_FORM_URL and a.age_group_conf['consent_form'] and days_before(7, c.EPOCH))
+               lambda a: c.CONSENT_FORM_URL and a.age_group_conf['consent_form'] and days_before(14, c.EPOCH))
 
 
 for _conf in DeptChecklistConf.instances.values():


### PR DESCRIPTION
Changed parental consent form to e-mail out 2 weeks beforehand instead of just 1.