### PR TITLE
Add ability to specify css ID for single checkbox

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -190,7 +190,7 @@ class checkbox(template.Node):
     def render(self, context):
         model = self.model.resolve(context)
         checked = 'checked' if getattr(model, self.field_name) else ''
-        return '<input type="checkbox" name="{}" value="1" {} />'.format(self.field_name, checked)
+        return '<input type="checkbox" name="{}" id="{}" value="1" {} />'.format(self.field_name, self.field_name, checked)
 
 
 @tag


### PR DESCRIPTION
Chaney added this:
This adds support to add in a css ID that Materialize (a CSS framework) needs.

It takes the name of the ID from the checkbox name, which should, in normal sane situations, always be unique.
