### PR TITLE
updated default panel email signature (see #1630)

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -18,8 +18,8 @@ http://www.magfest.org'''
 marketplace_email_signature = ''' - Danielle Pomfrey,
 MAGFest Marketplace Coordinator'''
 
-peglegs_email_signature = ''' - Tim Macneil,
-MAGFest Panels Department'''
+peglegs_email_signature = ''' -  Tom Hyre,
+MAGFest Director of Panel Operations'''
 
 guest_email_signature = ''' - Steph Prader,
 MAGFest Guest Coordinator'''


### PR DESCRIPTION
See #1630 for a "real" fix for this (by puppetizing the config option) but in the short run I need to update the Panels email signature so that the panel folks can approve their accept/decline emails.