### PR TITLE
Use relative urls for more stuff

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -29,7 +29,7 @@ from time import sleep, mktime
 from io import StringIO, BytesIO
 from itertools import chain, count
 from collections import defaultdict, OrderedDict
-from urllib.parse import quote, urlparse, parse_qsl
+from urllib.parse import quote, urlparse, parse_qsl, urljoin
 from datetime import date, time, datetime, timedelta
 from threading import Thread, RLock, local, current_thread
 from os.path import abspath, basename, dirname, exists, join

--- a/uber/templates/preregistration/paid_preregistrations.html
+++ b/uber/templates/preregistration/paid_preregistrations.html
@@ -57,7 +57,7 @@
     {% if prereg.first_name %}
         <tr>
             <td>{{ prereg.full_name }}</td>
-            <td><a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ prereg.id }}" target="_blank">Click Here</a></td>
+            <td><a href="../preregistration/confirm?id={{ prereg.id }}" target="_blank">Click Here</a></td>
         </tr>
     {% else %}
         <tr>

--- a/uber/templates/static_views/howToStaff.html
+++ b/uber/templates/static_views/howToStaff.html
@@ -6,7 +6,7 @@
 
 <h3 align="center"> How do I sign up to volunteer at {{ c.EVENT_NAME }}? </h3>
 
-All first-time volunteers must <a target="_blank" href="{{ c.URL_BASE }}/preregistration/">preregister</a> for a badge.
+All first-time volunteers must <a target="_blank" href="../preregistration/">preregister</a> for a badge.
 When you preregister, simply select the "Sign me up!" checkbox indicating that you wish to volunteer and you'll
 be contacted when shifts become available.
 

--- a/uber/tests/models/test_utils.py
+++ b/uber/tests/models/test_utils.py
@@ -1,0 +1,25 @@
+from uber.tests import *
+
+
+@pytest.fixture
+def base_url(monkeypatch):
+    monkeypatch.setattr(c, 'URL_BASE', 'https://server.com/uber')
+
+
+def test_absolute_urls(base_url):
+    assert convert_to_absolute_url('../somepage.html') == 'https://server.com/uber/somepage.html'
+
+
+def test_absolute_urls_empty(base_url):
+    assert convert_to_absolute_url(None) == ''
+
+
+def test_absolute_url_error(base_url):
+    with pytest.raises(ValueError) as e_info:
+        convert_to_absolute_url('..')
+
+    with pytest.raises(ValueError) as e_info:
+        convert_to_absolute_url('.')
+
+    with pytest.raises(ValueError) as e_info:
+        convert_to_absolute_url('////')

--- a/uber/tests/models/test_utils.py
+++ b/uber/tests/models/test_utils.py
@@ -12,6 +12,7 @@ def test_absolute_urls(base_url):
 
 def test_absolute_urls_empty(base_url):
     assert convert_to_absolute_url(None) == ''
+    assert convert_to_absolute_url('') == ''
 
 
 def test_absolute_url_error(base_url):

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -285,3 +285,20 @@ def mount_site_sections(module_root):
     for section in sections:
         module = importlib.import_module(basename(module_root) + '.site_sections.' + section)
         setattr(Root, section, module.Root())
+
+
+
+def build_uber_absolute_url(relative_uber_page_url):
+    """
+    In ubersystem, we always use relative url's of the form "../{some_site_section}/{somepage}"
+    We use relative URLs so that no matter what proxy server we are behind on the web, it always works.
+
+    We normally avoid using absolute URLs at al costs, but sometimes it's needed when creating URLs for
+    use with emails or CSV exports.  In that case, we need to take a relative URL and turn it into
+    an absolute URL.
+
+    Do not use this function unless you absolutely need to, instead use relative URLs as much as possible.
+    """
+
+    assert relative_uber_page_url[:3] == '../', "relative url MUST start with '../'"
+    return urljoin(c.URL_BASE + "/", relative_uber_page_url[3:])

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -287,7 +287,6 @@ def mount_site_sections(module_root):
         setattr(Root, section, module.Root())
 
 
-
 def build_uber_absolute_url(relative_uber_page_url):
     """
     In ubersystem, we always use relative url's of the form "../{some_site_section}/{somepage}"

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -287,7 +287,7 @@ def mount_site_sections(module_root):
         setattr(Root, section, module.Root())
 
 
-def build_uber_absolute_url(relative_uber_page_url):
+def convert_to_absolute_url(relative_uber_page_url):
     """
     In ubersystem, we always use relative url's of the form "../{some_site_section}/{somepage}"
     We use relative URLs so that no matter what proxy server we are behind on the web, it always works.

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -299,5 +299,10 @@ def convert_to_absolute_url(relative_uber_page_url):
     Do not use this function unless you absolutely need to, instead use relative URLs as much as possible.
     """
 
-    assert relative_uber_page_url[:3] == '../', "relative url MUST start with '../'"
+    if not relative_uber_page_url:
+        return ''
+
+    if relative_uber_page_url[:3] != '../':
+        raise ValueError("relative url MUST start with '../'")
+
     return urljoin(c.URL_BASE + "/", relative_uber_page_url[3:])


### PR DESCRIPTION
Wherever possible we should avoid using c.URL_BASE so that uber works from behind a proxy

This removes a few instances and sets up a function which builds an absolute URL for places where we HAVE to use absolute URLs, like emails and CSV exports.

That function expects relative URLs that begin with '../' (which is our standard way of doing it inside uber) and will do the right thing from there:

example:
input: ```relative url: "..bands/view_stage_plot?id=4"```
output: ```https://my_uber_box:4443/uber/bands/view_stage_plot?id=3```

merge before: https://github.com/magfest/bands/pull/49