### PR TITLE
test correct deadline in group unit test

### DIFF
--- a/uber/tests/conftest.py
+++ b/uber/tests/conftest.py
@@ -205,7 +205,7 @@ def shifts_not_created(monkeypatch): monkeypatch.setattr(c, 'SHIFTS_CREATED', ''
 
 
 @pytest.fixture
-def after_printed_badge_deadline(monkeypatch): monkeypatch.setattr(c, 'PRINTED_BADGE_DEADLINE', localized_now())
+def after_printed_badge_deadline(monkeypatch): monkeypatch.setattr(c, 'PRINTED_BADGE_DEADLINE', localized_now() - timedelta(days=1))
 
 
 @pytest.fixture

--- a/uber/tests/conftest.py
+++ b/uber/tests/conftest.py
@@ -205,4 +205,8 @@ def shifts_not_created(monkeypatch): monkeypatch.setattr(c, 'SHIFTS_CREATED', ''
 
 
 @pytest.fixture
+def after_printed_badge_deadline(monkeypatch): monkeypatch.setattr(c, 'PRINTED_BADGE_DEADLINE', localized_now())
+
+
+@pytest.fixture
 def custom_badges_ordered(monkeypatch): monkeypatch.setattr(c, 'SHIFT_CUSTOM_BADGES', False)

--- a/uber/tests/models/test_group.py
+++ b/uber/tests/models/test_group.py
@@ -158,7 +158,7 @@ def test_assign_removing_badges(monkeypatch, session):
     session.delete.assert_any_call(attendees[3])
 
 
-def test_assign_custom_badges_after_deadline(session, custom_badges_ordered):
+def test_assign_custom_badges_after_deadline(session, after_printed_badge_deadline):
     group = Group()
     message = session.assign_badges(group, 2, new_badge_type=c.STAFF_BADGE)
     assert message and 'ordered' in message


### PR DESCRIPTION
This unit test claims to want to test "after the printed badge deadline".  The code we're testing checks c.AFTER_PRINTED_BADGE_DEADLINE.

However, we were monkeypatching c.SHIFT_CUSTOM_BADGES (which is related, but separate).  Now we instead monkeypatch c.PRINTED_BADGE_DEADLINE such that c.AFTER_PRINTED_BADGE_DEADLINE is True.

I -think- this is the correct fix we want, but, @kitsuta if you can have a careful look here and make sure, that would be appreciated.