### PR TITLE
fix-#2146 DO NOT MERGE UNTIL COORDINATED WITH OTHERS PSEUDO-NAMES/BADGE NAMES

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -123,6 +123,13 @@
             </p>
         {% endif %}
     </div>
+    <div class="form-group">
+        <label for="badge_printed_name" class="col-sm-2 control-label">Badge Name</label>
+        <div class="col-sm-6">
+            <input type="text" name="badge_printed_name" id="badge_printed_name" value="{{ attendee.badge_printed_name }}" class="form-control" placeholder="Badge Name">
+        </div>
+    </div>
+
 {% endif %}
 
 {% if c.DONATIONS_ENABLED and c.PREREG_DONATION_OPTS and c.PAGE_PATH != '/registration/form' %}


### PR DESCRIPTION
#2146 will change all badge_printed_names to a pseudo-name on with a presave_adjustment. Requires a small function to just resave every attendee real quick, one time. Different PR. Pseudo-name currently Paul. #weAreAllPaul