### PR TITLE
Add fix for the revert of the revert of Invalid ID Decorator

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -489,7 +489,7 @@ class alias_to_site_section(object):
 
 def attendee_id_required(func):
     @wraps(func)
-    def check_id(self, **params):
+    def check_id(*args, **params):
         message = "No ID provided. Trying using a different link or going back."
         session = params['session']
         if params.get('id'):
@@ -500,6 +500,6 @@ def attendee_id_required(func):
             else:
                 message = "You weren't found in our database."
                 if session.query(sa.Attendee).filter(sa.Attendee.id == params['id']).first():
-                    return func(**params)
+                    return func(*args, **params)
         raise HTTPRedirect('../common/invalid?message=%s' % message)
     return check_id


### PR DESCRIPTION
I can't believe this works.

https://github.com/magfest/ubersystem/pull/2160 has merge conflicts because we reverted several of the commits in it. This PR lets us get around the merge conflicts by merging the fixed version of the branch to a reversion of the original revert. It makes for a bit of a messy commit stack but the workflow for resolving merge conflicts is almost always terrible.