### PR TITLE
Hide sandwich preferences for MAGLabs

### DIFF
--- a/uber/templates/signups/food_restrictions.html
+++ b/uber/templates/signups/food_restrictions.html
@@ -20,13 +20,15 @@ when they know what kind of food restrictions we all have.
     {% csrf_token %}
     <input type="hidden" name="id" value="{{ fr.db_id }}" />
 
-    {% checkgroup fr.standard %}
+    <div id="restrictions">{% checkgroup fr.standard %}</div>
 
-    <br/> <br/>
-    Please select sandwich options you like. This is to determine how much to buy: <br/>
+    <br/>
+    <div id="sandwich_prefs">
+        Please select sandwich options you like. This is to determine how much to buy: <br/>
     {% checkgroup fr.sandwich_pref %}
+    </div>
 
-    <br/> <br/>
+    <br/>
     Let us know if you have any other allergies or restrictions,
     please use commas to separate each allergy and food restriction.
     (We do not serve seafood or use ingredients with seafood in it.)


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/1935 by:
Putting the sandwich preferences in a div with a unique ID in the core plugin.
Hiding said div with jQuery in the magclassic plugin.
Setting all sandwich preferences to checked in the magclassic plugin; this is to bypass a validation check.