### PR TITLE
optimization: Charge class models generation, use a cache

### DIFF
--- a/uber/utils.py
+++ b/uber/utils.py
@@ -160,6 +160,10 @@ def send_email(source, dest, subject, body, format='text', cc=(), bcc=(), model=
 class Charge:
     def __init__(self, targets=(), amount=None, description=None):
         self.targets = [self.to_sessionized(m) for m in listify(targets)]
+
+        # performance optimization
+        self._models_cached = [self.from_sessionized(d) for d in self.targets]
+
         self.amount = amount or self.total_cost
         self.description = description or self.names
 
@@ -198,7 +202,7 @@ class Charge:
 
     @property
     def models(self):
-        return [self.from_sessionized(d) for d in self.targets]
+        return self._models_cached
 
     @property
     def total_cost(self):


### PR DESCRIPTION
  - using 2 groups and 1 attendee in the Charge(), speeds up baseline of 9.6seconds to 5seconds

very visible on the critical registration path of /preregistration/index which is where attendees pay, so we need to get this running faster

- [x] This box is checked if someone verified this actually still works correctly before merging
- [x] This box is checked if someone REALLY REALLY verified this still works correctly before merging, because if this doesn't work we won't charge people the right price for their badges.
- [x] Seriously you guys, I totally checked and it's fine.  REally. I promise.