### PR TITLE
Add alembic as a 'requirement'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,5 @@ distribute-*.tar.gz
 *.swp
 up.bat
 add_table_extras.sql
-alembic*
 bower_components/
 node_modules/

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,23 @@
+Generic single-database configuration.
+
+For the time being, please DO NOT check revisions into the rams (ubersystem) repository. Instead, copy the directory into your event plugin and work within that event's DB.
+
+To autogenerate migrations:
+```bash
+# Make changes to your models.py file(s) as appropriate
+# DO NOT use sep reset_uber_db!
+# Keep in mind, relationship "columns" are not real, you do not need migrations for them
+cd /your/event-plugin
+alembic revision --autogenerate -m "Message for revision"
+```
+
+Be sure to check your revision and edit it as necessary; auto-generation is not perfect and may try to drop columns.
+
+To run migrations:
+`alembic upgrade head`
+
+To "fast-foward" migrations, i.e., count them as being run without actually running them:
+`alembic stamp head`
+
+If you get any "ImportErrors" while auto-generating or running migrations, then it's likely that the system path is incorrect. This shouldn't happen but the relevant line in env.py is:
+`sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), '..')))`

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,77 @@
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+
+import os, sys
+sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), '..')))
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+import sideboard
+from uber.common import *
+target_metadata = Session.BaseClass.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+# We replace the INI option with RAMS' URL.
+config.set_main_option('sqlalchemy.url', c.SQLALCHEMY_URL)
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ stripe==1.11.0
 pytz==2014.4
 pep8==1.6.2
 pytest==2.7.2
+alembic==0.8.7


### PR DESCRIPTION
This ensures that all installs will have the same version of alembic, making it easier to manage and run DB migrations. Also includes a custom env.py file for using in event plugins. Simple instructions are in the alembic README.

Replaces https://github.com/magfest/ubersystem-deploy/pull/50.