### PR TITLE
fix wrong include path for ratings.js

### DIFF
--- a/uber/templates/jobs/everywhere.html
+++ b/uber/templates/jobs/everywhere.html
@@ -4,7 +4,7 @@
     <title>All Open Shifts</title>
     <link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />    
     <script type="text/javascript" src="../static/deps/combined.js"></script>
-    <script type="text/javascript" src="../static/js/ratings.js"></script>
+    <script type="text/javascript" src="../static_views/ratings.js"></script>
 </head>
 <body>
 

--- a/uber/templates/jobs/signups.html
+++ b/uber/templates/jobs/signups.html
@@ -2,7 +2,7 @@
 {% block title %}Shifts{% endblock %}
 {% block content %}
 
-<script type="text/javascript" src="../static/js/ratings.js"></script>
+<script type="text/javascript" src="../static_views/ratings.js"></script>
 
 {% include "jobs/main_menu.html" %}
 

--- a/uber/templates/registration/shifts.html
+++ b/uber/templates/registration/shifts.html
@@ -2,7 +2,7 @@
 {% block title %}Staffing Shifts - {{ attendee.full_name }}{% endblock %}
 {% block content %}
 
-<script type="text/javascript" src="../static/js/ratings.js"></script>
+<script type="text/javascript" src="../static_views/ratings.js"></script>
 <script type="text/javascript">
     var SHIFTS = {{ shifts|jsonize }};
     $(setupRatingClickHandler);


### PR DESCRIPTION
This was broken in the optimizations and we didn't notice til now, using correct path