### PR TITLE
Use guest_email for Guests instead of panels_email

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -79,7 +79,7 @@ class StopsEmail(AutomatedEmail):
 
 class GuestEmail(AutomatedEmail):
     def __init__(self, subject, template, filter=lambda a: True, **kwargs):
-        AutomatedEmail.__init__(self, Attendee, subject, template, lambda a: a.badge_type == c.GUEST_BADGE and filter(a), sender=c.PANELS_EMAIL, **kwargs)
+        AutomatedEmail.__init__(self, Attendee, subject, template, lambda a: a.badge_type == c.GUEST_BADGE and filter(a), sender=c.GUEST_EMAIL, **kwargs)
 
 
 class GroupEmail(AutomatedEmail):
@@ -189,7 +189,7 @@ AutomatedEmail(Attendee, '{EVENT_NAME} Panelist Badge Confirmation', 'placeholde
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Guest Badge Confirmation', 'placeholders/guest.txt',
                lambda a: a.placeholder and a.first_name and a.last_name and a.badge_type == c.GUEST_BADGE,
-               sender=c.PANELS_EMAIL)
+               sender=c.GUEST_EMAIL)
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Dealer Information Required', 'placeholders/dealer.txt',
                lambda a: a.placeholder and a.is_dealer and a.group.status == c.APPROVED,

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -203,8 +203,11 @@ staff_email = string(default="MAGFest Staffing <stops@magfest.org>")
 # Dealer-related emails are sent from this address.
 marketplace_email = string(default="MAGFest Marketplace <marketplace@magfest.org>")
 
-# Emails to guests and panelists are sent from this address.
+# Emails to panelists are sent from this address.
 panels_email = string(default="MAGFest Panels <panels@magfest.org>")
+
+# Emails to guests are sent from this address.
+guest_email = string(default="MAGFest Guests <guests@magfest.org>")
 
 # Emails relating to banned attendees are sent to and from this address.
 security_email = string(default="MAGFest Security <security@magfest.org>")


### PR DESCRIPTION
Uses a new email address for emails sent to Guests, since guests and panels are no longer one department.