### PR TITLE
Catch Missing CSRF_Token.

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -318,26 +318,30 @@ def prettify_breadcrumb(str):
 def renderable(func):
     @wraps(func)
     def with_rendering(*args, **kwargs):
-        result = func(*args, **kwargs)
-
         try:
-            result['breadcrumb_page_pretty_'] = prettify_breadcrumb(func.__name__) if func.__name__ != 'index' else 'Home'
-            result['breadcrumb_page_'] = func.__name__ if func.__name__ != 'index' else ''
-        except:
-            pass
+            result = func(*args, **kwargs)
 
-        try:
-            result['breadcrumb_section_pretty_'] = prettify_breadcrumb(get_module_name(func))
-            result['breadcrumb_section_'] = get_module_name(func)
-        except:
-            pass
+            try:
+                result['breadcrumb_page_pretty_'] = prettify_breadcrumb(func.__name__) if func.__name__ != 'index' else 'Home'
+                result['breadcrumb_page_'] = func.__name__ if func.__name__ != 'index' else ''
+            except:
+                pass
 
-        if c.UBER_SHUT_DOWN and not cherrypy.request.path_info.startswith('/schedule'):
-            return render('closed.html')
-        elif isinstance(result, dict):
-            return render(_get_template_filename(func), result)
-        else:
-            return result
+            try:
+                result['breadcrumb_section_pretty_'] = prettify_breadcrumb(get_module_name(func))
+                result['breadcrumb_section_'] = get_module_name(func)
+            except:
+                pass
+
+            if c.UBER_SHUT_DOWN and not cherrypy.request.path_info.startswith('/schedule'):
+                return render('closed.html')
+            elif isinstance(result, dict):
+                return render(_get_template_filename(func), result)
+            else:
+                return result
+        except CSRFException as e:
+            message = "Your CSRF token is invalid. Please go back and try again."
+            raise HTTPRedirect("../common/invalid?message={}", message)
     return with_rendering
 
 

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -81,17 +81,7 @@ suffix_property.check = _suffix_property_check
 def csrf_protected(func):
     @wraps(func)
     def protected(*args, csrf_token, **kwargs):
-        try:
-            check_csrf(csrf_token)
-        except Exception as e:
-            s = str(e).lower()
-            if "csrf" in s:
-                message = "Missing CSRF token. Your session may have timed out. Please go back and try again."
-                log.error("CSRF Error: {}", str(e))
-                raise HTTPRedirect("../common/invalid?message={}", message)
-            else:
-                raise
-
+        check_csrf(csrf_token)
         return func(*args, **kwargs)
     return protected
 
@@ -341,6 +331,7 @@ def renderable(func):
                 return result
         except CSRFException as e:
             message = "Your CSRF token is invalid. Please go back and try again."
+            log.error("CSRF Error: {}", e)
             raise HTTPRedirect("../common/invalid?message={}", message)
     return with_rendering
 

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -319,7 +319,7 @@ def renderable(func):
             result = func(*args, **kwargs)
         except CSRFException as e:
             message = "Your CSRF token is invalid. Please go back and try again."
-            uber.server.log_exception_with_verbose_context(e)
+            uber.server.log_exception_with_verbose_context(str(e))
             raise HTTPRedirect("../common/invalid?message={}", message)
         except (AssertionError, ValueError) as e:
             message = str(e)

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -81,7 +81,13 @@ suffix_property.check = _suffix_property_check
 def csrf_protected(func):
     @wraps(func)
     def protected(*args, csrf_token, **kwargs):
-        check_csrf(csrf_token)
+        try:
+            check_csrf(csrf_token)
+        except AssertionError as e:
+            raise HTTPRedirect("../common/invalid?message={}", "Session Time Out. Go Back And Try Again.")
+        except TypeError as e:
+            raise HTTPRedirect("../common/invalid?message={}", "CSRF Token Not Provided.")
+
         return func(*args, **kwargs)
     return protected
 

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -83,10 +83,14 @@ def csrf_protected(func):
     def protected(*args, csrf_token, **kwargs):
         try:
             check_csrf(csrf_token)
