### PR TITLE
add config option to not display prereg opening date

### DIFF
--- a/uber/templates/static_views/prereg_not_yet_open.html
+++ b/uber/templates/static_views/prereg_not_yet_open.html
@@ -2,7 +2,11 @@
 <head></head>
 <body style='text-align:center'>
     <h2 style='color:red'>{{ c.EVENT_NAME_AND_YEAR }} pre-registration is not yet open.</h2>
-    Please check back on {{ c.PREREG_OPEN|datetime:"%B %d" }}.<br/>
+    {% if not c.HIDE_PREREG_OPEN_DATE %}
+        Please check back on {{ c.PREREG_OPEN|datetime:"%B %d" }}.<br/>
+    {% else %}
+        Please check back soon.
+    {% endif %}
     <br/>
     Please <a href="{{ c.CONTACT_URL }}">contact us</a> if you have any questions.<br/>
 </body>


### PR DESCRIPTION
if c.HIDE_PREREG_OPEN_DATE is true, we don't show a date on the page that is displayed before the c.PREREG_OPEN date is reached.

i.e. this doesn't let attendees learn what date prereg might be open, which is apparently happening right now on social media by people looking at this page :)

goes with 2 other PRs