### PR TITLE
Make sure all check-in forms have unique IDs

### DIFF
--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -1,4 +1,4 @@
-<form action="/" id="check_in_form">
+<form action="/" id="check_in_form_{{ attendee.id }}">
     {% csrf_token %}
     <input type="hidden" name="id" value="{{ attendee.id }}" />
 <table class="check-in">

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -2,7 +2,7 @@
 {% block title %}Attendee Admin{% endblock %}
 {% block content %}
 
-{% block header %}
+{% block adminheader %}
 <div class="dialog-form" id="checkin-dialog" title="Quick Check-In"></div>
 <script type="text/javascript">    
     $(function(){
@@ -64,7 +64,7 @@
             method: 'POST',
             url: 'check_in',
             dataType: 'json',
-            data: $("#check_in_form").serialize(),
+            data: $("#check_in_form_" + id).serialize(),
             success: function (json) {
                 toastr.clear();
                 var message = json.message;
@@ -113,7 +113,7 @@
   <li>People</li>
   <li class="active">Attendees{% if search_results %} (Search Results){% endif %}</li>
 </ol>
-{% endblock header %}
+{% endblock adminheader %}
 {% block admin_controls %}
 <div class="row">
     <div class="panel col-md-5">

--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -1,7 +1,7 @@
 {% extends "base-admin.html" %}
 {% block title %}Recent At-the-Door Registrations{% endblock %}
 {% block content %}
-{% block header %}
+{% block adminheader %}
 <link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />
 
 {% if checked_in %}
@@ -75,7 +75,7 @@
     };
     $(showOrHideWhatText);
 </script>
-{% endblock header %}
+{% endblock adminheader %}
 
 {% block admin_controls %}
 <h2> {% if not show_all %}Recent{% endif %} At-the-Door Registrations </h2>
@@ -182,7 +182,7 @@
             </td>
             <td></td>
         {% else %}
-            <form method="post" id="new_checkin" action="new_checkin">
+            <form method="post" id="new_checkin_{{ attendee.id }}" action="new_checkin">
             {% if c.NUMBERED_BADGES %}
                 <td>
                     &nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
If a check-in form shares an ID with another form on the page, we run into unexpected problems (like the wrong fields saving). This also fixes an underlying bug where the quick checkin dialog was opening twice due to generically-named django blocks.