### PR TITLE
placeholder badge page/report now ignore invalid/deferred badges

### DIFF
--- a/uber/badge_funcs.py
+++ b/uber/badge_funcs.py
@@ -69,6 +69,7 @@ def check_placeholders():
                     placeholders = (session.query(Attendee)
                                            .filter(Attendee.placeholder == True,
                                                    Attendee.registered < localized_now() - timedelta(days=3),
+                                                   Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS]),
                                                    per_email_filter)
                                            .options(joinedload(Attendee.group))
                                            .order_by(Attendee.registered, Attendee.full_name).all())

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -890,6 +890,7 @@ class Root:
             'placeholders': [a for a in session.query(Attendee)
                                                .filter(Attendee.placeholder == True,
                                                        Attendee.staffing == True,
+                                                       Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS]),
                                                        Attendee.assigned_depts.contains(department))
                                                .order_by(Attendee.full_name).all()]
         }


### PR DESCRIPTION
In the long run we need to give some thought to how we handle invalid/deferred badges so that it's easier to not have to individually fix tons of different reports to all ignore these badge statuses, but in the meantime this is an easy fix.