### PR TITLE
fixes #2074

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -885,6 +885,9 @@ class Group(MagModel, TakesPaymentMixin):
             self.approved = datetime.now(UTC)
         if self.leader and self.is_dealer:
             self.leader.ribbon = c.DEALER_RIBBON
+        if not self.is_unpaid:
+            for a in self.attendees:
+                a.presave_adjustments()
 
     @property
     def sorted_attendees(self):
@@ -1141,7 +1144,7 @@ class Attendee(MagModel, TakesPaymentMixin):
                 log.error('unable to send banned email about {}', self)
         elif self.badge_status == c.NEW_STATUS and not self.placeholder and self.first_name \
                 and (self.paid in [c.HAS_PAID, c.NEED_NOT_PAY]
-                     or self.paid == c.PAID_BY_GROUP and self.group_id and not self.group.amount_unpaid):
+                     or self.paid == c.PAID_BY_GROUP and self.group_id and not self.group.is_unpaid):
             self.badge_status = c.COMPLETED_STATUS
 
     @presave_adjustment

--- a/uber/tests/models/test_group.py
+++ b/uber/tests/models/test_group.py
@@ -185,3 +185,12 @@ def test_new_extra():
 def test_existing_extra(monkeypatch):
     monkeypatch.setattr(Group, 'is_new', False)
     assert 0 == Group(attendees=[Attendee(paid=c.PAID_BY_GROUP, amount_extra=20)]).amount_extra
+
+
+def test_group_badge_status_cascade():
+    g = Group(cost=0, auto_recalc=False)
+    taken = Attendee(group_id=g.id, paid=c.PAID_BY_GROUP, badge_status=c.NEW_STATUS, first_name='Liam', last_name='Neeson')
+    floating = Attendee(group_id=g.id, paid=c.PAID_BY_GROUP, badge_status=c.NEW_STATUS)
+    g.attendees = [taken, floating]
+    g.presave_adjustments()
+    assert taken.badge_status == c.COMPLETED_STATUS and floating.badge_status == c.NEW_STATUS


### PR DESCRIPTION
Now when we save a group, it'll cascade down to mark the attendees as having the correct badge status by running the standard presave-adjustments on those attendees if the group is all paid up.