### PR TITLE
fixed bug with shift marking from the attendee shifts page

### DIFF
--- a/uber/templates/common.js
+++ b/uber/templates/common.js
@@ -71,14 +71,16 @@ var setupRatingClickHandler = function () {
 };
 var setStatus = function (shiftId, status) {
     var $status = $(status);
-    $.post('../jobs/set_worked', {id: shiftId, worked: $status.val(), csrf_token: csrf_token}, function (result) {
+    var statusVal = parseInt($status.val());
+    $.post('../jobs/set_worked', {id: shiftId, status: statusVal, csrf_token: csrf_token}, function (result) {
         if (result.error) {
             alert(result.error);
         } else {
+            var statusLabel = _(result.shifts).filter({id: shiftId}).pluck('worked_label').first() || 'Unexpected Error';
             $status.parent().empty()
-                .append('<i>' + result.status_label + '</i> &nbsp; ')
+                .append('<i>' + statusLabel + '</i> &nbsp; ')
                 .append($undoForm('../jobs/undo_worked', {id: shiftId}));
-            if ($status.val() == {{ c.SHIFT_WORKED }}) {
+            if (statusVal === {{ c.SHIFT_WORKED }}) {
                 renderRating(shiftId);
             }
         }

--- a/uber/templates/jobs/job_renderer.html
+++ b/uber/templates/jobs/job_renderer.html
@@ -77,7 +77,7 @@
                                     .append(
                                         $('<td></td>').append(
                                             shift.worked === {{ c.SHIFT_UNMARKED }} ? renderWorked(shift.id) : ('<i>' + shift.worked_label + '</i>')))
-                                    .append(shift.worked === {{ c.SHIFT_UNMARKED }} ? '' : renderRating(shift, $('<td></td>')));
+                                    .append(shift.worked !== {{ c.SHIFT_WORKED }} ? '' : renderRating(shift, $('<td></td>')));
                             }))));
     };
 


### PR DESCRIPTION
Two bugs are fixed here:

1) A recent refactor to simplify the job rendering code broke the ability to mark shifts as worked from the volunteer's shifts page, i.e. the "Shifts" tab of their admin form.  This fixes it.

2) Previously we were rendering the rating form for people who were marked as not showing up, which is not correct.