### PR TITLE
optimization: move angular dynamically genereated javascript out of static_views

### DIFF
--- a/uber/server.py
+++ b/uber/server.py
@@ -48,6 +48,18 @@ class StaticViews:
         return path_args[-1]
 
     @cherrypy.expose
+    def default(self, *path_args, **kwargs):
+        content_filename = self.get_filename_from_path_args(path_args)
+
+        template_name = self.get_full_path_from_path_args(path_args)
+        content = render(template_name)
+
+        guessed_content_type = mimetypes.guess_type(content_filename)[0]
+        return cherrypy.lib.static.serve_fileobj(content, name=content_filename, content_type=guessed_content_type)
+
+
+class AngularJavascript:
+    @cherrypy.expose
     def magfest_js(self):
         """
         We have several Angular apps which need to be able to access our constants like c.ATTENDEE_BADGE and such.
@@ -65,16 +77,6 @@ class StaticViews:
             '});'
         ])
 
-    @cherrypy.expose
-    def default(self, *path_args, **kwargs):
-        content_filename = self.get_filename_from_path_args(path_args)
-
-        template_name = self.get_full_path_from_path_args(path_args)
-        content = render(template_name)
-
-        guessed_content_type = mimetypes.guess_type(content_filename)[0]
-        return cherrypy.lib.static.serve_fileobj(content, name=content_filename, content_type=guessed_content_type)
-
 
 @all_renderable()
 class Root:
@@ -86,6 +88,7 @@ class Root:
         return render('common.js')
 
     static_views = StaticViews()
+    angular = AngularJavascript()
 
 mount_site_sections(c.MODULE_ROOT)
 

--- a/uber/templates/signups/shifts.html
+++ b/uber/templates/signups/shifts.html
@@ -4,7 +4,7 @@
     <title>{{ name }}'s shifts</title>
     <link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />
     <script src="../static/deps/combined.js"></script>
-    <script src="../static_views/magfest.js"></script>
+    <script src="../angular/magfest.js"></script>
     <script src="../static/angular-apps/signups/app.js"></script>
     <script>
         var JOBS = {{ jobs|jsonize }};  // the Job service checks for a global variable with this name to preload the data


### PR DESCRIPTION
- this is to make it so we can more aggressively cache /uber/static_views/ with nginx
- magfest.js is the only potentially dynamic file that likely we shouldn't cache

must merge with 
https://github.com/magfest/hotel/pull/50
https://github.com/magfest/tabletop/pull/7