### PR TITLE
Remove reference to unused badge type

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -152,7 +152,7 @@ class Config(_Overridable):
 
     @property
     def PREREG_BADGE_TYPES(self):
-        types = [self.ATTENDEE_BADGE, self.PSEUDO_DEALER_BADGE, self.IND_DEALER_BADGE]
+        types = [self.ATTENDEE_BADGE, self.PSEUDO_DEALER_BADGE]
         for reg_open, badge_type in [(self.BEFORE_GROUP_PREREG_TAKEDOWN, self.PSEUDO_GROUP_BADGE)]:
             if reg_open:
                 types.append(badge_type)

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -220,7 +220,6 @@ signups             = integer(default=1)  # not an admin access level, so handle
 pseudo_group_badge  = integer(default=1)  # people registering in groups will get attendee badges
 pseudo_dealer_badge = integer(default=2)  # dealers get attendee badges with a ribbon
 email_re            = string(default="^[a-zA-Z0-9_\-+.]+@[a-zA-Z0-9_\-+.]+(\.[a-zA-Z0-9_\-+.]+){1,}$")
-ind_dealer_badge    = integer(default=3)  # individual dealers get attendee badges with a ribbon
 
 # People occasionally refer to MAGFest as a "convention" and then someone such
 # as Nick sends an email to correct them, saying that we're a "festival".  Other


### PR DESCRIPTION
IND_DEALER_BADGE was from 2015 Anthrocon and has since been removed. It definitely doesn't need to be in the main codebase.