### PR TITLE
Only complain about custom badges if adding group badges

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -743,7 +743,7 @@ class Session(SessionManager):
 
             ribbon_to_use = new_ribbon_type or group.new_ribbon
 
-            if int(new_badge_type) in c.PREASSIGNED_BADGE_TYPES and c.AFTER_PRINTED_BADGE_DEADLINE:
+            if int(new_badge_type) in c.PREASSIGNED_BADGE_TYPES and c.AFTER_PRINTED_BADGE_DEADLINE and diff > 0:
                 return 'Custom badges have already been ordered, so you will need to select a different badge type'
             elif diff > 0:
                 group.cost += diff * group.new_badge_cost


### PR DESCRIPTION
We were having troubles at MAGLabs because any time you tried to save a group, as long as its 'badge type' was set to Staff, you'd get an error. This error now only triggers if you're actually trying to add Staff badges to the group.