### PR TITLE
Stop adding new_badge_cost to new badges

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -758,8 +758,7 @@ class Session(SessionManager):
 
             if int(new_badge_type) in c.PREASSIGNED_BADGE_TYPES and c.AFTER_PRINTED_BADGE_DEADLINE and diff > 0:
                 return 'Custom badges have already been ordered, so you will need to select a different badge type'
-            elif diff > 0 and group.auto_recalc:
-                group.cost += diff * group.new_badge_cost
+            elif diff > 0:
                 for i in range(diff):
                     group.attendees.append(Attendee(badge_type=new_badge_type, ribbon=ribbon_to_use, paid=paid, **extra_create_args))
             elif diff < 0:


### PR DESCRIPTION
Since groups now simply poll their attendees for their badge_cost, adding the `new_badge_cost` to the group's cost is unnecessary and may cause issues.