### PR TITLE
optimization: don't render the menu in a few prereg pages

### DIFF
--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -45,6 +45,7 @@
     </style>
     <script>
         var DISABLE_STRIPE_BUTTONS_ON_CLICK = true;
+        {% if c.PAGE_PATH != '/preregistration/form' and c.PAGE_PATH != '/preregistration/index' %}
         var MENU = [
             {% if c.HAS_ACCOUNTS_ACCESS %}
                 {Accounts: '../accounts/'},
@@ -73,6 +74,7 @@
                 {Statistics: '../summary/'}
             {% endif %}
         ];
+        {% endif %}
         $(function() {
             $(window).load(function() {
                 $(".loader").fadeOut("fast");
@@ -141,6 +143,7 @@
                     checkHour();
                 }
             {% endif %}
+            {% if c.PAGE_PATH != '/preregistration/form' and c.PAGE_PATH != '/preregistration/index' %}
             var $menu = $('#main-menu');
             $.each(MENU, function (i, section) {
                 var name = _.keys(section)[0], links = _.values(section)[0];
@@ -168,6 +171,7 @@
                         .appendTo($menu);
                 }
             });
+            {% endif %}
         });
     </script>
     {% block head_additional %}{% endblock %}


### PR DESCRIPTION
- menu calls stuff like c.HAS_PEOPLE_ACCESS, each of which is a DB call and thus slower
- when we rip out the javascript rendering framework we have and replace with jinja2 and inheritance, this will all be gotten for free

for the record this is all horribly broken and I hate it, we shall fix with a vengeance once https://github.com/magfest/ubersystem/pull/1888 and subsequent re-integration from javascript back into server-side templates where this kind of thing belongs

- [x] This box is checked if someone verified this actually still works correctly before merging
- [ ] Add other prereg pages in here like group register, etc