### PR TITLE
Update configspec.ini

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -558,8 +558,8 @@ path = string(default="")
 # item appears in the order defined by its key, so you can override the items
 # or remove them completely by setting the value to the empty string.
 1 = string(default="signups/placeholder_item.html")
-2 = string(default="signups/food_item.html")
-3 = string(default="signups/shirt_item.html")
+2 = string(default="signups/shirt_item.html")
+3 = string(default="signups/food_item.html")
 4 = string(default="signups/shifts_item.html")
 __many__ = string(default="")
 


### PR DESCRIPTION
This changes the order of the Volunteer Checklist. We tell staffers/volunteers  that they have to do the steps in order... so that the next step activates.   During the registration process, or badge confirmation process people are already able to add their shirt size so that completes that step..... Making that step 2 instead of 3 shows the staffer/volunteer that they have already completed 2 steps in the process.