### PR TITLE
WIP/DEMO ONLY: enable a few things to make it possible to edit the CSS one page at a time

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -37,6 +37,7 @@ from os.path import abspath, basename, dirname, exists, join
 import pytz
 import bcrypt
 import stripe
+import jinja2
 import cherrypy
 import django.conf
 from pytz import UTC

--- a/uber/config.py
+++ b/uber/config.py
@@ -272,6 +272,7 @@ class Config(_Overridable):
                 if value and key not in ['access']:
                     out[key] = value
 
+            out['name_key'] = o.name.replace(' ', '_').lower()
             return out
 
     @property

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -270,23 +270,27 @@ def prettify_breadcrumb(str):
     return str.replace('_', ' ').title()
 
 
+def add_breadcrumb_data(data, func):
+    try:
+        data['breadcrumb_page_pretty_'] = prettify_breadcrumb(func.__name__) if func.__name__ != 'index' else 'Home'
+        data['breadcrumb_page_'] = func.__name__ if func.__name__ != 'index' else ''
+    except:
+        pass
+
+    try:
+        data['breadcrumb_section_pretty_'] = prettify_breadcrumb(_get_module_name(func))
+        data['breadcrumb_section_'] = _get_module_name(func)
+    except:
+        pass
+
+    return data
+
+
 def renderable(func):
     @wraps(func)
     def with_rendering(*args, **kwargs):
         result = func(*args, **kwargs)
-
-        try:
-            result['breadcrumb_page_pretty_'] = prettify_breadcrumb(func.__name__) if func.__name__ != 'index' else 'Home'
-            result['breadcrumb_page_'] = func.__name__ if func.__name__ != 'index' else ''
-        except:
-            pass
-
-        try:
-            result['breadcrumb_section_pretty_'] = prettify_breadcrumb(_get_module_name(func))
-            result['breadcrumb_section_'] = _get_module_name(func)
-        except:
-            pass
-
+        result = add_breadcrumb_data(result, func)
         if c.UBER_SHUT_DOWN and not cherrypy.request.path_info.startswith('/schedule'):
             return render('closed.html')
         elif isinstance(result, dict):
@@ -300,6 +304,7 @@ def renderable_jinja2(func):
     @wraps(func)
     def with_rendering(*args, **kwargs):
         result = func(*args, **kwargs)
+        result = add_breadcrumb_data(result, func)
         if c.UBER_SHUT_DOWN and not cherrypy.request.path_info.startswith('/schedule'):
             return render_jinja2('closed.html')
         elif isinstance(result, dict):

--- a/uber/site_sections/budget.py
+++ b/uber/site_sections/budget.py
@@ -25,7 +25,7 @@ def sale_money(session):
     return dict(sales)  # converted to a dict so we can say sales.items in our template
 
 
-@all_renderable(c.MONEY)
+@all_renderable(c.MONEY, use_jinja2=True)
 class Root:
     @log_pageview
     def index(self, session):

--- a/uber/static/styles/new-ui.css
+++ b/uber/static/styles/new-ui.css
@@ -26,7 +26,7 @@
 	width: 100%;
 	height: 32px;
 	z-index: -22;
-	background-image: url("../static/theme/caution.jpg");
+	background-image: url("../theme/caution.jpg");
 	background-repeat: repeat-x;
     opacity: 0.1;
 }

--- a/uber/templates/base-new-ui.html
+++ b/uber/templates/base-new-ui.html
@@ -1,23 +1,23 @@
 {% extends "base-admin.html" %}
 
