### PR TITLE
Staffer summary fixes

### DIFF
--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -86,7 +86,7 @@ class Root:
         attendees = session.staffers().filter(*[Attendee.assigned_depts.contains(str(location))] if location else []).all()
         for attendee in attendees:
             attendee.trusted_here = attendee.trusted_in(location) if location else attendee.trusted_somewhere
-            attendee.hours_here = sum(shift.job.weighted_hours for shift in attendee.shifts) if location else attendee.weighted_hours
+            attendee.hours_here = sum(shift.job.weighted_hours for shift in attendee.shifts if shift.job.location == location) if location else attendee.weighted_hours
 
         counts = defaultdict(int)
         for job in session.jobs(location):

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -55,7 +55,6 @@
                     {Groups: '../groups/'},
                     {% if c.HAS_PEOPLE_ACCESS %}
                         {'All Untaken Shifts': '../jobs/everywhere'},
-                        {Staffers: '../registration/staffers'},
                         {Jobs: '../jobs/'},
                     {% endif %}
                     {% if c.HAS_WATCHLIST_ACCESS %}


### PR DESCRIPTION
Two changes here:

1) The count of "hours here" on the ``/jobs/staffers`` page now works again.  It was displaying the total hours as of the performance tuning because I forgot to include an if statement.

2) I removed the "Staffers" link from the main admin dropdown, since it's not the recommended way to look up staffer information and is only really intended to be used by Stops.  The page still exists and is accessible through the sitemap.