### PR TITLE
Stop charging for a new badge when a group badge is unset

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -344,6 +344,7 @@ class Root:
 
         session.assign_badges(attendee.group, attendee.group.badges + 1, registered=attendee.registered, paid=attendee.paid)
         session.delete_from_group(attendee, attendee.group)
+        attendee.group.cost -= attendee.group.new_badge_cost # We add this value to the group in assign_badges; undo!
         raise HTTPRedirect('group_members?id={}&message={}', attendee.group_id, 'Attendee unset; you may now assign their badge to someone else')
 
     def add_group_members(self, session, id, count):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -343,8 +343,8 @@ class Root:
             log.error('unable to send group unset email', exc_info=True)
 
         session.assign_badges(attendee.group, attendee.group.badges + 1, registered=attendee.registered, paid=attendee.paid)
+        attendee.group.cost -= attendee.group.new_badge_cost  # We add this value to the group in assign_badges; undo!
         session.delete_from_group(attendee, attendee.group)
-        attendee.group.cost -= attendee.group.new_badge_cost # We add this value to the group in assign_badges; undo!
         raise HTTPRedirect('group_members?id={}&message={}', attendee.group_id, 'Attendee unset; you may now assign their badge to someone else')
 
     def add_group_members(self, session, id, count):


### PR DESCRIPTION
Fixes #1992.

I also did a search for anywhere else the `assign_badges` function is called, this is the only place where we're not actually changing the badge count for a group.