### PR TITLE
fix a 'key error' by switching function to retrieve id

### DIFF
--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -102,7 +102,7 @@ class Root:
 
     def form(self, session, message='', **params):
         defaults = {}
-        if params['id'] == 'None' and cherrypy.request.method != 'POST':
+        if params.get('id') == 'None' and cherrypy.request.method != 'POST':
             defaults = cherrypy.session.get('job_defaults', defaultdict(dict))[params['location']]
             params.update(defaults)
 
@@ -112,7 +112,7 @@ class Root:
             message = check(job)
             if not message:
                 session.add(job)
-                if params['id'] == 'None':
+                if params.get('id') == 'None':
                     defaults = cherrypy.session.get('job_defaults', defaultdict(dict))
                     defaults[params['location']] = {field: getattr(job, field) for field in c.JOB_DEFAULTS}
                     cherrypy.session['job_defaults'] = defaults


### PR DESCRIPTION
Eli explained this problem to me at MAGCon.

`if params['id']` will throw an error if the key is not found.
`if params.get('id')` will return None if the key is not found. 

It'd be impossible for `if params['id'] == 'None'`to be true, because if id is not found it throws an error.

This _MAY_ possibly be an unwanted 'fix' if the user is meant to pass `'None'` and not meant to be passing nothing for the field. 