### PR TITLE
Add the ability to 'presell' one-day badges at-door

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -166,7 +166,21 @@ class Config(_Overridable):
     @property
     def AT_THE_DOOR_BADGE_OPTS(self):
         opts = [(self.ATTENDEE_BADGE, 'Full Weekend Pass (${})'.format(self.BADGE_PRICE))]
-        if self.ONE_DAYS_ENABLED:
+        if self.ONE_DAYS_ENABLED and self.PRESELL_ONE_DAYS:
+            iterdate = max(sa.localized_now(), self.EPOCH)
+            while iterdate.date() <= self.ESCHATON.date():
+                price = self.BADGE_PRICES['single_day'].get(iterdate.strftime('%A'))
+                if price:
+                    try:
+                        badge = getattr(c, iterdate.strftime('%A').upper() + "_BADGE")
+                    except:
+                        log.error('Could not add badge to AT_THE_DOOR_BADGE_OPTS. '
+                                  'Badge type not configured: {}', iterdate.strftime('%A').upper() + '_BADGE')
+                        iterdate += timedelta(days=1)
+                        continue
+                    opts.append((badge, iterdate.strftime('%A') + ' (${})'.format(price)))
+                iterdate += timedelta(days=1)
+        elif self.ONE_DAYS_ENABLED:
             opts.append((self.ONE_DAY_BADGE,  'Single Day Pass (${})'.format(self.ONEDAY_BADGE_PRICE)))
         return opts
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -156,6 +156,14 @@ class Config(_Overridable):
         return types
 
     @property
+    def PRESOLD_ONEDAY_BADGE_TYPES(self):
+        return {
+            badge_type: self.BADGES[badge_type]
+            for badge_type, desc in self.AT_THE_DOOR_BADGE_OPTS
+            if self.BADGES[badge_type] in c.DAYS_OF_WEEK
+        }
+
+    @property
     def PREREG_DONATION_OPTS(self):
         if self.BEFORE_SUPPORTER_DEADLINE and self.SUPPORTER_AVAILABLE:
             return self.DONATION_TIER_OPTS

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -131,11 +131,6 @@ collect_exact_birthdate = boolean(default=False)
 # emergency contact number, and cellphone number.
 collect_full_address = boolean(default=False)
 
-# An event may or may not want attendees to volunteer through pre-reg - this controls
-# the visibility of the volunteering checkbox.
-# TODO: Replace this with a larger per-form visibility configuration for all special fields
-volunteer_form_visible = boolean(default=False)
-
 # We try to predict our tshirt needs, but sometimes we run out during the
 # event.  Set this to True when that happens, and people receiving swag
 # will automatically be added to the list of people who received all of
@@ -218,7 +213,7 @@ signups             = integer(default=1)  # not an admin access level, so handle
 pseudo_group_badge  = integer(default=1)  # people registering in groups will get attendee badges
 pseudo_dealer_badge = integer(default=2)  # dealers get attendee badges with a ribbon
 email_re            = string(default="^[a-zA-Z0-9_\-+.]+@[a-zA-Z0-9_\-+.]+(\.[a-zA-Z0-9_\-+.]+){1,}$")
-ind_dealer_badge = integer(default=3)  # individual dealers get attendee badges with a ribbon
+ind_dealer_badge    = integer(default=3)  # individual dealers get attendee badges with a ribbon
 
 # People occasionally refer to MAGFest as a "convention" and then someone such
 # as Nick sends an email to correct them, saying that we're a "festival".  Other
@@ -344,6 +339,18 @@ __many__ = string
 # Set this to False to turn off single-day passes for your event.
 one_days_enabled = boolean(default=True)
 
+# There are two ways events typically handle single-day passes.  Either you must
+# purchase the pass on the day you use it, or you can pre-purchase a single day
+# pass for a future day.  If this is set to true, a new badge type is created for
+# each day from c.EPOCH to c.ESCHATON.  For example, if your event runs from
+# Friday through Sunday, you will end up with c.FRIDAY, c.SATURDAY, and c.SUNDAY
+# badge types.  The c.ONE_DAY_BADGE type still exists, and admins can use it to
+# create single day passes which can be redeemed on any day.
+#
+# This option does nothing if c.ONE_DAYS_ENABLED is set to False.
+#
+presell_one_days = boolean(default=True)
+
 # We support different single day badge prices on different days.  This is the
 # default price, which may be overridden in the [[single_day]] section below.
 default_single_day = integer(default=40)
