### PR TITLE
add verbose exception logging to all Stripe exception handling

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -188,9 +188,15 @@ def credit_card(func):
         except HTTPRedirect:
             raise
         except:
-            send_email(c.ADMIN_EMAIL, [c.ADMIN_EMAIL, 'dom@magfest.org'], 'MAGFest Stripe error',
-                       'Got an error while calling charge(self, payment_id={!r}, stripeToken={!r}, ignored={}):\n{}'
-                       .format(payment_id, stripeToken, ignored, traceback.format_exc()))
+            error_text = \
+                'Got an error while calling charge' \
+                '(self, payment_id={!r}, stripeToken={!r}, ignored={}):\n{}\n' \
+                '\n IMPORTANT: This could have resulted in an attendee paying and not being' \
+                'marked as paid in the database. Definitely double check.'\
+                .format(payment_id, stripeToken, ignored, traceback.format_exc())
+
+            send_email(c.ADMIN_EMAIL, [c.ADMIN_EMAIL, 'dom@magfest.org'], 'MAGFest Stripe error (Automated Message)', error_text)
+            uber.server.log_exception_with_verbose_context('IMPORTANT! STRIPE ERROR: \n' + error_text)
             return traceback.format_exc()
     return charge
 

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -195,8 +195,7 @@ def credit_card(func):
                 'marked as paid in the database. Definitely double check.'\
                 .format(payment_id, stripeToken, ignored, traceback.format_exc())
 
-            send_email(c.ADMIN_EMAIL, [c.ADMIN_EMAIL, 'dom@magfest.org'], 'MAGFest Stripe error (Automated Message)', error_text)
-            uber.server.log_exception_with_verbose_context('IMPORTANT! STRIPE ERROR: \n' + error_text)
+            report_critical_exception(msg=error_text, subject='ERROR: MAGFest Stripe error (Automated Message)')
             return traceback.format_exc()
     return charge
 

--- a/uber/server.py
+++ b/uber/server.py
@@ -11,9 +11,9 @@ def _add_email():
 cherrypy.tools.add_email_to_error_page = cherrypy.Tool('after_error_response', _add_email)
 
 
-def _custom_verbose_logger(debug=False):
+def log_exception_with_verbose_context(debug=False, msg=''):
     """
-    Write the request headers, and the last error's traceback to the cherrypy error log.
+    Write the request headers, session params, page location, and the last error's traceback to the cherrypy error log.
     Do this all one line so all the information can be collected by external log collectors and easily displayed.
     """
 
@@ -32,9 +32,9 @@ def _custom_verbose_logger(debug=False):
     h = ["  %s: %s" % (k, v) for k, v in cherrypy.request.header_list]
     headers_txt = 'Request Headers:\n' + '\n'.join(h)
 
-    msg = '\n'.join(['Exception encountered', page_location, admin_txt, post_txt, session_txt, headers_txt])
-    log.error(msg, exc_info=True)
-cherrypy.tools.custom_verbose_logger = cherrypy.Tool('before_error_response', _custom_verbose_logger)
+    full_msg = '\n'.join([msg, 'Exception encountered', page_location, admin_txt, post_txt, session_txt, headers_txt])
+    log.error(full_msg, exc_info=True)
+cherrypy.tools.custom_verbose_logger = cherrypy.Tool('before_error_response', log_exception_with_verbose_context)
 
 
 class StaticViews:

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -263,7 +263,7 @@ class Charge:
         except stripe.CardError as e:
             return 'Your card was declined with the following error from our processor: ' + str(e)
         except stripe.StripeError as e:
-            log.error('unexpected stripe error', exc_info=True)
+            uber.server.log_exception_with_verbose_context()
             return 'An unexpected problem occured while processing your card: ' + str(e)
 
 

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -262,15 +262,28 @@ class Charge:
             )
         except stripe.CardError as e:
             return 'Your card was declined with the following error from our processor: ' + str(e)
-        except stripe.error.InvalidRequestError as e:
-            log.error('Invalid source object provided', exc_info=True)
-            send_email(c.ADMIN_EMAIL, [c.ADMIN_EMAIL, 'dom@magfest.org'], 'MAGFest Stripe invalid request error',
-                       'Got an error while calling charge_cc(self, token={!r}):\n{}'
-                       .format(token, traceback.format_exc()))
-            return 'An invalid source object was provided: ' + str(e)
         except stripe.StripeError as e:
-            uber.server.log_exception_with_verbose_context()
+            error_txt = 'Got an error while calling charge_cc(self, token={!r})'.format(token)
+            report_critical_exception(msg=error_txt, subject='ERROR: MAGFest Stripe invalid request error')
             return 'An unexpected problem occured while processing your card: ' + str(e)
+
+
+def report_critical_exception(msg, subject="Critical Error"):
+    """
+    Report an exception to the loggers with as much context (request params/etc) as possible, and send an email.
+
+    Call this function when you really want to make some noise about something going really badly wrong.
+
+    :param msg: message to prepend to output
+    :param subject: optional: subject for emails going out
+    """
+
+    # log with lots of cherrypy context in here
+    uber.server.log_exception_with_verbose_context(msg)
+
+    # also attempt to email the admins
+    # TODO: Don't hardcode emails here.
+    send_email(c.ADMIN_EMAIL, [c.ADMIN_EMAIL, 'dom@magfest.org'], subject, msg + '\n{}'.format(traceback.format_exc()))
 
 
 def get_page(page, queryset):


### PR DESCRIPTION
trying to catch some issues happening in here that are masked by our currently user-friendly handling of Stripe exceptions

this will print the usual stuff when we get an exception - request params, session, etc