### PR TITLE
fix budget page

### DIFF
--- a/uber/site_sections/budget.py
+++ b/uber/site_sections/budget.py
@@ -4,7 +4,7 @@ from uber.common import *
 def prereg_money(session):
     preregs = defaultdict(int)
     for attendee in session.query(Attendee):
-        preregs['Attendee'] += attendee.amount_paid
+        preregs['Attendee'] += attendee.amount_paid - attendee.amount_extra
         preregs['extra'] += attendee.amount_extra
 
     preregs['group_badges'] = sum(g.badge_cost for g in session.query(Group)

--- a/uber/templates/budget/index.html
+++ b/uber/templates/budget/index.html
@@ -30,7 +30,7 @@
         <td>${{ preregs.Attendee }}</td>
     </tr>
     <tr>
-        <td>Kicked-In Extra</td>
+        <td>Extra Payments (Kickins, Shirts, Food, anything else)</td>
         <td>${{ preregs.extra }}</td>
     </tr>
     <tr>


### PR DESCRIPTION
budget page was previously counting kickins twice
 - once in "kickins" - attendee.amount_extra
 - again in "attendee sales" - attendee.amount_paid (which INCLUDES the kickin)

 this whole page probably needs a once over, I think it is also miscounting dealer table sales. not sure.

tested this by doing a bunch of registrations locally and they all match up money-wise now (before it was totaling up too much)