### PR TITLE
disabled ability to add custom badges to groups after the deadline

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -679,7 +679,9 @@ class Session(SessionManager):
 
             ribbon_to_use = new_ribbon_type or group.new_ribbon
 
-            if diff > 0:
+            if int(new_badge_type) in c.PREASSIGNED_BADGE_TYPES and not c.SHIFT_CUSTOM_BADGES:
+                return 'Custom badges have already been ordered, so you will need to select a different badge type'
+            elif diff > 0:
                 for i in range(diff):
                     group.attendees.append(Attendee(badge_type=new_badge_type, ribbon=ribbon_to_use, paid=paid, **extra_create_args))
             elif diff < 0:
@@ -804,10 +806,6 @@ class Group(MagModel, TakesPaymentMixin):
             self.approved = datetime.now(UTC)
         if self.leader and self.is_dealer:
             self.leader.ribbon = c.DEALER_RIBBON
-
-    @property
-    def is_new(self):
-        return not instance_state(self).persistent
 
     @property
     def sorted_attendees(self):

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -398,7 +398,7 @@ class TestStatusAdjustments:
     def test_set_group_paid_to_complete(self, monkeypatch):
         monkeypatch.setattr(Group, 'amount_unpaid', 0)
         g = Group()
-        a = Attendee(paid=c.PAID_BY_GROUP, badge_status=c.NEW_STATUS, first_name='Paid', placeholder=False, group=g)
+        a = Attendee(paid=c.PAID_BY_GROUP, badge_status=c.NEW_STATUS, first_name='Paid', placeholder=False, group=g, group_id=g.id)
         a._status_adjustments()
         assert a.badge_status == c.COMPLETED_STATUS
 

--- a/uber/tests/models/test_group.py
+++ b/uber/tests/models/test_group.py
@@ -158,6 +158,12 @@ def test_assign_removing_badges(monkeypatch, session):
     session.delete.assert_any_call(attendees[3])
 
 
+def test_assign_custom_badges_after_deadline(session, custom_badges_ordered):
+    group = Group()
+    message = session.assign_badges(group, 2, new_badge_type=c.STAFF_BADGE)
+    assert message and 'ordered' in message
+
+
 def test_badge_cost(monkeypatch):
     monkeypatch.setattr(c, 'get_group_price', Mock(return_value=c.DEALER_BADGE_PRICE + 10))
     assert 4 * c.DEALER_BADGE_PRICE + 20 == Group(attendees=[


### PR DESCRIPTION
There are three places where you can mark someone as getting a customized badge.  I already disabled 2 of those 3 places in a previous PR but forgot about one.  This PR fixes that.