### PR TITLE
specific emails may now be enabled onsite

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -359,7 +359,7 @@ AutomatedEmail(Group, '{EVENT_NAME} group payment received', 'reg_workflow/group
 
 AutomatedEmail(Attendee, '{EVENT_NAME} group registration confirmed', 'reg_workflow/attendee_confirmation.html',
          lambda a: a.group and a != a.group.leader and not a.placeholder,
-         needs_approval=False)
+         needs_approval=False, allow_during_con=True)
 
 AutomatedEmail(Attendee, '{EVENT_NAME} extra payment received', 'reg_workflow/group_donation.txt',
          lambda a: a.paid == c.PAID_BY_GROUP and a.amount_extra and a.amount_paid == a.amount_extra,

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -19,7 +19,7 @@ class AutomatedEmail:
 
     def __init__(self, model, subject, template, filter, *, when=(),
                  sender=None, extra_data=None, cc=None, bcc=None,
-                 post_con=False, needs_approval=True, ident=None):
+                 post_con=False, needs_approval=True, ident=None, allow_during_con=False):
 
         self.subject = subject.format(EVENT_NAME=c.EVENT_NAME)
         self.ident = ident or self.subject
@@ -28,7 +28,7 @@ class AutomatedEmail:
 
         self.instances[self.ident] = self
 
-        self.model, self.template, self.needs_approval = model, template, needs_approval
+        self.model, self.template, self.needs_approval, self.allow_during_con = model, template, needs_approval, allow_during_con
         self.cc = cc or []
         self.bcc = bcc or []
         self.extra_data = extra_data or {}
@@ -106,6 +106,7 @@ class AutomatedEmail:
         """
 
         return all(condition() for condition in [
+            lambda: not c.AT_THE_CON or self.allow_during_con,
             lambda: isinstance(model_inst, self.model),
             lambda: getattr(model_inst, 'email', None),
             lambda: not self._already_sent(model_inst),
@@ -189,8 +190,7 @@ class SendAllAutomatedEmailsJob:
 
         :param raise_errors: If False, exceptions are squashed during email sending and we'll try the next email.
         """
-        allowed_to_run = not c.AT_THE_CON and (c.DEV_BOX or c.SEND_EMAILS)
-        if not allowed_to_run:
+        if not (c.DEV_BOX or c.SEND_EMAILS):
             return
 
         if not SendAllAutomatedEmailsJob.run_lock.acquire(blocking=False):
@@ -351,7 +351,7 @@ ident naming RULES:
 
 AutomatedEmail(Attendee, '{EVENT_NAME} payment received', 'reg_workflow/attendee_confirmation.html',
          lambda a: a.paid == c.HAS_PAID,
-         needs_approval=False)
+         needs_approval=False, allow_during_con=True)
 
 AutomatedEmail(Group, '{EVENT_NAME} group payment received', 'reg_workflow/group_confirmation.html',
          lambda g: g.amount_paid == g.cost and g.cost != 0,

--- a/uber/tests/email/test_automated_email_categories.py
+++ b/uber/tests/email/test_automated_email_categories.py
@@ -62,6 +62,11 @@ class TestAutomatedEmailCategory:
     def test_should_send_not_approved(self, get_test_email_category, attendee1):
         assert not get_test_email_category._should_send(model_inst=attendee1)
 
+    def test_should_send_at_con(self, at_con, get_test_email_category, set_test_approved_idents, attendee1):
+        assert not get_test_email_category._should_send(model_inst=attendee1)
+        get_test_email_category.allow_during_con = True
+        assert get_test_email_category._should_send(model_inst=attendee1)
+
     # -----------
 
     def test_send_doesnt_throw_exception(self, monkeypatch, get_test_email_category):

--- a/uber/tests/email/test_automated_email_job.py
+++ b/uber/tests/email/test_automated_email_job.py
@@ -15,18 +15,13 @@ def send_all_emails_mock():
 
 @pytest.mark.usefixtures("email_subsystem_sane_setup")
 class TestSendAllAutomatedEmailsJob:
-    @pytest.mark.parametrize("c_at_the_con, c_send_emails, c_dev_box, expected_result", [
-        (True, True, True, 0),
-        (True, False, True, 0),
-        (True, True, False, 0),
-        (True, False, False, 0),
-        (False, True, True, 1),
-        (False, False, True, 1),
-        (False, True, False, 1),
-        (False, False, False, 0),
+    @pytest.mark.parametrize("c_send_emails, c_dev_box, expected_result", [
+        (True, True, 1),
+        (False, True, 1),
+        (True, False, 1),
+        (False, False, 0),
     ])
-    def test_run_when_config_changed(self, monkeypatch, send_all_emails_mock, c_at_the_con, c_send_emails, c_dev_box, expected_result):
-        monkeypatch.setattr(c, 'AT_THE_CON', c_at_the_con)
+    def test_run_when_config_changed(self, monkeypatch, send_all_emails_mock, c_send_emails, c_dev_box, expected_result):
         monkeypatch.setattr(c, 'SEND_EMAILS', c_send_emails)
         monkeypatch.setattr(c, 'DEV_BOX', c_dev_box)
 


### PR DESCRIPTION
This allow us to mark specific emails as being sendable while on-site.  Currently the only email we've marked this way is the one which confirms that an attendee has paid for their badge, which the regdesk department has asked us to turn on while on-site so that they don't have to answer emails about why people didn't get a confirmation email, etc.