### PR TITLE
Fixes what broke in the performance tuning

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -64,9 +64,9 @@ class AutomatedEmail:
                 all_sent = set(session.query(Email.model, Email.fk_id, Email.subject))
                 for model, lister in cls.queries.items():
                     for inst in lister(session):
+                        sleep(0.01)  # throttle CPU usage
                         for rem in cls.instances.values():
                             if isinstance(inst, rem.model) and (not rem.needs_approval or rem.subject in approved):
-                                sleep(0.01)  # throttle our CPU usage
                                 if rem.should_send(inst, all_sent):
                                     rem.send(inst, raise_errors=raise_errors)
 

--- a/uber/templates/summary/index.html
+++ b/uber/templates/summary/index.html
@@ -56,7 +56,7 @@
     {% endfor %}
 </ul>
 Of the "paid by group" badges,
-<br/> {{ counts.group.paid }} were from groups that actually gave us money, and
-<br/>{{ counts.group.free }} were from groups that we didn't charge.
+<br/> {{ counts.groups.paid }} were from groups that actually gave us money, and
+<br/>{{ counts.groups.free }} were from groups that we didn't charge.
 
 {% endblock %}


### PR DESCRIPTION
Two fixes:

1) Email throttling is now working correctly and causes a delay of less than 5 minutes instead of many hours.

2) Missing counts have been added to the summary page.