### PR TITLE
optimization: Request cached property

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -61,7 +61,7 @@ from sqlalchemy.schema import Column, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import Query, relationship, joinedload, subqueryload, backref
 from sqlalchemy.types import Boolean, Integer, Float, TypeDecorator, Date, Numeric
 
-from sideboard.lib import log, parse_config, entry_point, listify, DaemonTask, serializer, cached_property, stopped, on_startup, services
+from sideboard.lib import log, parse_config, entry_point, listify, DaemonTask, serializer, cached_property, stopped, on_startup, services, threadlocal
 from sideboard.lib.sa import declarative_base, SessionManager, UTCDateTime, UUID, CoerceUTF8 as UnicodeText
 
 import uber

--- a/uber/common.py
+++ b/uber/common.py
@@ -61,7 +61,7 @@ from sqlalchemy.schema import Column, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import Query, relationship, joinedload, subqueryload, backref
 from sqlalchemy.types import Boolean, Integer, Float, TypeDecorator, Date, Numeric
 
-from sideboard.lib import log, parse_config, entry_point, listify, DaemonTask, serializer, cached_property, stopped, on_startup, services, threadlocal
+from sideboard.lib import log, parse_config, entry_point, listify, DaemonTask, serializer, cached_property, request_cached_property, stopped, on_startup, services, threadlocal
 from sideboard.lib.sa import declarative_base, SessionManager, UTCDateTime, UUID, CoerceUTF8 as UnicodeText
 
 import uber

--- a/uber/config.py
+++ b/uber/config.py
@@ -130,6 +130,7 @@ class Config(_Overridable):
     def DEALER_REG_OPEN(self):
         return self.AFTER_DEALER_REG_START and self.BEFORE_DEALER_REG_SHUTDOWN
 
+    @request_cached_property
     def BADGES_SOLD(self):
         with sa.Session() as session:
             attendees = session.query(sa.Attendee)
@@ -260,6 +261,7 @@ class Config(_Overridable):
     def PAGE(self):
         return cherrypy.request.path_info.split('/')[-1]
 
+    @request_cached_property
     def CURRENT_ADMIN(self):
         try:
             with sa.Session() as session:
@@ -271,6 +273,7 @@ class Config(_Overridable):
     def HTTP_METHOD(self):
         return cherrypy.request.method
 
+    @request_cached_property
     def SUPPORTER_COUNT(self):
         with sa.Session() as session:
             attendees = session.query(sa.Attendee)
@@ -285,6 +288,7 @@ class Config(_Overridable):
     def REMAINING_BADGES(self):
         return max(0, self.MAX_BADGE_SALES - self.BADGES_SOLD)
 
+    @request_cached_property
     def ADMIN_ACCESS_SET(self):
         return sa.AdminAccount.access_set()
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -260,7 +260,6 @@ class Config(_Overridable):
     def PAGE(self):
         return cherrypy.request.path_info.split('/')[-1]
 
-    @property
     def CURRENT_ADMIN(self):
         try:
             with sa.Session() as session:
@@ -286,6 +285,9 @@ class Config(_Overridable):
     def REMAINING_BADGES(self):
         return max(0, self.MAX_BADGE_SALES - self.BADGES_SOLD)
 
+    def ADMIN_ACCESS_SET(self):
+        return sa.AdminAccount.access_set()
+
     def __getattr__(self, name):
         if name.split('_')[0] in ['BEFORE', 'AFTER']:
             date_setting = getattr(c, name.split('_', 1)[1])
@@ -296,7 +298,7 @@ class Config(_Overridable):
             else:
                 return sa.localized_now() > date_setting
         elif name.startswith('HAS_') and name.endswith('_ACCESS'):
-            return getattr(c, '_'.join(name.split('_')[1:-1])) in sa.AdminAccount.access_set()
+            return getattr(c, '_'.join(name.split('_')[1:-1])) in c.ADMIN_ACCESS_SET
         elif name.endswith('_COUNT'):
             item_check = name.rsplit('_', 1)[0]
             badge_type = getattr(self, item_check, None)

