### PR TITLE
WIP: Use jinja2 templates

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -37,6 +37,7 @@ from os.path import abspath, basename, dirname, exists, join
 import pytz
 import bcrypt
 import stripe
+import jinja2
 import cherrypy
 import django.conf
 from pytz import UTC

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -208,12 +208,44 @@ def renderable_data(data=None):
 
 
 # render using the first template that actually exists in template_name_list
+# uses DJANGO - old deprecated style
 def render(template_name_list, data=None):
     data = renderable_data(data)
     template = loader.select_template(listify(template_name_list))
     rendered = template.render(Context(data))
     rendered = screw_you_nick(rendered, template)  # lolz.
     return rendered.encode('utf-8')
+
+
+_jinja2_env = None
+
+
+# TODO: replace with a nicer way to initialize this
+# for now we initialize the first time it's called.
+# TODO: need to not use django settings (they'll be ripped out later) for TEMPLATE_DIRS
+# TODO: setup filters in a separate function, probably. probably same way as custom_tags.py
+# TODO: port over everything in custom_tags.py to hook in here
+def jinja2_env():
+    global _jinja2_env
+    if _jinja2_env is None:
+        _jinja2_env = jinja2.Environment(
+            # autoescape=_guess_autoescape,
+            loader=jinja2.FileSystemLoader(django.conf.settings.TEMPLATE_DIRS)
+        )
+        _jinja2_env.filters['jsonify'] = lambda x: _jinja2_env.filters['safe'](json.dumps(x))
+
+    return _jinja2_env
+
+
+# render using the first template that actually exists in template_name_list
+# uses JINJA2 - new style
+def render_jinja2(template_name_list, data=None):
+    data = renderable_data(data)
+    env = jinja2_env()
+    template = env.get_template(template_name_list)
+    rendered = template.render(data)
+    rendered = screw_you_nick(rendered, template)  # lolz.
+    return rendered
 
 
 # this is a Magfest inside joke.
@@ -242,6 +274,18 @@ def renderable(func):
             return render('closed.html')
         elif isinstance(result, dict):
             return render(_get_template_filename(func), result)
