### PR TITLE
Fix the Waitlist button

### DIFF
--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -66,7 +66,7 @@ class Root:
         }
 
     @ajax
-    def unapprove(self, session, id, action, email, convert=None):
+    def unapprove(self, session, id, action, email, convert=None, message=''):
         assert action in ['waitlisted', 'declined']
         group = session.group(id)
         subject = 'Your {EVENT_NAME} Dealer registration has been ' + action


### PR DESCRIPTION
A previous change had made waitlisting dealers impossible due to a minor variable reference bug. It will now work again.