### PR TITLE
fixed sort order of jobs

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -603,7 +603,7 @@ class Session(SessionManager):
         def jobs(self, location=None):
             return (self.query(Job)
                         .filter_by(**{'location': location} if location else {})
-                        .order_by(Job.name, Job.start_time)
+                        .order_by(Job.start_time, Job.name)
                         .options(subqueryload(Job.shifts).subqueryload(Shift.attendee).subqueryload(Attendee.group)))
 
         def staffers_for_dropdown(self):


### PR DESCRIPTION
When doing the performance refactor I accidentally swapped the sort order on jobs.  It's supposed to sort by start time THEN by name, but I accidentally reversed that.  This is a one-line fix that corrects all of the places where jobs weren't showing up in the order in which they start.