### PR TITLE
Use epoch for emails when appropriate

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -228,11 +228,11 @@ StopsEmail('Last chance to sign up for {EVENT_NAME} shifts', 'shifts/reminder.tx
                                                  and a.takes_shifts and not a.hours)
 
 StopsEmail('Still want to volunteer at {EVENT_NAME}?', 'shifts/volunteer_check.txt',
-              lambda a: c.SHIFTS_CREATED and days_before(5, c.UBER_TAKEDOWN)
+              lambda a: c.SHIFTS_CREATED and days_before(5, min(c.UBER_TAKEDOWN, c.EPOCH))
                                          and a.ribbon == c.VOLUNTEER_RIBBON and a.takes_shifts and a.weighted_hours == 0)
 
 StopsEmail('Your {EVENT_NAME} shift schedule', 'shifts/schedule.html',
-           lambda a: c.SHIFTS_CREATED and days_before(1, c.UBER_TAKEDOWN) and a.weighted_hours)
+           lambda a: c.SHIFTS_CREATED and days_before(1, min(c.UBER_TAKEDOWN, c.EPOCH)) and a.weighted_hours)
 
 
 # For events with customized badges, these emails remind people to let us know what we want on their badges.  We have

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -228,11 +228,11 @@ StopsEmail('Last chance to sign up for {EVENT_NAME} shifts', 'shifts/reminder.tx
                                                  and a.takes_shifts and not a.hours)
 
 StopsEmail('Still want to volunteer at {EVENT_NAME}?', 'shifts/volunteer_check.txt',
-              lambda a: c.SHIFTS_CREATED and days_before(5, min(c.UBER_TAKEDOWN, c.EPOCH))
+              lambda a: c.SHIFTS_CREATED and days_before(5, c.DEFAULT_EMAIL_DEADLINE)
                                          and a.ribbon == c.VOLUNTEER_RIBBON and a.takes_shifts and a.weighted_hours == 0)
 
 StopsEmail('Your {EVENT_NAME} shift schedule', 'shifts/schedule.html',
-           lambda a: c.SHIFTS_CREATED and days_before(1, min(c.UBER_TAKEDOWN, c.EPOCH)) and a.weighted_hours)
+           lambda a: c.SHIFTS_CREATED and days_before(1, c.DEFAULT_EMAIL_DEADLINE) and a.weighted_hours)
 
 
 # For events with customized badges, these emails remind people to let us know what we want on their badges.  We have

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -228,11 +228,11 @@ StopsEmail('Last chance to sign up for {EVENT_NAME} shifts', 'shifts/reminder.tx
                                                  and a.takes_shifts and not a.hours)
 
 StopsEmail('Still want to volunteer at {EVENT_NAME}?', 'shifts/volunteer_check.txt',
-              lambda a: c.SHIFTS_CREATED and days_before(5, c.DEFAULT_EMAIL_DEADLINE)
+              lambda a: c.SHIFTS_CREATED and days_before(5, c.FINAL_EMAIL_DEADLINE)
                                          and a.ribbon == c.VOLUNTEER_RIBBON and a.takes_shifts and a.weighted_hours == 0)
 
 StopsEmail('Your {EVENT_NAME} shift schedule', 'shifts/schedule.html',
-           lambda a: c.SHIFTS_CREATED and days_before(1, c.DEFAULT_EMAIL_DEADLINE) and a.weighted_hours)
+           lambda a: c.SHIFTS_CREATED and days_before(1, c.FINAL_EMAIL_DEADLINE) and a.weighted_hours)
 
 
 # For events with customized badges, these emails remind people to let us know what we want on their badges.  We have

--- a/uber/config.py
+++ b/uber/config.py
@@ -213,7 +213,7 @@ class Config(_Overridable):
         return not self.AT_OR_POST_CON
 
     @property
-    def DEFAULT_EMAIL_DEADLINE(self):
+    def FINAL_EMAIL_DEADLINE(self):
         return min(c.UBER_TAKEDOWN, c.EPOCH)
 
     @property

--- a/uber/config.py
+++ b/uber/config.py
@@ -213,6 +213,10 @@ class Config(_Overridable):
         return not self.AT_OR_POST_CON
 
     @property
+    def DEFAULT_EMAIL_DEADLINE(self):
+        return min(c.UBER_TAKEDOWN, c.EPOCH)
+
+    @property
     def CSRF_TOKEN(self):
         return cherrypy.session['csrf_token'] if 'csrf_token' in cherrypy.session else ''
 


### PR DESCRIPTION
The usage of uber_takedown has changed now that we often don't take down the system. This keeps emails from getting sent too late even if we decide to set uber_takedown to be after the start of the event (which is more accurate to reality).