### PR TITLE
Changes: c.event shifts available subject line.

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -216,7 +216,7 @@ AutomatedEmail(Attendee, 'Last Chance to Accept Your {EVENT_NAME} Badge', 'place
 
 # Volunteer emails; none of these will be sent unless SHIFTS_CREATED is set.
 
-StopsEmail('{EVENT_NAME} shifts available', 'shifts/created.txt',
+StopsEmail('Please complete your {EVENT_NAME} Staff/Volunteer Checklist', 'shifts/created.txt',
            lambda a: c.AFTER_SHIFTS_CREATED and a.takes_shifts)
 
 StopsEmail('Reminder to sign up for {EVENT_NAME} shifts', 'shifts/reminder.txt',


### PR DESCRIPTION
I am not sure if we want this change to be here or in the new magfest/magfest email section. 

This is a change to the Staff Operations email that goes out to all volunteers/staffers. 
The original iteration of the email was simply for volunteers to sign up for this shifts hence the "EVENT_NAME shifts available" subject line. 

For MAGFest events that email and the process has turned into a 4 or 5 step checklist (depending on if the person is a volunteer or staffer).   The MAGFest Staff Operations department refers to this Email notification and the process it entails as the Volunteer Checklist in all communication to staffers (Email, slack, fb.)   

This edit would chance the subject line of the email to: "Please complete your {EVENT_NAME} Staff/Volunteer Checklist"