### PR TITLE
make login page remember original URI request

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -307,10 +307,10 @@ def restricted(func):
         if func.restricted:
             if func.restricted == (c.SIGNUPS,):
                 if not cherrypy.session.get('staffer_id'):
-                    raise HTTPRedirect('../signups/login?message=You+are+not+logged+in')
+                    raise HTTPRedirect('../signups/login?message=You+are+not+logged+in', save_location=True)
 
             elif cherrypy.session.get('account_id') is None:
-                raise HTTPRedirect('../accounts/login?message=You+are+not+logged+in')
+                raise HTTPRedirect('../accounts/login?message=You+are+not+logged+in', save_location=True)
 
             else:
                 access = sa.AdminAccount.access_set()

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -53,7 +53,10 @@ class Root:
         raise HTTPRedirect('index?message={}', 'Account deleted')
 
     @unrestricted
-    def login(self, session, message='', **params):
+    def login(self, session, message='', original_location=None, **params):
+        if not original_location or 'login' in original_location:
+            original_location = 'homepage'
+
         if 'email' in params:
             try:
                 account = session.get_account_by_email(params['email'])
@@ -65,11 +68,12 @@ class Root:
             if not message:
                 cherrypy.session['account_id'] = account.id
                 cherrypy.session['csrf_token'] = uuid4().hex
-                raise HTTPRedirect('homepage')
+                raise HTTPRedirect(original_location)
 
         return {
             'message': message,
-            'email':   params.get('email', '')
+            'email':   params.get('email', ''),
+            'original_location': original_location,
         }
 
     @unrestricted

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -102,7 +102,10 @@ class Root:
             return {'jobs': session.jobs_for_signups()}
 
     @unrestricted
-    def login(self, session, message='', full_name='', email='', zip_code=''):
+    def login(self, session, message='', full_name='', email='', zip_code='', original_location=None):
+        if not original_location or 'login' in original_location:
+            original_location = 'index'
+
         if full_name or email or zip_code:
             try:
                 attendee = session.lookup_attendee(full_name, email, zip_code)
@@ -116,13 +119,14 @@ class Root:
             if not message:
                 cherrypy.session['csrf_token'] = uuid4().hex
                 cherrypy.session['staffer_id'] = attendee.id
-                raise HTTPRedirect('index')
+                raise HTTPRedirect(original_location)
 
         return {
             'message':   message,
             'full_name': full_name,
             'email':     email,
-            'zip_code':  zip_code
+            'zip_code':  zip_code,
+            'original_location': original_location,
         }
 
     def onsite_jobs(self, session, message=''):

--- a/uber/templates/accounts/login.html
+++ b/uber/templates/accounts/login.html
@@ -9,10 +9,10 @@
 <div class="container">
   <form class="form-signin" role="form" method="post" action="login">
 	<h2 class="form-signin-heading">Admin Login</h2>
-	<input type="email" class="form-control" placeholder="Email address" name="email" 
-		value="{{ email }}" required autofocus>
-	<input type="password" class="form-control" placeholder="Password" name="password" 
-		required>
+	<input type="email" class="form-control" placeholder="Email address" name="email"
+		value="{{ email }}" required autofocus />
+	<input type="password" class="form-control" placeholder="Password" name="password" required />
+    <input type="hidden" name="original_location" value="{{ original_location }}" />
 	<button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
  
  <div class="text-center">

--- a/uber/templates/signups/login.html
+++ b/uber/templates/signups/login.html
@@ -10,9 +10,10 @@
     {% if c.DEV_BOX or c.AFTER_SHIFTS_CREATED %}
         <form class="form-signin" role="form">
             <h2 class="form-signin-heading">Volunteer Login</h2>
-            <input type="text" class="form-control" placeholder="First and Last Name" name="full_name" value="{{ full_name }}" required autofocus>
-            <input type="email" class="form-control" placeholder="Email address" name="email" value="{{ email }}" required>
-            <input type="text" class="form-control" placeholder="Zip Code" name="zip_code" value="{{ zip_code }}" required>
+            <input type="text" class="form-control" placeholder="First and Last Name" name="full_name" value="{{ full_name }}" required autofocus />
+            <input type="email" class="form-control" placeholder="Email address" name="email" value="{{ email }}" required />
+            <input type="text" class="form-control" placeholder="Zip Code" name="zip_code" value="{{ zip_code }}" required />
+            <input type="hidden" name="original_location" value="{{ original_location }}" />
             <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
         </form>
     {% else %}

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -14,12 +14,27 @@ class HTTPRedirect(cherrypy.HTTPRedirect):
     current querystring to build an absolute URL.  Therefore it's EXTREMELY IMPORTANT
     that the only time you create this class is in the context of a pageload.
 
-    Do not persist this class, only create it when needed.
+    Do not save copies this class, only create it on-demand when needed as part of a 'raise' statement.
     """
     def __init__(self, page, *args, **kwargs):
+        save_location = kwargs.pop('save_location', False)
+
         args = [self.quote(s) for s in args]
         kwargs = {k: self.quote(v) for k, v in kwargs.items()}
-        cherrypy.HTTPRedirect.__init__(self, page.format(*args, **kwargs))
+        query = page.format(*args, **kwargs)
+
+        if save_location and cherrypy.request.method == 'GET':
+            # remember the original URI the user was trying to reach.
+            # useful if we want to redirect the user back to the same page after
+            # they complete an action, such as logging in
+            # example URI: '/uber/registration/form?id=786534'
+            original_location = cherrypy.request.wsgi_environ['REQUEST_URI']
+
+            # note: python does have utility functions for this. if this gets any more complex, use the urllib module
+            qs_char = '?' if '?' not in query else '&'
+            query += "{sep}original_location={loc}".format(sep=qs_char, loc=self.quote(original_location))
+
+        cherrypy.HTTPRedirect.__init__(self, query)
 
     def quote(self, s):
         return quote(s) if isinstance(s, str) else str(s)


### PR DESCRIPTION
If you are not logged in, then reach a page that requires a login, then login, you will be redirected to the original page.  Also does the same thing for the volunteer checklist.

This is a totally optional but really nice usability bonus.

fixes https://github.com/magfest/ubersystem/issues/1790

@earl7399 and @bds002 you guys will love this :)