### PR TITLE
Implement QR Codes for Check-In

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pytz==2014.4
 pep8==1.6.2
 alembic==0.8.7
 treepoem==1.0.1
-simple-crypt==4.1.7
+pycrypto==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ stripe==1.11.0
 pytz==2014.4
 pep8==1.6.2
 alembic==0.8.7
+treepoem==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytz==2014.4
 pep8==1.6.2
 alembic==0.8.7
 treepoem==1.0.1
+simple-crypt==4.1.7

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -365,8 +365,6 @@ AutomatedEmail(Attendee, '{EVENT_NAME} extra payment received', 'reg_workflow/gr
          lambda a: a.paid == c.PAID_BY_GROUP and a.amount_extra and a.amount_paid == a.amount_extra,
          needs_approval=False)
 
-AutomatedEmail(Attendee, '{EVENT_NAME} payment refunded', 'reg_workflow/payment_refunded.txt',
-         lambda a: a.amount_refunded)
 
 # Reminder emails for groups to allocated their unassigned badges.  These emails are safe to be turned on for
 # all events, because they will only be sent for groups with unregistered badges, so if group preregistration
@@ -495,6 +493,12 @@ AutomatedEmail(Attendee, '{EVENT_NAME} parental consent form reminder', 'reg_wor
                lambda a: c.CONSENT_FORM_URL and a.age_group_conf['consent_form'],
                when=days_before(14, c.EPOCH))
 
+
+# Emails sent out to all attendees who can check in. These emails contain useful information about the event and are
+# sent close to the event start date.
+AutomatedEmail(Attendee, 'Check in faster at {EVENT_NAME}', 'reg_workflow/attendee_qrcode.html',
+               lambda a: not a.is_not_ready_to_checkin and c.QR_CODE_PASSWORD,
+               when=days_before(14, c.EPOCH), ident='qrcode_for_checkin')
 
 for _conf in DeptChecklistConf.instances.values():
     DeptChecklistEmail(_conf)

--- a/uber/common.py
+++ b/uber/common.py
@@ -19,7 +19,6 @@ import importlib
 import mimetypes
 import threading
 import traceback
-import simplecrypt
 from glob import glob
 from uuid import uuid4
 from pprint import pprint
@@ -29,6 +28,7 @@ from hashlib import sha512
 from functools import wraps
 from xml.dom import minidom
 from random import randrange
+from Crypto.Cipher import AES
 from contextlib import closing
 from time import sleep, mktime
 from io import StringIO, BytesIO

--- a/uber/common.py
+++ b/uber/common.py
@@ -14,6 +14,7 @@ import inspect
 import decimal
 import binascii
 import warnings
+import treepoem
 import importlib
 import mimetypes
 import threading

--- a/uber/common.py
+++ b/uber/common.py
@@ -19,6 +19,7 @@ import importlib
 import mimetypes
 import threading
 import traceback
+import simplecrypt
 from glob import glob
 from uuid import uuid4
 from pprint import pprint

--- a/uber/config.py
+++ b/uber/config.py
@@ -502,7 +502,9 @@ c.EVENT_YEAR = c.EPOCH.strftime('%Y')
 c.EVENT_MONTH = c.EPOCH.strftime('%B')
 c.EVENT_START_DAY = int(c.EPOCH.strftime('%d')) % 100
 c.EVENT_END_DAY = int(c.ESCHATON.strftime('%d')) % 100
+
 c.EVENT_QR_ID = c.EVENT_QR_ID or c.EVENT_NAME_AND_YEAR.replace(' ', '_').lower()
+c.QR_CODE_PASSWORD = sha512(c.QR_CODE_PASSWORD.encode('UTF-8')).hexdigest()[:24] if c.QR_CODE_PASSWORD else None
 
 c.DAYS = sorted({(dt.strftime('%Y-%m-%d'), dt.strftime('%a')) for dt, desc in c.START_TIME_OPTS})
 c.HOURS = ['{:02}'.format(i) for i in range(24)]

--- a/uber/config.py
+++ b/uber/config.py
@@ -502,6 +502,7 @@ c.EVENT_YEAR = c.EPOCH.strftime('%Y')
 c.EVENT_MONTH = c.EPOCH.strftime('%B')
 c.EVENT_START_DAY = int(c.EPOCH.strftime('%d')) % 100
 c.EVENT_END_DAY = int(c.ESCHATON.strftime('%d')) % 100
+c.EVENT_QR_ID = c.EVENT_QR_ID or c.EVENT_NAME_AND_YEAR.replace(' ','_').lower()
 
 c.DAYS = sorted({(dt.strftime('%Y-%m-%d'), dt.strftime('%a')) for dt, desc in c.START_TIME_OPTS})
 c.HOURS = ['{:02}'.format(i) for i in range(24)]

