### PR TITLE
Tested working: attendee_id_required decorator.

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -489,7 +489,7 @@ class alias_to_site_section(object):
 
 def attendee_id_required(func):
     @wraps(func)
-    def check_id(self, **params):
+    def check_id(*args, **params):
         message = "No ID provided. Trying using a different link or going back."
         session = params['session']
         if params.get('id'):
@@ -500,6 +500,6 @@ def attendee_id_required(func):
             else:
                 message = "You weren't found in our database."
                 if session.query(sa.Attendee).filter(sa.Attendee.id == params['id']).first():
-                    return func(**params)
+                    return func(*args, **params)
         raise HTTPRedirect('../common/invalid?message=%s' % message)
     return check_id


### PR DESCRIPTION
My last decorator caused an error with passing onto the original function properly. Switching self to *args seems to fix it. Tested the following cases:
A. User does not enter ID whatsoever. WORKS
B. User modifies ID in url. WORKS
C. User has non-malformed valid ID. WORKS.