### PR TITLE
UX: add border, alignment fixes to history page

### DIFF
--- a/uber/templates/registration/history.html
+++ b/uber/templates/registration/history.html
@@ -6,7 +6,7 @@
 
 <h2>Changelog for {{ attendee.full_name }} {% if c.AT_THE_CON %}({{ attendee.badge }}){% endif %}</h2>
 
-<table class="list">
+<table class="list" border="1" borderspacing="0">
 <tr class="header">
     <td>Which</td>
     <td>What</td>
@@ -16,11 +16,11 @@
 </tr>
 {% for tracked in changes %}
     <tr>
-        <td style="white-space:nowrap">{{ tracked.model }}</td>
-        <td style="white-space:nowrap">{{ tracked.action_label }}</td>
-        <td style="white-space:nowrap">{{ tracked.when|full_datetime }}</td>
-        <td style="white-space:nowrap">{{ tracked.who }}</td>
-        <td>{{ tracked.data }}</td>
+        <td valign="top" style="white-space:nowrap">{{ tracked.model }}</td>
+        <td valign="top" style="white-space:nowrap">{{ tracked.action_label }}</td>
+        <td valign="top" style="white-space:nowrap">{{ tracked.when|full_datetime }}</td>
+        <td valign="top" style="white-space:nowrap">{{ tracked.who }}</td>
+        <td valign="top">{{ tracked.data }}</td>
     </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
small fixes that make the history page easier to read.

1) vertically align cells to the top
2) add a small black border

I'm ignoring CSS cause lazy and probably everything about this massively internal page needs a CSS overhaul anyway.

![image](https://cloud.githubusercontent.com/assets/5413064/12540086/d6266d4e-c2cf-11e5-9f38-16b76140855a.png)

been fixing minor things as I work on some other stuff.