### PR TITLE
Stop subtracting the age_discount

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1207,13 +1207,12 @@ class Attendee(MagModel, TakesPaymentMixin):
         elif self.is_presold_oneday:
             return c.get_presold_oneday_price(self.badge_type)
         elif self.age_discount:
-            return c.get_attendee_price(registered) - self.age_discount
+            return c.get_attendee_price(registered) + self.age_discount
         elif self.group and self.paid == c.PAID_BY_GROUP:
             return c.get_attendee_price(registered) - c.GROUP_DISCOUNT
         else:
             return c.get_attendee_price(registered)
 
-    @cost_property
     def age_discount(self):
         return -self.age_group_conf['discount']
 


### PR DESCRIPTION
We were accidentally subtracting a negative number, effectively adding the discount as if it were a cost. We also need to make it stop being a cost_property so it isn't applied twice.