### PR TITLE
optimize price bucketing by not calling this around 5 times

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -105,11 +105,12 @@ class Config(_Overridable):
     def get_attendee_price(self, dt):
         price = self.INITIAL_ATTENDEE
         if self.PRICE_BUMPS_ENABLED:
+            badges_sold = self.BADGES_SOLD # optimization: this call is expensive, db call
             for day, bumped_price in sorted(self.PRICE_BUMPS.items()):
                 if (dt or datetime.now(UTC)) >= day:
                     price = bumped_price
             for badge_cap, bumped_price in sorted(self.PRICE_LIMITS.items()):
-                if self.BADGES_SOLD >= badge_cap and bumped_price > price:
+                if badges_sold >= badge_cap and bumped_price > price:
                     price = bumped_price
         return price
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -105,7 +105,7 @@ class Config(_Overridable):
     def get_attendee_price(self, dt):
         price = self.INITIAL_ATTENDEE
         if self.PRICE_BUMPS_ENABLED:
-            badges_sold = self.BADGES_SOLD # optimization: this call is expensive, db call
+            badges_sold = self.BADGES_SOLD  # optimization: this call is expensive, db call
             for day, bumped_price in sorted(self.PRICE_BUMPS.items()):
                 if (dt or datetime.now(UTC)) >= day:
                     price = bumped_price


### PR DESCRIPTION
main prereg form page load time goes from ~4s to ~1.5s, a nice improvement

sadly my profiler was zero help in identifying this, we took a guess and can't believe it was correct