### PR TITLE
DEV ONLY: show first page attendee search results by default

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -32,7 +32,7 @@ def check_atd(func):
 
 @all_renderable(c.PEOPLE, c.REG_AT_CON)
 class Root:
-    def index(self, session, message='', page='0', search_text='', uploaded_id='', order='last_first', invalid=''):
+    def index(self, session, message='', page='1', search_text='', uploaded_id='', order='last_first', invalid=''):
         filter = Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS]) if not invalid else None
         attendees = session.query(Attendee) if invalid else session.query(Attendee).filter(filter)
         total_count = attendees.count()

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -38,7 +38,7 @@ class Root:
         # default due to the possibility of large amounts of reg stations accessing this
         # page at once. viewing the first page is also rarely useful in production when
         # there are thousands of attendees.
-        if c.DEV_BOX and (not page or page == 0):
+        if c.DEV_BOX and not int(page):
             page = 1
 
         filter = Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS]) if not invalid else None

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -752,7 +752,15 @@ class Root:
         session.delete(shift)
         raise HTTPRedirect('shifts?id={}&message={}', shift.attendee.id, 'Staffer unassigned from shift')
 
-    def feed(self, session, page='1', who='', what='', action=''):
+    def feed(self, session, page='0', who='', what='', action=''):
+        # DEVELOPMENT ONLY: it's an extremely convenient shortcut to show the first page
+        # of search results when doing testing. it's too slow in production to do this by
+        # default due to the possibility of large amounts of reg stations accessing this
+        # page at once. viewing the first page is also rarely useful in production when
+        # there are thousands of attendees.
+        if c.DEV_BOX and (not page or page == 0):
+            page = 1
+
         feed = session.query(Tracking).filter(Tracking.action != c.AUTO_BADGE_SHIFT).order_by(Tracking.when.desc())
         if who:
             feed = feed.filter_by(who=who)


### PR DESCRIPTION
UPDATED: this is now a DEVELOPMENT-ONLY change, production systems are unaffected. (checking for c.DEV_BOX)

on /registration/ this reverts to the previous behavior of the system before Bootstrap where we would show the first page of results instead of a blank search page.

this is really extremely handy for testing (saves one annoyingly well-placed click), slightly less useful in production.

old behavior:
![image](https://cloud.githubusercontent.com/assets/5413064/12421649/3103455e-be91-11e5-8b68-86f2a8ca72d6.png)

new behavior:
![image](https://cloud.githubusercontent.com/assets/5413064/12421633/1fb4d394-be91-11e5-9ad4-82b61e74927f.png)