### PR TITLE
enforce no changing of attendee printed badge name after deadline

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -184,6 +184,13 @@ def zip_code(attendee):
 
 
 @validation.Attendee
+def printed_badge_change(attendee):
+    if c.AFTER_PRINTED_BADGE_DEADLINE:
+        if attendee.badge_printed_name != attendee.orig_value_of('badge_printed_name'):
+            return 'Custom badges have already been ordered, so you cannot change the printed name of this Attendee'
+
+
+@validation.Attendee
 def printed_badge_deadline(attendee):
     if attendee.is_new and attendee.has_personalized_badge and c.AFTER_PRINTED_BADGE_DEADLINE:
         return 'Custom badges have already been ordered so you cannot create new {} badges'.format(attendee.badge_type_label)


### PR DESCRIPTION
Right now people can change their badge name, and it's after the export has been sent to the printer. add a validation check that enforces not allowing this to happen.

There is a part 2 of this which is to fix the UX in a few places to grey it out, but this will at least ensure it can't happen, even if it would be better to indicate this through the UI in a greyed out box.

anyway das bad yo.  fix it bro. fix it good.  I hope no future employers of mine read my commit messages because that would be embarassing. hi.