### PR TITLE
bulletproof tracking code by handling exceptions, part 2

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1758,7 +1758,19 @@ class Tracking(MagModel):
             new_val = getattr(instance, attr)
             old_val = instance.orig_value_of(attr)
             if old_val != new_val:
-                diff[attr] = "'{} -> {}'".format(cls.repr(column, old_val), cls.repr(column, new_val))
+                try:
+                    old_val_repr = cls.repr(column, old_val)
+                except Exception as e:
+                    log.error("tracking repr({}) failed on old value".format(attr), exc_info=True)
+                    old_val_repr = "<ERROR>"
+
+                try:
+                    new_val_repr = cls.repr(column, new_val)
+                except Exception as e:
+                    log.error("tracking repr({}) failed on new value".format(attr), exc_info=True)
+                    new_val_repr = "<ERROR>"
+
+                diff[attr] = "'{} -> {}'".format(old_val_repr, new_val_repr)
         return diff
 
     # TODO: add new table for page views to eliminated track_pageview method and to eliminate Budget special case

--- a/uber/models.py
+++ b/uber/models.py
@@ -1758,6 +1758,19 @@ class Tracking(MagModel):
             new_val = getattr(instance, attr)
             old_val = instance.orig_value_of(attr)
             if old_val != new_val:
+                """
+                important note: here we try and show the old vs new value for something that has been changed
+                so that we can report it in the tracking page.
+
+                Sometimes, however, if we changed the type of the value in the database (via a database migration)
+                the old value might not be able to be shown as the new type (i.e. it used to be a string, now it's int).
+                In that case, we won't be able to show a representation of the old value and instead we'll log it as
+                '<ERROR>'.  In theory the database migration SHOULD be the thing handling this, but if it doesn't, it
+                becomes our problem to deal with.
+
+                We are overly paranoid with exception handling here because the tracking code should be made to
+                never, ever, ever crash, even if it encounters insane/old data that really shouldn't be our problem.
+                """
                 try:
                     old_val_repr = cls.repr(column, old_val)
                 except Exception as e:


### PR DESCRIPTION
if a particular old column can't be rendered (because of bad DB migration or other weirdness), show <ERROR> instead of failing to track anything at all, or passing the error upstream.

merge alongside https://github.com/magfest/ubersystem/pull/1884 for even more kevlar armor.

------

backstory: kinda goes with #1881, see that for all the gory details

We encountered the problem with as the following scenario:
1) Magstock had a VARCHAR DB column called site_number
2) Dom's local DB had "BOGUS SITE" in there for an attendee
3) We change the sqlalchemy code to INTEGER, however we forgot to change the DB in the migration from VARCHAR to INTEGER.
4) Tracking code, on trying to change the campsite to an integer, would try and get the old value of "BOGUS SITE" and convert to int, which would explode.

This code change ensures that if we have bad data for some reason, the tracking code can handle it more gracefully.  Because really, The Tracking Code Should Never Crash, even if our DB has gone mad.

Many Bothnans Died To Bring You This Information

I hope with this and #1887 , we have eliminated a really tough to track down hang in ubersystem that seems to pop up only once we get onsite and have no time to look at it.