### PR TITLE
optimization: disable random hash for loading.gif

### DIFF
--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -30,7 +30,7 @@
             width: 60%;
             height: 25%;
             z-index: 9999;
-            background: rgb(249,249,249) url('../static/images/loading.gif?{% random_hash %}') no-repeat center center;
+            background: rgb(249,249,249) url('../static/images/loading.gif{% if not c.HARDCORE_OPTIMIZATIONS_ENABLED %}?{% random_hash %}{% endif %}') no-repeat center center;
             background-size: 50%;
         }
         .loader {


### PR DESCRIPTION
- this was originally added for browser compatibility, disabling the random hash so we can actually serve this from the cache

this is a pretty negligible optimization, it is just something that breaks caching and we're trying to serve all static content via nginx.