### PR TITLE
shirt sale figures on summary page now ONLY track actual shirts sold and not free shirts

### DIFF
--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -21,7 +21,7 @@ class Root:
             'age_counts':    [(desc, count(age_group=ag)) for ag, desc in c.AGE_GROUP_OPTS],
             'paid_group':    len([a for a in attendees if a.paid == c.PAID_BY_GROUP and a.group and a.group.amount_paid]),
             'free_group':    len([a for a in attendees if a.paid == c.PAID_BY_GROUP and a.group and not a.group.amount_paid]),
-            'shirt_sales':   [(i, len([a for a in attendees if a.registered <= datetime.now(UTC) - timedelta(days=i * 7) and a.shirt != c.NO_SHIRT])) for i in range(50)],
+            'shirt_sales':   [(i, len([a for a in attendees if a.registered <= datetime.now(UTC) - timedelta(days=i * 7) and a.shirt != c.NO_SHIRT and (a.amount_paid or a.group and a.group.amount_paid)])) for i in range(50)],
             'ribbons':       [(desc, count(ribbon=val)) for val, desc in c.RIBBON_OPTS if val != c.NO_RIBBON],
         }
 


### PR DESCRIPTION
Ryan from the merch department says this is the more useful number, and the numbers we had before weren't useful since they don't help with sales projections, which is the main reason for them.