### PR TITLE
Setup shifts now go configurably early

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -375,8 +375,10 @@ c.BADGE_LOCK = RLock()
 c.CON_LENGTH = int((c.ESCHATON - c.EPOCH).total_seconds() // 3600)
 c.START_TIME_OPTS = [(dt, dt.strftime('%I %p %a')) for dt in (c.EPOCH + timedelta(hours=i) for i in range(c.CON_LENGTH))]
 c.DURATION_OPTS = [(i, '%i hour%s' % (i, ('s' if i > 1 else ''))) for i in range(1, 9)]
-c.SETUP_TIME_OPTS = [(dt, dt.strftime('%I %p %a')) for dt in (c.EPOCH - timedelta(days=5) + timedelta(hours=i) for i in range(16))] \
-                  + [(dt, dt.strftime('%I %p %a')) for dt in (c.EPOCH - timedelta(days=1) + timedelta(hours=i) for i in range(24))]
+c.SETUP_TIME_OPTS = [(dt, dt.strftime('%I %p %a'))
+                     for dt in (c.EPOCH - timedelta(days=day) + timedelta(hours=hour)
+                                for day in range(c.SETUP_SHIFT_DAYS, 0, -1)
+                                for hour in range(24))]
 c.TEARDOWN_TIME_OPTS = [(dt, dt.strftime('%I %p %a')) for dt in (c.ESCHATON + timedelta(hours=i) for i in range(6))] \
                      + [(dt, dt.strftime('%I %p %a'))
                         for dt in ((c.ESCHATON + timedelta(days=1)).replace(hour=10) + timedelta(hours=i) for i in range(12))]

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -101,6 +101,10 @@ shiftless_depts = string_list(default=list())
 # informational pages and reports.
 hours_for_refund = integer(default=24)
 
+# Some events begin setting up the day of the event, others the week beforehand.
+# This setting determines how many days in advance we begin tracking setup shifts.
+setup_shift_days = integer(default=5)
+
 # There are two separate deadlines for custom badges; the one after which it's
 # too late for attendees to edit their custom badge submissions, and the one
 # where it's too late for an admin to shift badge numbers on the backend.  The


### PR DESCRIPTION
There's a new config option for determining how many days before the event setup shifts start.