### PR TITLE
implemented ability for volunteers to sign up for shifts in at-the-con mode

### DIFF
--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -124,3 +124,17 @@ class Root:
             'email':     email,
             'zip_code':  zip_code
         }
+
+    def onsite_jobs(self, session, message=''):
+        attendee = session.logged_in_volunteer()
+        return {
+            'message': message,
+            'attendee': attendee,
+            'jobs': [job for job in attendee.possible_and_current
+                         if getattr(job, 'taken', False) or job.start_time > localized_now()]
+        }
+
+    @csrf_protected
+    def onsite_sign_up(self, session, job_id):
+        message = session.assign(session.logged_in_volunteer().id, job_id)
+        raise HTTPRedirect('onsite_jobs?message={}', message or 'It worked')

--- a/uber/templates/signups/onsite_jobs.html
+++ b/uber/templates/signups/onsite_jobs.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% block title %}On-Site Shifts{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+
+<h2>All Available Shifts</h2>
+
+<div style="text-align:center ; font-style:italic">
+    <a href="login">Click here</a> to log in as someone else. <br/>
+    <a href="printable">Click here</a> to see a printable schedule of the {{ attendee.weighted_hours }} weighted hours worth of shifts you are signed up for.
+</div>
+
+<br/>
+{{ c.EVENT_NAME }} has already started, so it's too late to drop shifts.  However, you can sign up for new shifts below.
+<br/> <br/>
+If you cannot make it to one or more of your existing shifts, contact {{ c.STAFF_EMAIL }}
+<br/> <br/>
+
+<table class="datatable" style="width:100%" data-page-length="-1">
+    <thead>
+        <tr>
+            <th>Start</th>
+            <th>Hours</th>
+            <th>Department</th>
+            <th>Job</th>
+            <th>Weight</th>
+            <th>Weighted Total</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for job in jobs %}
+        <tr>
+            <td>Feb {{ job.start_time|datetime:"%-d at %H:%M (%-I %p %a)" }}</td>
+            <td>{{ job.duration }}</td>
+            <td>{{ job.location_label }}</td>
+            <td>{{ job.name }}</td>
+            <td>(x{{ job.weight }})</td>
+            <td>{{ job.weighted_hours }} hours</td>
+            <td>
+                {% if job.taken %}
+                    Signed Up!
+                {% else %}
+                    <form method="post" action="onsite_sign_up">
+                    {% csrf_token %}
+                    <input type="hidden" name="job_id" value="{{ job.id }}" />
+                    <button>Sign Up</button>
+                    </form>
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+{% endblock %}

--- a/uber/templates/signups/printable.html
+++ b/uber/templates/signups/printable.html
@@ -6,7 +6,8 @@
 <h2> {{ attendee.full_name }}'s Printable Schedule </h2>
 
 <div style="text-align:center ; font-style:italic">
-    <a href="login">Click here</a> to log in as someone else.
+    <a href="login">Click here</a> to log in as someone else. <br/>
+    <a href="onsite_jobs">Click here</a> to sign up for new shifts.
 </div>
 
 <br/> Our database has gone offline to be moved to {{ c.EVENT_NAME }}, but you can still print your schedule below: <br/> <br/>


### PR DESCRIPTION
We've always disabled the usual signups page when we're in on-site mode because we don't want people dropping shifts.  I added the ability for them to take new shifts so that we can direct on-site volunteers to sign up for new shifts on their smartphones.