### PR TITLE
Make checkgroup use labels

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -214,7 +214,7 @@ class checkgroup(template.Node):
         results = []
         for num, desc in options:
             checked = 'checked' if str(num) in defaults else ''
-            results.append('<nobr><input type="checkbox" name="{}" value="{}" {} /> {}</nobr>'
+            results.append('<label><input type="checkbox" name="{}" value="{}" {} /> {}</label>'
                            .format(self.field_name, num, checked, desc))
         return '&nbsp;&nbsp\n'.join(results)
 

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -214,7 +214,7 @@ class checkgroup(template.Node):
         results = []
         for num, desc in options:
             checked = 'checked' if str(num) in defaults else ''
-            results.append('<label><input type="checkbox" name="{}" value="{}" {} /> {}</label>'
+            results.append('<label style="font-weight: normal;"><input type="checkbox" name="{}" value="{}" {} /> {}</label>'
                            .format(self.field_name, num, checked, desc))
         return '&nbsp;&nbsp\n'.join(results)
 


### PR DESCRIPTION
nobr is not standard html and labels let you click the label to check the box. 

This has caused the interest in prereg to become bold as it is now picking up a bootstrap style.

Fixes https://github.com/magfest/ubersystem/issues/2243.