### PR TITLE
add custom error message handler that outputs extra info about context

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -606,11 +606,16 @@ DEBUG = boolean(default=True)
 TEMPLATE_DEBUG = boolean(default=True)
 TEMPLATE_DIRS = string_list(default=list('%(module_root)s/templates'))
 
-
 [appconf]
 # This is all CherryPy configuration.
 
-#[[/]]
+[[/]]
 #tools.proxy.on = boolean(default=True)
 #tools.proxy.base = string(default="%(url_root)s")
 #tools.add_email_to_error_page.on = boolean(default=True)
+
+# custom logging output:
+# turn off normal traceback and header logging on errors, instead use our custom on_cherrypy_before_error_response
+tools.log_tracebacks.on = boolean(default=False)
+tools.log_headers.on = boolean(default=False)
+tools.on_cherrypy_before_error_response.on = boolean(default=True)

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -615,7 +615,7 @@ TEMPLATE_DIRS = string_list(default=list('%(module_root)s/templates'))
 #tools.add_email_to_error_page.on = boolean(default=True)
 
 # custom logging output:
-# turn off normal traceback and header logging on errors, instead use our custom on_cherrypy_before_error_response
+# turn off normal traceback and header logging on errors, instead use our custom verbose logger that prints more info
 tools.log_tracebacks.on = boolean(default=False)
 tools.log_headers.on = boolean(default=False)
-tools.on_cherrypy_before_error_response.on = boolean(default=True)
+tools.custom_verbose_logger.on = boolean(default=True)

--- a/uber/server.py
+++ b/uber/server.py
@@ -11,6 +11,25 @@ def _add_email():
 cherrypy.tools.add_email_to_error_page = cherrypy.Tool('after_error_response', _add_email)
 
 
+def on_cherrypy_before_error_response(debug=False):
+    """
+    Write the request headers, and the last error's traceback to the cherrypy error log.
+    Do this all one line so all the information can be collected by external log collectors and easily displayed.
+    """
+
+    page_location = 'Request: ' + cherrypy.request.request_line
+
+    admin_name = AdminAccount.admin_name()
+    admin_txt = 'Current admin user is: {}'.format(admin_name if admin_name else '[non-admin user]')
+
+    h = ["  %s: %s" % (k, v) for k, v in cherrypy.request.header_list]
+    headers_txt = 'Request Headers:\n' + '\n'.join(h)
+
+    msg = '\n'.join(['Exception encountered', page_location, admin_txt, headers_txt])
+    log.error(msg, exc_info=True)
+
+cherrypy.tools.on_cherrypy_before_error_response = cherrypy.Tool('before_error_response', on_cherrypy_before_error_response)
+
 class StaticViews:
     def path_args_to_string(self, path_args):
         return '/'.join(path_args)

--- a/uber/server.py
+++ b/uber/server.py
@@ -27,8 +27,8 @@ def on_cherrypy_before_error_response(debug=False):
 
     msg = '\n'.join(['Exception encountered', page_location, admin_txt, headers_txt])
     log.error(msg, exc_info=True)
-
 cherrypy.tools.on_cherrypy_before_error_response = cherrypy.Tool('before_error_response', on_cherrypy_before_error_response)
+
 
 class StaticViews:
     def path_args_to_string(self, path_args):

--- a/uber/server.py
+++ b/uber/server.py
@@ -11,7 +11,7 @@ def _add_email():
 cherrypy.tools.add_email_to_error_page = cherrypy.Tool('after_error_response', _add_email)
 
 
