### PR TITLE
fix-#1976

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -318,6 +318,14 @@ class popup_link(template.Node):
         return """<a onClick="window.open('{self.href}', 'info', 'toolbar=no,height=500,width=375,scrollbars=yes').focus(); return false;"
                      href="{self.href}">{self.text}</a>""".format(self=self)
 
+@tag
+class escaped_popup_link(template.Node):
+    def __init__(self, href, text='"<sup>?</sup>"'):
+        self.href = href.strip('"')
+        self.text = text.strip('"')
+
+    def render(self, context):
+        return """<a onClick='window.open(\'{self.href}\', \'info\', \'toolbar=no,height=500,width=375,scrollbars=yes\').focus(); return false;' href='{self.href}'>{self.text}</a>""".format(self=self)
 
 @tag
 class must_contact(template.Node):


### PR DESCRIPTION
The problem is that popup_link uses a mix of double and single quotes making it very tough to use inside in-line javascript.

THIS MIGHT NEED TO BE MERGED AT THE SAME TIME AS A MERGE TO MAGPRIME