### PR TITLE
Update index.html

### DIFF
--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -98,7 +98,7 @@
     <tr>
         <th></th>
         <th style="text-align:right;"><i>Total:</i></th>
-        <th><b>${{ charge.dollar_amount|floatformat:2 }}</b></th>
+        <th><b>${{ charge.dollar_amount }}</b></th>
         <th></th>
     </tr>
 </tfoot>


### PR DESCRIPTION
Stripe wants an integer that looks like $$$CC and this was changed along with all the other items to support actual cents when it shouldn't have been.

Fixes https://github.com/magfest/magprime/issues/136