### PR TITLE
fix checkin erasing unrelated fields like interest, assigned_depts, etc

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -327,7 +327,7 @@ class Root:
 
     @ajax
     def check_in(self, session, message='', **params):
-        attendee = session.attendee(params, checkgroups=Attendee.all_checkgroups, bools=Attendee.all_bools, allow_invalid=True)
+        attendee = session.attendee(params, allow_invalid=True)
         group = session.group(attendee.group_id) if attendee.group_id else None
 
         pre_badge = attendee.badge_num
@@ -631,7 +631,7 @@ class Root:
 
     @csrf_protected
     def new_checkin(self, session, message='', **params):
-        attendee = session.attendee(params, checkgroups=Attendee.all_checkgroups, bools=Attendee.all_bools, allow_invalid=True)
+        attendee = session.attendee(params, allow_invalid=True)
         group = session.group(attendee.group_id) if attendee.group_id else None
 
         checked_in = ''


### PR DESCRIPTION
fixes #1878 I -think-

pretty sure that by including ```checkgroups=Attendee.all_checkgroups, bools=Attendee.all_bools``` here, it causes anything not in ```params``` to be zero'd out.

Removing this seems to fix it.  This code was recently touched in magstock refactorings.

really could use a second set of eyes ASAP on this though local testing seems to work just fine.