### PR TITLE
add manufacturing-specific shirt report

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -154,6 +154,9 @@ collect_full_address = boolean(default=False)
 # their swag except a shirt, so we can contact them later.
 out_of_shirts = boolean(default=False)
 
+# This is the number of staff shirts (i.e. the shirt that says "{EVENT_NAME} staff") that EACH staffer gets.
+shirts_per_staffer = integer(default=2)
+
 # The max number of tables a dealer can apply for.  Note that the admin
 # interface allows you to give a dealer a higher number than this.
 max_tables = integer(default=4)

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -260,7 +260,6 @@ class Root:
             ]
         }
 
-
     def shirt_counts(self, session):
         counts = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
         labels = ['size unknown'] + [label for val, label in c.SHIRT_OPTS][1:]

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -250,7 +250,7 @@ class Root:
             if gets_staff_shirt:
                 counts['staff'][label(shirt_label)] += c.SHIRTS_PER_STAFFER
 
-            if attendee.gets_paid_shirt:
+            if gets_swag_shirt:
                 counts['swag'][label(shirt_label)] += 1
 
         return {

--- a/uber/templates/summary/shirt_manufacturing_counts.html
+++ b/uber/templates/summary/shirt_manufacturing_counts.html
@@ -1,0 +1,31 @@
+{% extends "base-admin.html" %}
+{% block title %}Shirt Counts{% endblock %}
+{% block content %}
+
+<style type="text/css">
+    td { padding: 2px 5px 2px 5px; }
+</style>
+
+<h2>Shirt Manufacturing Reports</h2>
+<p>
+    This report is designed to give you the correct numbers ready to be sent to the manufacturer.
+    We recommend adding in a few extra shirts for safety margins to these numbers.
+</p>
+
+<p>
+    <b>IMPORTANT NOTE: The STAFF SHIRT report shows the result of EACH staffer receiving {{ c.SHIRTS_PER_STAFFER }} shirt(s).</b>
+</p>
+
+{% for name, category in categories %}
+    <h3>{{ name }} shirts</h3>
+    <table>
+    {% for label, counts in category %}
+        <tr>
+            <td>{{ label }}: </td>
+            <td>{{ counts }}</td>
+        </tr>
+    {% endfor %}
+    </table>
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
POLICY IMPLICATIONS NEED SANITY CHECKING ON THIS! CC @kitsuta @EliAndrewC  @ShevaDas 

for @bds002.  

There are 2 types of shirts now: (this is a change from previous years): 
       - "staff shirts" - staff uniforms, each staff (someone who has an actual staff badge) gets TWO
       - "swag shirts" - pre-ordered shirts, which the following groups receive:
           - volunteers (non-staff who get a swag shirt for free)  (NOT someone with a staff badge)
           - attendees (who get whatever they buy)


the new shirt manufacturing report shows:
1) count and sizes of staff shirts
2) count and sizes of swag pre-order shirts

this report will be given to the merch contractor (probably after we add some padding) so they know how many shirts to order

Whoever is doing this will need to pad out the number of shirts so there are safety margins.