### PR TITLE
re-un-re-un-revert unit test fix

### DIFF
--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -241,7 +241,7 @@ class TestUnsetVolunteer:
         monkeypatch.setattr(Attendee, 'is_new', False)
         a = Attendee(badge_num=1)
         a._misc_adjustments()
-        assert not a.checked_in
+        assert a.checked_in
 
     def test_names(self):
         a = Attendee(first_name='nac', last_name='mac Feegle')


### PR DESCRIPTION
THIS ONE IS CORRECT, ANYTHING ELSE IS WRONG

I accidentally reverted this somehow in a bunch of merges.