### PR TITLE
add diagnostics web display

### DIFF
--- a/uber/site_sections/devtools.py
+++ b/uber/site_sections/devtools.py
@@ -52,6 +52,7 @@ class Root:
 def database_pool_information():
     return Session.engine.pool.status()
 
+
 @register_diagnostics_status_function
 def global_badge_lock():
     return 'c.BADGE_LOCK = ' + repr(c.BADGE_LOCK)

--- a/uber/site_sections/devtools.py
+++ b/uber/site_sections/devtools.py
@@ -2,6 +2,8 @@ from uber.common import *
 import shlex
 import subprocess
 
+from sideboard.debugging import register_diagnostics_status_function, gather_diagnostics_status_information
+
 # admin utilities.  should not be used during normal ubersystem operations except by developers / sysadmins
 
 
@@ -19,7 +21,7 @@ def run_git_cmd(cmd):
     return run_shell_cmd(git + " " + cmd, working_dir=uber_base_dir)
 
 
-@all_renderable(c.PEOPLE)
+@all_renderable(c.ACCOUNTS)
 class Root:
     def index(self):
         return {}
@@ -39,3 +41,17 @@ class Root:
             'last_commit_log': last_commit_log,
             'git_status': git_status
         }
+
+    def dump_diagnostics(self):
+        return {
+            'diagnostics_data': gather_diagnostics_status_information(),
+        }
+
+
+@register_diagnostics_status_function
+def database_pool_information():
+    return Session.engine.pool.status()
+
+@register_diagnostics_status_function
+def global_badge_lock():
+    return 'c.BADGE_LOCK = ' + repr(c.BADGE_LOCK)

--- a/uber/templates/devtools/dump_diagnostics.html
+++ b/uber/templates/devtools/dump_diagnostics.html
@@ -1,0 +1,12 @@
+{% extends "base-admin.html" %}
+{% block title %}Developer Utility - System Diagnostics{% endblock %}
+{% block content %}
+
+<h1>System Diagnostics</h1>
+Showing live information about the state of this server<br/>
+
+<pre>
+{{ diagnostics_data|linebreaksbr }}
+</pre>
+
+{% endblock %}


### PR DESCRIPTION
- show output from diagnostics output via webpage
- add some diagnostics output with info on c.BADGE_LOCK and db connection pools

merge after https://github.com/magfest/sideboard/pull/23

The output from this is super-cool and useful, it shows each thread.  Deadlocks should stand out like sore thumb now. Here's an example of the output of 2 threads (there are 100+ threads currently showing):
```
--------------------------------------------------------------------------
# Thread name: "CP Server Thread-70"
# Python thread.ident: 140343307474688
# Linux Thread PID (TID): 7338
# Run Status: sleeping
File: "/usr/lib/python3.4/threading.py", line 888, in _bootstrap
  self._bootstrap_inner()
File: "/home/vagrant/uber/sideboard/sideboard/lib/_threads.py", line 58, in _thread_name_insert
  threading.Thread._bootstrap_inner_original(self)
File: "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
  self.run()
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/wsgiserver/wsgiserver3.py", line 1233, in run
  conn = self.server.requests.get()
File: "/usr/lib/python3.4/queue.py", line 167, in get
  self.not_empty.wait()
File: "/usr/lib/python3.4/threading.py", line 290, in wait
  waiter.acquire()

--------------------------------------------------------------------------
# Thread name: "CP Server Thread-11"
# Python thread.ident: 140344423343872
# Linux Thread PID (TID): 7279
# Run Status: running
File: "/usr/lib/python3.4/threading.py", line 888, in _bootstrap
  self._bootstrap_inner()
File: "/home/vagrant/uber/sideboard/sideboard/lib/_threads.py", line 58, in _thread_name_insert
  threading.Thread._bootstrap_inner_original(self)
File: "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
  self.run()
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/wsgiserver/wsgiserver3.py", line 1241, in run
  conn.communicate()
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/wsgiserver/wsgiserver3.py", line 1068, in communicate
  req.respond()
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/wsgiserver/wsgiserver3.py", line 856, in respond
  self.server.gateway(self).respond()
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/wsgiserver/wsgiserver3.py", line 1958, in respond
  response = self.req.server.wsgi_app(self.env, self.start_response)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cptree.py", line 299, in __call__
  return app(environ, start_response)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cptree.py", line 151, in __call__
  return self.wsgiapp(environ, start_response)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpwsgi.py", line 422, in __call__
  return head(environ, start_response)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpwsgi.py", line 145, in __call__
  self.throws
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpwsgi.py", line 160, in __init__
  self.nextapp, self.environ, self.start_response)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpwsgi.py", line 180, in trap
  return func(*args, **kwargs)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpwsgi.py", line 99, in __call__
  return self.nextapp(environ, start_response)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpwsgi.py", line 410, in tail
  return self.response_class(environ, start_response, self.cpapp)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpwsgi.py", line 234, in __init__
  self.run()
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpwsgi.py", line 349, in run
  request.run(meth, path, qs, rproto, headers, rfile)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 589, in run
  self.respond(pi)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 670, in respond
  response.body = self.handler()
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/lib/encoding.py", line 217, in __call__
  self.body = self.oldhandler(*args, **kwargs)
File: "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpdispatch.py", line 61, in __call__
  return self.callable(*self.args, **self.kwargs)
File: "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 196, in with_timing
  return func(*args, **kwargs)
File: "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 187, in with_caching
  return func(*args, **kwargs)
File: "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 207, in with_session
  return func(*args, **kwargs)
File: "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 327, in with_restrictions
  return func(*args, **kwargs)
File: "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 276, in with_rendering
  result = func(*args, **kwargs)
File: "/home/vagrant/uber/sideboard/plugins/uber/uber/site_sections/devtools.py", line 47, in dump_diagnostics
  'diagnostics_data': gather_diagnostics_status_information(),
File: "/home/vagrant/uber/sideboard/sideboard/debugging.py", line 14, in gather_diagnostics_status_information
  out += '--------- {} ---------\n{}\n\n\n'.format(func.__name__.replace('_', ' ').upper(), func())
File: "/home/vagrant/uber/sideboard/sideboard/lib/_threads.py", line 234, in threading_information
  out += _get_thread_current_stacktrace(thread_stack, thread)
```