### PR TITLE
Stop throwing an error for overridden_price == 0

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -240,12 +240,6 @@ def attendee_money(attendee):
                 return 'Overridden price must be a positive integer'
         except:
             return 'Invalid overridden price ({})'.format(attendee.overridden_price)
-        else:
-            if attendee.overridden_price == 0:
-                if attendee.paid == c.NOT_PAID:
-                    attendee.paid = c.NEED_NOT_PAY
-                elif attendee.paid == c.HAS_PAID:
-                    return 'Please do not manually set a badge price to $0 if an attendee has already paid.'
 
     try:
         amount_refunded = int(float(attendee.amount_refunded))

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -242,7 +242,10 @@ def attendee_money(attendee):
             return 'Invalid overridden price ({})'.format(attendee.overridden_price)
         else:
             if attendee.overridden_price == 0:
-                return 'Please set the payment type to "doesn\'t need to" instead of setting the badge price to 0.'
+                if attendee.paid == c.NOT_PAID:
+                    attendee.paid = c.NEED_NOT_PAY
+                elif attendee.paid == c.HAS_PAID:
+                    return 'Please do not manually set a badge price to $0 if an attendee has already paid.'
 
     try:
         amount_refunded = int(float(attendee.amount_refunded))

--- a/uber/models.py
+++ b/uber/models.py
@@ -858,6 +858,7 @@ class Group(MagModel, TakesPaymentMixin):
     wares         = Column(UnicodeText)
     description   = Column(UnicodeText)
     special_needs = Column(UnicodeText)
+    overridden_price = Column(Integer, nullable=True, admin_only=True)
     amount_paid   = Column(Integer, default=0, admin_only=True)
     cost          = Column(Integer, default=0, admin_only=True)
     auto_recalc   = Column(Boolean, default=True, admin_only=True)

--- a/uber/models.py
+++ b/uber/models.py
@@ -858,7 +858,6 @@ class Group(MagModel, TakesPaymentMixin):
     wares         = Column(UnicodeText)
     description   = Column(UnicodeText)
     special_needs = Column(UnicodeText)
-    overridden_price = Column(Integer, nullable=True, admin_only=True)
     amount_paid   = Column(Integer, default=0, admin_only=True)
     cost          = Column(Integer, default=0, admin_only=True)
     auto_recalc   = Column(Boolean, default=True, admin_only=True)
@@ -1049,6 +1048,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     checked_in = Column(UTCDateTime, nullable=True)
 
     paid             = Column(Choice(c.PAYMENT_OPTS), default=c.NOT_PAID, admin_only=True)
+    overridden_price = Column(Integer, nullable=True, admin_only=True)
     amount_paid      = Column(Integer, default=0, admin_only=True)
     amount_extra     = Column(Choice(c.DONATION_TIER_OPTS, allow_unspecified=True), default=0)
     amount_refunded  = Column(Integer, default=0, admin_only=True)

--- a/uber/models.py
+++ b/uber/models.py
@@ -1048,7 +1048,6 @@ class Attendee(MagModel, TakesPaymentMixin):
     checked_in = Column(UTCDateTime, nullable=True)
 
     paid             = Column(Choice(c.PAYMENT_OPTS), default=c.NOT_PAID, admin_only=True)
-    overridden_price = Column(Integer, nullable=True, admin_only=True)
     amount_paid      = Column(Integer, default=0, admin_only=True)
     amount_extra     = Column(Choice(c.DONATION_TIER_OPTS, allow_unspecified=True), default=0)
     amount_refunded  = Column(Integer, default=0, admin_only=True)
@@ -1096,6 +1095,9 @@ class Attendee(MagModel, TakesPaymentMixin):
 
         if self.paid != c.REFUNDED:
             self.amount_refunded = 0
+            
+        if self.overridden_price == 0 and self.paid == c.NOT_PAID:
+            self.paid = c.NEED_NOT_PAY
 
         if c.AT_THE_CON and self.badge_num and (self.is_new or self.badge_type not in c.PREASSIGNED_BADGE_TYPES):
             self.checked_in = datetime.now(UTC)


### PR DESCRIPTION
Now that we often set the overridden_price to 0 through code, people were getting an error about setting it to 0 when they weren't actually doing so. This removes that error.