### PR TITLE
add badge consistency checks to devtools

### DIFF
--- a/uber/badge_funcs.py
+++ b/uber/badge_funcs.py
@@ -98,6 +98,66 @@ def check_unassigned():
 # TODO: perhaps a check_leaderless() for checking for leaderless groups, since those don't get emails
 
 
+# run through all badges and check 2 things:
+# 1) there are no gaps in badge numbers
+# 2) all badge numbers are in the ranges set by c.BADGE_RANGES
+# note: does not do any duplicates checking, that's a different pre-existing check
+def badge_consistency_check(session):
+    errors = []
+
+    # check 1, see if anything is out of range, or has a duplicate badge number
+    badge_nums_seen = []
+
+    attendees = session.query(Attendee)\
+        .filter(Attendee.first_name != '')\
+        .filter(Attendee.badge_num != 0)\
+        .order_by('badge_num')\
+        .all()
+
+    for attendee in attendees:
+        out_of_range_error = check_range(attendee.badge_num, attendee.badge_type)
+        if out_of_range_error:
+            msg = '{a.full_name}: badge #{a.badge_num}: {err}'.format(a=attendee, err=out_of_range_error)
+            errors.append(msg)
+
+        if attendee.badge_num in badge_nums_seen:
+            msg = '{a.full_name}: badge #{a.badge_num}: Has been assigned the same badge number ' \
+                  'of another badge, which is not supposed to happen'.format(a=attendee)
+            errors.append(msg)
+
+        badge_nums_seen.append(attendee.badge_num)
+
+    # check 2: see if there are any gaps in each of the badge ranges
+    for badge_type_val, badge_type_desc in c.BADGE_OPTS:
+        prev_badge_num = -1
+        prev_attendee_name = ""
+
+        attendees = session.query(Attendee) \
+            .filter_by(badge_type=badge_type_val)\
+            .filter(Attendee.first_name != '') \
+            .filter(Attendee.badge_num != 0) \
+            .order_by('badge_num') \
+            .all()
+
+        for attendee in attendees:
+            if prev_badge_num == -1:
+                prev_badge_num = attendee.badge_num
+                prev_attendee_name = attendee.full_name
+                continue
+
+            if attendee.badge_num - 1 != prev_badge_num:
+                msg = "gap in badge sequence between " + badge_type_desc + " " + \
+                      "badge# " + str(prev_badge_num) + "(" + prev_attendee_name + ")" + " and " + \
+                      "badge# " + str(attendee.badge_num) + "(" + attendee.full_name + ")"
+
+                errors.append(msg)
+
+            prev_badge_num = attendee.badge_num
+            prev_attendee_name = attendee.full_name
+
+    return errors
+
+
 def needs_badge_num(attendee=None, badge_type=None):
     """
     Takes either an Attendee object, a badge_type, or both and returns whether or not the attendee should be

--- a/uber/site_sections/devtools.py
+++ b/uber/site_sections/devtools.py
@@ -47,6 +47,18 @@ class Root:
             'diagnostics_data': gather_diagnostics_status_information(),
         }
 
+    def badge_number_consistency_check(self, session, run_check=None):
+        errors = []
+
+        if run_check:
+            errors = badge_consistency_check(session)
+
+        return {
+            'errors_found': len(errors) > 0,
+            'errors': errors,
+            'ran_check': run_check,
+        }
+
 
 @register_diagnostics_status_function
 def database_pool_information():

--- a/uber/templates/devtools/badge_number_consistency_check.html
+++ b/uber/templates/devtools/badge_number_consistency_check.html
@@ -1,0 +1,27 @@
+{% extends "base-admin.html" %}
+{% block title %}Developer Utility - Badge consistency check{% endblock %}
+{% block content %}
+
+    <h1>Badge numbering consistency utility</h1>
+
+    <a href="badge_number_consistency_check?run_check=yes">Run badge check</a> - This check ensures that all badges in the system
+    conform to the numbers we have setup in BADGE_RANGES.  If any errors are found you will have the opportunity to fix
+    them after the check runs.<br/><br/>
+
+    {% if ran_check %}
+        <p><b>Badge check run is completed.</b></p>
+        {% if errors_found %}
+            <p>
+            <font color="red">
+                <b>Badge consistency errors found!</b> Errors were:<br/><br/>
+                {% for error in errors %}
+                    {{ error }}<br>
+                {% endfor %}
+            </font>
+            </p>
+        {% else %}
+            <p><font color="green"><b>No consistency errors detected!</b></font></p>
+        {% endif %}
+    {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
this will check all badge numbers to make sure that:
1) there are no duplicate badge#s in the system
2) that all badge#'s fall within range

This is resurrected from magfest 8.5 code.  There is a second part I'm not including which also allows you to fix up the badge numbering code.  If we need that we can bring that back later.