### PR TITLE
Fixed dept head ribbon / badge issue

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1067,7 +1067,8 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.ribbon == c.DEPT_HEAD_RIBBON:
             self.staffing = True
             self.trusted_depts = self.assigned_depts
-            self.badge_type = c.STAFF_BADGE
+            if c.SHIFT_CUSTOM_BADGES or c.STAFF_BADGE not in c.PREASSIGNED_BADGE_TYPES:
+                self.badge_type = c.STAFF_BADGE
             if self.paid == c.NOT_PAID:
                 self.paid = c.NEED_NOT_PAY
         elif self.ribbon == c.VOLUNTEER_RIBBON and self.is_new:


### PR DESCRIPTION
When someone is marked as a department head, they are automatically assigned a staff badge.  In general this is good, but we don't want to do this after the badges have been ordered.  I added an if statement to ensure that after badges have been ordered, people's badge type is not adjusted.