### PR TITLE
Fix calculation of group.amount_extra

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -972,7 +972,7 @@ class Group(MagModel, TakesPaymentMixin):
     @cost_property
     def amount_extra(self):
         if self.is_new:
-            return sum(a.amount_unpaid for a in self.attendees if a.paid == c.PAID_BY_GROUP)
+            return sum(a.total_cost - a.badge_cost for a in self.attendees if a.paid == c.PAID_BY_GROUP)
         else:
             return 0
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -212,8 +212,7 @@ class Root:
         for group in charge.groups:
             group.amount_paid = group.default_cost - group.amount_extra
             for attendee in group.attendees:
-                if attendee.amount_extra:
-                    attendee.amount_paid = attendee.total_cost
+                attendee.amount_paid = attendee.total_cost - attendee.badge_cost
             session.add(group)
 
         self.unpaid_preregs.clear()


### PR DESCRIPTION
The way we calculated group.amount_extra was based on the old costs of attendees who were paid by group. This updates it so it's more accurately the amount_extra.