### PR TITLE
Handle _label problems more gracefully

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -297,9 +297,11 @@ class MagModel:
     @suffix_property
     def _label(self, name, val):
         try:
-            return self.get_field(name).type.choices[int(val)]
-        except KeyError:
-            return ''
+            val = int(val)
+        except ValueError:
+            return val
+
+        return self.get_field(name).type.choices.get(val)
 
     @suffix_property
     def _local(self, name, val):


### PR DESCRIPTION
There are two potential problems when accessing a label that can cause an exception. We already fixed one in https://github.com/magfest/ubersystem/pull/1841 - this refactors that to be cleaner, and fixes the other.