### PR TITLE
Updates Stops Email - Want to Staff

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -194,7 +194,7 @@ AutomatedEmail(Attendee, '{EVENT_NAME} Dealer Information Required', 'placeholde
                lambda a: a.placeholder and a.is_dealer and a.group.status == c.APPROVED,
                sender=c.MARKETPLACE_EMAIL)
 
-StopsEmail('Want to staff {EVENT_NAME} again?', 'placeholders/imported_volunteer.txt',
+StopsEmail('Want to staff {EVENT_NAME} ?', 'placeholders/imported_volunteer.txt',
            lambda a: a.placeholder and a.staffing and a.registered_local <= c.PREREG_OPEN)
 
 StopsEmail('{EVENT_NAME} Volunteer Badge Confirmation', 'placeholders/volunteer.txt',


### PR DESCRIPTION
Related to the creation of our new event MAGLabs, -- the Subject line of our Staffing Email reads:
"Want to staff (event_name) again?"

With MAGFest Laboratories as a new event, we find that the phrasing "Staffing again" doesn't differentiate this event from other events.
The proposed file change removed the work "again" from the subject line in the email.

There might be a better location for this in the Classic config file, instead of a global change.