### PR TITLE
Use two decimals in prices in templates

### DIFF
--- a/uber/templates/emails/dealers/application.html
+++ b/uber/templates/emails/dealers/application.html
@@ -5,8 +5,8 @@
 Your group ({{ attendee.group.name}}) has successfully submitted a Dealer application for {{ c.EVENT_NAME }}
 this coming {% event_dates %}.  Your application includes the following:
 <ul>
-    <li> {{ attendee.group.tables }} table{{ attendee.group.tables|pluralize }} (${{ attendee.group.table_cost }}) </li>
-    <li> {{ attendee.group.badges }} badge{{ attendee.group.badges|pluralize }} (${{ attendee.group.badge_cost }}) </li>
+    <li> {{ attendee.group.tables }} table{{ attendee.group.tables|pluralize }} (${{ attendee.group.table_cost|floatformat:2 }}) </li>
+    <li> {{ attendee.group.badges }} badge{{ attendee.group.badges|pluralize }} (${{ attendee.group.badge_cost|floatformat:2 }}) </li>
 </ul>
 
 {% if c.AFTER_DEALER_REG_DEADLINE %}

--- a/uber/templates/emails/dealers/approved.html
+++ b/uber/templates/emails/dealers/approved.html
@@ -17,8 +17,8 @@ Payment is expected by: {{ c.DEALER_PAYMENT_DUE|datetime }} or your application 
 
 This registration includes:
 <ul>
-    <li> {{ group.tables }} table{{ group.tables|pluralize }} (${{ group.table_cost }}) </li>
-    <li> {{ group.badges }} badge{{ group.badges|pluralize }} (${{ group.badge_cost }}) </li>
+    <li> {{ group.tables }} table{{ group.tables|pluralize }} (${{ group.table_cost|floatformat:2 }}) </li>
+    <li> {{ group.badges }} badge{{ group.badges|pluralize }} (${{ group.badge_cost|floatformat:2 }}) </li>
 </ul>
 
 <br/> <u>Dealer Rules and Information</u>

--- a/uber/templates/preregistration/attendee_donation_form.html
+++ b/uber/templates/preregistration/attendee_donation_form.html
@@ -8,7 +8,7 @@
 {% if attendee.paid == c.NOT_PAID or attendee.overridden_price %}
     <h2> Badge Payment for {{ attendee.full_name }} </h2>
 
-    You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ attendee.overridden_price|default:attendee.badge_cost }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid }}.
+    You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ attendee.overridden_price|default:attendee.badge_cost|floatformat:2 }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra|floatformat:2 }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|floatformat:2 }}.
 
     <table style="width:auto ; margin-left:auto ; margin-right: auto"><tr>
         <td>{% stripe_form process_attendee_donation charge %}</td>
@@ -20,7 +20,7 @@
 {% else %}
     <h2> Extra Payment for {{ attendee.full_name }} </h2>
 
-    Thanks for offering to kick in money to help make {{ c.EVENT_NAME }} better.  As thanks, your total donation (of which ${{ attendee.amount_unpaid }} is outstanding) entitles you to the following:
+    Thanks for offering to kick in money to help make {{ c.EVENT_NAME }} better.  As thanks, your total donation (of which ${{ attendee.amount_unpaid|floatformat:2 }} is outstanding) entitles you to the following:
     <ul>
         {% for swag in attendee.donation_swag|add:attendee.addons %}
             <li>{{ swag }}</li>

--- a/uber/templates/preregistration/group_extra_payment_form.html
+++ b/uber/templates/preregistration/group_extra_payment_form.html
@@ -7,7 +7,7 @@
 <div class="panel panel-default">
 <h2> Extra Payment for {{ attendee.full_name }} </h2>
 
-Thanks for offering to kick in ${{ charge.dollar_amount }} extra to help make {{ c.EVENT_NAME }} better.  As thanks, this entitles you to the following:
+Thanks for offering to kick in ${{ charge.dollar_amount|floatformat:2 }} extra to help make {{ c.EVENT_NAME }} better.  As thanks, this entitles you to the following:
 <ul>
     {% for swag in attendee.donation_swag %}
         <li>{{ swag }}</li>

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -67,7 +67,7 @@
                 {% endfor %}
             </ul>
         </td>
-        <td>${{ attendee.total_cost }}</td>
+        <td>${{ attendee.total_cost|floatformat:2 }}</td>
         <td>
             <a href="form?edit_id={{ attendee.id }}">Edit</a> /
             <a href="delete?id={{ attendee.id }}">Delete</a>
@@ -85,7 +85,7 @@
                 {% endfor %}
             </ul>
         </td>
-        <td>${{ group.default_cost }}</td>
+        <td>${{ group.default_cost|floatformat:2 }}</td>
         <td>
             <a href="form?edit_id={{ group.id }}">Edit</a> /
             <a href="delete?id={{ group.id }}">Delete</a>
@@ -98,7 +98,7 @@
     <tr>
         <th></th>
         <th style="text-align:right;"><i>Total:</i></th>
-        <th><b>${{ charge.dollar_amount }}</b></th>
+        <th><b>${{ charge.dollar_amount|floatformat:2 }}</b></th>
         <th></th>
     </tr>
 </tfoot>

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -253,7 +253,7 @@
 <div class="form-group">
     <label class="col-sm-2 control-label">Badge Price</label>
     <div class="col-sm-6">
-        Base Price: $<input type="text" style="width:4em" name="overridden_price" value="{{ attendee.badge_cost }}" />
+        Base Price: $<input type="text" style="width:4em" name="overridden_price" value="{{ attendee.badge_cost|floatformat:2 }}" />
         <input type="checkbox" name="no_override" {% if not attendee.overridden_price %} checked {% endif %}> Automatically recalculate badge price.
     </div>
 </div>


### PR DESCRIPTION
This was brought on by https://github.com/magfest/magprime/pull/95 - using division to reduce the badge price results in it being a float, which would display as, e.g., "$40.0". Since there could theoretically be a price involving cents anyway, I went ahead and just changed the formatting in the templates to make it pretty.