### PR TITLE
removed sandwich preferences as a requirement, since we removed it from the form

### DIFF
--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -20,15 +20,12 @@ class Root:
         attendee = session.logged_in_volunteer()
         fr = attendee.food_restrictions or FoodRestrictions()
         if params:
-            fr = session.food_restrictions(dict(params, attendee_id=attendee.id), checkgroups=['standard', 'sandwich_pref'])
-            if not fr.sandwich_pref:
-                message = 'Please tell us your sandwich preference'
+            fr = session.food_restrictions(dict(params, attendee_id=attendee.id), checkgroups=['standard'])
+            session.add(fr)
+            if attendee.badge_type == c.GUEST_BADGE:
+                raise HTTPRedirect('food_restrictions?message={}', 'Your info has been recorded, thanks a bunch!')
             else:
-                session.add(fr)
-                if attendee.badge_type == c.GUEST_BADGE:
-                    raise HTTPRedirect('food_restrictions?message={}', 'Your info has been recorded, thanks a bunch!')
-                else:
-                    raise HTTPRedirect('index?message={}', 'Your dietary restrictions have been recorded')
+                raise HTTPRedirect('index?message={}', 'Your dietary restrictions have been recorded')
 
         return {
             'fr': fr,


### PR DESCRIPTION
I hotfixed this on the server since we just sent out like a thousand emails and didn't want people to run into this.

In the future we should probably make this more configurable, since whether or not an event asks about sandwich preferences probably shouldn't require a code change in the main repo.  I'm inclined to keep the database column around in the meantime since we might turn this back on for other events before we have a chance to make it more generic.

The diff looks a little weird because I removed a level of indentation (dedented?) but it was a very simple change.