+        else:
+            return result
+    return with_rendering
+
+def renderable_jinja2(func):
+    @wraps(func)
+    def with_rendering(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if c.UBER_SHUT_DOWN and not cherrypy.request.path_info.startswith('/schedule'):
+            return render_jinja2('closed.html') # TODO: renders_template
+        elif isinstance(result, dict):
+            return render_jinja2(_get_template_filename(func), result)
         else:
             return result
     return with_rendering
@@ -280,14 +324,21 @@ def restricted(func):
 
 
 class all_renderable:
-    def __init__(self, *needs_access):
+    def __init__(self, *needs_access, use_jinja2=False):
         self.needs_access = needs_access
+        self.use_jinja2 = use_jinja2
 
     def __call__(self, klass):
         for name, func in klass.__dict__.items():
             if hasattr(func, '__call__'):
                 func.restricted = getattr(func, 'restricted', self.needs_access)
-                new_func = timed(cached_page(sessionized(restricted(renderable(func)))))
+                render_func = None
+                if not self.use_jinja2:
+                    render_func = renderable(func)
+                else:
+                    render_func = renderable_jinja2(func)
+
+                new_func = timed(cached_page(sessionized(restricted(render_func))))
                 new_func.exposed = True
                 setattr(klass, name, new_func)
         return klass

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -278,12 +278,13 @@ def renderable(func):
             return result
     return with_rendering
 
+
 def renderable_jinja2(func):
     @wraps(func)
     def with_rendering(*args, **kwargs):
         result = func(*args, **kwargs)
         if c.UBER_SHUT_DOWN and not cherrypy.request.path_info.startswith('/schedule'):
-            return render_jinja2('closed.html') # TODO: renders_template
+            return render_jinja2('closed.html')
         elif isinstance(result, dict):
             return render_jinja2(_get_template_filename(func), result)
         else:

--- a/uber/site_sections/budget.py
+++ b/uber/site_sections/budget.py
@@ -25,7 +25,7 @@ def sale_money(session):
     return dict(sales)  # converted to a dict so we can say sales.items in our template
 
 
-@all_renderable(c.MONEY)
+@all_renderable(c.MONEY, use_jinja2=True)
 class Root:
     @log_pageview
     def index(self, session):

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -30,7 +30,7 @@
             width: 60%;
             height: 25%;
             z-index: 9999;
-            background: rgb(249,249,249) url('../static/images/loading.gif?{% random_hash %}') no-repeat center center;
+            background: rgb(249,249,249) url('../static/images/loading.gif?HACK-REPLACE-THIS=true') no-repeat center center;
             background-size: 50%;
         }
         .loader {

--- a/uber/templates/budget/index.html
+++ b/uber/templates/budget/index.html
@@ -18,6 +18,12 @@
     <h1 class="text-center">(${{ total }} total)</h1>
 </div>
 
+{% macro table_entry(label, value) -%}
+    <tr>
+        <td>{{ label }}</td>
+        <td>${{ value }}</td>
+    </tr>
+{%- endmacro %}
 
 <div class="panel panel-default">
     <table class="table table-striped datatable">
@@ -25,43 +31,20 @@
         <th>Name</th>
         <th>Amount</th>
     </tr></thead>
-    <tr>
-        <td>Attendee Badges</td>
-        <td>${{ preregs.Attendee }}</td>
-    </tr>
-    <tr>
-        <td>Extra Payments (Kickins, Shirts, Food, anything else)</td>
-        <td>${{ preregs.extra }}</td>
-    </tr>
-    <tr>
-        <td>Group Badges</td>
-        <td>${{ preregs.group_badges }}</td>
-    </tr>
-    <tr>
-        <td>Dealer Badges</td>
-        <td>${{ preregs.dealer_badges }}</td>
-    </tr>
-    <tr>
-        <td>Dealer Tables</td>
-        <td>${{ preregs.dealer_tables }}</td>
-    </tr>
-    <tr>
-        <td>Staff Badges</td>
-        <td>${{ preregs.Staff }} </td>
-    </tr>
-    <tr>
-        <td>Single Day Badges</td>
-        <td>${{ preregs.OneDay }}</td>
-    </tr>
-    {% for what, total in sales.items %}
-        <tr>
-            <td>{{ what }} sales</td>
-            <td>${{ total }}</td>
-        </tr>
+
+    {{ table_entry('Attendee Badges', preregs.Attendee) }}
+    {{ table_entry('Extra Payments (Kickins, Shirts, Food, anything else)', preregs.extra) }}
+    {{ table_entry('Group Badges', preregs.group_badges) }}
+    {{ table_entry('Dealer Badges', preregs.dealer_badges) }}
+    {{ table_entry('Staff Badges', preregs.Staff) }}
+    {{ table_entry('Single Day Badges', preregs.OneDay) }}
+
+    {% for what, total in sales.items() %}
+        {{ table_entry(what, total) }}
     {% endfor %}
     {% for item in credits %}
         <tr>
-            <td><a href="form?id={{ item.id }}">{{ item.name }}</a>
+            <td><a href="form?id={{ item.id }}">{{ item.name }}</a></td>
             <td>${{ item.amount }}</td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
NOT PRODUCTION READY, DO NOT MERGE YET
- VERY rough, but working, Jinja2 example
- Turn on Jinja2 template engine for just budget.py.
- Does not make any attempt to use anything in custom_tags.py yet
- Seems (on my windows box) to run about 4x slower than Django (.4sec/page vs .1sec/page), definitely need to check on performance.  Zero optimization right now
- Initialization of Jinja2 is via hacky singleton and relies on django template paths existing
- Lots of stuff would need to get ripped out and refactored

I'm opening a PR and pushing this to a branch mostly so that I can include it on my WIP UI demo branch, and submit how we're doing this for review.