### PR TITLE
Allow events to have blank prereg_takedown

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -315,8 +315,8 @@ supporter_deadline = string(default="")
 # if they didn't provide anything.
 printed_badge_deadline = string(default="2015-12-26")
 
-# Even after preregistration goes offline, we still allow groups to allocate their
-# unassigned badges until this date.
+# Users can no longer create groups after this date, though admins can. Set this
+# blank to keep the group registration open through the event's end date (eschaton).
 group_prereg_takedown = string(default="2016-01-11")
 
 # Even after preregistration goes offline, we still allow people with placeholder
@@ -326,7 +326,8 @@ group_prereg_takedown = string(default="2016-01-11")
 placeholder_deadline  = string(default="2016-01-18")
 
 # New preregistrations can no longer be made after this date, but all other features will
-# continue to work, such as badge transfers, group management, and shift signup.
+# continue to work, such as badge transfers, group management, and shift signup. Set this
+# blank to keep the preregistration page open through the event's end date (eschaton).
 prereg_takedown = string(default="2016-01-18")
 
 # All parts of the site go offline after this date (which is also used in several emails).

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -535,8 +535,7 @@ class PriceNotice(template.Node):
 
     def _notice(self, label, takedown, amount_extra, discount):
         if not takedown:
-            raise ValueError('price_notice tag error: Takedown date not valid{}'.format(
-                ' for "' + label + '"' if label else ''))
+            takedown = c.ESCHATON
 
         if c.PAGE_PATH not in ['/preregistration/form', '/preregistration/register_group_member']:
             return ''  # we only display notices for new attendees
@@ -544,9 +543,12 @@ class PriceNotice(template.Node):
             for day, price in sorted(c.PRICE_BUMPS.items()):
                 if day < takedown and localized_now() < day:
                     return '<div class="prereg-price-notice">Price goes up to ${} at 11:59pm {} on {}</div>'.format(price - int(discount) + int(amount_extra), (day - timedelta(days=1)).strftime('%Z'), (day - timedelta(days=1)).strftime('%A, %b %e'))
-                elif localized_now() < day and takedown == c.PREREG_TAKEDOWN:
+                elif localized_now() < day and takedown == c.PREREG_TAKEDOWN and takedown < c.EPOCH:
                     return '<div class="prereg-type-closing">{} closes at 11:59pm {} on {}. Price goes up to ${} at-door.</div>'.format(label, takedown.strftime('%Z'), takedown.strftime('%A, %b %e'), price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
-            return '<div class="prereg-type-closing">{} closes at 11:59pm {} on {}</div>'.format(label, takedown.strftime('%Z'), takedown.strftime('%A, %b %e'))
+            if takedown < c.EPOCH:
+                return '<div class="prereg-type-closing">{} closes at 11:59pm {} on {}</div>'.format(label, takedown.strftime('%Z'), takedown.strftime('%A, %b %e'))
+            else:
+                return ''
 
     def render(self, context):
         return self._notice(self.label, self.takedown.resolve(context), self.amount_extra.resolve(context), self.discount.resolve(context))


### PR DESCRIPTION
Events can now set group_prereg_takedown and prereg_takedown to an empty string and the pre-reg page will still work. The pre-reg page will no longer warn about pre-reg closing if the takedowns are set blank.