### PR TITLE
Stop charging staff badges in groups

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1100,7 +1100,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.paid != c.REFUNDED:
             self.amount_refunded = 0
 
-        if self.badge_cost == 0 and self.paid == c.NOT_PAID:
+        if self.badge_cost == 0 and self.paid in [c.NOT_PAID, c.PAID_BY_GROUP]:
             self.paid = c.NEED_NOT_PAY
 
         if c.AT_THE_CON and self.badge_num and (self.is_new or self.badge_type not in c.PREASSIGNED_BADGE_TYPES):
@@ -1171,6 +1171,8 @@ class Attendee(MagModel, TakesPaymentMixin):
 
         if self.badge_type == c.STAFF_BADGE:
             self.staffing = True
+            if not self.overridden_price and self.paid in [c.NOT_PAID, c.PAID_BY_GROUP]:
+                self.paid = c.NEED_NOT_PAY
 
         # remove trusted status from any dept we are not assigned to
         self.trusted_depts = ','.join(str(td) for td in self.trusted_depts_ints if td in self.assigned_depts_ints)

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -279,7 +279,7 @@
     <label class="col-sm-2 control-label">Badge Price</label>
     <div class="col-sm-6">
         Base Price: $<input type="text" style="width:4em" name="overridden_price" value="{{ attendee.badge_cost|floatformat:2 }}" />
-        <input type="checkbox" name="no_override" {% if not attendee.overridden_price %} checked {% endif %}> Automatically recalculate badge price.
+        <input type="checkbox" name="no_override" {% if attendee.overridden_price == None %} checked {% endif %}> Automatically recalculate badge price.
     </div>
 </div>
 


### PR DESCRIPTION
A slight oversight in the way we set up badge_cost for groups meant that if a staff was paid_by_group, they'd be treated as a regular attendee. Our overridden_price setting also was not respecting an overridden price of $0. This fixes both those problems.