### PR TITLE
unassigned group badges now track payment type when being claimed

### DIFF
--- a/uber/tests/models/test_group.py
+++ b/uber/tests/models/test_group.py
@@ -124,6 +124,14 @@ def test_assign_new_badges(session, monkeypatch):
         assert attendee.badge_type == 222
 
 
+def test_assign_new_comped_badges(session, monkeypatch):
+    group = Group()
+    session.assign_badges(group, 2, paid=c.NEED_NOT_PAY)
+    assert 2 == group.badges == len(group.attendees)
+    for attendee in group.attendees:
+        assert attendee.paid == c.NEED_NOT_PAY
+
+
 def test_assign_extra_create_arguments(session):
     group = Group()
     registered = localized_now()


### PR DESCRIPTION
We just uncovered an issue which we haven't run into before.  MIVS studios get groups created for them, where they're asked to fill out badges.

These are NOT paid-by-group badges because we need them to be need-not-pay badges.  This is because we want them to be able to add new badges to their groups, but additional badges need to be paid for.

This change allows us to claim need-not-pay group badges through the Group Members page.