### PR TITLE
implement first pass functional testing via selenium and saucelabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ add_table_extras.sql
 alembic*
 bower_components/
 node_modules/
+selenium-tests/.cache/

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ stripe==1.11.0
 pytz==2014.4
 pep8==1.6.2
 pytest==2.7.2
+selenium==2.53.5
+pytest-selenium==1.2.1

--- a/selenium-tests/capabilities.json
+++ b/selenium-tests/capabilities.json
@@ -1,0 +1,4 @@
+{ "capabilities": {
+    "browserName": "Firefox",
+    "platform": "MAC" }
+}

--- a/selenium-tests/pytest.ini
+++ b/selenium-tests/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+# fill in via env var, or here:
+# sauce_labs_username =
+# sauce_labs_api_key =
+base_url = https://stage3.uber.magfest.org
+addopts = --driver=SauceLabs --variables capabilities.json
+sensitive_url = ^(?!http[s]?:\/\/stag(e[0-9]?|ing)).+

--- a/selenium-tests/test_registration.py
+++ b/selenium-tests/test_registration.py
@@ -1,0 +1,109 @@
+import pytest
+import uuid
+
+@pytest.fixture
+def selenium(selenium):
+    selenium.implicitly_wait(10)
+    selenium.maximize_window()
+    return selenium
+
+
+def text_in_error_message(driver, text):
+    html = driver.find_elements_by_class_name("toast-message")[0].get_attribute("innerHTML")
+    return text in html
+
+
+def text_exists_in_head(driver, text):
+    head_html = driver.find_element_by_tag_name("head").get_attribute("innerHTML")
+    return text in head_html
+
+
+def fill_in_text_field(driver, field_name, text):
+    elem = driver.find_element_by_name(field_name)
+    elem.send_keys(text)
+    return elem
+
+
+def fill_in_birthdate_field(driver, field_names, date_text):
+    date_values = date_text.split('-')
+    assert len(field_names) == len(date_values)
+    fields_and_values = zip(field_names, date_values)
+
+    elem = None
+    for field,text in fields_and_values:
+        elem = driver.find_elements_by_class_name(field)[0]
+        elem.send_keys(text)
+    return elem
+
+
+class FormValidator:
+    def __init__(self, **kwargs):
+        self.field_name = None
+        self.field_value = None
+        self.expected_error = None
+        self.fill_fn = fill_in_text_field
+        self.submit_only = False
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def ensure_found_error(self, driver):
+        if self.expected_error:
+            assert text_in_error_message(driver, self.expected_error)
+
+    def run(self, driver):
+        if self.field_name:
+            if self.submit_only:
+                elem = driver.find_element_by_name(self.field_name)
+            else:
+                elem = self.fill_fn(driver, self.field_name, self.field_value)
+            elem.submit()
+
+
+def generate_unique_email():
+    return "testemail-{}@testemail.com".format(str(uuid.uuid4()))
+
+birthdate_elements = ["jq-dte-month", "jq-dte-day", "jq-dte-year"]
+
+regform_validations = [
+    FormValidator(field_name="first_name", submit_only=True),
+    FormValidator(
+        expected_error="First Name is a required field",
+        field_name="first_name", field_value="FIRSTNAME_Attendee"),
+    FormValidator(
+        expected_error="Last Name is a required field",
+        field_name="last_name", field_value="LASTNAME_Attendee"),
+    FormValidator(
+        expected_error="Enter your date of birth.", fill_fn=fill_in_birthdate_field,
+        field_name=birthdate_elements, field_value = "12-09-1945"),
+    FormValidator(
+        expected_error="Enter a valid email address",
+        field_name="email", field_value=generate_unique_email()),
+    FormValidator(
+        expected_error="Enter a 10-digit emergency contact number",
+        field_name="ec_phone", field_value="410-765-9867"),
+    FormValidator(
+        expected_error="Enter a valid zip code",
+        field_name="zip_code", field_value="21211"),
+    # magstock-specific stuff, need a way to filter this out
+    FormValidator(
+        expected_error="Noise Level is a required field",
+        field_name="noise_level", field_value="as"),
+
+    # ------------------- #
+    FormValidator(expected_error="Site Type is a required field"),
+]
+
+
+def validate_form(driver, validators):
+    for validator in regform_validations:
+        validator.ensure_found_error(driver)
+        validator.run(driver)
+
+
+# @pytest.mark.nondestructive  # not true anymore
+def test_regfield_validations(base_url, selenium):
+    selenium.get('{0}/uber/preregistration/form'.format(base_url))
+    assert "Preregistration" in selenium.title
+
+    validate_form(selenium, regform_validations)

