### PR TITLE
enforce no changing of attendee printed badge name after deadline

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -190,6 +190,27 @@ def printed_badge_deadline(attendee):
 
 
 @validation.Attendee
+def printed_badge_change(attendee):
+    badge_name_changes_allowed = True
+
+    # this is getting kinda messy and we probably need to rework the entire concept of "printed badge deadline".
+    # right now we want to:
+    # 1) allow supporters to change their badge names until c.SUPPORTER_DEADLINE
+    # 2) allow staff to change their badge names until c.PRINTED_BADGE_DEADLINE
+    #
+    # this implies that we actually have two different printed badge deadlines: 1 for staff, 1 for supporters.
+    # we might just want to make that explicit.
+    if attendee.badge_type == c.STAFF_BADGE and c.AFTER_PRINTED_BADGE_DEADLINE:
+        badge_name_changes_allowed = False
+    elif attendee.amount_extra >= c.SUPPORTER_LEVEL and c.AFTER_SUPPORTER_DEADLINE:
+        badge_name_changes_allowed = False
+
+    if not badge_name_changes_allowed:
+        if attendee.badge_printed_name != attendee.orig_value_of('badge_printed_name'):
+            return 'Custom badges have already been ordered, so you cannot change the printed name of this Attendee'
+
+
+@validation.Attendee
 def allowed_to_volunteer(attendee):
     if attendee.staffing and not attendee.age_group_conf['can_volunteer'] and attendee.badge_type != c.STAFF_BADGE and c.PRE_CON:
         return 'Your interest is appreciated, but ' + c.EVENT_NAME + ' volunteers must be 18 or older.'


### PR DESCRIPTION
- implicitly creates concept of separate deadline for supporters vs staff

this is a second pass at the original concept which was in #2150