### PR TITLE
fix session flush hooks not releasing the badge lock on exception

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -1,6 +1,19 @@
 from uber.common import *
 
 
+def catch_all_exceptions(func):
+    """
+    Use this only where it's critical, such as dealing with locking functionality.
+    """
+    @wraps(func)
+    def catch_exceptions(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            log.error('encountered exception, forcing continuation anyway', exc_info=True)
+    return catch_exceptions
+
+
 def log_pageview(func):
     @wraps(func)
     def with_check(*args, **kwargs):

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -1,17 +1,19 @@
 from uber.common import *
 
 
-def catch_all_exceptions(func):
+def swallow_exceptions(func):
     """
-    Use this only where it's critical, such as dealing with locking functionality.
+    Don't allow ANY Exceptions to be raised from this.
+    Use this ONLY where it's absolutely needed, such as dealing with locking functionality.
+    WARNING: DO NOT USE THIS UNLESS YOU KNOW WHAT YOU'RE DOING :)
     """
     @wraps(func)
-    def catch_exceptions(*args, **kwargs):
+    def swallow_exception(*args, **kwargs):
         try:
             return func(*args, **kwargs)
         except Exception:
             log.error('encountered exception, forcing continuation anyway', exc_info=True)
-    return catch_exceptions
+    return swallow_exception
 
 
 def log_pageview(func):

--- a/uber/models.py
+++ b/uber/models.py
@@ -1863,7 +1863,7 @@ def _acquire_badge_lock(session, context, instances='deprecated'):
     c.BADGE_LOCK.acquire()
 
 
-@catch_all_exceptions
+@swallow_exceptions
 def _presave_adjustments(session, context, instances='deprecated'):
     """
     precondition: c.BADGE_LOCK is acquired already.
@@ -1891,7 +1891,7 @@ def _release_badge_lock_on_error(*args, **kwargs):
                  'does occur')
 
 
-@catch_all_exceptions
+@swallow_exceptions
 def _track_changes(session, context, instances='deprecated'):
     for action, instances in {c.CREATED: session.new, c.UPDATED: session.dirty, c.DELETED: session.deleted}.items():
         for instance in instances:
@@ -1901,11 +1901,14 @@ def _track_changes(session, context, instances='deprecated'):
 
 def register_session_listeners():
     """
-    IMPORTANT!!! Because we are locking our c.BADGE_LOCK at the start of this, all of these functions MUST NOT
+    NOTE 1: IMPORTANT!!! Because we are locking our c.BADGE_LOCK at the start of this, all of these functions MUST NOT
     THROW ANY EXCEPTIONS.  If they do throw exceptions, the chain of hooks will not be completed, and the lock won't
-    be released, resulting in a deadlock.
+    be released, resulting in a deadlock and heinous, horrible, and hard to debug server lockup.
 
-    The order in which we call these matters here.
+    You MUST use the @swallow_exceptions decorator on ALL functions
+    between _acquire_badge_lock and _release_badge_lock in order to prevent them from throwing exceptions.
+
+    NOTE 2: The order in which we register these listeners matters.
     """
     listen(Session.session_factory, 'before_flush', _acquire_badge_lock)
     listen(Session.session_factory, 'before_flush', _presave_adjustments)


### PR DESCRIPTION
- if in the sqlalchemy flush hooks, we acquired a badge lock and then had an exception, we would not release it
- this results in a deadlock which we generally don't catch because that code is usually already fairly bulletproof

This was a nightmare to diagnose, but totally worth it.

Replaces https://github.com/magfest/ubersystem/pull/1884, which has the technical details