### PR TITLE
Assign numbers to unassigned badges with a preassigned badge type

### DIFF
--- a/uber/badge_funcs.py
+++ b/uber/badge_funcs.py
@@ -177,6 +177,6 @@ def needs_badge_num(attendee=None, badge_type=None):
     if c.NUMBERED_BADGES:
         if attendee:
             return (badge_type in c.PREASSIGNED_BADGE_TYPES or attendee.checked_in) \
-                   and attendee.paid != c.NOT_PAID and not attendee.is_unassigned and attendee.badge_status != c.INVALID_STATUS
+                   and attendee.paid != c.NOT_PAID and attendee.badge_status != c.INVALID_STATUS
         else:
             return badge_type in c.PREASSIGNED_BADGE_TYPES


### PR DESCRIPTION
We want people to be able to claim unassigned badges even after we lock them down, so we want to assign numbers to them before the deadline.