--- a/uber/config.py
+++ b/uber/config.py
@@ -502,7 +502,7 @@ c.EVENT_YEAR = c.EPOCH.strftime('%Y')
 c.EVENT_MONTH = c.EPOCH.strftime('%B')
 c.EVENT_START_DAY = int(c.EPOCH.strftime('%d')) % 100
 c.EVENT_END_DAY = int(c.ESCHATON.strftime('%d')) % 100
-c.EVENT_QR_ID = c.EVENT_QR_ID or c.EVENT_NAME_AND_YEAR.replace(' ','_').lower()
+c.EVENT_QR_ID = c.EVENT_QR_ID or c.EVENT_NAME_AND_YEAR.replace(' ', '_').lower()
 
 c.DAYS = sorted({(dt.strftime('%Y-%m-%d'), dt.strftime('%a')) for dt, desc in c.START_TIME_OPTS})
 c.HOURS = ['{:02}'.format(i) for i in range(24)]

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -31,6 +31,10 @@ organization_name = string(default='MAGFest')
 event_name = string(default='%(organization_name)s')
 year = string(default='')
 
+# This is a unique (between events!) ID used to prevent lookup collisions in QR codes.
+# If not set, we generate one using the event_name and year variables above.
+event_qr_id = string(default='')
+
 # These are used for web server configuration and for linking back to our
 # pages in emails; these definitely needs to be overridden in production.
 path = string(default="/magfest")
@@ -281,6 +285,10 @@ banned_staffers = string_list(default=list())
 #
 aws_access_key = string(default="")
 aws_secret_key = string(default="")
+
+# This is used to encrypt and decrypt attendee UUIDs for use in QR codes.
+# If not set, no QR codes are generated. Do not publish this key.
+qr_code_password = string(default="")
 
 
 [dates]

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -486,19 +486,6 @@ class Root:
             'affiliates':    session.affiliates()
         }
 
-    def barcode_generator(self, id):
-        cherrypy.response.headers['Content-Type'] = "image/png"
-
-        checkin_barcode = treepoem.generate_barcode(
-            barcode_type='azteccode',
-            data=id,
-            options={},
-        )
-        buffer = BytesIO()
-        checkin_barcode.save(buffer, "PNG")
-        buffer.seek(0)
-        return cherrypy.lib.file_generator(buffer)
-
     def guest_food(self, session, id):
         attendee = session.attendee(id)
         assert attendee.badge_type == c.GUEST_BADGE, 'This form is for guests only'

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -486,6 +486,19 @@ class Root:
             'affiliates':    session.affiliates()
         }
 
+    def barcode_generator(self, id):
+        cherrypy.response.headers['Content-Type'] = "image/png"
+
+        checkin_barcode = treepoem.generate_barcode(
+            barcode_type='azteccode',
+            data=id,
+            options={},
+        )
+        buffer = BytesIO()
+        checkin_barcode.save(buffer, "PNG")
+        buffer.seek(0)
+        return cherrypy.lib.file_generator(buffer)
+
     def guest_food(self, session, id):
         attendee = session.attendee(id)
         assert attendee.badge_type == c.GUEST_BADGE, 'This form is for guests only'

--- a/uber/templates/emails/reg_workflow/attendee_qrcode.html
+++ b/uber/templates/emails/reg_workflow/attendee_qrcode.html
@@ -1,0 +1,26 @@
+<html>
+<head></head>
+<body>
+
+{{ attendee.first_name }},
+
+{{ c.EVENT_NAME_AND_YEAR }} is coming up soon ({% event_dates %})!
+
+<br/><br/>To help speed up check-in, please bring the QR code below with you when you pick up your badge. You can print it out or display it on your phone.
+<br/><br/>Please note, however, that this code is <strong>not</strong> a replacement for your photo ID. You must still present your photo ID when picking up your badge.
+You cannot pick up badges on behalf of other attendees, even if you have a copy of their QR code.
+<img src="{{ c.URL_BASE }}/registration/qrcode_generator?data={{ attendee.id }}" />
+
+<br/> <br/>
+{% include "emails/reg_workflow/reg_notes.html" %}
+
+{% if attendee.is_transferable %}
+    <br/> <br/>
+    {{ c.EVENT_NAME }} has a no-refund policy for all registrations.  If for any reason you can't make it, we allow and encourage
+    you to resell your registration for the exact price you paid for it.  To transfer your registration to another person,
+    send them <a href="{{ c.URL_BASE }}/preregistration/transfer_badge?id={{ attendee.id }}">this personalized link</a>,
+    which will work until {{ c.FINAL_EMAIL_DEADLINE|datetime }}.
+{% endif %}
+
+</body>
+</html>

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -61,7 +61,7 @@
     </div>
 </div>
 
-{% if not attendee.is_not_ready_to_checkin %}
+{% if not attendee.is_not_ready_to_checkin and c.QR_CODE_PASSWORD %}
     <div class="form-group">
     <label class="col-sm-2 control-label">Check-in Barcode</label>
         <div class="col-sm-6">

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -61,6 +61,18 @@
     </div>
 </div>
 
