### PR TITLE
Include invalid parameter in Attendee search

### DIFF
--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -150,6 +150,7 @@
     <div class="panel col-md-5">
         <form role="form" method="get" action="index">
             <input type="hidden" name="order" value="{{ order }}" />
+            <input type="hidden" name="invalid" value="{{ invalid }}" />
             <div class="input-group">
                 <input class="focus form-control" id="search_bar" type="text" name="search_text" value="{{ search_text }}" />
                 <span class="input-group-btn">


### PR DESCRIPTION
If you chose "show all badges" and THEN searched for a badge, you'd only get valid badges because we weren't passing the 'invalid' parameter in the search form. This has been annoying reg staff for a while.

Also includes the changes from https://github.com/magfest/ubersystem/pull/2283 cause I dun goofed.