### PR TITLE
if onsite, redirect main prereg form to the at-door kiosk page

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -54,7 +54,7 @@ code_of_conduct_url = string(default="http://magfest.org/codeofconduct")
 contact_url = string(default="")
 
 # when you access the kiosk landing page, this is where it will redirect you
-kiosk_redirect_url =  = string(default="../registration/register")
+kiosk_redirect_url = string(default="../registration/register")
 
 # There are a huge slew of behaviors which are different before and during the
 # event.  For example, during the event the registration page actually lets

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -53,6 +53,9 @@ code_of_conduct_url = string(default="http://magfest.org/codeofconduct")
 # This link is to give users a generic way to contact your organization.
 contact_url = string(default="")
 
+# when you access the kiosk landing page, this is where it will redirect you
+kiosk_redirect_url =  = string(default="../registration/register")
+
 # There are a huge slew of behaviors which are different before and during the
 # event.  For example, during the event the registration page actually lets
 # admins check people in.  This switches between the "during the year" mode and

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -30,6 +30,15 @@ def log_pageview(func):
     return with_check
 
 
+def redirect_if_at_con_to_kiosk(func):
+    @wraps(func)
+    def with_check(*args, **kwargs):
+        if c.AT_THE_CON:
+            raise HTTPRedirect(c.KIOSK_REDIRECT_URL)
+        return func(*args, **kwargs)
+    return with_check
+
+
 def check_if_can_reg(func):
     @wraps(func)
     def with_check(*args, **kwargs):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -62,7 +62,7 @@ class Root:
         to land on.  The reason this is a redirect is that at-the-door laptops might be imaged and hard to change
         their default landing page.  If sysadmins want to change the landing page, they can do it here.
         """
-        raise HTTPRedirect('../registration/register')
+        raise HTTPRedirect(c.KIOSK_REDIRECT_URL)
 
     def check_prereg(self):
         return json.dumps({'force_refresh': not c.AT_THE_CON and (c.AFTER_PREREG_TAKEDOWN or c.BADGES_SOLD >= c.MAX_BADGE_SALES)})
@@ -98,6 +98,7 @@ class Root:
     def dealer_registration(self, message=''):
         return self.form(badge_type=c.PSEUDO_DEALER_BADGE, message=message)
 
+    @redirect_if_at_con_to_kiosk
     @check_if_can_reg
     def form(self, session, message='', edit_id=None, **params):
         params['id'] = 'None'   # security!


### PR DESCRIPTION
still testing, basically this is for attendees visiting the main prereg page, they get directed to the kiosk form which is more at-event friendly and allows buying day passes online.