### PR TITLE
WIP: mail previewing

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -47,9 +47,12 @@ class AutomatedEmail:
         model = getattr(x, 'email_model_name', x.__class__.__name__.lower())
         return render('emails/' + self.template, dict({model: x}, **self.extra_data))
 
+    def is_html(self):
+        return not self.template.endswith('.txt')
+
     def send(self, x, raise_errors=True):
         try:
-            format = 'text' if self.template.endswith('.txt') else 'html'
+            format = 'text' if self.is_html() else 'html'
             send_email(self.sender, x.email, self.subject, self.render(x), format, model=x, cc=self.cc)
         except:
             log.error('error sending {!r} email to {}', self.subject, x.email, exc_info=True)

--- a/uber/site_sections/devtools.py
+++ b/uber/site_sections/devtools.py
@@ -19,6 +19,85 @@ def run_git_cmd(cmd):
     return run_shell_cmd(git + " " + cmd, working_dir=uber_base_dir)
 
 
+def generate_test_email_models():
+    test_models = dict()
+
+    attendee = Attendee(first_name='John', last_name='Dudebro', email='hey@hey.com')
+    attendee2 = Attendee(first_name='Ima', last_name='Coolman', email='bro@bro.com')
+    test_models[Attendee] = attendee
+
+    group = Group(name="the coolest group", leader=attendee)
+    test_models[Group] = group
+
+    try:
+        import panels
+        event = panels.Event(name="Cool Event Bro", start_time=c.EPOCH,
+                             duration=30, description="This is cool as anything")
+        test_models[panels.PanelApplication] = panels.PanelApplication(event=event,
+                                                                       name="My Panel Is Better Than Yours")
+    except:
+        pass
+
+    try:
+        import bands
+        test_models[bands.Band] = bands.Band(
+            group=Group(name="DE Coolest Bandz2", leader=attendee),
+            info=bands.BandInfo(),
+            bio=bands.BandBio(),
+            taxes=bands.BandTaxes(),
+            stage_plot=bands.BandStagePlot(),
+            panel=bands.BandPanel(),
+            merch=bands.BandMerch(),
+            charity=bands.BandCharity()
+        )
+    except:
+        pass
+
+    try:
+        import attendee_tournaments
+        test_models[attendee_tournaments.AttendeeTournament] = attendee_tournaments.AttendeeTournament(
+            game="Mario 6", first_name="Joe", last_name="Dudeman"
+        )
+    except:
+        pass
+
+    try:
+        import hotel
+        test_models[hotel.Room] = hotel.Room(
+            assignments=[hotel.RoomAssignment(attendee=attendee), hotel.RoomAssignment(attendee=attendee2)],
+            nights=','.join(map(str, c.CORE_NIGHTS))
+        )
+    except:
+        pass
+
+    try:
+        import mivs
+
+        game = mivs.IndieGame(
+            title="Mario 7",
+        )
+        test_models[mivs.IndieGame] = game
+
+        test_models[mivs.IndieStudio] = mivs.IndieStudio(
+            group=group,
+            name="Bossman Studios",
+            games=[game],
+            developers=[mivs.IndieDeveloper(
+                first_name="Mancrunch",
+                last_name="Jones",
+                primary_contact=True
+            )]
+        )
+
+        test_models[mivs.IndieJudge] = mivs.IndieJudge(
+            admin_account=AdminAccount(attendee=attendee),
+        )
+    except:
+        pass
+
+    return test_models
+
+
 @all_renderable(c.PEOPLE)
 class Root:
     def index(self):
@@ -38,4 +117,22 @@ class Root:
             'git_current_sha': git_current_sha,
             'last_commit_log': last_commit_log,
             'git_status': git_status
+        }
+
+    def test_all_emails(self):
+        test_models = generate_test_email_models()
+
+        rendered_emails = []
+        for email in [email[1] for email in AutomatedEmail.instances.items()]:
+            if email.model not in test_models:
+                rendered = "<font color='red'>Skipping {} because we don't have the model yet.</font>".format(email.subject)
+            else:
+                rendered = email.render(test_models[email.model]).decode('utf-8')
+                if not email.is_html():
+                    rendered = "<pre>{}</pre>".format(rendered)
+
+            rendered_emails.append({'text': rendered, 'subject': email.subject})
+
+        return {
+            'emails': rendered_emails
         }

--- a/uber/templates/devtools/test_all_emails.html
+++ b/uber/templates/devtools/test_all_emails.html
@@ -1,0 +1,17 @@
+{% extends "base-admin.html" %}
+{% block title %}Test email sending{% endblock %}
+{% block content %}
+
+<style>
+pre {
+    white-space: pre-wrap;       /* Since CSS 2.1 */
+}
+</style>
+
+{% for email in emails %}
+<hr />
+<h1>{{ email.subject }}</h1>
+{{ email.text }}
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
- this can be used to view all email templates to make sure they render correctly
- uses faked model data for magfest-specific models

notes:
I'm using this to test the JINJA2 template refactor (found a few that needed help, most were fine).  With this tool I have made recent changes to the JINJA2 template branch that fixed up a few email templates (and, caught some template errors that currently exist in the master branch)

output is a page that looks like this:
![image](https://cloud.githubusercontent.com/assets/5413064/16968049/6c317e10-4dda-11e6-852a-98e73fce2465.png)

If an email template needs a model whose data we aren't faking, it will display `Skipping because we don't have the model yet.`.

This PR is fully functional, however, it contains references to downstream plugins.  As such, we might want to put this in some kind of magfest-specific development plugin.  For now, wanted to put it here so we didn't forget about it.
