### PR TITLE
send headers later so that CSV errors show up

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -106,11 +106,13 @@ def multifile_zipfile(func):
 def csv_file(func):
     @wraps(func)
     def csvout(self, session, **kwargs):
-        cherrypy.response.headers['Content-Type'] = 'application/csv'
-        cherrypy.response.headers['Content-Disposition'] = 'attachment; filename=' + func.__name__ + '.csv'
         writer = StringIO()
         func(self, csv.writer(writer), session, **kwargs)
-        return writer.getvalue().encode('utf-8')
+        output = writer.getvalue().encode('utf-8')
+        # set headers last in case there were errors, so end user still see error page
+        cherrypy.response.headers['Content-Type'] = 'application/csv'
+        cherrypy.response.headers['Content-Disposition'] = 'attachment; filename=' + func.__name__ + '.csv'
+        return output
     return csvout
 
 


### PR DESCRIPTION
If we send the headers first, the site won't show a traceback if an exception gets thrown (it just has a cryptic browser-specific error message with no info about what went wrong).

The order in which we generate the CSV and then set the headers doesn't matter, so we can switch them with no consequences.