### PR TITLE
optimization: split up common.js so that we can do better caching

### DIFF
--- a/uber/server.py
+++ b/uber/server.py
@@ -81,10 +81,6 @@ class Root:
     def index(self):
         raise HTTPRedirect('common/')
 
-    def common_js(self):
-        cherrypy.response.headers['Content-Type'] = 'text/javascript'
-        return render('common.js')
-
     static_views = StaticViews()
 
 mount_site_sections(c.MODULE_ROOT)

--- a/uber/static/js/common-static.js
+++ b/uber/static/js/common-static.js
@@ -1,0 +1,32 @@
+// STATIC CONTENT ONLY, included in EVERY PAGE
+
+var setVisible = function (selector, visible) {
+    $(selector)[visible ? 'show' : 'hide']();
+}
+
+$.field = function (field) {
+    var $field = $('[name=' + field + ']');
+    return $field.size() ? $field : null;
+};
+
+$.val = function (field) {
+    var val = $.field(field).val();
+    if ($.field(field).is(':radio')) {
+        val = $.field(field).filter(':checked').val();
+    }
+    return val.match(/^\W*\d+\W*$/) ? parseInt(val) : val;
+};
+
+$.focus = function (field) {
+    $.field(field).focus();
+};
+
+$(function () {
+    $('.datepicker').datepicker({
+        changeMonth: true,
+        changeYear: true,
+        yearRange: '-100:+0',
+        defaultDate: '-20y',
+        dateFormat: 'yy-mm-dd'
+    });
+});

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -12,7 +12,10 @@
     <link rel="icon" href="../static/images/favicon.png" type="image/x-icon" />
     <link rel="stylesheet" href="../static/deps/combined.css" />
     <script type="text/javascript" src="../static/deps/combined.js"></script>
-    <script src="../common.js" type="text/javascript"></script>
+    <script type="text/javascript">
+        var csrf_token = '{{ c.CSRF_TOKEN }}';
+    </script>
+    <script src="../static/js/common-static.js" type="text/javascript"></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/uber/templates/jobs/everywhere.html
+++ b/uber/templates/jobs/everywhere.html
@@ -4,7 +4,7 @@
     <title>All Open Shifts</title>
     <link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />    
     <script type="text/javascript" src="../static/deps/combined.js"></script>
-    <script src="../common.js" type="text/javascript"></script>
+    <script type="text/javascript" src="../static/js/ratings.js"></script>
 </head>
 <body>
 

--- a/uber/templates/jobs/signups.html
+++ b/uber/templates/jobs/signups.html
@@ -2,6 +2,8 @@
 {% block title %}Shifts{% endblock %}
 {% block content %}
 
+<script type="text/javascript" src="../static/js/ratings.js"></script>
+
 {% include "jobs/main_menu.html" %}
 
 {% if c.POST_CON and checklist.relevant %}

--- a/uber/templates/registration/shifts.html
+++ b/uber/templates/registration/shifts.html
@@ -2,6 +2,7 @@
 {% block title %}Staffing Shifts - {{ attendee.full_name }}{% endblock %}
 {% block content %}
 
+<script type="text/javascript" src="../static/js/ratings.js"></script>
 <script type="text/javascript">
     var SHIFTS = {{ shifts|jsonize }};
     $(setupRatingClickHandler);

--- a/uber/templates/static_views/ratings.js
+++ b/uber/templates/static_views/ratings.js
@@ -1,26 +1,3 @@
-var csrf_token = '{{ c.CSRF_TOKEN }}';
-
-var setVisible = function (selector, visible) {
-    $(selector)[visible ? 'show' : 'hide']();
-}
-
-$.field = function (field) {
-    var $field = $('[name=' + field + ']');
-    return $field.size() ? $field : null;
-};
-
-$.val = function (field) {
-    var val = $.field(field).val();
-    if ($.field(field).is(':radio')) {
-        val = $.field(field).filter(':checked').val();
-    }
-    return val.match(/^\W*\d+\W*$/) ? parseInt(val) : val;
-};
-
-$.focus = function (field) {
-    $.field(field).focus();
-};
-
 var RATINGS = {
     {{ c.RATED_GOOD }}: {
         false: '../static/images/check_blank.png',
@@ -37,6 +14,7 @@ var RATINGS = {
         true:  '../static/images/aplus_filled.jpg'
     }
 };
+
 var renderRating = function (shift, $td) {
     shift = typeof shift === 'string' ? SHIFTS[shift] : shift;
     $td = ($td || $('#rating' + shift.id)).addClass('rating').data('shift', shift);
@@ -48,6 +26,7 @@ var renderRating = function (shift, $td) {
     });
     return $td;
 };
+
 var setupRatingClickHandler = function () {
     $(document.body).on('click', 'td.rating img', function (event) {
         var $img = $(event.target);
@@ -69,6 +48,7 @@ var setupRatingClickHandler = function () {
         }
     });
 };
+
 var setStatus = function (shiftId, status) {
     var $status = $(status);
     var statusVal = parseInt($status.val());
@@ -86,6 +66,7 @@ var setStatus = function (shiftId, status) {
         }
     });
 };
+
 var $undoForm = function (path, params, linkText) {
     var $form = $('<form method="POST"></form>').attr("action", path);
     $.each($.extend(params, {csrf_token: csrf_token}), function (name, value) {
@@ -97,13 +78,3 @@ var $undoForm = function (path, params, linkText) {
     });
     return $().add($undoLink).add($form);
 };
-
-$(function () {
-    $('.datepicker').datepicker({
-        changeMonth: true,
-        changeYear: true,
-        yearRange: '-100:+0',
-        defaultDate: '-20y',
-        dateFormat: 'yy-mm-dd'
-    });
-});


### PR DESCRIPTION
take all truly static JS content and put it in common-static.js where it can be cached with nginx

other stuff:
- compute CSRF token inline now
- move all ratings stuff into its own file and only include it in the files that use it

needs a little more testing on the admin side, but prereg form appears to work.

REALLY MAKE SURE that CSRF_TOKEN is ok.

also, this just so happens to fix https://github.com/magfest/ubersystem/issues/1851

- [x] This box is checked if someone verified this actually still works correctly before merging
- [x] javascript in other pages is still able to access the global variable of 'csrf_token' (seems that way)