--- a/uber/config.py
+++ b/uber/config.py
@@ -507,7 +507,7 @@ c.PREREG_SHIRT_OPTS = c.SHIRT_OPTS[1:]
 c.MERCH_SHIRT_OPTS = [(c.SIZE_UNKNOWN, 'select a size')] + list(c.PREREG_SHIRT_OPTS)
 c.DONATION_TIER_OPTS = [(amt, '+ ${}: {}'.format(amt, desc) if amt else desc) for amt, desc in c.DONATION_TIER_OPTS]
 
-c.DONATION_TIER_DESCRIPTIONS = _config.get('donation_tier_descriptions', [])
+c.DONATION_TIER_DESCRIPTIONS = _config.get('donation_tier_descriptions', {})
 for tier in c.DONATION_TIER_DESCRIPTIONS.items():
     tier[1]['price'] = [amt for amt, name in c.DONATION_TIERS.items() if name == tier[1]['name']][0]
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -130,7 +130,6 @@ class Config(_Overridable):
     def DEALER_REG_OPEN(self):
         return self.AFTER_DEALER_REG_START and self.BEFORE_DEALER_REG_SHUTDOWN
 
-    @property
     def BADGES_SOLD(self):
         with sa.Session() as session:
             attendees = session.query(sa.Attendee)
@@ -273,7 +272,6 @@ class Config(_Overridable):
     def HTTP_METHOD(self):
         return cherrypy.request.method
 
-    @property
     def SUPPORTER_COUNT(self):
         with sa.Session() as session:
             attendees = session.query(sa.Attendee)

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -409,3 +409,19 @@ class class_property(object):
 
     def __get__(self, obj, owner):
         return self.func(owner)
+
+
+def request_cached_property(func):
+    """Like @cached_property but only caches per-request."""
+    @property
+    @wraps(func)
+    def with_caching(self):
+        val = threadlocal.get(func.__name__)
+        if val is None:
+            val = func(self)
+            threadlocal.set(func.__name__, val)
+        return val
+    return with_caching
+
+c.BADGES_SOLD = request_cached_property(c.BADGES_SOLD)
+c.SUPPORTER_COUNT = request_cached_property(c.SUPPORTER_COUNT)

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -424,4 +424,4 @@ def request_cached_property(func):
     return with_caching
 
 for _prop in ['BADGES_SOLD', 'CURRENT_ADMIN', 'SUPPORTER_COUNT', 'ADMIN_ACCESS_SET']:
-    setattr(c.__class__, prop, request_cached_property(getattr(c.__class__, _prop))
+    setattr(c.__class__, _prop, request_cached_property(getattr(c.__class__, _prop)))

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -409,19 +409,3 @@ class class_property(object):
 
     def __get__(self, obj, owner):
         return self.func(owner)
-
-
-def request_cached_property(func):
-    """Like @cached_property but only caches per-request."""
-    @property
-    @wraps(func)
-    def with_caching(self):
-        val = threadlocal.get(func.__name__)
-        if val is None:
-            val = func(self)
-            threadlocal.set(func.__name__, val)
-        return val
-    return with_caching
-
-for _prop in ['BADGES_SOLD', 'CURRENT_ADMIN', 'SUPPORTER_COUNT', 'ADMIN_ACCESS_SET']:
-    setattr(c.__class__, _prop, request_cached_property(getattr(c.__class__, _prop)))

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -423,5 +423,5 @@ def request_cached_property(func):
         return val
     return with_caching
 
-c.BADGES_SOLD = request_cached_property(c.BADGES_SOLD)
-c.SUPPORTER_COUNT = request_cached_property(c.SUPPORTER_COUNT)
+for _prop in ['BADGES_SOLD', 'CURRENT_ADMIN', 'SUPPORTER_COUNT', 'ADMIN_ACCESS_SET']:
+    setattr(c.__class__, prop, request_cached_property(getattr(c.__class__, _prop))


### PR DESCRIPTION
We currently have two types of properties:

1) Regular old ``@property``.  These get invoked every time.

2) ``@cached_property`` which is invoked once and then never again for the lifetime of an object.

We found that we needed a third option, which is ``@request_cached_property``, which caches for the duration of a request.

I've added ``@request_cached_property`` to Sideboard, which means that https://github.com/magfest/sideboard/pull/20 MUST be merged BEFORE this is merged, or else this branch will be invalid.

- [ ] This box is checked if someone verified this actually still works correctly before merging