### PR TITLE
Stop missing labels from preventing function

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -296,7 +296,10 @@ class MagModel:
 
     @suffix_property
     def _label(self, name, val):
-        return '' if val is None else self.get_field(name).type.choices[int(val)]
+        try:
+            return self.get_field(name).type.choices[int(val)]
+        except KeyError:
+            return ''
 
     @suffix_property
     def _local(self, name, val):


### PR DESCRIPTION
The new single day badge feature, which involves checking badge labels, broke dealer applications because dealer badges are not configured with labels. This is silly. We now swallow KeyErrors for badge labels.

Fixes #1840.