### PR TITLE
Use ident rather than subject for email approval

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -21,8 +21,8 @@ class AutomatedEmail:
         self.bcc = bcc or []
         self.extra_data = extra_data or {}
         self.sender = sender or c.REGDESK_EMAIL
-        self.instances[self.subject] = self
         self.ident = (ident or self.subject).format(EVENT_NAME=c.EVENT_NAME)
+        self.instances[self.ident] = self
         if post_con:
             self.filter = lambda x: c.POST_CON and filter(x)
         else:
@@ -30,6 +30,12 @@ class AutomatedEmail:
 
     def __repr__(self):
         return '<{}: {!r}>'.format(self.__class__.__name__, self.subject)
+
+    @property
+    def approved(self):
+        """Returns a boolean indicating whether this email has been approved."""
+        with Session() as session:
+            return bool(session.query(ApprovedEmail).filter_by(ident=self.ident).first())
 
     def prev(self, x, all_sent=None):
         if all_sent:

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -37,6 +37,15 @@ class AutomatedEmail:
         with Session() as session:
             return bool(session.query(ApprovedEmail).filter_by(ident=self.ident).first())
 
+    def computed_subject(self, x):
+        """
+        Given a model instance, return an email subject email for that instance.
+        By default this just returns the default subject unmodified; this method
+        exists only to be overriden in subclasses.  For example, we might want
+        our panel email subjects to contain the name of the panel.
+        """
+        return self.subject
+
     def prev(self, x, all_sent=None):
         if all_sent:
             return (x.__class__.__name__, x.id, self.ident) in all_sent
@@ -56,8 +65,9 @@ class AutomatedEmail:
 
     def send(self, x, raise_errors=True):
         try:
+            subject = self.computed_subject(x)
             format = 'text' if self.template.endswith('.txt') else 'html'
-            send_email(self.sender, x.email, self.subject, self.render(x), format, model=x, cc=self.cc, ident=self.ident)
+            send_email(self.sender, x.email, subject, self.render(x), format, model=x, cc=self.cc, ident=self.ident)
         except:
             log.error('error sending {!r} email to {}', self.subject, x.email, exc_info=True)
             if raise_errors:

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -67,13 +67,13 @@ class AutomatedEmail:
     def send_all(cls, raise_errors=False):
         if not c.AT_THE_CON and (c.DEV_BOX or c.SEND_EMAILS):
             with Session() as session:
-                approved = {ae.subject for ae in session.query(ApprovedEmail)}
+                approved = {ae.ident for ae in session.query(ApprovedEmail)}
                 all_sent = set(session.query(Email.model, Email.fk_id, Email.ident))
                 for model, lister in cls.queries.items():
                     for inst in lister(session):
                         sleep(0.01)  # throttle CPU usage
                         for rem in cls.instances.values():
-                            if isinstance(inst, rem.model) and (not rem.needs_approval or rem.subject in approved):
+                            if isinstance(inst, rem.model) and (not rem.needs_approval or rem.ident in approved):
                                 if rem.should_send(inst, all_sent):
                                     rem.send(inst, raise_errors=raise_errors)
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -1749,9 +1749,9 @@ class ArbitraryCharge(MagModel):
 
 
 class ApprovedEmail(MagModel):
-    subject = Column(UnicodeText)
+    ident = Column('subject', UnicodeText)  # TODO: rename column to "ident" in the database; will require a db migration
 
-    _repr_attr_names = ['subject']
+    _repr_attr_names = ['ident']
 
 
 class Email(MagModel):

--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -16,16 +16,16 @@ class Root:
     sent.restricted = [c.PEOPLE, c.REG_AT_CON]
 
     def pending(self, session, message=''):
-        approved = {ae.subject for ae in session.query(ApprovedEmail).all()}
+        approved = {ae.ident for ae in session.query(ApprovedEmail).all()}
         return {
             'message': message,
-            'pending': [ae for ae in AutomatedEmail.instances.values() if ae.needs_approval and ae.subject not in approved]
+            'pending': [ae for ae in AutomatedEmail.instances.values() if ae.needs_approval and ae.ident not in approved]
         }
 
-    def pending_examples(self, session, subject):
+    def pending_examples(self, session, ident):
         count = 0
         examples = []
-        email = AutomatedEmail.instances[subject]
+        email = AutomatedEmail.instances[ident]
         for x in AutomatedEmail.queries[email.model](session):
             if email.filter(x):
                 count += 1
@@ -38,8 +38,8 @@ class Root:
 
         return {
             'count': count,
-            'subject': subject,
-            'examples': examples
+            'examples': examples,
+            'subject': email.subject
         }
 
     def test_email(self, session, subject=None, body=None, from_address=None, to_address=None, **params):
@@ -66,8 +66,8 @@ class Root:
         }
 
     @csrf_protected
-    def approve(self, session, subject):
-        session.add(ApprovedEmail(subject=subject))
+    def approve(self, session, ident):
+        session.add(ApprovedEmail(ident=ident))
         raise HTTPRedirect('pending?message={}', 'Email approved and will be sent out shortly')
 
     def emails_by_interest(self, message=''):

--- a/uber/templates/emails/pending.html
+++ b/uber/templates/emails/pending.html
@@ -15,11 +15,11 @@
     <tr>
         <td>{{ email.subject }}</td>
         <td>{{ email.sender }}</td>
-        <td><a href="pending_examples?subject={{ email.subject|urlencode }}">See Examples</a></td>
+        <td><a href="pending_examples?ident={{ email.ident|urlencode }}">See Examples</a></td>
         <td>
             <form method="post" action="approve">
             {% csrf_token %}
-            <input type="hidden" name="subject" value="{{ email.subject }}" />
+            <input type="hidden" name="ident" value="{{ email.ident }}" />
             <input type="submit" value="Approve" />
             </form>
         </td>


### PR DESCRIPTION
There are two things for which we should definitely be using the new `ident` field for emails:
- Approving emails.  Right now, if you changed the email subject, the email would suddenly become unapproved.
- Looking up emails in `AutomatedEmail.instances`.  It's much more convenient to be able to look up the email by its slug than by its full subject.

This is a prerequisite for https://github.com/magfest/panels/pull/52 which relies on the second change being present.

This change is backwards-compatible, since all of our existing approvals are (as far as I can tell) for emails where the ident and subject are identical.

We'll want to make sure to test this on staging (with mailinator) before deploying to production.  Not because it's a huge change, but because our automated email code is so important that we want to be really sure we're not about to send 10,000 extra emails accidentally :)
