### PR TITLE
Fix silent failure of change badge page when updating minor to attendee

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -154,8 +154,7 @@ class Root:
                     attendee.birthdate = attendee.birthdate\
                         .replace(year=int(attendee.birthdate.year - reduce_years_by))
                     attendee.ribbon = c.NO_RIBBON
-                    birthday_message = "This attendee's birth-year has been changed to make them 18," \
-                                       " please make sure to update it accordingly."
+                    birthday_message = "This attendee's birth year may now be incorrect. Please fix it."
 
             message = check(attendee)
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -142,7 +142,7 @@ class Root:
             except ValueError:
                 attendee.badge_num = None
 
-            birthday_message = False
+            birthday_message = None
             # This if statement will check if the badge has changed from Minor, to Not-Minor
             # If it has it will alter their birthday to be 18 so that the badge is not re-saved as a minor.
             if attendee.badge_type != c.CHILD_BADGE and old_badge_type == c.CHILD_BADGE:

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -154,7 +154,7 @@ class Root:
                     attendee.birthdate = attendee.birthdate\
                         .replace(year=int(attendee.birthdate.year - reduce_years_by))
                     attendee.ribbon = c.NO_RIBBON
-                    birthday_message = "This attendee's birth year may now be incorrect. Please fix it."
+                    birthday_message = " This attendee's birth year may now be incorrect. Please fix it."
 
             message = check(attendee)
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -142,6 +142,14 @@ class Root:
             except ValueError:
                 attendee.badge_num = None
 
+            if attendee.badge_type != c.CHILD_BADGE and old_badge_type == c.CHILD_BADGE:
+                day = c.EPOCH.date() if date.today() <= c.EPOCH.date() else sa.localized_now().date()
+                attendee_age = (day - attendee.birthdate).days // 365.2425
+                reduce_years_by = 18-attendee_age
+                attendee.birthdate = attendee.birthdate\
+                    .replace(year=int(attendee.birthdate.year - reduce_years_by))
+                attendee.ribbon = c.NO_RIBBON
+
             message = check(attendee)
 
             if not message:

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -142,19 +142,31 @@ class Root:
             except ValueError:
                 attendee.badge_num = None
 
+            altered = False
+            # This if statement will check if the badge has changed from Minor, to Not-Minor
             if attendee.badge_type != c.CHILD_BADGE and old_badge_type == c.CHILD_BADGE:
+                # This will set the date either to the start of MAGFest, or if that has already passed, this moment.
                 day = c.EPOCH.date() if date.today() <= c.EPOCH.date() else sa.localized_now().date()
+                # This calculates how old the attendee is
                 attendee_age = (day - attendee.birthdate).days // 365.2425
+                # This figures out how many years need to be subtracted from their current birthyear to make them 18
+                # Subtracted because 1993-2 == 1991
                 reduce_years_by = 18-attendee_age
+                # Make sure they aren't going to be younger instead of older
                 if reduce_years_by > 0.0:
                     attendee.birthdate = attendee.birthdate\
                         .replace(year=int(attendee.birthdate.year - reduce_years_by))
+                    # Remove minor ribbon.
                     attendee.ribbon = c.NO_RIBBON
+                    altered = True
 
             message = check(attendee)
 
             if not message:
                 message = session.update_badge(attendee, old_badge_type, old_badge_num)
+                if altered:
+                    message = "This attendee's birth-year has been changed to make them 18," \
+                              " please make sure to update it accordingly"
                 raise HTTPRedirect('form?id={}&message={}', attendee.id, message or '')
 
         return {

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -146,9 +146,10 @@ class Root:
                 day = c.EPOCH.date() if date.today() <= c.EPOCH.date() else sa.localized_now().date()
                 attendee_age = (day - attendee.birthdate).days // 365.2425
                 reduce_years_by = 18-attendee_age
-                attendee.birthdate = attendee.birthdate\
-                    .replace(year=int(attendee.birthdate.year - reduce_years_by))
-                attendee.ribbon = c.NO_RIBBON
+                if reduce_years_by > 0.0:
+                    attendee.birthdate = attendee.birthdate\
+                        .replace(year=int(attendee.birthdate.year - reduce_years_by))
+                    attendee.ribbon = c.NO_RIBBON
 
             message = check(attendee)
 


### PR DESCRIPTION
When updating a minor to an attendee through the change badge page, it will silently fail and say that the badge was updated. The following changes automatically adjust the minors age to be 18 so that they may become an attendee.