### PR TITLE
move needs_badge_num from Session into its own standalone static function, to fix unit tests

### DIFF
--- a/uber/badge_funcs.py
+++ b/uber/badge_funcs.py
@@ -95,6 +95,28 @@ def check_unassigned():
             if unassigned and session.no_email(subject):
                 body = render('emails/daily_checks/unassigned.html', {'unassigned': unassigned})
                 send_email(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
-
-
 # TODO: perhaps a check_leaderless() for checking for leaderless groups, since those don't get emails
+
+
+def needs_badge_num(attendee=None, badge_type=None):
+    """
+    Takes either an Attendee object, a badge_type, or both and returns whether or not the attendee should be
+    assigned a badge number. If neither parameter is given, always returns False.
+
+    :param attendee: Passing an existing attendee allows us to check for a new badge num whenever the attendee
+    is updated, particularly for when they are checked in.
+    :param badge_type: Must be an integer. Allows checking for a new badge number before adding/updating the
+    Attendee() object.
+    :return:
+    """
+    if not badge_type and attendee:
+        badge_type = attendee.badge_type
+    elif not badge_type and not attendee:
+        return None
+
+    if c.NUMBERED_BADGES:
+        if attendee:
+            return (badge_type in c.PREASSIGNED_BADGE_TYPES or attendee.checked_in) \
+                   and attendee.paid != c.NOT_PAID and not attendee.is_unassigned and attendee.badge_status != c.INVALID_STATUS
+        else:
+            return badge_type in c.PREASSIGNED_BADGE_TYPES

--- a/uber/tests/models/test_badge_funcs.py
+++ b/uber/tests/models/test_badge_funcs.py
@@ -1,5 +1,5 @@
 from uber.tests import *
-
+from uber.badge_funcs import needs_badge_num
 
 @pytest.fixture
 def session(request):
@@ -50,48 +50,48 @@ def change_badge(session, attendee, new_type, new_num=None, expected_num=None):
 class TestNeedsBadgeNum:
     def test_numbered_badges_off(self, session, monkeypatch):
         monkeypatch.setattr(c, 'NUMBERED_BADGES', False)
-        assert not session.needs_badge_num(badge_type=c.STAFF_BADGE)
-        assert not session.needs_badge_num(session.regular_attendee)
+        assert not needs_badge_num(badge_type=c.STAFF_BADGE)
+        assert not needs_badge_num(session.regular_attendee)
 
     def test_preassigned_by_type(self, session):
-        assert session.needs_badge_num(badge_type=c.STAFF_BADGE)
+        assert needs_badge_num(badge_type=c.STAFF_BADGE)
 
     def test_non_preassigned_by_type(self, session):
-        assert not session.needs_badge_num(badge_type=c.ATTENDEE_BADGE)
+        assert not needs_badge_num(badge_type=c.ATTENDEE_BADGE)
 
     def test_preassigned_ready(self, session):
-        assert session.needs_badge_num(session.staff_one)
+        assert needs_badge_num(session.staff_one)
 
     def test_non_preassigned_ready(self, session):
-        assert session.needs_badge_num(attendee=session.regular_attendee)
+        assert needs_badge_num(attendee=session.regular_attendee)
 
     def test_non_preassigned_not_checked_in(self, session):
         session.regular_attendee.checked_in = None
-        assert not session.needs_badge_num(attendee=session.regular_attendee)
+        assert not needs_badge_num(attendee=session.regular_attendee)
 
     def test_preassigned_unassigned(self, session):
         session.staff_one.first_name = ''
-        assert not session.needs_badge_num(attendee=session.staff_one)
+        assert not needs_badge_num(attendee=session.staff_one)
 
     def test_non_preassigned_unassigned(self, session):
         session.regular_attendee.first_name = ''
-        assert not session.needs_badge_num(attendee=session.regular_attendee)
+        assert not needs_badge_num(attendee=session.regular_attendee)
 
     def test_preassigned_not_paid(self, session):
         session.staff_one.paid = c.NOT_PAID
-        assert not session.needs_badge_num(attendee=session.staff_one)
+        assert not needs_badge_num(attendee=session.staff_one)
 
     def test_non_preassigned_not_paid(self, session):
         session.regular_attendee.paid = c.NOT_PAID
-        assert not session.needs_badge_num(attendee=session.regular_attendee)
+        assert not needs_badge_num(attendee=session.regular_attendee)
 
     def test_preassigned_invalid_status(self, session):
         session.staff_one.badge_status = c.INVALID_STATUS
-        assert not session.needs_badge_num(attendee=session.staff_one)
+        assert not needs_badge_num(attendee=session.staff_one)
 
     def test_non_preassigned_invalid_status(self, session):
         session.regular_attendee.badge_status = c.INVALID_STATUS
-        assert not session.needs_badge_num(attendee=session.regular_attendee)
+        assert not needs_badge_num(attendee=session.regular_attendee)
 
 
 class TestGetNextBadgeNum:

--- a/uber/tests/models/test_badge_funcs.py
+++ b/uber/tests/models/test_badge_funcs.py
@@ -1,6 +1,7 @@
 from uber.tests import *
 from uber.badge_funcs import needs_badge_num
 
+
 @pytest.fixture
 def session(request):
     session = Session().session


### PR DESCRIPTION
- this means presave_adjustment()'s don't rely on 'session' existing
- hotel unit tests don't have 'session' populated, so choke when they try and access it
- this method doesn't need anything in Session, it was just a convenient place for it

only weird thing: I have to do some extremely bizzare 'import' stuff to get this to work for seemingly no reason. I have no idea why but I see it in other areas of the codebase too.