### PR TITLE
fix some unit tests by clearing thread-local cache each test

### DIFF
--- a/uber/tests/conftest.py
+++ b/uber/tests/conftest.py
@@ -52,6 +52,9 @@ def sensible_defaults():
     c.DEALER_BADGE_PRICE = 20
     c.PRICE_BUMPS = {}
 
+    # tests should turn this on to test the effects
+    c.HARDCORE_OPTIMIZATIONS_ENABLED = False
+
 
 @pytest.fixture(scope='session', autouse=True)
 def init_db(request, sensible_defaults):
@@ -182,6 +185,11 @@ def db(request, init_db):
 @pytest.fixture(autouse=True)
 def cp_session():
     cherrypy.session = {}
+
+
+@pytest.fixture(autouse=True)
+def reset_threadlocal_cache():
+    threadlocal.clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
some properties of Config are cached the first time the thread uses them. 

this is great in web server context, it messes up unit tests though because they all run in one thread :)

unrelated fix: set hardcore_optimizations to false by default.  it's a sensible default, and we should write some tests that explicitly turn it on and make sure things still function well.