### PR TITLE
Assign dealer ribbons before adjusting badge type

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1132,11 +1132,10 @@ class Attendee(MagModel, TakesPaymentMixin):
     @presave_adjustment
     def _badge_adjustments(self):
         # _assert_badge_lock()
-
-        self.badge_type = get_real_badge_type(self.badge_type)
-
         if self.is_dealer:
             self.ribbon = c.DEALER_RIBBON
+
+        self.badge_type = get_real_badge_type(self.badge_type)
 
         if not self.session.needs_badge_num(self):
             if self.orig_value_of('badge_num'):


### PR DESCRIPTION
When we added get_real_badge_type, we put the badge type adjustment before the check for `is_dealer`. However, that check relies on the attendee's badge type being PSEUDO_DEALER_BADGE, so we were essentially making sure that people with dealer badges never got ribbons. This swaps those lines around, which fixes the unit test and should also fix the corresponding bug.