### PR TITLE
Remove typo from if check

### DIFF
--- a/uber/templates/emails/shifts/schedule.html
+++ b/uber/templates/emails/shifts/schedule.html
@@ -9,7 +9,7 @@
 Thanks again for Staffing at {{ c.EVENT_NAME }}!
 {% endif %}
     
-{% if attendee.ribbon == c.VOLUNTEER_RIBBON) %}    
+{% if attendee.ribbon == c.VOLUNTEER_RIBBON %}    
 Thanks again for Volunteering at {{ c.EVENT_NAME }}!
 {% endif %}
 <br/> <br/>


### PR DESCRIPTION
This would have likely errored out the template, so we definitely need to remove it.