--- a/selenium-tests/test_registration.py
+++ b/selenium-tests/test_registration.py
@@ -1,15 +1,34 @@
 import pytest
 from selenium.webdriver.support.select import Select
 import uuid
+import time
 
 # TODO: eventually, make this configurable
 EVENT_NAME = "magstock"
 
+STRIPE_FAKE_CREDIT_CARD = "4242"  # this will be repeated 4 times
+STRIPE_FAKE_EXP_DATE = "12/25"  # MM/YY
+STRIPE_FAKE_CSC = "111"
+STRIPE_FAKE_ZIP = "54321"
+
+
+def is_mobile(driver):
+    # TODO: likely need to update this for IOS and other stuff, or maybe check for Appnium
+    return driver.capabilities["platform"] == "ANDROID"
+
+
 @pytest.fixture
 def selenium(selenium):
     selenium.implicitly_wait(10)
-    selenium.maximize_window()
+    if not is_mobile(selenium):
+        selenium.maximize_window()
     return selenium
+
+
+@pytest.fixture
+def clear_session_cookie(selenium):
+    # this logs you out, or if you have unsaved prereg's, will clear them
+    selenium.delete_cookie('session_id')
 
 
 def ensure_text_in_error_message(driver, text):
@@ -17,9 +36,8 @@ def ensure_text_in_error_message(driver, text):
     assert text in html
 
 
-def ensure_text_exists_in_head(driver, text):
-    head_html = driver.find_element_by_tag_name("head").get_attribute("innerHTML")
-    assert text in head_html
+def innerhtml(driver, tag):
+    return driver.find_element_by_tag_name(tag).get_attribute("innerHTML")
 
 
 class ArgsBase:
@@ -37,24 +55,26 @@ class FormValidator(ArgsBase):
 
         super(FormValidator, self).__init__(**kwargs)
 
-    def run(self, driver):
+    def check_for_expected_error(self, driver):
         if self.expected_error:
             ensure_text_in_error_message(driver, self.expected_error)
 
+    def fill_if_needed(self, driver):
+        form_element = None
         if self.field_name and (not self.event_specific or self.event_specific == EVENT_NAME):
-            elem = self.fill(driver)
-            elem.submit()
+            form_element = self.fill(driver)
+        return form_element
 
-    def fill(self, driver):
-        """
-        Fill out a field. Can be overridden, and must return an element that is part of the form
-        that we are filling out.
-        """
-        elem = driver.find_element_by_xpath("//input[@name='{}']".format(self.field_name))
-        if self.field_value:
-            elem.clear()
-            elem.send_keys(self.field_value)
-        return elem
+    def run(self, driver, submit=False, check_expected_error=False):
+        if check_expected_error:
+            self.check_for_expected_error(driver)
+
+        form_element = self.fill_if_needed(driver)
+
+        if submit:
+            form_element.submit()
+
+        return form_element
 
 
 class BirthdateFieldValidator(FormValidator):
@@ -70,11 +90,20 @@ class BirthdateFieldValidator(FormValidator):
         return elem
 
 
-class TextFieldValidator(FormValidator):
-    pass
+class InputFieldValidator(FormValidator):
+    def fill(self, driver):
+        """
+        Fill out a field. Can be overridden, and must return an element that is part of the form
+        that we are filling out.
+        """
+        elem = driver.find_element_by_xpath("//input[@name='{}']".format(self.field_name))
+        if self.field_value:
+            elem.clear()
+            elem.send_keys(self.field_value)
+        return elem
 
 
-class DropDownValidator(TextFieldValidator):
+class DropDownValidator(FormValidator):
     def fill(self, driver):
         elem = driver.find_element_by_name(self.field_name)
         if self.field_value:
@@ -87,30 +116,65 @@ class EnsurePage(ArgsBase):
         assert self.expected_page in driver.current_url
 
 
