### PR TITLE
optimization: disable screw_you_nick for now

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -241,7 +241,8 @@ def render(template_name_list, data=None):
                     break
         raise Exception('error rendering template [{}]'.format(source_template_name)) from e
 
-    rendered = screw_you_nick(rendered, template)  # lolz.
+    # disabled for performance optimzation.  so sad. IT SHALL RETURN
+    # rendered = screw_you_nick(rendered, template)  # lolz.
     return rendered.encode('utf-8')
 
 


### PR DESCRIPTION
this popped up as a slight performance hit, we'll re-enable later if we feel like it.  it's both doing heavy string manipulation and it's a DB call to find out if the current user is Nick :)

- [x] This box is checked if someone verified this actually still works correctly before merging