### PR TITLE
check that CSV has standard parameters, or it will hide from site-map.

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -137,7 +137,9 @@ def _set_csv_base_filename(base_filename):
 
 
 def csv_file(func):
-    func.site_mappable = True
+    parameters = inspect.getargspec(func)
+    if len(parameters[0]) == 3:
+        func.site_mappable = True
 
     @wraps(func)
     def csvout(self, session, set_headers=True, **kwargs):


### PR DESCRIPTION
fixes issue #2204 by checking that the length of the parameters of a CSV function is exactly three. The decorator by default should supply 'self' 'out' and 'session'. Tested on local box.