### PR TITLE
Always return date-based badge price if it's between epoch and eschaton

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -113,14 +113,11 @@ class Config(_Overridable):
                     if c.EPOCH >= day >= c.ESCHATON:
                         return price
 
-            if dt or c.HARDCORE_OPTIMIZATIONS_ENABLED:
                 # Disable the bucket-based pricing if we're checking an existing badge OR
                 # if we have hardcore_optimizations_enabled config on.
-                badges_sold = 0
-            else:
                 # this is a database query and very expensive
-                badges_sold = self.BADGES_SOLD
-            
+                badges_sold = self.BADGES_SOLD if dt or c.HARDCORE_OPTIMIZATIONS_ENABLED else 0
+
             for badge_cap, bumped_price in sorted(self.PRICE_LIMITS.items()):
                 if badges_sold >= badge_cap and bumped_price > price:
                     price = bumped_price

--- a/uber/config.py
+++ b/uber/config.py
@@ -112,12 +112,16 @@ class Config(_Overridable):
                 badges_sold = 0
             else:
                 dt = sa.localized_now()
-                # this is a database query and very expensive
-                badges_sold = self.BADGES_SOLD
 
             for day, bumped_price in sorted(self.PRICE_BUMPS.items()):
                 if (dt or datetime.now(UTC)) >= day:
                     price = bumped_price
+                    # If we set a price during the event, it should be used regardless of badge sales
+                    if c.EPOCH >= day >= c.ESCHATON:
+                        return price
+
+            # this is a database query and very expensive
+            badges_sold = self.BADGES_SOLD
             for badge_cap, bumped_price in sorted(self.PRICE_LIMITS.items()):
                 if badges_sold >= badge_cap and bumped_price > price:
                     price = bumped_price

--- a/uber/config.py
+++ b/uber/config.py
@@ -106,22 +106,21 @@ class Config(_Overridable):
         price = self.INITIAL_ATTENDEE
         if self.PRICE_BUMPS_ENABLED:
 
-            if dt or c.HARDCORE_OPTIMIZATIONS_ENABLED:
-                # Disable the bucket-based pricing if we're checking an existing badge OR
-                # if we have hardcore_optimizations_enabled config on.
-                badges_sold = 0
-            else:
-                dt = sa.localized_now()
-
             for day, bumped_price in sorted(self.PRICE_BUMPS.items()):
-                if (dt or datetime.now(UTC)) >= day:
+                if (dt or sa.localized_now()) >= day:
                     price = bumped_price
                     # If we set a price during the event, it should be used regardless of badge sales
                     if c.EPOCH >= day >= c.ESCHATON:
                         return price
 
-            # this is a database query and very expensive
-            badges_sold = self.BADGES_SOLD
+            if dt or c.HARDCORE_OPTIMIZATIONS_ENABLED:
+                # Disable the bucket-based pricing if we're checking an existing badge OR
+                # if we have hardcore_optimizations_enabled config on.
+                badges_sold = 0
+            else:
+                # this is a database query and very expensive
+                badges_sold = self.BADGES_SOLD
+            
             for badge_cap, bumped_price in sorted(self.PRICE_LIMITS.items()):
                 if badges_sold >= badge_cap and bumped_price > price:
                     price = bumped_price


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2235. Also moves around the badges_sold calculation so we only poll the DB if we need to.