### PR TITLE
bulletproof tracking code by handling exceptions

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1882,10 +1882,14 @@ def _release_badge_lock_on_error(*args, **kwargs):
 
 
 def _track_changes(session, context, instances='deprecated'):
-    for action, instances in {c.CREATED: session.new, c.UPDATED: session.dirty, c.DELETED: session.deleted}.items():
-        for instance in instances:
-            if instance.__class__ not in Tracking.UNTRACKED:
-                Tracking.track(action, instance)
+    try:
+        for action, instances in {c.CREATED: session.new, c.UPDATED: session.dirty, c.DELETED: session.deleted}.items():
+            for instance in instances:
+                if instance.__class__ not in Tracking.UNTRACKED:
+                    Tracking.track(action, instance)
+    except Exception as e:
+        log.error('encountered error when trying to save tracking info, not tracking', exc_info=True)
+        pass
 
 
 def register_session_listeners():


### PR DESCRIPTION
- this is CRUCIAL when the tracking code is called FROM an HTTPRedirect exception
- failure to have this here results in a deadlock
- probably deadlocks because cherrypy doesn't excpect us to do anything once we raise the HTTPRedirect, but in fact we do stuff in a hook for tracking and it causes problems if the hook causes an issue
- Many bothnans died to bring you this information

fixes #1881 though it's not the only fix we're going to do this fix. If the tracking code pukes, with this code alone, it will not track anything.  I will also later introduce a change which tells you the specific field that pukes and at least print ERROR.