### PR TITLE
removed superfluous price bump day from config

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -52,7 +52,6 @@ Sunday = 40
 Monday = 30
 
 [[attendee]]
-2016-01-18 = 70
 
 
 [table_prices]


### PR DESCRIPTION
We had a price bump defined in ``development-defaults.ini`` for some reason, probably as a holdover from last year (which fits with the date).  This was making its way into production and yielding a confusing error message where the price was already $70 but a message explained that it would be raised to $70 in the future.