### PR TITLE
stopped hardcoding February

### DIFF
--- a/uber/templates/signups/onsite_jobs.html
+++ b/uber/templates/signups/onsite_jobs.html
@@ -31,7 +31,7 @@ If you cannot make it to one or more of your existing shifts, contact {{ c.STAFF
     <tbody>
     {% for job in jobs %}
         <tr>
-            <td>Feb {{ job.start_time|datetime:"%-d at %H:%M (%-I %p %a)" }}</td>
+            <td>{{ job.start_time|datetime:"%b %-d at %H:%M (%-I %p %a)" }}</td>
             <td>{{ job.duration }}</td>
             <td>{{ job.location_label }}</td>
             <td>{{ job.name }}</td>


### PR DESCRIPTION
Last MAGFest we realized onsite that it would be super-convenient if people could log in on their phones to sign up for new shifts onsite.  I threw together a quick page while people were waiting in line to make this happen.

I have no idea why I hard-coded the month to February when I went through the trouble to make everything else automatic, though I'm guessing it was from some quick copy/pasting or something.

Anyway, people logging in on their phones to take shifts are wondering why it says "Feb" for the month.