### PR TITLE
Allow Supporter Deadline to work after Printed Badge Deadline

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -317,12 +317,12 @@
     <div class="badge-row extra-row form-group" style="display:none">
         <label for="badge_printed_name" class="col-sm-2 control-label optional-field">Name Printed on Badge</label>
         <div class="col-sm-6">
-            <input type="text" class="form-control" name="badge_printed_name" maxlength="20" value="{{ attendee.badge_printed_name }}" {% if c.AFTER_PRINTED_BADGE_DEADLINE %}readonly{% endif %} />
+            <input type="text" class="form-control" name="badge_printed_name" maxlength="20" value="{{ attendee.badge_printed_name }}" {% if c.AFTER_PRINTED_BADGE_DEADLINE and attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or c.AFTER_SUPPORTER_DEADLINE %}readonly{% endif %} />
         </div>
         <p class="help-block col-sm-6">Badge names have a maximum of 20 characters.</p>
     </div>
 
-    {% if c.AFTER_PRINTED_BADGE_DEADLINE %}
+    {% if c.AFTER_PRINTED_BADGE_DEADLINE and attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or c.AFTER_SUPPORTER_DEADLINE %}
         <div class="badge-row extra-row form-group" style="display:none">
             <p class="help-block col-sm-6 col-sm-offset-2">(custom badges have already been ordered, so you can no longer set this)</p>
         </div>


### PR DESCRIPTION
We want to keep selling supporter badges after the hard deadline for Staff badge names, because the customized Supporter badges use a different manufacturing process. This let people change their badge name as long as they're not Staff (or another "Preassigned type").