+def fill_and_submit_stripe_form(driver):
+    """
+    This function assumes you use a unique email address, if not, Stripe will try and verify you with
+    an SMS message code, and we don't handle that case yet.
+    """
+    pay_button_xpath = "//form[@class='stripe']/button[@class='stripe-button-el']"
+    button = driver.find_element_by_xpath(pay_button_xpath)
+    button.click()
+
+    if not is_mobile(driver):
+        # mobile stripe doesn't use an iframe, just opens a new tab
+        stripe_iframe = driver.find_element_by_xpath("//iframe[@name='stripe_checkout_app']")
+        driver.switch_to_frame(stripe_iframe)
+    else:
+        driver.switch_to.window("stripe_checkout_tabview")
+
+    # we can't just send the entire card# for some reason, send it in 4 chunks.
+    for i in range(4):
+        driver.find_element_by_id('card_number').send_keys(STRIPE_FAKE_CREDIT_CARD)
+
+    for part in STRIPE_FAKE_EXP_DATE.split('/'):
+        driver.find_element_by_id('cc-exp').send_keys(part)
+
+    driver.find_element_by_id('cc-csc').send_keys(STRIPE_FAKE_CSC)
+    zip_elem = driver.find_element_by_id('billing-zip')
+    zip_elem.send_keys(STRIPE_FAKE_ZIP)
+    zip_elem.submit()
+
+    if not is_mobile(driver):
+        driver.switch_to_default_content()
+
+    time.sleep(4)  # hax.
+
+
 def generate_unique_email():
     return "testemail-{}@testemail.com".format(str(uuid.uuid4()))
