### PR TITLE
Signups pages no longer default to first volunteer in dropdown

### DIFF
--- a/uber/templates/jobs/job_renderer.html
+++ b/uber/templates/jobs/job_renderer.html
@@ -2,6 +2,7 @@
 <div style="position:fixed ; top:25% ; right: 2% ; text-align:right">
     <b>Assign someone to any of these positions:</b> <br/>
     <select id="attendee">
+        <option value="">Select a volunteer</option>
         {% for attendee in attendees %}
             <option value="{{ attendee.id }}">{{ attendee.full_name }}</option>
         {% endfor %}
@@ -51,11 +52,16 @@
                     .append(
                         $('<td></td>').append(
                             jobIsFull ? '' : $('<button>Assign</button>').click(function () {
-                                $.post('assign', {
-                                    csrf_token: csrf_token,
-                                    job_id: job.id,
-                                    staffer_id: $('#attendee').val()
-                                }, renderJob, 'json');
+                                var attendee = $('#attendee').val();
+                                if (attendee) {
+                                    $.post('assign', {
+                                        csrf_token: csrf_token,
+                                        job_id: job.id,
+                                        staffer_id: $('#attendee').val()
+                                    }, renderJob, 'json');
+                                } else {
+                                    alert('You must select a volunteer to assign.');
+                                }
                             }))))
             .append(
                 $('<tr></tr>')


### PR DESCRIPTION
David Boyd pointed out that in our floating dropdown of volunteers to assign to shifts, the first volunteer was selected by default.  This has led to a tendency to assign people named "Aaron" to shifts accidentally, forcing us to remove them and then assign the correct person.

This implements a "Select a volunteer" default first option, and clicking "Assign" when that option is selected will throw up an error alert box.