### PR TITLE
Change link to HTML emails to always work

### DIFF
--- a/uber/templates/registration/history.html
+++ b/uber/templates/registration/history.html
@@ -60,7 +60,7 @@
     {% if forloop.first %}<h2> Automated Emails </h2>{% endif %}
     <h3> {{ email.subject }} ({{ email.when|full_datetime }}) </h3>
     {% if email.is_html %}
-        (content of HTML email omitted; you can view the full email <a href="../emails/sent?dest={{ attendee.email }}">here</a>)
+        (content of HTML email omitted; you can view the full email <a href="../emails/sent?id={{ email.id }}">here</a>)
     {% else %}
         <div style="font-family:courier">{{ email.html }}</div>
     {% endif %}


### PR DESCRIPTION
If an attendee changes their email address, this link would result in an error because it was only searching by attendee email. We have the exact email available to the template so there's no reason to link using fuzzy search terms.