### PR TITLE
add config option: hardcore_optimizations_enabled

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -7,6 +7,16 @@
 # after a deadline or on-site.
 dev_box = boolean(default=True)
 
+# Turn on some extremely aggressive optimizations that disable certain expensive elements of page rendering.
+# Use this only if you ABSOLUTELY NEED TO and understand what it does, and only use it temporarily under heavy load,
+# such as when opening preregistration on the first day and you have the entire internet trying to buy a badge.
+# This may cause parts of ubersystem (like badge pricing text, supporter counts, etc) to stop updating, so you
+# need to carefully keep an eye out for older data.  Use this if you have no other options. You have been warned -Dom
+#
+# IMPORTANT NOTE 2: THIS DISABLES BADGE PRICING HIKES FROM UPDATING BASED ON BADGE COUNTS. YOU NEED TO KEEP AN EYE
+# ON YOUR BADGE PRICES AS IT WILL NOT INCREASE CORRECTLY WHEN BADGE THRESHOLDS ARE REACHED.
+hardcore_optimizations_enabled = boolean(default=False)
+
 # This turns on our automated emails.  See the description in the [secret]
 # section below for an explanation of how this works.
 send_emails = boolean(default=False)


### PR DESCRIPTION
adds the config option for hardcore optimizations

- use these for extreme server load cases, these enable extremely aggressive and potentially breaking optimizations
- never use this unless you know EXACTLY what you're doing, and you have no other choice because your server's face is melting

merge with
https://github.com/magfest/production-config/pull/98
https://github.com/magfest/ubersystem-puppet/pull/102