### PR TITLE
Use PREREG_DONATION_DESCRIPTIONS to turn on/off slider

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -43,9 +43,14 @@ printed_badge_deadline = "2016-01-04"
 room_deadline = "2015-11-30"
 
 
+
 [badge_prices]
 
 [[single_day]]
+Friday = 35
+Saturday = 40
+Sunday = 40
+Monday = 30
 
 [[attendee]]
 

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -180,12 +180,6 @@ max_badge_sales = integer(default=20000)
 # If this is False, we won't display the "Want to Kick in Extra" stuff.
 donations_enabled = boolean(default=True)
 
-# This controls how badges and kick-in levels are displayed on the pre-
-# registration form. If it's true, the badge prices are displayed
-# separately from the badge add-ons and there is a slider to select
-# extra kick-in levels beyond what is shown in the badge level boxes.
-donation_slider_display = boolean(default=True)
-
 # Attendees kicking in extra can enter their own new "affiliate" or select
 # from a list of all affiliates which have already been entered.  This is
 # the list of the top affiliates from last year which we use to prepopulate

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -94,7 +94,7 @@
         {% endif %}
 
         var togglePrices = function () {
-            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' and not c.DONATION_SLIDER_DISPLAY %}($.val('badge_type') === {{ c.ATTENDEE_BADGE }}){% else %}false{% endif %};
+            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' and not c.PREREG_DONATION_DESCRIPTIONS %}($.val('badge_type') === {{ c.ATTENDEE_BADGE }}){% else %}false{% endif %};
             $.each(BADGE_TYPES.options, function (i, type) {
                 var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
                 var $price_notice = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price_notice').empty();
@@ -136,7 +136,7 @@
         var setKickinFromBadge = function (types, index) {
             var type = types.options[index];
             if (type.extra !== undefined && type.extra !== null && $.field('amount_extra')) {
-                {% if c.DONATION_SLIDER_DISPLAY %}
+                {% if c.PREREG_DONATION_DESCRIPTIONS %}
                     $('input:radio[name=amount_extra][value='+ type.extra +']').prop('checked', true).trigger('change');
                 {% else %}
                     $.field('amount_extra').val(type.extra).trigger('change');
@@ -179,7 +179,7 @@
                 }
                 makeBadgeMatchExtra();
                 if ($.field('amount_extra')) {
-                    {% if not c.DONATION_SLIDER_DISPLAY %}
+                    {% if not c.PREREG_DONATION_DESCRIPTIONS %}
                         $.field('amount_extra').parents('.form-group').hide();
                     {% else %}
                         $.field('amount_extra').on('change', makeBadgeMatchExtra);

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -183,7 +183,7 @@
                     {{ attendee.amount_extra_label }}
                     <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" />
                 {% else %}
-                    {% if c.DONATION_SLIDER_DISPLAY %}
+                    {% if c.PREREG_DONATION_DESCRIPTIONS %}
 
                         <style>
                             @media all {


### PR DESCRIPTION
Fixes #2001.
Back when we had plain radio buttons for the 'kick in slider,' we added a DONATION_SLIDER_DISPLAY option to toggle between the radio buttons and the regular dropdown box. However, when we upgraded the kick-in slider to include descriptions and the like, we created a use-case where the slider could exist _but have no options in it_. In such a situation, the badge upgrade buttons would stop working and it wouldn't be clear why. This gets rid of the old variable in exchange for checking based on PREREG_DONATION_DESCRIPTIONS, which is required for the new slider to work anyway.