### PR TITLE
Add badge_type_real for use in model_checks

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -297,7 +297,7 @@ def no_more_custom_badges(attendee):
 def out_of_badge_type(attendee):
     if attendee.badge_type != attendee.orig_value_of('badge_type'):
         with Session() as session:
-            if session.get_next_badge_num(attendee.badge_type) > c.BADGE_RANGES[attendee.badge_type][1]:
+            if session.get_next_badge_num(attendee.badge_type_real) > c.BADGE_RANGES[attendee.badge_type_real][1]:
                 return 'There are no more badges available for that type'
 
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -1212,6 +1212,10 @@ class Attendee(MagModel, TakesPaymentMixin):
         else:
             return self.badge_type_label
 
+    @property
+    def badge_type_real(self):
+        return c.ATTENDEE_BADGE if self.badge_type in [c.PSEUDO_DEALER_BADGE, c.PSEUDO_GROUP_BADGE] else self.badge_type
+
     @cost_property
     def badge_cost(self):
         registered = self.registered_local if self.registered else sa.localized_now()

--- a/uber/models.py
+++ b/uber/models.py
@@ -529,8 +529,7 @@ class Session(SessionManager):
             the badge type's range.
             :return:
             """
-            if badge_type in [c.PSEUDO_GROUP_BADGE, c.PSEUDO_DEALER_BADGE]:
-                badge_type = c.ATTENDEE_BADGE
+            badge_type = get_real_badge_type(badge_type)
 
             new_badge_num = self.auto_badge_num(badge_type)
             # Adjusts the badge number based on badges in the session
@@ -1134,10 +1133,10 @@ class Attendee(MagModel, TakesPaymentMixin):
     def _badge_adjustments(self):
         # _assert_badge_lock()
 
-        if self.badge_type in [c.PSEUDO_GROUP_BADGE, c.PSEUDO_DEALER_BADGE]:
-            if self.is_dealer:
-                self.ribbon = c.DEALER_RIBBON
-            self.badge_type = c.ATTENDEE_BADGE
+        self.badge_type = get_real_badge_type(self.badge_type)
+
+        if self.is_dealer:
+            self.ribbon = c.DEALER_RIBBON
 
         if not self.session.needs_badge_num(self):
             if self.orig_value_of('badge_num'):
@@ -1214,7 +1213,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def badge_type_real(self):
-        return c.ATTENDEE_BADGE if self.badge_type in [c.PSEUDO_DEALER_BADGE, c.PSEUDO_GROUP_BADGE] else self.badge_type
+        return get_real_badge_type(self.badge)
 
     @cost_property
     def badge_cost(self):

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -307,3 +307,7 @@ def convert_to_absolute_url(relative_uber_page_url):
         raise ValueError("relative url MUST start with '../'")
 
     return urljoin(c.URL_BASE + "/", relative_uber_page_url[3:])
+
+
+def get_real_badge_type(badge_type):
+    return c.ATTENDEE_BADGE if badge_type in [c.PSEUDO_DEALER_BADGE, c.PSEUDO_GROUP_BADGE] else badge_type


### PR DESCRIPTION
Fixes https://github.com/magfest/magprime/issues/133. Again.

So far we've been relying on our presave adjustments to always use a real badge type, but model_checks.py is run before any of those. So now we have a property that we can use in that case.