### PR TITLE
fixed Mark Paid button being disabled on initial page load

### DIFF
--- a/uber/templates/registration/new.html
+++ b/uber/templates/registration/new.html
@@ -27,7 +27,7 @@
         }
     };
     $(function () {
-        $('table.list select[name=payment_method]').each(function (i, dropdown) {
+        $('table select[name=payment_method]').each(function (i, dropdown) {
             toggleMarkButton(dropdown);
         });
     });


### PR DESCRIPTION
When we implemented ``DataTables`` on the New registrations page, we change the class name on the table.  This broke the jQuery selector we used to set the "disabled" status of the buttons on that page, which resulted in us not being able to click the "Mark Paid" button until we changed the value in the dropdown, even if a correct value was already selected.