### PR TITLE
provide template source, if available, on django template errors

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -212,8 +212,20 @@ def renderable_data(data=None):
 # render using the first template that actually exists in template_name_list
 def render(template_name_list, data=None):
     data = renderable_data(data)
-    template = loader.select_template(listify(template_name_list))
-    rendered = template.render(Context(data))
+
+    try:
+        template = loader.select_template(listify(template_name_list))
+        rendered = template.render(Context(data))
+    except Exception as e:
+        source_template_name = '[unknown]'
+        django_template_source_info = getattr(e, 'django_template_source')
+        if django_template_source_info:
+            for info in django_template_source_info:
+                if 'LoaderOrigin' in str(type(info)):
+                    source_template_name = info.name
+                    break
+        raise Exception('error rendering template [{}]'.format(source_template_name)) from e
+
     rendered = screw_you_nick(rendered, template)  # lolz.
     return rendered.encode('utf-8')
 


### PR DESCRIPTION
- current stack traces don't tell you where the errors were, this now shows you
- this allows more pinpointing of error messages, useful when used with alerting to figure out what went wrong

sample stacktrace output (note that it displays the template source name where the problem I artificially created was, 'preregbase.html'):
```
HTTP Traceback (most recent call last):
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 274, in parse
        compile_func = self.tags[command]
    KeyError: 'endblock43445'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 218, in render
        rendered = template.render(Context(data))
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 140, in render
        return self._render(context)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 134, in _render
        return self.nodelist.render(context)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 840, in render
        bit = self.render_node(node, context)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/debug.py", line 78, in render_node
        return node.render(context)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader_tags.py", line 101, in render
        compiled_parent = self.get_parent(context)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader_tags.py", line 98, in get_parent
        return get_template(parent)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader.py", line 138, in get_template
        template, origin = find_template(template_name)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader.py", line 127, in find_template
        source, display_name = loader(name, dirs)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader.py", line 43, in __call__
        return self.load_template(template_name, template_dirs)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader.py", line 49, in load_template
        template = get_template_from_string(source, origin, template_name)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader.py", line 149, in get_template_from_string
        return Template(source, origin, name)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 125, in __init__
        self.nodelist = compile_string(template_string, origin)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 153, in compile_string
        return parser.parse()
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 278, in parse
        compiled_result = compile_func(self, token)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader_tags.py", line 215, in do_extends
        nodelist = parser.parse()
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 278, in parse
        compiled_result = compile_func(self, token)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/loader_tags.py", line 190, in do_block
        nodelist = parser.parse(('endblock',))
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 276, in parse
        self.invalid_block_tag(token, command, parse_until)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/django/template/base.py", line 331, in invalid_block_tag
        (command, get_text_list(["'%s'" % p for p in parse_until])))
    django.template.base.TemplateSyntaxError: Invalid block tag: 'endblock43445', expected 'endblock'
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 670, in respond
        response.body = self.handler()
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/lib/encoding.py", line 217, in __call__
        self.body = self.oldhandler(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpdispatch.py", line 61, in __call__
        return self.callable(*self.args, **self.kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 181, in with_timing
        return func(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 172, in with_caching
        return func(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 196, in with_session
        retval = func(*args, session=session, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 292, in with_restrictions
        return func(*args, **kwargs)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 258, in with_rendering
        return render(_get_template_filename(func), result)
      File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 227, in render
        raise Exception('error rendering template [{}]'.format(source_template_name)) from e
    Exception: error rendering template [/home/vagrant/uber/sideboard/plugins/uber/uber/templates/preregistration/preregbase.html]
````