### PR TITLE
Hide shirt levels after shirt_deadline to fix at-door kickin display

### DIFF
--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -78,7 +78,7 @@
                 extra: 0
             }]
         };
-        {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS and not attendee.gets_free_shirt %}
+        {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS and c.SHIRT_AVAILABLE %}
             BADGE_TYPES.options.push({
                 title: 'Add a tshirt',
                 description: 'Add a {{ c.EVENT_NAME }} themed t-shirt to your registration.',

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -105,7 +105,7 @@
     </div>
 {% endif %}
 
-{% if c.DONATIONS_ENABLED and c.PREREG_DONATION_OPTS and c.PAGE_PATH != '/registration/form' %}
+{% if c.DONATIONS_ENABLED and c.PAGE_PATH != '/registration/form' and c.PREREG_DONATION_OPTS.length > 1 or attendee.amount_extra %}
     <script type="text/javascript">
         var donationChanged = function () {
             setVisible('.affiliate-row', $.val('amount_extra') > 0);
@@ -165,7 +165,7 @@
             {% popup_link "../static_views/givingExtra.html" "Why do this?" %}
             </label>
             <div class="col-sm-8">
-                {% if c.AFTER_SUPPORTER_DEADLINE and attendee.amount_extra >= c.SUPPORTER_LEVEL %}
+                {% if c.AFTER_SUPPORTER_DEADLINE and attendee.amount_extra >= c.SUPPORTER_LEVEL or c.AFTER_SHIRT_DEADLINE and attendee.amount_extra >= c.SHIRT_LEVEL %}
                     {{ attendee.amount_extra_label }}
                     <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" />
                 {% else %}


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2224 and fixes https://github.com/magfest/ubersystem/issues/2210 so that shirt_deadline is actually meaningful. Also adds shirt_count so it mirrors the way the supporter count works. Slightly tweaks the kick-in display so that it will be hidden for attendees who have not already kicked in if there's only one option (because that option is always 'no thanks').