### PR TITLE
Badge printer duplicate badge num check

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -136,13 +136,16 @@ def _set_csv_base_filename(base_filename):
 
 def csv_file(func):
     @wraps(func)
-    def csvout(self, session, **kwargs):
+    def csvout(self, session, set_headers=True, **kwargs):
         writer = StringIO()
         func(self, csv.writer(writer), session, **kwargs)
         output = writer.getvalue().encode('utf-8')
+
         # set headers last in case there were errors, so end user still see error page
-        cherrypy.response.headers['Content-Type'] = 'application/csv'
-        _set_csv_base_filename(func.__name__)
+        if set_headers:
+            cherrypy.response.headers['Content-Type'] = 'application/csv'
+            _set_csv_base_filename(func.__name__)
+
         return output
     return csvout
 

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -191,7 +191,7 @@ class Root:
         """
         for badge_csv_fn in self.badge_zipfile_contents:
             csv_filename = '{}.csv'.format(badge_csv_fn.__name__)
-            output = badge_csv_fn(self, session)
+            output = badge_csv_fn(self, session, set_headers=False)
             zip_file.writestr(csv_filename, output)
 
     def food_eligible(self, session):


### PR DESCRIPTION
add crude duplicate badge number check to printed badge exports
  - this won't catch every weird case but will catch the bulk of the issues we're seeing

tell CSV exports from multi-file zipfiles to not set headers from the CSV file itself
- this is important because if we're exporting multiple csv files, and the first one succeeds but a later one has an error, the user won't see the error's text because the headers were set to a CSV file.