### PR TITLE
setting a badge number now checks in automatically

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1019,7 +1019,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.paid != c.REFUNDED:
             self.amount_refunded = 0
 
-        if c.AT_THE_CON and self.badge_num and self.is_new:
+        if c.AT_THE_CON and self.badge_num and (self.is_new or self.badge_type not in c.PREASSIGNED_BADGE_TYPES):
             self.checked_in = datetime.now(UTC)
 
         if self.birthdate:


### PR DESCRIPTION
If you set the badge number on a non-preassigned badge type in at-the-con mode it now automatically checks in the badge.  Previously it only did this when the badge was first created.
