### PR TITLE
fixed order of volunteer checklist to work for attendee volunteers

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -479,7 +479,7 @@ __many__ = string
 [[worked_status]]
 shift_unmarked = string(default="SELECT A STATUS")
 shift_worked   = string(default="This shift was worked")
-shift_unworked = string(default="Staffer didn"t show up")
+shift_unworked = string(default="Staffer didn't show up")
 
 [[rating]]
 unrated     = string(default="Shift Unrated")

--- a/uber/templates/signups/food_item.html
+++ b/uber/templates/signups/food_item.html
@@ -1,6 +1,6 @@
 <li>
     {% checked_if attendee.food_restrictions %}
-    {% if not attendee.placeholder %}
+    {% if not attendee.placeholder and attendee.shirt_size_marked %}
         <a href="food_restrictions">Let us know</a>
     {% else %}
         Let us know

--- a/uber/templates/signups/shirt_item.html
+++ b/uber/templates/signups/shirt_item.html
@@ -1,6 +1,6 @@
 <li>
     {% checked_if attendee.shirt_size_marked %}
-    {% if not attendee.placeholder and attendee.food_restrictions %}
+    {% if not attendee.placeholder %}
         <a href="shirt_size">Let us know</a>
     {% else %}
         Let us know


### PR DESCRIPTION
We changed the default order of the volunteer checklist, but forgot to change the if-statements that determine when you can complete each step.  That meant that even though the order of the steps changed, you still had to complete them in the original order (e.g. 1-3-2-4-5).  This is now fixed.