### PR TITLE
fix merge error resulting in badge transfers not working

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -387,7 +387,7 @@ class Root:
         attendee = session.attendee(params, restricted=True)
 
         if 'first_name' in params:
-            message = check(attendee) or check_prereg_reqs(attendee)
+            message = check(attendee, prereg=True)
             if old.first_name == attendee.first_name and old.last_name == attendee.last_name:
                 message = 'You cannot transfer your badge to yourself.'
             elif not message and (not params['first_name'] and not params['last_name']):


### PR DESCRIPTION
this code https://github.com/magfest/ubersystem/commit/fe4266d24ebe1844c59260ded8175c4941a8c7cc#diff-9c3818f655c258e1b711348de8f069c9R400 introduced a merge error which we didn't notice til now.

```check_prereg_reqs(attendee)``` was replaced with ```check(attendee, prereg=True)```, did that here and tested, so it works.

fixes https://github.com/magfest/magstock/issues/36