### PR TITLE
Ux improvements: 2nd button added to attendee edit page, change "upload" to "save"

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -104,12 +104,11 @@ class Root:
                     raise HTTPRedirect(return_to + '&message={}', 'Attendee data saved')
                 else:
                     msg_text = '{} has been saved'.format(attendee.full_name)
-                    if c.AT_THE_CON:
-                        # redirect back to search page for registration staffers to quickly process the next checkin
+                    return_to_search = 'save_return_to_search' in params['save'] if 'save' in params else False
+                    if return_to_search:
                         raise HTTPRedirect('index?uploaded_id={}&message={}&search_text={}', attendee.id, msg_text,
                             '{} {}'.format(attendee.first_name, attendee.last_name) if c.AT_THE_CON else '')
                     else:
-                        # when not at-the-con, it's more convenient to show the attendee edit form
                         raise HTTPRedirect('form?id={}&message={}', attendee.id, msg_text)
 
         return {

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -104,8 +104,7 @@ class Root:
                     raise HTTPRedirect(return_to + '&message={}', 'Attendee data saved')
                 else:
                     msg_text = '{} has been saved'.format(attendee.full_name)
-                    return_to_search = 'save_return_to_search' in params['save'] if 'save' in params else False
-                    if return_to_search:
+                    if params.get('save') == 'save_return_to_search':
                         raise HTTPRedirect('index?uploaded_id={}&message={}&search_text={}', attendee.id, msg_text,
                             '{} {}'.format(attendee.first_name, attendee.last_name) if c.AT_THE_CON else '')
                     else:

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -103,9 +103,14 @@ class Root:
                 if return_to:
                     raise HTTPRedirect(return_to + '&message={}', 'Attendee data saved')
                 else:
-                    raise HTTPRedirect('index?uploaded_id={}&message={}&search_text={}', attendee.id,
-                        '{} has been saved'.format(attendee.full_name),
-                        '{} {}'.format(attendee.first_name, attendee.last_name) if c.AT_THE_CON else '')
+                    msg_text = '{} has been saved'.format(attendee.full_name)
+                    if c.AT_THE_CON:
+                        # redirect back to search page for registration staffers to quickly process the next checkin
+                        raise HTTPRedirect('index?uploaded_id={}&message={}&search_text={}', attendee.id, msg_text,
+                            '{} {}'.format(attendee.first_name, attendee.last_name) if c.AT_THE_CON else '')
+                    else:
+                        # when not at-the-con, it's more convenient to show the attendee edit form
+                        raise HTTPRedirect('form?id={}&message={}', attendee.id, msg_text)
 
         return {
             'message':    message,

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -101,10 +101,10 @@ class Root:
                     attendee.checked_in = localized_now()
                 session.add(attendee)
                 if return_to:
-                    raise HTTPRedirect(return_to + '&message={}', 'Attendee data uploaded')
+                    raise HTTPRedirect(return_to + '&message={}', 'Attendee data saved')
                 else:
                     raise HTTPRedirect('index?uploaded_id={}&message={}&search_text={}', attendee.id,
-                        '{} has been uploaded'.format(attendee.full_name),
+                        '{} has been saved'.format(attendee.full_name),
                         '{} {}'.format(attendee.first_name, attendee.last_name) if c.AT_THE_CON else '')
 
         return {

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -219,7 +219,7 @@
 
 <div class="form-group">
     <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary" value="Upload">Upload</button>
+        <button type="submit" class="btn btn-primary" value="Upload">Save</button>
     </div>
 </div>
 

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -327,7 +327,7 @@
 
 <div class="form-group">
     <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary" value="Upload">Upload</button>
+        <button type="submit" class="btn btn-primary" value="Upload">Save</button>
     </div>
 </div>
 

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -327,7 +327,8 @@
 
 <div class="form-group">
     <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary" value="Upload">Save</button>
+        <button type="submit" name="save" class="btn btn-primary" value="save_return_to_search">Save + return to search</button>
+        <button type="submit" name="save" class="btn btn-primary" value="save">Save</button>
     </div>
 </div>
 


### PR DESCRIPTION
UPDATED, does something slightly different now.

2 unrelated but really minor things so I put them in the same PR.  

These are some arbitrary UX/design things that were slowing me down, I'm open to not doing them if people have strong opinions.

1) Two buttons at the bottom of the attendee edit page instead of one:
* Save - which when clicked, brings you back to edit the attendee info
* Save + return to search - when clicked, saves the attendee and returns to the search page (this is the original behavior)

If the user presses Enter on the form, it will use Save+return to search.

Looks like:
![image](https://cloud.githubusercontent.com/assets/5413064/12534349/a176d942-c222-11e5-8e18-3e11a9bdeae8.png)

2) change a bunch of button text from "Upload" to "Save", mostly around attendees and groups.  I only changed the text as this was the most minimal change I could do.  "Upload" always struck me as a slightly more dated way to say "Save".

This is unrelated to but vaguely part of some quick UX stuff I was doing in #1638 