### PR TITLE
remove pytest from here

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ py3k-bcrypt==0.3
 stripe==1.11.0
 pytz==2014.4
 pep8==1.6.2
-pytest==2.7.2
 alembic==0.8.7


### PR DESCRIPTION
- this is an old version that conflicts with sideboard, and this one wins
- since sideboard is going to install this anyway, let's just remove it from here.  eventually may have to be added back in due to

the longer term solution if we want to keep this is probably to do something like pytest>=2.7.2, which if the other version is installed, will probably satisfy that requirement.  not sure, need to test.

eventually if we're running tests via Travis that involve just this repo and not with sideboard in the mix we may need to do this.