### PR TITLE
Update price-based unit tests to reflect changed functionality

### DIFF
--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -12,7 +12,7 @@ class TestCosts:
         assert 20 == Attendee().badge_cost
         assert 30 == Attendee(overridden_price=30).badge_cost
         assert 0 == Attendee(paid=c.NEED_NOT_PAY).badge_cost
-        assert 0 == Attendee(paid=c.PAID_BY_GROUP).badge_cost
+        assert 20 == Attendee(paid=c.PAID_BY_GROUP).badge_cost
 
     def test_total_cost(self):
         assert 20 == Attendee().total_cost
@@ -25,19 +25,19 @@ class TestCosts:
         assert 0 == Attendee(amount_paid=50).amount_unpaid
         assert 0 == Attendee(amount_paid=51).amount_unpaid
 
-    def test_discount(self, monkeypatch):
+    def test_age_discount(self, monkeypatch):
         monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 5})
         assert 15 == Attendee().total_cost
         assert 20 == Attendee(amount_extra=5).total_cost
-        assert 5 == Attendee(overridden_price=10).total_cost
-        assert 10 == Attendee(overridden_price=10, amount_extra=5).total_cost
+        assert 10 == Attendee(overridden_price=10).total_cost
+        assert 15 == Attendee(overridden_price=10, amount_extra=5).total_cost
 
-    def test_free(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 999})  # make sure we minimizee non-kickin costs at 0
+    def test_age_free(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 999})  # makes badge_cost free unless overridden_price is set
         assert 0 == Attendee().total_cost
         assert 5 == Attendee(amount_extra=5).total_cost
-        assert 0 == Attendee(overridden_price=10).total_cost
-        assert 5 == Attendee(overridden_price=10, amount_extra=5).total_cost
+        assert 10 == Attendee(overridden_price=10).total_cost
+        assert 15 == Attendee(overridden_price=10, amount_extra=5).total_cost
 
 
 def test_is_unpaid():

--- a/uber/tests/models/test_config.py
+++ b/uber/tests/models/test_config.py
@@ -30,7 +30,7 @@ class TestPriceLimits:
         monkeypatch.setattr(c, 'PRICE_LIMITS', {1: 50})
 
     def test_under_limit_no_price_bump(self):
-        assert 40 == c.get_attendee_price(datetime.now(UTC))
+        assert 40 == c.get_attendee_price()
 
     def test_over_limit_price_bump(self):
         session = Session().session
@@ -41,7 +41,7 @@ class TestPriceLimits:
             session.commit()
 
         assert c.BADGES_SOLD == 1
-        assert 50 == c.get_attendee_price(datetime.now(UTC))
+        assert 50 == c.get_attendee_price()
 
     def test_refunded_badge_price_bump(self):
         session = Session().session
@@ -52,7 +52,7 @@ class TestPriceLimits:
             session.commit()
 
         assert c.BADGES_SOLD == 1
-        assert 50 == c.get_attendee_price(datetime.now(UTC))
+        assert 50 == c.get_attendee_price()
 
     def test_invalid_badge_no_price_bump(self):
         session = Session().session
@@ -63,7 +63,7 @@ class TestPriceLimits:
             session.commit()
 
         assert c.BADGES_SOLD == 0
-        assert 40 == c.get_attendee_price(datetime.now(UTC))
+        assert 40 == c.get_attendee_price()
 
     def test_free_badge_no_price_bump(self):
         session = Session().session
@@ -74,6 +74,6 @@ class TestPriceLimits:
             session.commit()
 
         assert c.BADGES_SOLD == 0
-        assert 40 == c.get_attendee_price(datetime.now(UTC))
+        assert 40 == c.get_attendee_price()
 
     # todo: Test badges that are paid by group


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2225. I had changed the way group pricing and discounts worked, but failed to update the unit tests to match. This is me catching up.

Specifically, paid_by_group badges are no longer set to $0 owed, and overridden_price now overrides age-based discounts.