### PR TITLE
inject breadcrumb data

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -244,12 +244,14 @@ def renderable(func):
         result = func(*args, **kwargs)
 
         try:
-            result['__breadcrumb_page__'] = prettify_breadcrumb(func.__name__)
+            result['breadcrumb_page_pretty_'] = prettify_breadcrumb(func.__name__) if func.__name__ != 'index' else 'Home'
+            result['breadcrumb_page_'] = func.__name__ if func.__name__ != 'index' else ''
         except:
             pass
 
         try:
-            result['__breadcrumb_section__'] = prettify_breadcrumb(_get_module_name(func))
+            result['breadcrumb_section_pretty_'] = prettify_breadcrumb(_get_module_name(func))
+            result['breadcrumb_section_'] = _get_module_name(func)
         except:
             pass
 

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -234,10 +234,25 @@ def _get_template_filename(func):
     return os.path.join(_get_module_name(func), func.__name__ + '.html')
 
 
+def prettify_breadcrumb(str):
+    return str.replace('_', ' ').title()
+
+
 def renderable(func):
     @wraps(func)
     def with_rendering(*args, **kwargs):
         result = func(*args, **kwargs)
+
+        try:
+            result['__breadcrumb_page__'] = prettify_breadcrumb(func.__name__)
+        except:
+            pass
+
+        try:
+            result['__breadcrumb_section__'] = prettify_breadcrumb(_get_module_name(func))
+        except:
+            pass
+
         if c.UBER_SHUT_DOWN and not cherrypy.request.path_info.startswith('/schedule'):
             return render('closed.html')
         elif isinstance(result, dict):


### PR DESCRIPTION
- breadcrumb data is navigational menu data in the UI
- this data can be used by UI designers to automatically show which page and section we're on
- Chaney wants this for future UI updates

would be available in templates like this:

```
{{ breadcrumb_page_pretty_ }} - {{ breadcrumb_page_section_ }}
```

for ```/uber/registration/watch_list``` it would show:

```
Registration - Watch List
```