### PR TITLE
fix-#1859 Move Site Map index to section header

### DIFF
--- a/uber/templates/accounts/sitemap.html
+++ b/uber/templates/accounts/sitemap.html
@@ -9,9 +9,7 @@
     <div class="panel-heading"><a href="../{{ section }}/index">{{ section|title }}</a></div>
         <ul class="nav nav-pills">
         {% for page in pagelist %}
-            {% if page.name != 'Index' %}
             <li><a href="..{{ page.path }}">{{ page.name }}</a></li>
-            {% endif %}
         {% endfor %}
         </ul>
     </div>

--- a/uber/templates/accounts/sitemap.html
+++ b/uber/templates/accounts/sitemap.html
@@ -6,10 +6,12 @@
 
 {% for section, pagelist in pages %}
     <div class="panel panel-default">
-    <div class="panel-heading">{{ section|title }}</div>
+    <div class="panel-heading"><a href="../{{ section }}/index">{{ section|title }}</a></div>
         <ul class="nav nav-pills">
         {% for page in pagelist %}
+            {% if page.name != 'Index' %}
             <li><a href="..{{ page.path }}">{{ page.name }}</a></li>
+            {% endif %}
         {% endfor %}
         </ul>
     </div>


### PR DESCRIPTION
Makes sitemap a little more legible, and moves index to title