### PR TITLE
Include age discounts in badge_cost

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1207,7 +1207,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         elif self.is_presold_oneday:
             return c.get_presold_oneday_price(self.badge_type)
         else:
-            return c.get_attendee_price(registered)
+            return c.get_attendee_price(registered) - self.age_discount
 
     @cost_property
     def age_discount(self):


### PR DESCRIPTION
In the future, we will want to have a @badge_cost_property so that we can affect attendee's badge_cost. For now, however, we only need to account for the age discount. It is subtracted from only a regular attendee price by design.