### PR TITLE
Remove defaults for single day prices

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -48,10 +48,6 @@ badge_price_waived = "2016-02-21 12"
 [badge_prices]
 
 [[single_day]]
-Friday = 35
-Saturday = 40
-Sunday = 40
-Monday = 30
 
 [[attendee]]
 


### PR DESCRIPTION
These aren't needed; even if PRESELL_ONE_DAYS is set, the system will use the default oneday badge price. Again, we want to phase out this config file as it often leads to unexpected results.