### PR TITLE
Sanitize all relevant custom tags

### DIFF
--- a/uber/common.py
+++ b/uber/common.py
@@ -4,6 +4,7 @@ import csv
 import sys
 import json
 import math
+import html
 import string
 import socket
 import random

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -16,7 +16,7 @@ def timestamp(dt):
 
 @register.filter
 def jsonize(x):
-    return SafeString(json.dumps(x, cls=serializer))
+    return SafeString(html.escape(json.dumps(x, cls=serializer), quote=False))
 
 
 @register.filter
@@ -182,8 +182,8 @@ class options(template.Node):
                 val = val.strftime(c.TIMESTAMP_FORMAT)
             else:
                 selected = 'selected="selected"' if str(val) == str(default) else ''
-            val  = str(val).replace('"',  '&quot;').replace('\n', '')
-            desc = str(desc).replace('"', '&quot;').replace('\n', '')
+            val  = html.escape(str(val), quote=False).replace('"',  '&quot;').replace('\n', '')
+            desc = html.escape(str(desc), quote=False).replace('"', '&quot;').replace('\n', '')
             results.append('<option value="{}" {}>{}</option>'.format(val, selected, desc))
         return '\n'.join(results)
 
@@ -268,6 +268,7 @@ class radiogroup(template.Node):
         default = getattr(model, self.field_name, None)
         results = []
         for num, desc in options:
+            desc = html.escape(desc)
             checked = 'checked' if num == default else ''
             results.append('<label class="btn btn-default" style="text-align: left;"><input type="radio" name="{}" autocomplete="off" value="{}" onchange="donationChanged();" {} /> {}</label>'
                            .format(self.field_name, num, checked, desc))

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -108,13 +108,6 @@ def total_cost_over_paid(attendee):
 
 
 @validation.Attendee
-def no_script_injection(attendee):
-    if '</script>' in attendee.affiliate:
-        attendee.affiliate = None
-        return 'Quit that.'
-
-
-@validation.Attendee
 @ignore_unassigned_and_placeholders
 def full_name(attendee):
     if not attendee.first_name:


### PR DESCRIPTION
This is a better fix than https://github.com/magfest/ubersystem/pull/2073, and addresses more vulnerability issues. Essentially, we were in some cases bypassing Django's default template safe-rendering, thus creating vulnerabilities.