### PR TITLE
optimization: add hardcore-mode optimizations to badge price notices rendering

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -541,16 +541,27 @@ class PriceNotice(template.Node):
         self.takedown, self.amount_extra, self.discount = Variable(takedown), Variable(amount_extra), Variable(discount)
 
     def _notice(self, label, takedown, amount_extra, discount):
+
+        if c.HARDCORE_OPTIMIZATIONS_ENABLED:
+            # CPU optimizaiton: the calculations done in this function are somewhat expensive and even with caching,
+            # still do some expensive DB queries.  if hardcore optimizations mode is enabled, we display a
+            # simpler message.  This is intended to be enabled during the heaviest loads at the beginning of an event
+            # in order to reduce server load so the system stays up.  After the rush, it should be safe to turn this
+            # back off
+            return ''
+
         if not takedown:
             takedown = c.ESCHATON
 
         if c.PAGE_PATH not in ['/preregistration/form', '/preregistration/register_group_member']:
             return ''  # we only display notices for new attendees
         else:
+            badge_price = c.BADGE_PRICE    # optimization.  this call is VERY EXPENSIVE.
+
             for day, price in sorted(c.PRICE_BUMPS.items()):
-                if day < takedown and localized_now() < day and price > c.BADGE_PRICE:
+                if day < takedown and localized_now() < day and price > badge_price:
                     return '<div class="prereg-price-notice">Price goes up to ${} no later than 11:59pm {} on {}</div>'.format(price - int(discount) + int(amount_extra), (day - timedelta(days=1)).strftime('%Z'), (day - timedelta(days=1)).strftime('%A, %b %e'))
-                elif localized_now() < day and takedown == c.PREREG_TAKEDOWN and takedown < c.EPOCH and price > c.BADGE_PRICE:
+                elif localized_now() < day and takedown == c.PREREG_TAKEDOWN and takedown < c.EPOCH and price > badge_price:
                     return '<div class="prereg-type-closing">{} closes at 11:59pm {} on {}. Price goes up to ${} at-door.</div>'.format(label, takedown.strftime('%Z'), takedown.strftime('%A, %b %e'), price + amount_extra, (day - timedelta(days=1)).strftime('%A, %b %e'))
             if takedown < c.EPOCH:
                 return '<div class="prereg-type-closing">{} closes at 11:59pm {} on {}</div>'.format(label, takedown.strftime('%Z'), takedown.strftime('%A, %b %e'))


### PR DESCRIPTION
 - if your server is melting, you can enable this to disable automatic increase of badge prices based on # badges sold
 - use only in extreme heavy load situations, and when you can keep an eye on your badge prices manually
 - DONT USE UNLESS YOU REALLY KNOW WHAT YOU'RE DOING
 - also, added an unrelated regular optimize to cache the output of c.BADGES_SOLD which is an expensive DB call

needs more testing, and merge after the PR that enables c.HARDCORE_OPTIMIZATIONS_ENABLED

- [x] This box is checked if someone verified this actually still works correctly before merging