### PR TITLE
deal with None badge_nums

### DIFF
--- a/uber/reports.py
+++ b/uber/reports.py
@@ -28,9 +28,10 @@ class PersonalizedBadgeReport(ReportBase):
                          .order_by(order_by).all()):
 
             # sanity check no duplicate badges
-            if a.badge_num in badge_nums_seen:
-                raise ValueError("duplicate badge number detected: %s" % a.badge_num)
-            badge_nums_seen += [a.badge_num]
+            if a.badge_num:
+                if a.badge_num in badge_nums_seen:
+                    raise ValueError("duplicate badge number detected: %s" % a.badge_num)
+                badge_nums_seen += [a.badge_num]
 
             # write the actual data
             row = [a.badge_num] if self._include_badge_nums else []


### PR DESCRIPTION
Forgot, a bunch of our staff badges in groups have a None value for badge#

Which kind of begs the question.... is our CSV exporting a bunch of blank rows for these? Will check.