### PR TITLE
Only adjust group cost for new badges if auto_recalc is on

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -758,7 +758,7 @@ class Session(SessionManager):
 
             if int(new_badge_type) in c.PREASSIGNED_BADGE_TYPES and c.AFTER_PRINTED_BADGE_DEADLINE and diff > 0:
                 return 'Custom badges have already been ordered, so you will need to select a different badge type'
-            elif diff > 0:
+            elif diff > 0 and group.auto_recalc:
                 group.cost += diff * group.new_badge_cost
                 for i in range(diff):
                     group.attendees.append(Attendee(badge_type=new_badge_type, ribbon=ribbon_to_use, paid=paid, **extra_create_args))


### PR DESCRIPTION
This solves the second major unexpected functionality of groups, which is that new badge costs would always be added.