### PR TITLE
added special casing for HTML emails on history page

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1674,9 +1674,13 @@ class Email(MagModel):
             return self.fk.full_name
 
     @property
+    def is_html(self):
+        return '<body' in self.body
+
+    @property
     def html(self):
-        if '<body>' in self.body:
-            return SafeString(self.body.split('<body>')[1].split('</body>')[0])
+        if self.is_html:
+            return SafeString(re.split('<body[^>]*>', self.body)[1].split('</body>')[0])
         else:
             return SafeString(self.body.replace('\n', '<br/>'))
 

--- a/uber/templates/emails/sent.html
+++ b/uber/templates/emails/sent.html
@@ -7,7 +7,7 @@
 <div style="text-align:center"><a href="index">Go Back</a></div>
 
 {% for email in emails  %}
-    <h3> {{ email.subject }} ({{ email.when }}) </h3>
+    <h3> {{ email.subject }} ({{ email.when|full_datetime }}) </h3>
     <div style="font-family:courier">{{ email.html }}</div>
 {% endfor %}
 

--- a/uber/templates/registration/history.html
+++ b/uber/templates/registration/history.html
@@ -59,7 +59,11 @@
 {% for email in emails  %}
     {% if forloop.first %}<h2> Automated Emails </h2>{% endif %}
     <h3> {{ email.subject }} ({{ email.when|full_datetime }}) </h3>
-    <div style="font-family:courier">{{ email.html }}</div>
+    {% if email.is_html %}
+        (content of HTML email omitted; you can view the full email <a href="../emails/sent?dest={{ attendee.email }}">here</a>)
+    {% else %}
+        <div style="font-family:courier">{{ email.html }}</div>
+    {% endif %}
 {% endfor %}
 
 {% endblock %}


### PR DESCRIPTION
Now on the history page for an attendee, we continue to show text emails as we always have, and for HTML emails we instead show a link to where they can view the email.  This addresses the performance issues we've seen.