### PR TITLE
changed shirt count again, this time even more refined

### DIFF
--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -21,7 +21,7 @@ class Root:
             'age_counts':    [(desc, count(age_group=ag)) for ag, desc in c.AGE_GROUP_OPTS],
             'paid_group':    len([a for a in attendees if a.paid == c.PAID_BY_GROUP and a.group and a.group.amount_paid]),
             'free_group':    len([a for a in attendees if a.paid == c.PAID_BY_GROUP and a.group and not a.group.amount_paid]),
-            'shirt_sales':   [(i, len([a for a in attendees if a.registered <= datetime.now(UTC) - timedelta(days=i * 7) and a.shirt != c.NO_SHIRT and (a.amount_paid or a.group and a.group.amount_paid)])) for i in range(50)],
+            'shirt_sales':   [(i, len([a for a in attendees if a.registered <= datetime.now(UTC) - timedelta(days=i * 7) and a.gets_paid_shirt])) for i in range(50)],
             'ribbons':       [(desc, count(ribbon=val)) for val, desc in c.RIBBON_OPTS if val != c.NO_RIBBON],
         }
 


### PR DESCRIPTION
From my conversation with Ryan from Merch in email:

> Ryan: And not to be a nitpicker, but... The total number of "prepaid" shirts according to the "shirt counts" list is 1,068. However, over at the week by week summary of sold shirts, the total count is 1170. Why the 102 shirt difference?

> Me: Whoops!  Not a nitpick at all, with a difference that big!  I made a mistake - the week-by-week summary is looking at shirts of paid attendees, instead of paid shirts.  Those are two completely different numbers, because e.g. someone with a free badge can also kick in at the shirt level.  This is what accounts for the 102 shirt difference.

This PR fixes that discrepancy.

Since this is NOT a super-urgent fix, I'll wait for someone to actually +1 it before merging for once :)