### PR TITLE
return 404 error when template not found in static_views

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -231,6 +231,8 @@ def render(template_name_list, data=None):
     try:
         template = loader.select_template(listify(template_name_list))
         rendered = template.render(Context(data))
+    except django.template.base.TemplateDoesNotExist:
+        raise
     except Exception as e:
         source_template_name = '[unknown]'
         django_template_source_info = getattr(e, 'django_template_source')

--- a/uber/server.py
+++ b/uber/server.py
@@ -52,7 +52,10 @@ class StaticViews:
         content_filename = self.get_filename_from_path_args(path_args)
 
         template_name = self.get_full_path_from_path_args(path_args)
-        content = render(template_name)
+        try:
+            content = render(template_name)
+        except django.template.base.TemplateDoesNotExist as e:
+            raise cherrypy.HTTPError(404, "Couldn't find {}".format(template_name)) from e
 
         guessed_content_type = mimetypes.guess_type(content_filename)[0]
         return cherrypy.lib.static.serve_fileobj(content, name=content_filename, content_type=guessed_content_type)


### PR DESCRIPTION
- also, fix underlying render() issue where we were causing an exception in the exception handler if a template wasn't found

fixes #2003 

this is actually a pretty tiny detail, however, it'll do 2 things:
1) prevent our error reporting from tripping when googlebot repeatedly tries to re-index a non-existent template page and gets a 500 error response (not a 404)
2) make googlebot stop trying to read a non-existent page, over and over and over and over again :)