-def on_cherrypy_before_error_response(debug=False):
+def _custom_verbose_logger(debug=False):
     """
     Write the request headers, and the last error's traceback to the cherrypy error log.
     Do this all one line so all the information can be collected by external log collectors and easily displayed.
@@ -22,12 +22,19 @@ def on_cherrypy_before_error_response(debug=False):
     admin_name = AdminAccount.admin_name()
     admin_txt = 'Current admin user is: {}'.format(admin_name if admin_name else '[non-admin user]')
 
+    max_reporting_length = 1000   # truncate to reasonably large size in case they uploaded attachments
+
+    p = ["  %s: %s" % (k, v[:max_reporting_length]) for k, v in cherrypy.request.params.items()]
+    post_txt = 'Request Params:\n' + '\n'.join(p)
+
+    session_txt = 'Session Params:\n' + pformat(cherrypy.session.items(), width=40)
+
     h = ["  %s: %s" % (k, v) for k, v in cherrypy.request.header_list]
     headers_txt = 'Request Headers:\n' + '\n'.join(h)
 
-    msg = '\n'.join(['Exception encountered', page_location, admin_txt, headers_txt])
+    msg = '\n'.join(['Exception encountered', page_location, admin_txt, post_txt, session_txt, headers_txt])
     log.error(msg, exc_info=True)
-cherrypy.tools.on_cherrypy_before_error_response = cherrypy.Tool('before_error_response', on_cherrypy_before_error_response)
+cherrypy.tools.custom_verbose_logger = cherrypy.Tool('before_error_response', _custom_verbose_logger)
 
 
 class StaticViews:


### PR DESCRIPTION
- this adds a ton of info to traceback logs like requesting URL+query string, admin user if logged in, HTTP headers
- can be turned on and off via config
- extremely useful when used with alerting via ELK stack reporting, now when these are posted in slack it will be MUCH clearer what's going on

Sample log error (this will show up in alerts on Slack now). Note that it displays useful info at the top.

```
2016-07-24 20:10:13,924 [ERROR] uber.server: Exception encountered
    Request: GET /uber/registration/form?id=7c7be9c0-78f1-4f41-9c80-1064b429f84a3 HTTP/1.0
    Current admin user is: Test Developer
    Request Headers:
      HOST: localhost
      ACCEPT-ENCODING: gzip, deflate, sdch, br
      ACCEPT: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
      CACHE-CONTROL: max-age=0
      UPGRADE-INSECURE-REQUESTS: 1
      COOKIE: _ga=GA1.1.950237344.1453473795; session_id=4a9ec6e68e8f09486576937d2370163d5ddd828c
      X-FORWARDED-FOR: 10.0.2.2
      CONNECTION: close
      X-REAL-IP: 10.0.2.2
      USER-AGENT: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36
      Remote-Addr: 127.0.0.1
      ACCEPT-LANGUAGE: en-US,en;q=0.8
    Traceback (most recent call last):
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/base.py", line 1073, in _execute_context
        context = constructor(dialect, self, conn, *args)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/default.py", line 600, in _init_compiled
        for key in compiled_params
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/default.py", line 600, in <genexpr>
        for key in compiled_params
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/sql/type_api.py", line 931, in process
        return impl_processor(process_param(value, dialect))
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 404, in process
        value = _python_UUID(value)
      File "/usr/lib/python3.4/uuid.py", line 137, in __init__
        raise ValueError('badly formed hexadecimal UUID string')
    ValueError: badly formed hexadecimal UUID string
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 670, in respond
        response.body = self.handler()
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/lib/encoding.py", line 217, in __call__
        self.body = self.oldhandler(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpdispatch.py", line 61, in __call__
        return self.callable(*self.args, **self.kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 181, in with_timing
        return func(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 172, in with_caching
        return func(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 196, in with_session
        retval = func(*args, session=session, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 292, in with_restrictions
        return func(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 254, in with_rendering
        result = func(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 13, in with_check
        sa.Tracking.track_pageview(cherrypy.request.path_info, cherrypy.request.query_string)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/models.py", line 1830, in track_pageview
        attendee = session.query(Attendee).filter(Attendee.id == params['id']).first()
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/orm/query.py", line 2444, in first
        ret = list(self[0:1])
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/orm/query.py", line 2280, in __getitem__
        return list(res)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/orm/query.py", line 2515, in __iter__
        return self._execute_and_instances(context)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/orm/query.py", line 2530, in _execute_and_instances
        result = conn.execute(querycontext.statement, self._params)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/base.py", line 914, in execute
        return meth(self, multiparams, params)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/sql/elements.py", line 323, in _execute_on_connection
        return connection._execute_clauseelement(self, multiparams, params)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/base.py", line 1010, in _execute_clauseelement
        compiled_sql, distilled_params
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/base.py", line 1078, in _execute_context
        None, None)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/base.py", line 1332, in _handle_dbapi_exception
        exc_info
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/util/compat.py", line 188, in raise_from_cause
        reraise(type(exception), exception, tb=exc_tb, cause=exc_value)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/util/compat.py", line 181, in reraise
        raise value.with_traceback(tb)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/base.py", line 1073, in _execute_context
        context = constructor(dialect, self, conn, *args)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/default.py", line 600, in _init_compiled
        for key in compiled_params
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/engine/default.py", line 600, in <genexpr>
        for key in compiled_params
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/sql/type_api.py", line 931, in process
        return impl_processor(process_param(value, dialect))
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 404, in process
        value = _python_UUID(value)
      File "/usr/lib/python3.4/uuid.py", line 137, in __init__
        raise ValueError('badly formed hexadecimal UUID string')
    sqlalchemy.exc.StatementError: (builtins.ValueError) badly formed hexadecimal UUID string [snip]
```