### PR TITLE
Remove default for badge_price_waived

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -42,8 +42,6 @@ printed_badge_deadline = "2016-01-04"
 
 room_deadline = "2015-11-30"
 
-badge_price_waived = "2016-02-21 12"
-
 
 [badge_prices]
 


### PR DESCRIPTION
The system works perfectly fine without this variable being set, so there's no reason to include it in the 'defaults' file, which we want to phase out anyway.

Fixes https://github.com/magfest/magstock/issues/81.