### PR TITLE
Fix sitemap to show content from all plugins

### DIFF
--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -154,15 +154,15 @@ class Root:
 
     @unrestricted
     def sitemap(self):
-        from uber import site_sections
+        site_sections = cherrypy.tree.apps[c.PATH].root
         modules = {name: getattr(site_sections, name) for name in dir(site_sections) if not name.startswith('_')}
         pages = defaultdict(list)
-        for module_name, module in modules.items():
-            for name in dir(module.Root):
-                method = getattr(module.Root, name)
+        for module_name, module_root in modules.items():
+            for name in dir(module_root):
+                method = getattr(module_root, name)
                 if getattr(method, 'exposed', False):
                     spec = inspect.getfullargspec(get_innermost(method))
-                    if set(method.restricted or []).intersection(AdminAccount.access_set()) \
+                    if set(getattr(method, 'restricted', []) or []).intersection(AdminAccount.access_set()) \
                             and (getattr(method, 'site_mappable', False)
                               or len([arg for arg in spec.args[1:] if arg != 'session']) == len(spec.defaults or []) and not spec.varkw):
                         pages[module_name].append({


### PR DESCRIPTION
fixes #1428

BRO, DO YOU EVEN SITEMAP? for my sanity, I needed this fixed in the course of fixing something else.  PyCharm debugger+inspector to the rescue.  Many Bothnans died to bring you this information.

verified that the output for core pages is identical, and it adds pages from plugins now.

sample output:
![image](https://cloud.githubusercontent.com/assets/5413064/11449407/c616b1a4-9541-11e5-8a18-278eb3f565f1.png)

only thing is that the page takes about 5sec to load.  seems a little high, maybe we want to cache this output the first time it's used or something.  it works fine though.