### PR TITLE
fixed merch prices and merch check layout

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -123,20 +123,33 @@ no_shirt     = 0
 'No thanks' = 0
 
 [[shirt]]
-'no shirt'         = NO_SHIRT
+'no shirt' = NO_SHIRT
 
 [[fee_price]]
-'Wristband Replacement' = 5
-'Badge Replacement'     = 60
+'Badge Replacement' = 80
 
 [[store_price]]
-'MAGFest 13 tshirt'           = 15
-'MAGFest 12 tshirt'           = 10
-'MAGFest hoodie'              = 30
-'MAGFest 13 sticker'          = 1
-'Squarewave Bumper Sticker'   = 2
-'Squarewave Car Window Decal' = 4
-'Squarewave Lanyard'          = 3
+'MAGFest 2016 tshirt'            = 20
+'Squarewave tshirt'              = 15
+'Polo Shirt'                     = 25
+'Hoodie'                         = 30
+'Scarf'                          = 25
+'Beanie'                         = 15
+'Pin (MAGBadge)'                 = 8
+'Pin (MAGFest Logo)'             = 8
+'Pin set of 2'                   = 15
+'Poster'                         = 3
+'Lanyard'                        = 5
+'Wristband'                      = 1
+'MAGnet (indoor)'                = 2
+'MAGnet (outdoor)'               = 4
+'Bumper Sticker'                 = 3
+'Squarewave Bumper Sticker'      = 2
+'MAGFest 2016 Car Decal (Small)' = 3
+'MAGFest 2016 Car Decal (Large)' = 5
+'Squarewave Car Decal (Small)'   = 3
+'Squarewave Car Decal (Large)'   = 5
+'Other Sticker'                  = 1
 
 
 [enums]

--- a/uber/config.py
+++ b/uber/config.py
@@ -58,18 +58,18 @@ class _Overridable:
         """
         opts, lookup, varnames = [], {}, []
         for name, desc in section.items():
-            if isinstance(name, int):
-                if prices:
-                    val, desc = desc, name
-                else:
-                    val = name
+            if isinstance(desc, int):
+                val, desc = desc, name
             else:
                 varnames.append(name.upper())
                 val = self.create_enum_val(name)
 
             if desc:
                 opts.append((val, desc))
-                lookup[val] = desc
+                if prices:
+                    lookup[desc] = val
+                else:
+                    lookup[val] = desc
 
         enum_name = enum_name.upper()
         setattr(self, enum_name + '_OPTS', opts)
@@ -376,11 +376,11 @@ for _name, _section in _config['integer_enums'].items():
         _interpolated = OrderedDict()
         for _desc, _val in _section.items():
             if _is_intstr(_val):
-                key = int(_val)
+                _price = int(_val)
             else:
-                key = getattr(c, _val.upper())
+                _price = getattr(c, _val.upper())
 
-            _interpolated[key] = _desc
+            _interpolated[_desc] = _price
 
         c.make_enum(_name, _interpolated, prices=_name.endswith('_price'))
 
@@ -460,8 +460,8 @@ c.PREREG_SHIRT_OPTS = c.SHIRT_OPTS[1:]
 c.MERCH_SHIRT_OPTS = [(c.SIZE_UNKNOWN, 'select a size')] + list(c.PREREG_SHIRT_OPTS)
 c.DONATION_TIER_OPTS = [(amt, '+ ${}: {}'.format(amt, desc) if amt else desc) for amt, desc in c.DONATION_TIER_OPTS]
 
-c.STORE_ITEM_NAMES = list(c.STORE_PRICES.keys())
-c.FEE_ITEM_NAMES = list(c.FEE_PRICES.keys())
+c.STORE_ITEM_NAMES = [desc for val, desc in c.STORE_PRICE_OPTS]
+c.FEE_ITEM_NAMES = [desc for val, desc in c.FEE_PRICE_OPTS]
 
 c.WRISTBAND_COLORS = defaultdict(lambda: c.WRISTBAND_COLORS[c.DEFAULT_WRISTBAND], c.WRISTBAND_COLORS)
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -1289,7 +1289,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         elif self.gets_free_shirt:
             shirt = '2nd ' + c.DONATION_TIERS[c.SHIRT_LEVEL]
             if self.takes_shifts and self.worked_hours < 6:
-                shirt += ' (tell them they will be reported if they take their shirt and then do not work their shifts)'
+                shirt += ' (tell them they will be reported if they take their shirt then do not work their shifts)'
             merch.append(shirt)
         if self.extra_merch:
             merch.append(self.extra_merch)

--- a/uber/templates/registration/merch.html
+++ b/uber/templates/registration/merch.html
@@ -117,9 +117,10 @@
                 if (!resp.id) {
                     $('#message').html(resp.message);
                 } else {
-                    $('#give').html(resp.message.replace(' and ', ' ')
+                    $('#give').html(resp.message.replace(' and ', ',')
                                         .replace(' received ', ' received<br/>- ')
                                         .replace(/,/g, '<br/>- ')
+                                        .replace('<br/>- <br/>- ', '<br/>- ')
                                   + '<br/>');
                     if (resp.shirt != {{ c.NO_SHIRT }}) {
                         $('#give').append('Choose a shirt size:').append($shirtOpts);


### PR DESCRIPTION
Three fixes here:

1) I set the merch prices for this year.  We really need to move this out of ``development-defaults,ini`` but that's where it's always been, and fixing that is out of scope for this PR.  (I'm hoping to get Dom to tackle https://github.com/magfest/ubersystem-puppet/issues/28 in the next couple of months and then we'd get that for free.)

2) I fixed a minor display bug with the "Check Merch" button on the merch page.  We now property listify all of the "number of things you get" cases (nothing, 1 thing, 2 things, many things).

3) Most seriously, there was a bug in the merch code that we never noticed because it only triggers when two items in your store cost the same thing,  This didn't happen for MagClassic, but it's totally a thing for us.  I fixed the ``prices`` feature in ``config.py`` so this is no longer an issue.