### PR TITLE
Fix Error of Being Unable to Register Child Badges

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -195,7 +195,6 @@ class Root:
         charge = Charge(listify(self.unpaid_preregs.values()))
         if charge.total_cost <= 0:
             for attendee in charge.attendees:
-                attendee.paid = c.NEED_NOT_PAY
                 session.add(attendee)
 
             for group in charge.groups:

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -191,12 +191,31 @@ class Root:
         attendee, group = self._get_unsaved(id)
         return {'attendee': attendee}
 
+    def freereg_payment(self, session):
+        charge = Charge(listify(self.unpaid_preregs.values()))
+        if charge.total_cost == 0:
+            for attendee in charge.attendees:
+                attendee.paid = c.HAS_PAID
+                attendee.amount_paid = attendee.total_cost
+                session.add(attendee)
+
+            for group in charge.groups:
+                group.amount_paid = group.default_cost - group.amount_extra
+                for attendee in group.attendees:
+                    attendee.amount_paid = attendee.total_cost - attendee.badge_cost
+                session.add(group)
+
+            self.unpaid_preregs.clear()
+            self.paid_preregs.extend(charge.targets)
+            raise HTTPRedirect('paid_preregistrations?payment_received={}', charge.dollar_amount)
+        else:
+            message = "These badges aren't free! Please pay for them."
+            raise HTTPRedirect('index?message={}', message)
+
     @credit_card
     def prereg_payment(self, session, payment_id, stripeToken):
         charge = Charge.get(payment_id)
-        if not charge.total_cost:
-            message = 'Your preregistration has already been paid for, so your credit card has not been charged'
-        elif charge.amount != charge.total_cost:
+        if charge.amount != charge.total_cost:
             message = 'Our preregistration price has gone up; please fill out the payment form again at the higher price'
         else:
             message = charge.charge_cc(stripeToken)

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -32,7 +32,11 @@
     <div class="row">
         <div class="col-sm-8 col-sm-offset-2">
             <div class="col-sm-5 text-center">
-                {% stripe_form prereg_payment charge %}
+                {% if charge.total_cost > 0 %}
+                    {% stripe_form prereg_payment charge %}
+                {% else %}
+                    <a href="freereg_payment">{% stripe_button "Register!" %}</a>
+                {% endif %}
             </div>
             <div class="col-sm-2 text-center">
                 or

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -35,7 +35,7 @@
                 {% if charge.total_cost > 0 %}
                     {% stripe_form prereg_payment charge %}
                 {% else %}
-                    <a href="freereg_payment">{% stripe_button "Register!" %}</a>
+                    <a href="process_free_prereg">{% stripe_button "Register!" %}</a>
                 {% endif %}
             </div>
             <div class="col-sm-2 text-center">


### PR DESCRIPTION
Currently, when an attendee's cart has a total cost of ZERO they are required to still put in their credit card information, and after doing so the page then returns that they have free badges and have not been charged. BUT, we never actually run the code to add them to the database, a line of code under preregistration/prereg_payment will return to the index before we ever get the chance. 

This should fix that.