### PR TITLE
Disabled custom badges

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -148,6 +148,12 @@ def allowed_to_register(attendee):
 
 
 @validation.Attendee
+def printed_badge_deadline(attendee):
+    if attendee.is_new and attendee.has_personalized_badge and not c.SHIFT_CUSTOM_BADGES:
+        return 'Custom badges have already been ordered so you cannot create new {} badges'.format(attendee.badge_type_label)
+
+
+@validation.Attendee
 def group_leadership(attendee):
     if attendee.session and not attendee.group_id:
         orig_group_id = attendee.orig_value_of('group_id')

--- a/uber/models.py
+++ b/uber/models.py
@@ -553,6 +553,8 @@ class Session(SessionManager):
                 return out_of_range
             elif not badge_num and next > c.BADGE_RANGES[badge_type][1]:
                 return 'There are no more badges available for that type'
+            elif badge_type in c.PREASSIGNED_BADGE_TYPES and not c.SHIFT_CUSTOM_BADGES:
+                return 'Custom badges have already been ordered'
 
             if not c.SHIFT_CUSTOM_BADGES:
                 badge_num = badge_num or next


### PR DESCRIPTION
Turning off badge shifting now ALSO turns off the ability to add new custom badges, which is a feature we've had in past years but which must have broken in some refactor or other.

Since there are two ways to give someone a badge type (creating or changing the badge), we add a check in both places.