+
 
 birthdate_elements = ["jq-dte-month", "jq-dte-day", "jq-dte-year"]
 
 # order matters
 regform_validations = [
-    TextFieldValidator(field_name="first_name"),
-    TextFieldValidator(
+    InputFieldValidator(field_name="first_name"),
+    InputFieldValidator(
         expected_error="First Name is a required field",
         field_name="first_name", field_value="FIRSTNAME_Attendee"),
-    TextFieldValidator(
+    InputFieldValidator(
         expected_error="Last Name is a required field",
         field_name="last_name", field_value="LASTNAME_Attendee"),
     BirthdateFieldValidator(
         expected_error="Enter your date of birth.",
-        field_name=birthdate_elements, field_value = "12-09-1945"),
-    TextFieldValidator(
+        field_name=birthdate_elements, field_value="12-09-1945"),
+    InputFieldValidator(
         expected_error="Enter a valid email address",
         field_name="email", field_value=generate_unique_email()),
-    TextFieldValidator(
+    InputFieldValidator(
         expected_error="Enter a 10-digit emergency contact number",
         field_name="ec_phone", field_value="410-765-9867"),
-    TextFieldValidator(
+    InputFieldValidator(
         expected_error="Enter a valid zip code",
         field_name="zip_code", field_value="21211"),
     DropDownValidator(
@@ -129,24 +193,70 @@ regform_validations = [
         event_specific="magstock",
         expected_error="Please tell us whether you are leading a group",
         field_name="coming_as", field_value="I'm not the one coordinating my group"),
-    TextFieldValidator(
+    InputFieldValidator(
         event_specific="magstock",
         expected_error="Please tell us who your camp leader is",
         field_name="coming_with", field_value="Marianne Testguy"),
-    EnsurePage(
-        expected_page="/uber/preregistration/index"
-    )
+]
+
+stripe_payment_form = [
+
 ]
 
 
-def validate_form(driver, validators):
-    for validator in regform_validations:
-        validator.run(driver)
+class FormFiller:
+    def __init__(self, validations):
+        self.validations = validations
+
+    def run_each_then_submit_each(self, driver):
+        """
+        Run each field validation one at a time in sequence, then submit the form after each one.
+        This will check that error messages pop up for required form elements.
+        """
+        for validator in self.validations:
+            validator.run(driver, submit=True, check_expected_error=True)
+
+    def fill_entire_form_then_submit(self, driver):
+        """
+        Fill in the entire form all at once and submit at the end.  Doesn't check for individual error
+        messages.
+        """
+        last_form_element = None
+        for validator in self.validations:
+            last_form_element = validator.run(driver)
+
+        last_form_element.submit()
 
 
 # @pytest.mark.nondestructive  # not true anymore
-def test_full_regfield_completion(base_url, selenium):
+@pytest.mark.skip
+def test_full_validations_main_prereg_page(base_url, selenium):
+    """
+    Test all validations for one path through the front prereg page.
+    Example: If you leave off "First Name", we want to see an error message about "First name is required"
+    """
+
     selenium.get('{0}/uber/preregistration/form'.format(base_url))
     assert "Preregistration" in selenium.title
 
-    validate_form(selenium, regform_validations)
+    FormFiller(regform_validations).run_each_then_submit_each(selenium)
+
+    assert "/uber/preregistration/index" in selenium.current_url
+
+
+def test_prereg_payment(base_url, selenium):
+    """
+    Test entire public registration workflow from filling out the form
+    to then filling out the stripe credit card page
+    """
+    selenium.get('{0}/uber/preregistration/form'.format(base_url))
+    assert "Preregistration" in selenium.title
+
+    FormFiller(regform_validations).fill_entire_form_then_submit(selenium)
+
+    assert "/uber/preregistration/index" in selenium.current_url
+
+    fill_and_submit_stripe_form(selenium)
+
+    assert "/uber/preregistration/paid_preregistrations" in selenium.current_url
+    assert "The following preregistrations have been made from this computer" in innerhtml(selenium, "body")

--- a/selenium-tests/test_registration.py
+++ b/selenium-tests/test_registration.py
@@ -1,5 +1,9 @@
 import pytest
+from selenium.webdriver.support.select import Select
 import uuid
+
+# TODO: eventually, make this configurable
+EVENT_NAME = "magstock"
 
 @pytest.fixture
 def selenium(selenium):
@@ -8,56 +12,79 @@ def selenium(selenium):
     return selenium
 
 
-def text_in_error_message(driver, text):
+def ensure_text_in_error_message(driver, text):
     html = driver.find_elements_by_class_name("toast-message")[0].get_attribute("innerHTML")
-    return text in html
+    assert text in html
 
 
-def text_exists_in_head(driver, text):
+def ensure_text_exists_in_head(driver, text):
     head_html = driver.find_element_by_tag_name("head").get_attribute("innerHTML")
-    return text in head_html
+    assert text in head_html
 
 
-def fill_in_text_field(driver, field_name, text):
-    elem = driver.find_element_by_name(field_name)
-    elem.send_keys(text)
-    return elem
+class ArgsBase:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
 
-def fill_in_birthdate_field(driver, field_names, date_text):
-    date_values = date_text.split('-')
-    assert len(field_names) == len(date_values)
-    fields_and_values = zip(field_names, date_values)
-
-    elem = None
-    for field,text in fields_and_values:
-        elem = driver.find_elements_by_class_name(field)[0]
-        elem.send_keys(text)
-    return elem
-
-
-class FormValidator:
+class FormValidator(ArgsBase):
     def __init__(self, **kwargs):
         self.field_name = None
         self.field_value = None
         self.expected_error = None
-        self.fill_fn = fill_in_text_field
-        self.submit_only = False
+        self.event_specific = None
 
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
-    def ensure_found_error(self, driver):
-        if self.expected_error:
-            assert text_in_error_message(driver, self.expected_error)
+        super(FormValidator, self).__init__(**kwargs)
 
     def run(self, driver):
-        if self.field_name:
-            if self.submit_only:
-                elem = driver.find_element_by_name(self.field_name)
-            else:
-                elem = self.fill_fn(driver, self.field_name, self.field_value)
+        if self.expected_error:
+            ensure_text_in_error_message(driver, self.expected_error)
+
+        if self.field_name and (not self.event_specific or self.event_specific == EVENT_NAME):
+            elem = self.fill(driver)
             elem.submit()
+
+    def fill(self, driver):
+        """
+        Fill out a field. Can be overridden, and must return an element that is part of the form
+        that we are filling out.
+        """
+        elem = driver.find_element_by_xpath("//input[@name='{}']".format(self.field_name))
+        if self.field_value:
+            elem.clear()
+            elem.send_keys(self.field_value)
+        return elem
+
+
+class BirthdateFieldValidator(FormValidator):
+    def fill(self, driver):
+        date_values = self.field_value.split('-')
+        assert len(self.field_name) == len(date_values)
+        fields_and_values = zip(self.field_name, date_values)
+
+        elem = None
+        for field, text in fields_and_values:
+            elem = driver.find_elements_by_class_name(field)[0]
+            elem.send_keys(text)
+        return elem
+
+
+class TextFieldValidator(FormValidator):
+    pass
+
+
+class DropDownValidator(TextFieldValidator):
+    def fill(self, driver):
+        elem = driver.find_element_by_name(self.field_name)
+        if self.field_value:
+            Select(elem).select_by_visible_text(self.field_value)
+        return elem
+
+
+class EnsurePage(ArgsBase):
+    def run(self, driver):
+        assert self.expected_page in driver.current_url
 
 
 def generate_unique_email():
@@ -65,39 +92,55 @@ def generate_unique_email():
 
 birthdate_elements = ["jq-dte-month", "jq-dte-day", "jq-dte-year"]
 
+# order matters
 regform_validations = [
-    FormValidator(field_name="first_name", submit_only=True),
-    FormValidator(
+    TextFieldValidator(field_name="first_name"),
+    TextFieldValidator(
         expected_error="First Name is a required field",
         field_name="first_name", field_value="FIRSTNAME_Attendee"),
-    FormValidator(
+    TextFieldValidator(
         expected_error="Last Name is a required field",
         field_name="last_name", field_value="LASTNAME_Attendee"),
-    FormValidator(
-        expected_error="Enter your date of birth.", fill_fn=fill_in_birthdate_field,
+    BirthdateFieldValidator(
+        expected_error="Enter your date of birth.",
         field_name=birthdate_elements, field_value = "12-09-1945"),
-    FormValidator(
+    TextFieldValidator(
         expected_error="Enter a valid email address",
         field_name="email", field_value=generate_unique_email()),
-    FormValidator(
+    TextFieldValidator(
         expected_error="Enter a 10-digit emergency contact number",
         field_name="ec_phone", field_value="410-765-9867"),
-    FormValidator(
+    TextFieldValidator(
         expected_error="Enter a valid zip code",
         field_name="zip_code", field_value="21211"),
-    # magstock-specific stuff, need a way to filter this out
-    FormValidator(
+    DropDownValidator(
+        event_specific="magstock",
         expected_error="Noise Level is a required field",
-        field_name="noise_level", field_value="as"),
-
-    # ------------------- #
-    FormValidator(expected_error="Site Type is a required field"),
+        field_name="noise_level", field_value="As quiet as possible at night"),
+    DropDownValidator(
+        event_specific="magstock",
+        expected_error="Site Type is a required field",
+        field_name="site_type", field_value="Normal - has electric and water hookups"),
+    DropDownValidator(
+        event_specific="magstock",
+        expected_error="Please tell us how you are camping",
+        field_name="camping_type", field_value="Small Tent (6 or fewer)"),
+    DropDownValidator(
+        event_specific="magstock",
+        expected_error="Please tell us whether you are leading a group",
+        field_name="coming_as", field_value="I'm not the one coordinating my group"),
+    TextFieldValidator(
+        event_specific="magstock",
+        expected_error="Please tell us who your camp leader is",
+        field_name="coming_with", field_value="Marianne Testguy"),
+    EnsurePage(
+        expected_page="/uber/preregistration/index"
+    )
 ]
 
 
 def validate_form(driver, validators):
     for validator in regform_validations:
-        validator.ensure_found_error(driver)
         validator.run(driver)
 
 

--- a/selenium-tests/test_registration.py
+++ b/selenium-tests/test_registration.py
@@ -145,7 +145,7 @@ def validate_form(driver, validators):
 
 
 # @pytest.mark.nondestructive  # not true anymore
-def test_regfield_validations(base_url, selenium):
+def test_full_regfield_completion(base_url, selenium):
     selenium.get('{0}/uber/preregistration/form'.format(base_url))
     assert "Preregistration" in selenium.title
 


### PR DESCRIPTION
- you have to provide your credentials via env vars, but this works pretty nicely
- magstock-specific version currently
- all of this is very prototype and WIP, but works great so far

This is pretty damn cool.  We are using py.test, selenium, and saucelabs to run functional tests on the app (i.e. automated clicking around on the end-user-facing webform). This python code runs locally, or can run from Travis, and uses https://saucelabs.com/ (which we can use for free since we're open source), to run selenium tests that test out the frontpage of uber.

We can use saucelabs to test any combo of browsers on any OS, currently I have this set to test firefox on MacOSX. I hope to use it for mobile testing, which is totally possible.

My dream is that someday we'll have the public-facing registration workflow extremely well covered with functional tests so that we can find out if we break reg forms way before we end up deploying it.  This code is a really painless and promising start.

For now, here's the code in this PR filling out fields on the prereg page one at a time and making sure it sees the correct error messages when something is left off.  About 50% completion: https://saucelabs.com/beta/tests/660834e956e3455fbf79425e2d89da74/commands

YOU CAN WATCH A VIDEO! ^^ Click "watch" there and you'll see it.
