### PR TITLE
re-enable 'email us if you're not sure why you are seeing this' text on errors

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -613,4 +613,4 @@ TEMPLATE_DIRS = string_list(default=list('%(module_root)s/templates'))
 #[[/]]
 #tools.proxy.on = boolean(default=True)
 #tools.proxy.base = string(default="%(url_root)s")
-#tools.add_email_to_error_page.on = boolean(default=True)
+tools.add_email_to_error_page.on = boolean(default=True)

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -610,7 +610,7 @@ TEMPLATE_DIRS = string_list(default=list('%(module_root)s/templates'))
 [appconf]
 # This is all CherryPy configuration.
 
-#[[/]]
+[[/]]
 #tools.proxy.on = boolean(default=True)
 #tools.proxy.base = string(default="%(url_root)s")
 tools.add_email_to_error_page.on = boolean(default=True)


### PR DESCRIPTION
If an end user sees a 500 internal server error, we now display a message that says:

![image](https://cloud.githubusercontent.com/assets/5413064/17087781/a2d3d432-51df-11e6-8bbe-494b52f0130d.png)

(based on c.CONTACT_URL)

@thaeli you had this disabled sometime last year, though it looks like it was part of some other unrelated change and maybe disabled by accident.  Can you think of any reason not to turn this back on?  If so, I think we should probably turn it back on.  It was part of https://github.com/magfest/ubersystem/commit/e5f34097d37709ebe00726adbb98582c59427278 entitled 'get rid of tools.proxy.base', it looks like it was likely an overzealous delete there?