### PR TITLE
two minor fixes for at-the-door registration

### DIFF
--- a/uber/templates/registration/new.html
+++ b/uber/templates/registration/new.html
@@ -142,10 +142,8 @@
         </td>
         <td>{{ attendee.badge_type_label }}</td>
         <td>{{ attendee.age_group_conf.desc }}</td>
-        {% if attendee.paid != c.PAID_BY_GROUP %}
-            <td>${{ attendee.total_cost }}</td>
-        {% endif %}
-        <td {% if attendee.paid == c.PAID_BY_GROUP %}colspan="2"{% endif %}>
+        <td>{% if attendee.paid != c.PAID_BY_GROUP %}${{ attendee.total_cost }}{% endif %}</td>
+        <td>
             {% if attendee.paid == c.HAS_PAID %}
                 paid
             {% elif attendee.paid == c.PAID_BY_GROUP %}
@@ -163,9 +161,10 @@
             {% endif %}
         </td>
         {% if attendee.paid == c.PAID_BY_GROUP %}
-            <td colspan="2">
+            <td>
                 check in group badges <a href="index?search_text={{ attendee.id }}">here</a>
             </td>
+            <td></td>
         {% else %}
             <form method="post" action="new_checkin">
             {% if c.NUMBERED_BADGES %}

--- a/uber/templates/registration/register.html
+++ b/uber/templates/registration/register.html
@@ -10,10 +10,10 @@
 
     var maybeBold = function() {
         var $emailLabel = $('#email').parents('.form-group').find('label');
-        if (!$.field('payment_method') || $.val('payment_method') === {{ c.MANUAL }}) {
-            $emailLabel.addClass('optional-field');
-        } else {
+        if (!$.field('payment_method') || _(['', {{ c.STRIPE }}]).contains($.val('payment_method'))) {
             $emailLabel.removeClass('optional-field');
+        } else {
+            $emailLabel.addClass('optional-field');
         }
     };
     var maybeWarn = function () {


### PR DESCRIPTION
Two fixes here:

1) Bob pointed out that in the at-the-door reg form, "Email Address" is bolded, making it look like a required field.  In fact it's optional.  I fixed it so that it shows up as required for Stripe and nothing else.  (In theory it's option for Stripe as well, but we might as well make it bold since they'll need to type in their email when they pay via Stripe anyway.)

2) There was a DataTables error on the at-the-door registration page, which I fixed.  Apparently datatables doesn't support colspan, which is unfortunate.