-        except AssertionError as e:
-            raise HTTPRedirect("../common/invalid?message={}", "Session Time Out. Go Back And Try Again.")
-        except TypeError as e:
-            raise HTTPRedirect("../common/invalid?message={}", "CSRF Token Not Provided.")
+        except Exception as e:
+            s = str(e).lower()
+            if "csrf" in s:
+                message = "Missing CSRF token. Your session may have timed out. Please go back and try again."
+                log.error("CSRF Error: {}", str(e))
+                raise HTTPRedirect("../common/invalid?message={}", message)
+            else:
+                raise
 
         return func(*args, **kwargs)
     return protected

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -341,7 +341,6 @@ def renderable(func):
     return with_rendering
 
 
-
 def unrestricted(func):
     func.restricted = False
     return func

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -319,11 +319,11 @@ def renderable(func):
             result = func(*args, **kwargs)
         except CSRFException as e:
             message = "Your CSRF token is invalid. Please go back and try again."
-            log.error("CSRF Error: {}", e)
+            uber.server.log_exception_with_verbose_context(e)
             raise HTTPRedirect("../common/invalid?message={}", message)
-        except AssertionError as e:
+        except (AssertionError, ValueError) as e:
             message = str(e)
-            log.error("Assertion Error: {}", e)
+            uber.server.log_exception_with_verbose_context(message)
             raise HTTPRedirect("../common/invalid?message={}", message)
         else:
             try:

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -76,9 +76,8 @@ def check_csrf(csrf_token):
     """
     if csrf_token is None:
         csrf_token = cherrypy.request.headers.get('CSRF-Token')
-    if __debug__:
-        if not csrf_token:
-            raise CSRFException("CSRF token missing")
+    if not csrf_token:
+        raise CSRFException("CSRF token missing")
     if csrf_token != cherrypy.session['csrf_token']:
         log.error("csrf tokens don't match: {!r} != {!r}", csrf_token, cherrypy.session['csrf_token'])
         raise CSRFException('CSRF check failed')

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1,5 +1,6 @@
 from uber.common import *
 
+
 class CSRFException(Exception):
     """
     This class will raise a custom exception to help catch a specific error in later functions.

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1,5 +1,10 @@
 from uber.common import *
 
+class CSRFException(Exception):
+    """
+    This class will raise a custom exception to help catch a specific error in later functions.
+    """
+
 
 class HTTPRedirect(cherrypy.HTTPRedirect):
     """
@@ -70,7 +75,7 @@ def check_csrf(csrf_token):
     assert csrf_token, 'CSRF token missing'
     if csrf_token != cherrypy.session['csrf_token']:
         log.error("csrf tokens don't match: {!r} != {!r}", csrf_token, cherrypy.session['csrf_token'])
-        raise AssertionError('CSRF check failed')
+        raise CSRFException('CSRF check failed')
     else:
         cherrypy.request.headers['CSRF-Token'] = csrf_token
 

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -73,7 +73,9 @@ def check_csrf(csrf_token):
     """
     if csrf_token is None:
         csrf_token = cherrypy.request.headers.get('CSRF-Token')
-    assert csrf_token, 'CSRF token missing'
+    if __debug__:
+        if not csrf_token:
+            raise CSRFException("CSRF token missing")
     if csrf_token != cherrypy.session['csrf_token']:
         log.error("csrf tokens don't match: {!r} != {!r}", csrf_token, cherrypy.session['csrf_token'])
         raise CSRFException('CSRF check failed')


### PR DESCRIPTION
Should catch the missing CSRF_Token error that keeps popping up in devbot-errors. Needs to have #2165 merged before this can be merged. Tested by deleting the CSRF input element from registration/form