### PR TITLE
Move main menu data into python

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -73,6 +73,7 @@ from uber.decorators import *
 from uber.models import *
 from uber.automated_emails import *
 from uber.badge_funcs import *
+from uber.menu import *
 from uber import model_checks
 from uber import custom_tags
 from uber import server

--- a/uber/menu.py
+++ b/uber/menu.py
@@ -1,0 +1,51 @@
+from uber.common import *
+
+
+class MenuItem:
+    access = None   # list of permission levels allowed to display this menu
+    href = None     # link to render
+    submenu = None  # submenu to show
+    name = None     # name of Menu item to show
+
+    def __init__(self, href=None, access=None, submenu=None, name=None):
+        if submenu:
+            self.submenu = listify(submenu)
+        else:
+            self.href = href
+
+        self.name = name
+        self.access = access
+
+    def __getitem__(self, key):
+        for sm in self.submenu:
+            if sm.name == key:
+                return sm
+
+    def append_menu_item(self, m):
+        # if we aren't a submenu, convert us to one now
+        if not self.submenu and self.href:
+            self.submenu = [MenuItem(name=self.name, href=self.href)]
+            self.href = None
+
+        self.submenu.append(m)
+
+
+c.MENU = MenuItem(name='Root', submenu=[
+    MenuItem(name='Accounts', href='../accounts/', access=c.ACCOUNTS),
+
+    MenuItem(name='People', access=[c.PEOPLE, c.REG_AT_CON], submenu=[
+        MenuItem(name='Attendees', href='../registration/{}'.format('?invalid=True' if c.AT_THE_CON else '')),
+        MenuItem(name='Groups', href='../groups/'),
+        MenuItem(name='All Untaken Shifts', access=c.PEOPLE, href='../jobs/everywhere'),
+        MenuItem(name='Jobs', access=c.PEOPLE, href='../jobs/'),
+        MenuItem(name='Watchlist', access=c.WATCHLIST, href='../registration/watchlist_entries'),
+        MenuItem(name='Feed of Database Changes', href='../registration/feed'),
+    ]),
+
+    MenuItem(name='Schedule', access=c.STUFF, submenu=[
+        MenuItem(name='View Schedule', href='../schedule/'),
+        MenuItem(name='Edit Schedule', href='../schedule/edit'),
+    ]),
+
+    MenuItem(name='Statistics', href='../summary/'),
+])

--- a/uber/static/js/menu.js
+++ b/uber/static/js/menu.js
@@ -1,0 +1,34 @@
+function renderMainMenu() {
+    var MainMenu = window.MENU;
+    var $menu = $('#main-menu');
+    $.each(MENU, function (i, menuitem) {
+        if (!menuitem) {
+            return;
+        }
+        if (menuitem['href']) {
+            $menu.append(
+                $('<li></li>').append(
+                    $('<a></a>').attr('href', menuitem.href).text(menuitem.name)));
+        } else if (menuitem['submenu']) {
+            var $submenu = $('<ul class="dropdown-menu" role="menu"></ul>');
+            $.each(menuitem.submenu, function (i, submenuitem) {
+                if (!submenuitem) {
+                    return;
+                }
+                var $li = $('<li></li>');
+                var $link = $('<a></a>').text(submenuitem.name);
+                if (submenuitem.href) {
+                    $link.attr('href', submenuitem.href);
+                } else {
+                    $li.addClass('disabled');
+                }
+                $submenu.append($li.append($link));
+            });
+            $('<li></li>')
+                .addClass('dropdown')
+                .append('<a href="#" class="dropdown-toggle" data-toggle="dropdown">' + menuitem.name + '<span class="caret"></span></a>')
+                .append($submenu)
+                .appendTo($menu);
+        }
+    });
+}

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="../static/deps/combined.css" />
     <script type="text/javascript" src="../static/deps/combined.js"></script>
     <script src="../common.js" type="text/javascript"></script>
+    <script src="../static/js/menu.js" type="text/javascript"></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -45,34 +46,7 @@
     </style>
     <script>
         var DISABLE_STRIPE_BUTTONS_ON_CLICK = true;
-        var MENU = [
-            {% if c.HAS_ACCOUNTS_ACCESS %}
-                {Accounts: '../accounts/'},
-            {% endif %}
-            {% if c.HAS_PEOPLE_ACCESS or c.HAS_REG_AT_CON_ACCESS %}
-                {People: [
-                    {Attendees: '../registration/{% if c.AT_THE_CON %}?invalid=True{% endif %}'},
-                    {Groups: '../groups/'},
-                    {% if c.HAS_PEOPLE_ACCESS %}
-                        {'All Untaken Shifts': '../jobs/everywhere'},
-                        {Jobs: '../jobs/'},
-                    {% endif %}
-                    {% if c.HAS_WATCHLIST_ACCESS %}
-                        {Watchlist: '../registration/watchlist_entries'},
-                    {% endif %}
-                    {'Feed of Database Changes': '../registration/feed'}
-                ]},
-            {% endif %}
-            {% if c.HAS_STUFF_ACCESS %}
-                {Schedule: [
-                    {'View Schedule': '../schedule/'},
-                    {'Edit Schedule': '../schedule/edit'}
-                ]},
-            {% endif %}
-            {% if c.HAS_STATS_ACCESS %}
-                {Statistics: '../summary/'}
-            {% endif %}
-        ];
+        var MENU = {{ c.MENU_JSON|safe }};
         $(function() {
             $(window).load(function() {
                 $(".loader").fadeOut("fast");
@@ -141,33 +115,7 @@
                     checkHour();
                 }
             {% endif %}
-            var $menu = $('#main-menu');
-            $.each(MENU, function (i, section) {
-                var name = _.keys(section)[0], links = _.values(section)[0];
-                if (typeof links === 'string') {
-                    $menu.append(
-                        $('<li></li>').append(
-                            $('<a></a>').attr('href', links).text(name)));
-                } else {
-                    var $submenu = $('<ul class="dropdown-menu" role="menu"></ul>');
-                    $.each(links, function (i, link) {
-                        var label = _.keys(link)[0], href = _.values(link)[0];
-                        var $li = $('<li></li>');
-                        var $link = $('<a></a>').text(label);
-                        if (href) {
-                            $link.attr('href', href);
-                        } else {
-                            $li.addClass('disabled');
-                        }
-                        $submenu.append($li.append($link));
-                    });
-                    $('<li></li>')
-                        .addClass('dropdown')
-                        .append('<a href="#" class="dropdown-toggle" data-toggle="dropdown">' + name + '<span class="caret"></span></a>')
-                        .append($submenu)
-                        .appendTo($menu);
-                }
-            });
+            renderMainMenu();
         });
     </script>
     {% block head_additional %}{% endblock %}


### PR DESCRIPTION
Previously, main menu data was in javascript and was slightly hard to modify from other plugins.

Now, other plugins can just append whatever they want to c.MENU, and there is logic in there to merge submenu sections intelligently.

We render this into JSON data via c.MENU_JSON (I am using a custom encoder so couldn't just ```|json``` it in the template)

This also opens up the future possibility of driving the main menu from some type of reflection process, like the sitemap currently does.