### PR TITLE
Updated closing date.

### DIFF
--- a/uber/templates/emails/shifts/reminder.txt
+++ b/uber/templates/emails/shifts/reminder.txt
@@ -4,7 +4,7 @@ Thanks again for signing up to volunteer at {{ c.EVENT_NAME }}!  You're not curr
 
 Please sign up for shifts at {{ c.URL_BASE }}/signups/login and if you have trouble logging in, you can verify/update your personal information at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
 
-You can add / drop / change your shifts anytime until {{ c.EPOCH|datetime }}.
+You can add / drop / change your shifts anytime until {{ c.FINAL_EMAIL_DEADLINE|datetime }}.
 
 Please let us know if you have any questions.
 

--- a/uber/templates/emails/shifts/reminder.txt
+++ b/uber/templates/emails/shifts/reminder.txt
@@ -4,7 +4,7 @@ Thanks again for signing up to volunteer at {{ c.EVENT_NAME }}!  You're not curr
 
 Please sign up for shifts at {{ c.URL_BASE }}/signups/login and if you have trouble logging in, you can verify/update your personal information at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
 
-You can add / drop / change your shifts anytime until {{ c.UBER_TAKEDOWN|datetime }}.
+You can add / drop / change your shifts anytime until {{ c.EPOCH|datetime }}.
 
 Please let us know if you have any questions.
 


### PR DESCRIPTION
Emailed Code about this - but this email was linked to uber_takedown variable, which is set to be the middle of the event. 
I think that's old code related to when Uber was taken offline during load-in.
I have updated the link here to be Event Epoch (Start).

This makes it so volunteers can't change their schedule at event, but must have a DH/Staff Ops change the schedule, so the departments are aware of changes.