### PR TITLE
allow setting a custom password in post-con mode

### DIFF
--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -28,10 +28,10 @@ class Root:
     def update(self, session, password='', message='', **params):
         account = session.admin_account(params, checkgroups=['access'])
         if account.is_new:
-            if c.AT_THE_CON and not password:
+            if c.AT_OR_POST_CON and not password:
                 message = 'You must enter a password'
             else:
-                password = password if c.AT_THE_CON else genpasswd()
+                password = password if c.AT_OR_POST_CON else genpasswd()
                 account.hashed = bcrypt.hashpw(password, bcrypt.gensalt())
 
         message = message or check(account)
@@ -39,7 +39,7 @@ class Root:
             message = 'Account settings uploaded'
             account.attendee = session.attendee(account.attendee_id)   # dumb temporary hack, will fix later with tests
             session.add(account)
-            if account.is_new and not c.AT_THE_CON:
+            if account.is_new and not c.AT_OR_POST_CON:
                 body = render('emails/accounts/new_account.txt', {
                     'account': account,
                     'password': password

--- a/uber/templates/accounts/index.html
+++ b/uber/templates/accounts/index.html
@@ -22,14 +22,14 @@
     <div class="input-group input-group-sm">
     <label for="password" class="sr-only">Password</label>
     <input type="password" class="form-control" id="password" name="password" placeholder="Password" 
-       {% if not c.AT_THE_CON %}disabled{% endif %}>
-       {% if not c.AT_THE_CON %}
+       {% if not c.AT_OR_POST_CON %}disabled{% endif %}>
+       {% if not c.AT_OR_POST_CON %}
            <span class="input-group-addon glyphicon glyphicon-ban-circle">
            </span>
        {% endif %}
     </div>
     <input type="password" class="form-control" id="check-password" name="check-password" placeholder="Re-enter Password"
-           {% if not c.AT_THE_CON %}disabled{% endif %}>
+           {% if not c.AT_OR_POST_CON %}disabled{% endif %}>
     </div>
 </div>
 <div class="form-group">


### PR DESCRIPTION
After the event ends, we have generally been removing the amazon SES credentials to make sure older instances, if they ever go haywire, don't email all our people.

This creates a problem in that the 'forgot my password' link no longer sends an email.

This PR addresses this by allowing the password setting overrides that normally only work in AT_THE_CON mode to now work in normal mode.

This allows an admin to do a password reset by deleting and then re-creating someone's account

- not great UX but does allow a solution
- will need to backport this fix into older ubers