-{% comment %}
+{#
 This is a new base template that totally ignores uber's existing UI, and replaces it for any
 pages that extend from this template with our own UI.
 
 In this demo, we'll use ONLY Materialize on just, while leaving the rest of uber
 untouched and using Bootstrap 3
-{% endcomment %}
+#}
 
 {% block head_styles %}
-    {% comment %}
-        IMPORTANT NOTE: We leave off {{ block.super }}, so we don't inherit ANY of the ubersystem CSS
+    {#
+        IMPORTANT NOTE: We leave off {{ super() }}, so we don't inherit ANY of the ubersystem CSS
         and can start our CSS from scratch here without affecting other pages.
 
         This can be one page at a time in order to restyle ubersystem little by little, instead
         of needing to do everything all at once.
 
         This can also be done in the page template as well, if desired.
-    {% endcomment %}
+     #}
     <link rel="stylesheet" type="text/css" href="../static/styles/new-ui.css" />
 
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -25,13 +25,13 @@ untouched and using Bootstrap 3
 {% endblock %}
 
 {% block scripts %}
-    {% comment %}
-        We do use {{ block.super }} here in order to use the default javascript from ubersystem,
+    {#
+        We do use {{ super() }} here in order to use the default javascript from ubersystem,
         and then also add our own.
 
         This can also be done in the page template as well, if desired.
-    {% endcomment %}
-    {{ block.super }}
+    #}
+    {{ super() }}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.6/js/materialize.min.js"></script>
 
@@ -88,7 +88,7 @@ untouched and using Bootstrap 3
                         </li>
                     {% endif %}
                 {% endfor %}
-                <li>Logged in as: whatever</li>
+                <li>Logged in as: {{ c.CURRENT_ADMIN.first_name }} {{ c.CURRENT_ADMIN.last_name }}</li>
             </ul>
         </div>
     </nav>

--- a/uber/templates/base-new-ui.html
+++ b/uber/templates/base-new-ui.html
@@ -1,0 +1,110 @@
+{% extends "base-admin.html" %}
+
+{% comment %}
+This is a new base template that totally ignores uber's existing UI, and replaces it for any
+pages that extend from this template with our own UI.
+
+In this demo, we'll use ONLY Materialize on just, while leaving the rest of uber
+untouched and using Bootstrap 3
+{% endcomment %}
+
+{% block head_styles %}
+    {% comment %}
+        IMPORTANT NOTE: We leave off {{ block.super }}, so we don't inherit ANY of the ubersystem CSS
+        and can start our CSS from scratch here without affecting other pages.
+
+        This can be one page at a time in order to restyle ubersystem little by little, instead
+        of needing to do everything all at once.
+
+        This can also be done in the page template as well, if desired.
+    {% endcomment %}
+    <link rel="stylesheet" type="text/css" href="../static/styles/new-ui.css" />
+
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.6/css/materialize.min.css">
+{% endblock %}
+
+{% block scripts %}
+    {% comment %}
+        We do use {{ block.super }} here in order to use the default javascript from ubersystem,
+        and then also add our own.
+
+        This can also be done in the page template as well, if desired.
+    {% endcomment %}
+    {{ block.super }}
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.6/js/materialize.min.js"></script>
+
+    <script>
+        $(document).ready(function () {
+            $('.button-collapse').sideNav(
+                {
+                    menuWidth: 300, // Default is 240
+                    closeOnClick: true // Closes side-nav on <a> clicks, useful for Angular/Meteor
+                }
+            );
+            $('.collapsible').collapsible();
+        });
+    </script>
+{% endblock %}
+
+{% block backlink %}
+    <ul id="slide-out" class="side-nav">
+        {% for menu_item in c.MENU_JSON_DECODED %}
+            {% if menu_item.href %}
+                <li>
+                    <a class="waves-effect waves-teal" href="{{ menu_item.href }}">{{ menu_item.name }}</a>
+                </li>
+            {% elif menu_item.submenu %}
+
+                <!-- submenu-->
+                <li class="no-padding">
+                    <ul class="collapsible collapsible-accordion">
+                    <li>
+
+                        <a class="collapsible-header">{{  menu_item.name }}<i class="material-icons">play_arrow</i></a>
+
+                        <div class="collapsible-body">
+                            <ul>
+                             <!--items -->
+                            {% for submenu_item in menu_item.submenu %}
+                                <li>
+                                    {% if not submenu_item.href %}
+                                        <a href="{{ submenu_item.href }}">
+                                    {% else %}
+                                        <a class="disabled">
+                                    {% endif %}
+                                    {{ submenu_item.name }}</a>
+                                </li>
+                            {% endfor %}
+                            </ul>
+                        </div>
+
+                    </li>
+
+                    </ul>
+                </li>
+
+            {% endif %}
+        {% endfor %}
+    </ul>
+
+    <nav>
+        <div class="nav-wrapper">
+            <div class="brand-logo">{{ c.EVENT_NAME }}</div>
+            <ul class="right hide-on-med-and-down">
+                <li>Logged in as: whatever</li>
+                <li><a href="#" data-activates="slide-out"><i class="material-icons left">insert_chart</i></a></li>
+            </ul>
+        </div>
+    </nav>
+    <a href="#" data-activates="slide-out" class="button-collapse"><i class="material-icons">insert_chart</i></a>
+    <nav>
+        <div>
+            <a href="../{{ breadcrumb_section_ }}" class="breadcrumb">{{ breadcrumb_section_pretty_ }}</a>
+            <a href="../{{ breadcrumb_section_ }}/{{ breadcrumb_page_ }}" class="breadcrumb">
+                {{ breadcrumb_page_pretty_ }}
+            </a>
+        </div>
+    </nav>
+{% endblock backlink %}

--- a/uber/templates/base-new-ui.html
+++ b/uber/templates/base-new-ui.html
@@ -1,4 +1,5 @@
-{% extends "base-admin.html" %}
+{% set admin_area=True %}
+{% extends "base.html" %}
 
 {#
 This is a new base template that totally ignores uber's existing UI, and replaces it for any
@@ -49,7 +50,7 @@ untouched and using Bootstrap 3
 {% endblock %}
 
 {% block backlink %}
-
+    {% if admin_area %}
         {% for menu_item in c.MENU_JSON_DECODED %}
 
             {% if menu_item.submenu %}
@@ -100,4 +101,5 @@ untouched and using Bootstrap 3
             </a>
         </div>
     </nav>
+    {% endif %}
 {% endblock backlink %}

--- a/uber/templates/base-new-ui.html
+++ b/uber/templates/base-new-ui.html
@@ -49,58 +49,51 @@ untouched and using Bootstrap 3
 {% endblock %}
 
 {% block backlink %}
-    <ul id="slide-out" class="side-nav">
+
         {% for menu_item in c.MENU_JSON_DECODED %}
-            {% if menu_item.href %}
-                <li>
-                    <a class="waves-effect waves-teal" href="{{ menu_item.href }}">{{ menu_item.name }}</a>
-                </li>
-            {% elif menu_item.submenu %}
 
-                <!-- submenu-->
-                <li class="no-padding">
-                    <ul class="collapsible collapsible-accordion">
-                    <li>
+            {% if menu_item.submenu %}
+                <ul id="{{ menu_item.name_key }}_dropdown" class="dropdown-content">
 
-                        <a class="collapsible-header">{{  menu_item.name }}<i class="material-icons">play_arrow</i></a>
-
-                        <div class="collapsible-body">
-                            <ul>
-                             <!--items -->
-                            {% for submenu_item in menu_item.submenu %}
-                                <li>
-                                    {% if not submenu_item.href %}
-                                        <a href="{{ submenu_item.href }}">
-                                    {% else %}
-                                        <a class="disabled">
-                                    {% endif %}
-                                    {{ submenu_item.name }}</a>
-                                </li>
-                            {% endfor %}
-                            </ul>
-                        </div>
-
-                    </li>
-
-                    </ul>
-                </li>
-
+                    {% for submenu_item in menu_item.submenu %}
+                        <li>
+                            {% if submenu_item.href %}
+                                <a href="{{ submenu_item.href }}">
+                            {% else %}
+                                <a class="disabled">
+                            {% endif %}
+                            {{ submenu_item.name }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
             {% endif %}
+
         {% endfor %}
-    </ul>
 
     <nav>
         <div class="nav-wrapper">
-            <div class="brand-logo">{{ c.EVENT_NAME }}</div>
+            <a href="../accounts/homepage" class="brand-logo">{{ c.EVENT_NAME }}</a>
+
             <ul class="right hide-on-med-and-down">
+                {% for menu_item in c.MENU_JSON_DECODED %}
+                    {% if menu_item.submenu %}
+                        <li>
+                            <a class="dropdown-button" href="#!" data-activates="{{ menu_item.name_key }}_dropdown">
+                                {{ menu_item.name }}<i class="material-icons right">arrow_drop_down</i>
+                            </a>
+                        </li>
+                    {% elif menu_item.href %}
+                        <li>
+                            <a href="{{ menu_item.href }}">{{ menu_item.name }}</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
                 <li>Logged in as: whatever</li>
-                <li><a href="#" data-activates="slide-out"><i class="material-icons left">insert_chart</i></a></li>
             </ul>
         </div>
     </nav>
-    <a href="#" data-activates="slide-out" class="button-collapse"><i class="material-icons">insert_chart</i></a>
     <nav>
-        <div>
+        <div class="red darken-2">
             <a href="../{{ breadcrumb_section_ }}" class="breadcrumb">{{ breadcrumb_section_pretty_ }}</a>
             <a href="../{{ breadcrumb_section_ }}/{{ breadcrumb_page_ }}" class="breadcrumb">
                 {{ breadcrumb_page_pretty_ }}

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -14,11 +14,21 @@
     {% block head_styles %}
         <link rel="stylesheet" href="../static/deps/combined.css" />
         <link rel="stylesheet" href="../static_views/styles/main.css" />
+        {% if admin_area %}
+            <link rel="stylesheet" type="text/css" href="../static_views/additional-styles.css" />
+        {% else %}
+            <link rel="stylesheet" href="../static/theme/prereg.css">
+            <link rel="stylesheet" href="../static/theme/prereg_extra.css">
+        {% endif %}
     {% endblock %}
 
     {% block head_javascript %}
         <script type="text/javascript" src="../static/deps/combined.js"></script>
         <script src="../common.js" type="text/javascript"></script>
+
+        {% if not admin_area %}
+            <script src="../static_views/js/prereg-common.js" type="text/javascript"></script>
+        {% endif %}
     {% endblock %}
 
     <meta charset="utf-8">
@@ -29,7 +39,17 @@
     {% if c.PRE_CON %}
         <div class="loader"><a class="loader_link" href="../static_views/slow_load.html" target="_blank"></a></div>
     {% endif %}
-    {% block top_of_body_additional %}{% endblock %}
+    {% block top_of_body_additional %}
+        {% if admin_area %}
+            <div id="floating_logo">
+                <img src="../static/theme/bg-logo.png"/>
+            </div>
+            {% if c.DEV_BOX %}
+                <div id="devbox_cautiontape"></div>
+                <div id="devbox_text">DEVELOPMENT</div>
+            {% endif %}
+        {% endif %}
+    {% endblock %}
     <div id="mainContainer" class="container-fluid">
         {% block backlink %}
             <nav class="navbar navbar-default navbar-static-top" role="navigation">

--- a/uber/templates/budget/index.html
+++ b/uber/templates/budget/index.html
@@ -1,26 +1,11 @@
-{% extends "base-admin.html" %}
-{% block title %}Budget{% endblock %}
+{% extends "base-new-ui.html" %}
+{% block title %}Budget NEW UI DEMO{% endblock %}
 {% block content %}
 
-<style type="text/css">
-    table.list td {
-        border: 0px;
-    }
-</style>
-
-<ol class="breadcrumb">
-  <li><a href="../accounts/homepage">Home</a></li>
-  <li>Money</li>
-  <li class="active">Budget</li>
-</ol>
-
-<div class="jumbotron">
-    <h1 class="text-center">(${{ total }} total)</h1>
-</div>
+<h1 class="text-center">${{ total }} total</h1>
 
 
-<div class="panel panel-default">
-    <table class="table table-striped datatable">
+    <table class="bordered">
     <thead><tr>
         <th>Name</th>
         <th>Amount</th>
@@ -66,6 +51,6 @@
         </tr>
     {% endfor %}
     </table>
-</div>
+
 
 {% endblock %}

--- a/uber/templates/budget/index.html
+++ b/uber/templates/budget/index.html
@@ -2,51 +2,34 @@
 {% block title %}Budget NEW UI DEMO{% endblock %}
 {% block content %}
 
-<h1 class="text-center">${{ total }} total</h1>
+{% macro table_entry(label, value) -%}
+    <tr>
+        <td>{{ label }}</td>
+        <td>${{ value }}</td>
+    </tr>
+{%- endmacro %}
 
+<h1 class="text-center">${{ total }} total</h1>
 
     <table class="bordered">
     <thead><tr>
         <th>Name</th>
         <th>Amount</th>
     </tr></thead>
-    <tr>
-        <td>Attendee Badges</td>
-        <td>${{ preregs.Attendee }}</td>
-    </tr>
-    <tr>
-        <td>Extra Payments (Kickins, Shirts, Food, anything else)</td>
-        <td>${{ preregs.extra }}</td>
-    </tr>
-    <tr>
-        <td>Group Badges</td>
-        <td>${{ preregs.group_badges }}</td>
-    </tr>
-    <tr>
-        <td>Dealer Badges</td>
-        <td>${{ preregs.dealer_badges }}</td>
-    </tr>
-    <tr>
-        <td>Dealer Tables</td>
-        <td>${{ preregs.dealer_tables }}</td>
-    </tr>
-    <tr>
-        <td>Staff Badges</td>
-        <td>${{ preregs.Staff }} </td>
-    </tr>
-    <tr>
-        <td>Single Day Badges</td>
-        <td>${{ preregs.OneDay }}</td>
-    </tr>
-    {% for what, total in sales.items %}
-        <tr>
-            <td>{{ what }} sales</td>
-            <td>${{ total }}</td>
-        </tr>
+
+    {{ table_entry('Attendee Badges', preregs.Attendee) }}
+    {{ table_entry('Extra Payments (Kickins, Shirts, Food, anything else)', preregs.extra) }}
+    {{ table_entry('Group Badges', preregs.group_badges) }}
+    {{ table_entry('Dealer Badges', preregs.dealer_badges) }}
+    {{ table_entry('Staff Badges', preregs.Staff) }}
+    {{ table_entry('Single Day Badges', preregs.OneDay) }}
+
+    {% for what, total in sales.items() %}
+        {{ table_entry(what, total) }}
     {% endfor %}
     {% for item in credits %}
         <tr>
-            <td><a href="form?id={{ item.id }}">{{ item.name }}</a>
+            <td><a href="form?id={{ item.id }}">{{ item.name }}</a></td>
             <td>${{ item.amount }}</td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
this is a demo only, please ignore every single thing about the way I have styled this, I don't know jack about frontend frameworks.

The purpose of this is to combine a few WIP feature branches and try something out:
- main menu from python and rendered with templates (no javascript involved anymore)
- automatically calculated breadcrumb navigation
- large simplification of template blocks using {{block.super}} across uber

It looks like this:
![image](https://cloud.githubusercontent.com/assets/5413064/15986649/bfe8692e-2fda-11e6-8f2a-0428ad405d8f.png)

The purpose of this pull request (NOTE: it's not against master, it's against demo_new_ui) is to provide an example of some of the new in progress features that will enable someone like @cybersenshi to accomplish larger refactorings without being limited to touching every single page in one gigantic pull request.

The important thing to note here is that any page can extend "base-new-ui.html" which discards all the existing underlying ubersystem UI (and javascript if we want), so that we can start working individual page by page to clean up the UI in ubersystem.

For the purposes of this demo, I made the budget page render 100% with Materialize and 0% with Bootstrap 3, in order to demonstrate that that one page could be radically changed while leaving everything else in tact as bootstrap.  In a UI conversion we can now proceed page by page instead of having one gigantic request that is take-it-or-leave-it.