@@ -371,6 +378,13 @@ __many__ = integer
 [[attendee]]
 # Set dates equal to the price as of that date.  For example, you could say
 # "2014-10-01 = 45" to have the price go up to $45 on October 1st.
+__many__ = integer
+
+[[stocks]]
+# Use this to set limits on how many copies of each badge can be issues, e.g.
+# if you only have 200 Friday badges you'd say "friday = 200".  Although you
+# can list arbitrary things here, the intention is for options in this section
+# to correspond to badge types, e.g. "attendee_badge = 2000", etc.
 __many__ = integer
 
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -500,7 +500,7 @@ class Root:
                 message = 'Please select a payment type'
             elif attendee.payment_method == c.MANUAL and not re.match(c.EMAIL_RE, attendee.email):
                 message = 'Email address is required to pay with a credit card at our registration desk'
-            elif attendee.badge_type not in [c.ATTENDEE_BADGE, c.ONE_DAY_BADGE]:
+            elif attendee.badge_type not in [badge for badge, desc in c.AT_THE_DOOR_BADGE_OPTS]:
                 message = 'No hacking allowed!'
             else:
                 session.add(attendee)

--- a/uber/templates/registration/register.html
+++ b/uber/templates/registration/register.html
@@ -16,8 +16,6 @@
             $emailLabel.removeClass('optional-field');
         }
     };
-    $(maybeBold);
-
     var removeDonationRows = function () {
         $('.extra-row').remove();
     };
@@ -25,9 +23,14 @@
         $('.staffing').remove();
     };
     $(function () {
-        removeDonationRows();
-        removeVolunteerRows();
-        $('#bold-field-message').detach().prependTo('.form-horizontal');
+        {% if c.AT_THE_DOOR_BADGE_OPTS %}
+            maybeBold();
+            removeDonationRows();
+            removeVolunteerRows();
+            $('#bold-field-message').detach().prependTo('.form-horizontal');
+        {% else %}
+            $('.panel').empty().append('<h1>All badges are sold out!</h1>');
+        {% endif %}
     });
 </script>
 

--- a/uber/templates/registration/register.html
+++ b/uber/templates/registration/register.html
@@ -16,6 +16,15 @@
             $emailLabel.removeClass('optional-field');
         }
     };
+    var maybeWarn = function () {
+        var types = {{ c.PRESOLD_ONEDAY_BADGE_TYPES|jsonize }};
+        var badgeType = $.val('badge_type');
+        if (badgeType in types && types[badgeType] !== moment().format('dddd')) {
+            $('#day-warning').text('This badge can ONLY be picked up on ' + types[badgeType] + '.  You cannot pick it up today or any other day than ' + types[badgeType] + '.');
+        } else {
+            $('#day-warning').empty();
+        }
+    };
     var removeDonationRows = function () {
         $('.extra-row').remove();
     };
@@ -28,6 +37,8 @@
             removeDonationRows();
             removeVolunteerRows();
             $('#bold-field-message').detach().prependTo('.form-horizontal');
+            $.field('badge_type').on('change', maybeWarn);
+            maybeWarn();
         {% else %}
             $('.panel').empty().append('<h1>All badges are sold out!</h1>');
         {% endif %}
@@ -61,6 +72,7 @@
         <select name="badge_type" class="form-control">
             {% options c.AT_THE_DOOR_BADGE_OPTS attendee.badge_type %}
         </select>
+        <p id="day-warning" class="help-block"></p>
     </div>
 </div>
 


### PR DESCRIPTION
For this year, we wanted to allow anyone to buy any day's badge through our 'at-door' page.

This was trickier than expected, because our badge configuration is fairly limited - you can't have multiple 'attendee'-type badges with their own sets of prices. While this is a good argument for refactoring badge types into object-based entities, that was too much to tackle right now.

I'll explain the changes in-line.