### PR TITLE
Add Internal and External Schedules To Uber Navbar

### DIFF
--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -69,7 +69,8 @@
             {% endif %}
             {% if c.HAS_STUFF_ACCESS %}
                 {Schedule: [
-                    {'View Schedule': '../schedule/'},
+                    {% if c.ALT_SCHEDULE_URL %}{'View External Schedule': '../schedule/guidebook'},{% endif %}
+                    {'View Internal Schedule': '../schedule/'},
                     {'Edit Schedule': '../schedule/edit'}
                 ]},
             {% endif %}

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -69,8 +69,8 @@
             {% endif %}
             {% if c.HAS_STUFF_ACCESS %}
                 {Schedule: [
-                    {% if c.ALT_SCHEDULE_URL %}{'View External Schedule': '../schedule/guidebook'},{% endif %}
-                    {'View Internal Schedule': '../schedule/'},
+                    {% if c.ALT_SCHEDULE_URL %}{'View External Schedule': '../schedule/'},{% endif %}
+                    {'View Internal Schedule': '../schedule/internal'},
                     {'Edit Schedule': '../schedule/edit'}
                 ]},
             {% endif %}

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -69,8 +69,8 @@
             {% endif %}
             {% if c.HAS_STUFF_ACCESS %}
                 {Schedule: [
-                    {% if c.ALT_SCHEDULE_URL %}{'View External Schedule': '../schedule/'},{% endif %}
-                    {'View Internal Schedule': '../schedule/internal'},
+                    {'View Schedule': '../schedule/'},
+                    {'View Schedule (Internal Only)': '../schedule/internal'},
                     {'Edit Schedule': '../schedule/edit'}
                 ]},
             {% endif %}


### PR DESCRIPTION
To be merged with PR in Panels, not yet made, that moves guidebook redirect to schedule/redirect, and lets schedule/index be viewable again by internal staff. I had a staffer bring up to me that they found it useful, and quick to load as our website isn't filled with ads or tracking. I was unaware we essentially removed the old schedule by blocking all access to it.