### PR TITLE
Stop removing fields from at-door page

### DIFF
--- a/uber/templates/registration/register.html
+++ b/uber/templates/registration/register.html
@@ -25,17 +25,9 @@
             $('#day-warning').empty();
         }
     };
-    var removeDonationRows = function () {
-        $('.extra-row').remove();
-    };
-    var removeVolunteerRows = function () {
-        $('.staffing').remove();
-    };
     $(function () {
         {% if c.AT_THE_DOOR_BADGE_OPTS %}
             maybeBold();
-            removeDonationRows();
-            removeVolunteerRows();
             $('#bold-field-message').detach().prependTo('.form-horizontal');
             $.field('badge_type').on('change', maybeWarn);
             maybeWarn();


### PR DESCRIPTION
Doing this is unnecessary and is liable to break JavaScript in plugins' regextra.html.