### PR TITLE
override daemon thread names with better names

### DIFF
--- a/uber/server.py
+++ b/uber/server.py
@@ -91,10 +91,10 @@ mount_site_sections(c.MODULE_ROOT)
 cherrypy.tree.mount(Root(), c.PATH, c.APPCONF)
 static_overrides(join(c.MODULE_ROOT, 'static'))
 
-DaemonTask(check_unassigned, interval=300)
-DaemonTask(detect_duplicates, interval=300)
-DaemonTask(check_placeholders, interval=300)
-DaemonTask(AutomatedEmail.send_all, interval=300)
+DaemonTask(check_unassigned, interval=300,          name="mail unassg")
+DaemonTask(detect_duplicates, interval=300,         name="mail dupes")
+DaemonTask(check_placeholders, interval=300,        name="mail placeh")
+DaemonTask(AutomatedEmail.send_all, interval=300,   name="send emails")
 
 # TODO: this should be replaced by something a little cleaner, but it can be a useful debugging tool
 # DaemonTask(lambda: log.error(Session.engine.pool.status()), interval=5)


### PR DESCRIPTION
"better" here meaning:
1) they can be more easily displayed by the OS 16 char limit
2) they show the word "mail" in them so we know these are email-related threads

requires https://github.com/magfest/sideboard/pull/22