### PR TITLE
Check if redirect_kiosk_url exists before using it

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -30,15 +30,6 @@ def log_pageview(func):
     return with_check
 
 
-def redirect_if_at_con_to_kiosk(func):
-    @wraps(func)
-    def with_check(*args, **kwargs):
-        if c.AT_THE_CON:
-            raise HTTPRedirect(c.KIOSK_REDIRECT_URL)
-        return func(*args, **kwargs)
-    return with_check
-
-
 def check_if_can_reg(func):
     @wraps(func)
     def with_check(*args, **kwargs):

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -30,6 +30,15 @@ def log_pageview(func):
     return with_check
 
 
+def redirect_if_at_con_to_kiosk(func):
+    @wraps(func)
+    def with_check(*args, **kwargs):
+        if c.AT_THE_CON and c.KIOSK_REDIRECT_URL:
+            raise HTTPRedirect(c.KIOSK_REDIRECT_URL)
+        return func(*args, **kwargs)
+    return with_check
+
+
 def check_if_can_reg(func):
     @wraps(func)
     def with_check(*args, **kwargs):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -98,12 +98,9 @@ class Root:
     def dealer_registration(self, message=''):
         return self.form(badge_type=c.PSEUDO_DEALER_BADGE, message=message)
 
+    @redirect_if_at_con_to_kiosk
     @check_if_can_reg
     def form(self, session, message='', edit_id=None, **params):
-        # We generally don't want people using the 'pre-reg' form when registering from their phones during the event
-        if c.AT_THE_CON and c.KIOSK_REDIRECT_URL:
-            raise HTTPRedirect(c.KIOSK_REDIRECT_URL)
-
         params['id'] = 'None'   # security!
         if edit_id is not None:
             attendee, group = self._get_unsaved(edit_id, if_not_found=HTTPRedirect('form?message={}', 'That preregistration has already been finalized'))

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -98,9 +98,12 @@ class Root:
     def dealer_registration(self, message=''):
         return self.form(badge_type=c.PSEUDO_DEALER_BADGE, message=message)
 
-    @redirect_if_at_con_to_kiosk
     @check_if_can_reg
     def form(self, session, message='', edit_id=None, **params):
+        # We generally don't want people using the 'pre-reg' form when registering from their phones during the event
+        if c.AT_THE_CON and c.KIOSK_REDIRECT_URL:
+            raise HTTPRedirect(c.KIOSK_REDIRECT_URL)
+
         params['id'] = 'None'   # security!
         if edit_id is not None:
             attendee, group = self._get_unsaved(edit_id, if_not_found=HTTPRedirect('form?message={}', 'That preregistration has already been finalized'))


### PR DESCRIPTION
This lets us easily use config to allow people to access the pre-reg form during the event, should we so desire. It also removes the decorator in place of putting the redirect inside the page, since it's two lines of code that don't actually get used elsewhere.