### PR TITLE
Allow children to register at-door without entering CC info

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1096,7 +1096,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.paid != c.REFUNDED:
             self.amount_refunded = 0
 
-        if self.overridden_price == 0 and self.paid == c.NOT_PAID:
+        if self.badge_cost == 0 and self.paid == c.NOT_PAID:
             self.paid = c.NEED_NOT_PAY
 
         if c.AT_THE_CON and self.badge_num and (self.is_new or self.badge_type not in c.PREASSIGNED_BADGE_TYPES):
@@ -1209,7 +1209,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         elif self.is_presold_oneday:
             return c.get_presold_oneday_price(self.badge_type)
         elif self.age_discount != 0:
-            return c.get_attendee_price(registered) + self.age_discount
+            return max(0, c.get_attendee_price(registered) + self.age_discount)
         elif self.group and self.paid == c.PAID_BY_GROUP:
             return c.get_attendee_price(registered) - c.GROUP_DISCOUNT
         else:

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -528,8 +528,8 @@ class Root:
     @check_atd
     def pay(self, session, id, message=''):
         attendee = session.attendee(id)
-        if attendee.paid == c.HAS_PAID:
-            raise HTTPRedirect('register?message={}', 'You are already paid and should proceed to the preregistration desk to pick up your badge')
+        if attendee.paid != c.NOT_PAID:
+            raise HTTPRedirect('register?message={}', 'You are already paid (or registered for a free badge) and should proceed to the preregistration desk to pick up your badge')
         else:
             return {
                 'message': message,


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2207 and sets need_not_pay based on badge cost, not just overridden_price, so that we can then fix https://github.com/magfest/ubersystem/issues/2233 by checking for anything that is not "NOT_PAID" and redirect away from the Stripe form.