+{% if not attendee.is_not_ready_to_checkin %}
+    <div class="form-group">
+    <label class="col-sm-2 control-label">Check-in Barcode</label>
+        <div class="col-sm-6">
+        <img src="barcode_generator?id={{ attendee.id }}" />
+        </div>
+    <p class="help-block col-sm-6 col-sm-offset-2">This can be shown at badge pick-up to help check in. <br/>
+        <strong>This barcode <em>does not</em> replace your Photo ID.</strong> <br/>
+        You will receive an email with this code before the event.</p>
+    </div>
+{% endif %}
+
 </form>
 
     {% if not attendee.amount_paid or not attendee.paid == c.NEED_NOT_PAY %}
@@ -68,6 +80,7 @@
         <input type="hidden" name="id" value="{{ attendee.id }}"/>
     </form>
     {% endif %}
+
 </div>
 
 {% endblock %}

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -65,7 +65,7 @@
     <div class="form-group">
     <label class="col-sm-2 control-label">Check-in Barcode</label>
         <div class="col-sm-6">
-        <img src="barcode_generator?id={{ attendee.id }}" />
+        <img src="../registration/qrcode_generator?data={{ attendee.id }}" />
         </div>
     <p class="help-block col-sm-6 col-sm-offset-2">This can be shown at badge pick-up to help check in. <br/>
         <strong>This barcode <em>does not</em> replace your Photo ID.</strong> <br/>

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -8,7 +8,38 @@
     $(function(){
         document.getElementById('search_bar').select();
     });
-    
+
+    $(function(){
+        $("#qr-scan").click(function(){
+            bootbox.prompt({
+                title: "Scan QR Code",
+                backdrop: true,
+                callback: function (result) {
+                    if(result) {
+                        $.ajax({
+                            method: 'POST',
+                            url: 'qrcode_reader',
+                            dataType: 'json',
+                            data: {qrcode: result, csrf_token: csrf_token},
+                            success: function (json) {
+                                toastr.clear();
+                                var message = json.message;
+                                if (json.success) {
+                                    $("#search_bar").val(json.data).parents('form').submit()
+                                } else {
+                                    toastr.error(message);
+                                }
+                            },
+                            error: function () {
+                                toastr.error('Unable to connect to server, please try again.');
+                            }
+                        });
+                    }
+                }
+            });
+        });
+    });
+
     $(function() {
         var $dialog = $('#checkin-dialog').dialog({
             autoOpen: false,
@@ -140,6 +171,8 @@
         {% else %}
             <a class="btn btn-info" href="index?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode }}&invalid=True">Show all badge statuses</a>
         {% endif %}
+
+        <button class="btn btn-primary" id="qr-scan">Scan QR Code</button>
     </div>
     <div class="panel col-md-4">
         <div class="col-md-6">{{ attendee_count }} Attendee{{ attendee_count|pluralize }}</div>

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1,6 +1,9 @@
 from uber.common import *
 
 
+qr_cipher = AES.new(c.QR_CODE_PASSWORD, AES.MODE_ECB)
+
+
 class HTTPRedirect(cherrypy.HTTPRedirect):
     """
     CherryPy uses exceptions to indicate things like HTTP 303 redirects.  This


### PR DESCRIPTION
Fixes #2107.

Currently, this feature branch Works. It:
1. Encrypts attendee's UUIDs and displays an Aztec QR code on their confirmation page
2. Takes a QR code via a modal pop-up, decrypts it, then automatically searches for the decrypted UUID.

There's a few problems with this as it stands.
1. ~There's no emails generated or sent. Sending an automated email will be pretty simple, but it will access our server to display the QR code when people view the email, which is not necessarily ideal. However, some folks have pointed out that email clients frequently cache images, so this may be fine.~ The email now exists -- we'll need to see what kind of performance hit it entails.
2. ~Encryption and decryption are Slow. This is the fault of the encryption library I chose. They explain the reasoning here: https://github.com/andrewcooke/simple-crypt#speed It wasn't until I implemented it that I realized what 'a couple seconds per decryption' feels like. The speed may not be acceptable, in which case we'll have to find a new library (most of this code shouldn't change, though).~ Thanks to Eli's comments below, I've gotten rid of the delay.
3. You have to use a special modal pop-up to scan the QR code. There's a javascript library to 'detect' barcode scanners that we can implement (https://github.com/kabachello/jQuery-Scanner-Detection), though we'll always want this pop-up as a fallback (some scanners are weird and function more like clipboards than fast keyboards).
4. ~In order for our barcode generation library `treepoem` to work, you need to `sudo apt-get install libjpeg-dev ghostscript` before you install it. There's no way around this unless we want to use someone else's server to generate barcodes or set up our own node.js app (please not now).~ Solved via https://github.com/magfest/ubersystem-puppet/pull/121 (thanks Dom!)

All of these are solvable problems but most of them require non-unilateral decision-making.