### PR TITLE
Fix Chrome vulnerability on the pre-reg page

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -108,6 +108,13 @@ def total_cost_over_paid(attendee):
 
 
 @validation.Attendee
+def no_script_injection(attendee):
+    if '</script>' in attendee.affiliate:
+        attendee.affiliate = None
+        return 'Quit that.'
+
+
+@validation.Attendee
 @ignore_unassigned_and_placeholders
 def full_name(attendee):
     if not attendee.first_name:


### PR DESCRIPTION
Because we take input for affiliates and then add it to a JSONized list, but JSON dump only escapes quotes, users could run scripts on their Chrome browser. This is the emergency stop-gap solution, assuming there's a better one.