### PR TITLE
Let Uber Admins See Group Weighted Hours

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -69,7 +69,6 @@ def sum(values, attribute):
     return sum
 
 
-
 def _getter(x, attrName):
     if '.' in attrName:
         first, rest = attrName.split('.', 1)

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -61,6 +61,15 @@ def numeric_range(count):
     return range(count)
 
 
+@register.filter
+def sum(values, attribute):
+    sum = 0
+    for value in values:
+        sum += getattr(value, attribute, 0)
+    return sum
+
+
+
 def _getter(x, attrName):
     if '.' in attrName:
         first, rest = attrName.split('.', 1)

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -243,6 +243,7 @@
 {% if not group.is_new %} <a style="font-size:10pt" href="../preregistration/group_members?id={{ group.id }}">Link for group leader</a> {% endif %}
 {% if not group.is_new and group.sorted_attendees %}
     <hr/>
+    <h5>Total Hours: {{ group.attendees|sum:'weighted_hours' }}</h5>
     <h3> Badges: &nbsp; </h3>
     <table style="width:auto;">
     {% for attendee in group.attendees %}
@@ -288,6 +289,7 @@
                     <b>Kicked in an extra ${{ attendee.amount_extra }}!</b>
                 {% endif %}
             </td>
+            <td style="padding:15px;">{{ attendee.weighted_hours }} Hours</td>
         </tr>
     {% endfor %}
     </table>


### PR DESCRIPTION
This pull request will fix #2215 by adding a column with the weighted hours of each attendee, as well as add a new django tag `sum` usable like so `attendees|sum:'weighted_hours'`