### PR TITLE
Use badge caps for price bumps

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -108,6 +108,9 @@ class Config(_Overridable):
             for day, bumped_price in sorted(self.PRICE_BUMPS.items()):
                 if (dt or datetime.now(UTC)) >= day:
                     price = bumped_price
+            for badge_cap, bumped_price in sorted(self.PRICE_LIMITS.items()):
+                if self.BADGES_SOLD >= badge_cap and bumped_price > price:
+                    price = bumped_price
         return price
 
     def get_group_price(self, dt):
@@ -345,8 +348,14 @@ c.EVENT_TIMEZONE = pytz.timezone(c.EVENT_TIMEZONE)
 c.make_dates(_config['dates'])
 
 c.PRICE_BUMPS = {}
+c.PRICE_LIMITS = {}
 for _opt, _val in c.BADGE_PRICES['attendee'].items():
-    c.PRICE_BUMPS[c.EVENT_TIMEZONE.localize(datetime.strptime(_opt, '%Y-%m-%d'))] = _val
+    try:
+        date = c.EVENT_TIMEZONE.localize(datetime.strptime(_opt, '%Y-%m-%d'))
+    except ValueError:
+        c.PRICE_LIMITS[int(_opt)] = _val
+    else:
+        c.PRICE_BUMPS[date] = _val
 
 
 def _is_intstr(s):

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -390,8 +390,10 @@ dealer_badge_price = integer(default=30)
 __many__ = integer
 
 [[attendee]]
-# Set dates equal to the price as of that date.  For example, you could say
+# Set dates equal to the price as of that date. For example, you could say
 # "2014-10-01 = 45" to have the price go up to $45 on October 1st.
+# You can also set a badge cap for a price, e.g., "5000 = 50" will raise
+# the badge price to $50 once 5000 badges are sold.
 __many__ = integer
 
 [[stocks]]

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -541,9 +541,9 @@ class PriceNotice(template.Node):
             return ''  # we only display notices for new attendees
         else:
             for day, price in sorted(c.PRICE_BUMPS.items()):
-                if day < takedown and localized_now() < day:
+                if day < takedown and localized_now() < day and price > c.BADGE_PRICE:
                     return '<div class="prereg-price-notice">Price goes up to ${} at 11:59pm {} on {}</div>'.format(price - int(discount) + int(amount_extra), (day - timedelta(days=1)).strftime('%Z'), (day - timedelta(days=1)).strftime('%A, %b %e'))
-                elif localized_now() < day and takedown == c.PREREG_TAKEDOWN and takedown < c.EPOCH:
+                elif localized_now() < day and takedown == c.PREREG_TAKEDOWN and takedown < c.EPOCH and price > c.BADGE_PRICE:
                     return '<div class="prereg-type-closing">{} closes at 11:59pm {} on {}. Price goes up to ${} at-door.</div>'.format(label, takedown.strftime('%Z'), takedown.strftime('%A, %b %e'), price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
             if takedown < c.EPOCH:
                 return '<div class="prereg-type-closing">{} closes at 11:59pm {} on {}</div>'.format(label, takedown.strftime('%Z'), takedown.strftime('%A, %b %e'))

--- a/uber/tests/conftest.py
+++ b/uber/tests/conftest.py
@@ -29,6 +29,12 @@ def sensible_defaults():
     # we need to set some default table prices so we can write tests against them without worrying about what's been configured
     c.TABLE_PRICES = defaultdict(lambda: 400, {1: 100, 2: 200, 3: 300})
 
+    # default attendee prices
+    c.INITIAL_ATTENDE = 40
+    c.GROUP_DISCOUNT = 10
+    c.DEALER_BADGE_PRICE = 20
+    c.PRICE_BUMPS = {}
+
 
 @pytest.fixture(scope='session', autouse=True)
 def init_db(request, sensible_defaults):

--- a/uber/tests/models/test_config.py
+++ b/uber/tests/models/test_config.py
@@ -1,0 +1,58 @@
+from uber.tests import *
+
+class TestPrices:
+    def test_initial_attendee(self):
+        assert 40 == c.get_attendee_price(datetime.now(UTC))
+
+    def test_group_member(self):
+        assert 30 == c.get_group_price(datetime.now(UTC))
+
+
+class TestPriceBumps:
+    @pytest.fixture(autouse=True)
+    def add_price_bump_day(request, monkeypatch):
+        monkeypatch.setattr(c, 'PRICE_BUMPS', {(datetime.now(UTC) - timedelta(days=1)): 50})
+
+    def test_after_date_price_bump(self):
+        assert 50 == c.get_attendee_price(datetime.now(UTC))
+
+    def test_before_date_no_price_bump(self):
+        assert 40 == c.get_attendee_price((datetime.now(UTC) - timedelta(days=2)))
+
+    def test_on_date_no_price_bump(self):
+        assert 40 == c.get_attendee_price((datetime.now(UTC) - timedelta(days=1, hours=2)))
+
+
+class TestPriceLimits:
+    @pytest.fixture(autouse=True)
+    def add_price_bump_limit(request, monkeypatch):
+        monkeypatch.setattr(c, 'PRICE_LIMITS', {1: 50})
+
+    def test_under_limit_no_price_bump(self):
+        assert 40 == c.get_attendee_price(datetime.now(UTC))
+
+    def test_over_limit_price_bump(self):
+        session = Session().session
+        session.add(Attendee(paid=c.HAS_PAID, badge_status=c.COMPLETED_STATUS))
+        session.commit()
+        assert 50 == c.get_attendee_price(datetime.now(UTC))
+
+    def test_refunded_badge_price_bump(self):
+        session = Session().session
+        session.add(Attendee(paid=c.REFUNDED, badge_status=c.COMPLETED_STATUS))
+        session.commit()
+        assert 50 == c.get_attendee_price(datetime.now(UTC))
+
+    def test_invalid_badge_no_price_bump(self):
+        session = Session().session
+        session.add(Attendee(paid=c.HAS_PAID, badge_status=c.INVALID_STATUS))
+        session.commit()
+        assert 40 == c.get_attendee_price(datetime.now(UTC))
+
+    def test_free_badge_no_price_bump(self):
+        session = Session().session
+        session.add(Attendee(paid=c.NEED_NOT_PAY, badge_status=c.COMPLETED_STATUS))
+        session.commit()
+        assert 40 == c.get_attendee_price(datetime.now(UTC))
+
+    # todo: Test badges that are paid by group

--- a/uber/tests/models/test_config.py
+++ b/uber/tests/models/test_config.py
@@ -1,5 +1,6 @@
 from uber.tests import *
 
+
 class TestPrices:
     def test_initial_attendee(self):
         assert 40 == c.get_attendee_price(datetime.now(UTC))


### PR DESCRIPTION
Allows admins to set a badge cap for each price bump, rather than just relying on dates. Fixes #1906.

To add a badge-cap-based price bump, simply add it in the same place in the config as the dates - the system automatically sorts the type of price bump it is based on whether it can be cast to a Date type or not.

This is the simple version, which doesn't store the badge price permanently; thus, there is a chance that the badge price can go _down_ if, e.g., several badges are deleted. However, I'm leaning towards that being preferable, as changing a single config option (or adding fake badges) to force a badge price to stay high is easier than trying to modify the database if the badge price was erroneously bumped (like if a group of 50 people all registered and then requested a refund or something silly).