### PR TITLE
optimization: add hardcore-mode optimizations to get_attendee_price()

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -107,7 +107,7 @@ class Config(_Overridable):
         if self.PRICE_BUMPS_ENABLED:
 
             if c.HARDCORE_OPTIMIZATIONS_ENABLED:
-                # WARNING: EXTREMELY AGRESSIVE. Don't run the DB query that gets # of badges sold in order
+                # WARNING: EXTREMELY AGGRESSIVE. Don't run the DB query that gets # of badges sold in order
                 # to lighten the server load / blocking time on the DB. THIS ****BREAKS**** BADGE PRICE INCREASES
                 # THAT ARE BASED ON THE NUMBER OF TICKETS SOLD.  Only turn this on if you know EXACTLY what
                 # you are doing, your server is having its face melted off, and you have no other options.

--- a/uber/config.py
+++ b/uber/config.py
@@ -105,7 +105,18 @@ class Config(_Overridable):
     def get_attendee_price(self, dt):
         price = self.INITIAL_ATTENDEE
         if self.PRICE_BUMPS_ENABLED:
-            badges_sold = self.BADGES_SOLD  # optimization: this call is expensive, db call
+
+            if c.HARDCORE_OPTIMIZATIONS_ENABLED:
+                # WARNING: EXTREMELY AGRESSIVE. Don't run the DB query that gets # of badges sold in order
+                # to lighten the server load / blocking time on the DB. THIS ****BREAKS**** BADGE PRICE INCREASES
+                # THAT ARE BASED ON THE NUMBER OF TICKETS SOLD.  Only turn this on if you know EXACTLY what
+                # you are doing, your server is having its face melted off, and you have no other options.
+                # YOU HAVE BEEN WARNED!!!! -Dom
+                badges_sold = 0
+            else:
+                # this is a database query and very expensive
+                badges_sold = self.BADGES_SOLD
+
             for day, bumped_price in sorted(self.PRICE_BUMPS.items()):
                 if (dt or datetime.now(UTC)) >= day:
                     price = bumped_price


### PR DESCRIPTION
part 2 of HARDCORE_OPTIMIZATIONS_ENABLED, similar to the other PR

 - if your server is melting, you can enable this to disable automatic increase of badge prices based on # badges sold
 - use only in extreme heavy load situations, and when you can keep an eye on your badge prices manually
 - DONT USE UNLESS YOU REALLY KNOW WHAT YOU'RE DOING

- [x] This box is checked if someone verified this actually still works correctly before merging