### PR TITLE
reject cross-domain redirects on login page

### DIFF
--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -54,8 +54,7 @@ class Root:
 
     @unrestricted
     def login(self, session, message='', original_location=None, **params):
-        if not original_location or 'login' in original_location:
-            original_location = 'homepage'
+        original_location = create_valid_user_supplied_redirect_url(original_location, default_url='homepage')
 
         if 'email' in params:
             try:

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -103,8 +103,7 @@ class Root:
 
     @unrestricted
     def login(self, session, message='', full_name='', email='', zip_code='', original_location=None):
-        if not original_location or 'login' in original_location:
-            original_location = 'index'
+        original_location = create_valid_user_supplied_redirect_url(original_location, default_url='index')
 
         if full_name or email or zip_code:
             try:

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -40,6 +40,28 @@ class HTTPRedirect(cherrypy.HTTPRedirect):
         return quote(s) if isinstance(s, str) else str(s)
 
 
+def create_valid_user_supplied_redirect_url(url, default_url):
+    """
+    Create a valid redirect from user-supplied data.
+
+    If there is invalid data, or a security issue is detected, then ignore and redirect to the homepage
+
+    :param url: user-supplied URL that is being requested to redirect to
+    :param default_url: the name of the URL we should redirect to if there's an issue
+    :return: a secure and valid URL that we allow a redirect to be made to
+    """
+
+    # security: ignore cross-site redirects that aren't for local pages.
+    # i.e. if an attacker passes in 'original_location=https://badsite.com/stuff/" then just ignore it
+    parsed_url = urlparse(url)
+    security_issue = parsed_url.scheme or parsed_url.netloc
+
+    if not url or 'login' in url or security_issue:
+        return default_url
+
+    return url
+
+
 def localized_now():
     """Returns datetime.now() but localized to the event's configured timezone."""
     utc_now = datetime.utcnow().replace(tzinfo=UTC)


### PR DESCRIPTION
this is a security issue where an attacker could craft a url that after logging in redirects users to an external website
