### PR TITLE
Add "On Hold" status

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -484,6 +484,7 @@ completed_status = string(default="Complete")
 invalid_status = string(default="Invalid")
 refunded_status = string(default="Refunded")
 deferred_status = string(default="Deferred")
+watched_status = string(default="On Hold")
 
 [[ribbon]]
 no_ribbon        = string(default="no ribbon")

--- a/uber/models.py
+++ b/uber/models.py
@@ -1049,7 +1049,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     @presave_adjustment
     def _status_adjustments(self):
         if self.badge_status == c.NEW_STATUS and self.banned:
-            self.badge_status = c.DEFERRED_STATUS
+            self.badge_status = c.WATCHED_STATUS
             try:
                 send_email(c.SECURITY_EMAIL, [c.REGDESK_EMAIL, c.SECURITY_EMAIL], 'Banned attendee registration',
                            render('emails/reg_workflow/banned_attendee.txt', {'attendee': self}), model='n/a')

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -21,7 +21,7 @@ class Root:
             'all_attendees': sorted([
                 (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], ' #{}'.format(badge_num) if badge_num else ''))
                 for id, name, badge_type, badge_num in session.query(Attendee.id, Attendee.last_first, Attendee.badge_type, Attendee.badge_num)
-                                    .filter(Attendee.first_name != '').filter(Attendee.badge_status not in [c.INVALID_STATUS, c.DEFERRED_STATUS]).all()
+                                    .filter(Attendee.first_name != '').filter(Attendee.badge_status not in [c.INVALID_STATUS, c.WATCHED_STATUS]).all()
             ], key=lambda tup: tup[1])
         }
 

--- a/uber/templates/registration/watchlist.html
+++ b/uber/templates/registration/watchlist.html
@@ -54,7 +54,7 @@
             (Permanently associate watchlist entry with this attendee, ignoring any other watchlist entries.)
         </div>
         {% endif %}
-        {% if attendee.badge_status == c.DEFERRED_STATUS %}
+        {% if attendee.badge_status == c.WATCHED_STATUS %}
         <div class="form-group">
             <label class="btn btn-default">
                 <input type="checkbox" name="ignore" />

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -423,7 +423,7 @@ class TestStatusAdjustments:
         a = Attendee(paid=c.HAS_PAID, badge_status=c.NEW_STATUS, first_name='Paid', placeholder=False)
         monkeypatch.setattr(Attendee, 'banned', True)
         a._status_adjustments()
-        assert a.badge_status == c.DEFERRED_STATUS
+        assert a.badge_status == c.WATCHED_STATUS
 
 
 class TestLookupAttendee:


### PR DESCRIPTION
Fixes https://github.com/magfest/magprime/issues/92. We found that admins often set attendees to "Deferred" status in order to reserve their badges for next year, so this adds a less unclear badge status for the watchlist.