### PR TITLE
Shirt model updates

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1381,16 +1381,6 @@ class Attendee(MagModel, TakesPaymentMixin):
            and self.badge_type in c.TRANSFERABLE_BADGE_TYPES \
            and not self.admin_account
 
-    # -----------------------------------------------------------------------------------------
-    # Swag shirts properties
-    #
-    # Attendees can get a swag (non-staff) shirt by either:
-    # 1) buying one, or
-    # 2) by being an eligible volunteer
-    #
-    # Staffers do not get swag shirts automatically
-    # -----------------------------------------------------------------------------------------
-
     @property
     def paid_for_a_swag_shirt(self):
         return self.amount_extra >= c.SHIRT_LEVEL
@@ -1426,6 +1416,12 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def merch(self):
+        """
+        Here is the business logic surrounding shirts:
+        -> people who kick in enough to get a shirt get a shirt
+        -> people with staff badges get a configurable number of staff shirts
+        -> volunteers who meet the requirements get a complementary swag shirt (NOT a staff shirt)
+        """
         merch = self.donation_swag
 
         if self.volunteer_swag_shirt_eligible:

--- a/uber/models.py
+++ b/uber/models.py
@@ -1043,7 +1043,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     ribbon       = Column(Choice(c.RIBBON_OPTS), default=c.NO_RIBBON, admin_only=True)
 
     affiliate    = Column(UnicodeText)
-    shirt        = Column(Choice(c.SHIRT_OPTS), default=c.NO_SHIRT)
+    shirt        = Column(Choice(c.SHIRT_OPTS), default=c.NO_SHIRT)   # attendee shirt size for both swag and staff shirts
     can_spam     = Column(Boolean, default=False)
     regdesk_info = Column(UnicodeText, admin_only=True)
     extra_merch  = Column(UnicodeText, admin_only=True)
@@ -1071,7 +1071,9 @@ class Attendee(MagModel, TakesPaymentMixin):
     can_work_setup    = Column(Boolean, default=False, admin_only=True)
     can_work_teardown = Column(Boolean, default=False, admin_only=True)
 
+    # TODO: a record of when an attendee is unable to pickup a shirt (which type? swag or staff? prob swag)
     no_shirt          = relationship('NoShirt', backref=backref('attendee', load_on_pending=True), uselist=False)
+
     admin_account     = relationship('AdminAccount', backref=backref('attendee', load_on_pending=True), uselist=False)
     food_restrictions = relationship('FoodRestrictions', backref=backref('attendee', load_on_pending=True), uselist=False)
 
@@ -1097,7 +1099,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.birthdate == '':
             self.birthdate = None
 
-        if not self.shirt_eligible:
+        if not self.gets_any_kind_of_shirt:
             self.shirt = c.NO_SHIRT
 
         if self.paid != c.REFUNDED:
@@ -1300,6 +1302,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         return None
 
     @property
+    # should be OK
     def shirt_size_marked(self):
         return self.shirt not in [c.NO_SHIRT, c.SIZE_UNKNOWN]
 
@@ -1375,23 +1378,42 @@ class Attendee(MagModel, TakesPaymentMixin):
            and self.badge_type in c.TRANSFERABLE_BADGE_TYPES \
            and not self.admin_account
 
-    @property
-    def gets_free_shirt(self):
-        return self.is_dept_head \
-            or self.badge_type == c.STAFF_BADGE \
-            or self.staffing and (self.assigned_depts and not self.takes_shifts or self.weighted_hours >= 6)
+    # -----------------------------------------------------------------------------------------
+    # Swag shirts properties
+    #
+    # Attendees can get a swag (non-staff) shirt by either:
+    # 1) buying one, or
+    # 2) by being an eligible volunteer
+    #
+    # Staffers do not get swag shirts automatically
+    # -----------------------------------------------------------------------------------------
 
     @property
-    def gets_paid_shirt(self):
+    def paid_for_a_swag_shirt(self):
         return self.amount_extra >= c.SHIRT_LEVEL
 
     @property
-    def gets_shirt(self):
-        return self.gets_paid_shirt or self.gets_free_shirt
+    def eligible_for_free_swag_shirt(self):
+        return self.badge_type != c.STAFF_BADGE and self.ribbon == c.VOLUNTEER_RIBBON
 
     @property
-    def shirt_eligible(self):
-        return self.gets_shirt or self.staffing
+    def completed_enough_shift_hours_to_claim_staff_shirt(self):
+        return bool(self.assigned_depts_ints) and (not self.takes_shifts or self.weighted_hours >= 6)
+
+    @property
+    def num_swag_shirts_owed(self):
+        return int(self.paid_for_a_swag_shirt) + int(self.eligible_for_free_swag_shirt)
+
+    @property
+    def gets_staff_shirt(self):
+        return self.badge_type == c.STAFF_BADGE
+
+    @property
+    def gets_any_kind_of_shirt(self):
+        return self.gets_staff_shirt or self.num_swag_shirts_owed > 0
+
+    # -----------------------------------------------------------------------------------------
+    # -----------------------------------------------------------------------------------------
 
     @property
     def has_personalized_badge(self):
@@ -1404,14 +1426,29 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def merch(self):
+        # KEEP
         merch = self.donation_swag
-        if self.gets_shirt and c.DONATION_TIERS[c.SHIRT_LEVEL] not in merch:
+
+
+
+        # FIX
+        """
+        if self.gets_paid_swag_shirt and c.DONATION_TIERS[c.SHIRT_LEVEL] not in merch:
             merch.append(c.DONATION_TIERS[c.SHIRT_LEVEL])
-        elif self.gets_free_shirt:
+        elif self.gets_free_swag_shirt:
             shirt = '2nd ' + c.DONATION_TIERS[c.SHIRT_LEVEL]
             if self.takes_shifts and self.worked_hours < 6:
                 shirt += ' (tell them they will be reported if they take their shirt then do not work their shifts)'
             merch.append(shirt)
+        """
+
+        if self.gets_staff_shirt:
+            merch.append('{} Staff Shirt{}'.format(c.SHIRTS_PER_STAFFER, 's' if c.SHIRTS_PER_STAFFER > 1 else ''))
+
+        if self.staffing:
+            merch.append('Staffer Info Packet')
+
+        # KEEP
         if self.extra_merch:
             merch.append(self.extra_merch)
         return comma_and(merch)
@@ -1610,6 +1647,7 @@ class FoodRestrictions(MagModel):
                 return restriction in self.standard_ints
 
 
+# mark if they wanted to, but couldn't, pick up a SWAG shirt because we ran out of shirts
 class NoShirt(MagModel):
     attendee_id = Column(UUID, ForeignKey('attendee.id'), unique=True)
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -518,7 +518,7 @@ class Root:
                     message = '{a.full_name} ({a.badge}) already got {a.merch}'.format(a=attendee)
                 else:
                     id = attendee.id
-                    shirt = (attendee.shirt or c.SIZE_UNKNOWN) if attendee.gets_shirt else c.NO_SHIRT
+                    shirt = (attendee.shirt or c.SIZE_UNKNOWN) if attendee.gets_swag_shirt else c.NO_SHIRT
                     message = '{a.full_name} ({a.badge}) has not yet received {a.merch}'.format(a=attendee)
         return {
             'id': id,

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -518,7 +518,7 @@ class Root:
                     message = '{a.full_name} ({a.badge}) already got {a.merch}'.format(a=attendee)
                 else:
                     id = attendee.id
-                    shirt = (attendee.shirt or c.SIZE_UNKNOWN) if attendee.gets_swag_shirt else c.NO_SHIRT
+                    shirt = (attendee.shirt or c.SIZE_UNKNOWN) if attendee.gets_any_kind_of_shirt else c.NO_SHIRT
                     message = '{a.full_name} ({a.badge}) has not yet received {a.merch}'.format(a=attendee)
         return {
             'id': id,

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -301,8 +301,6 @@ class Root:
         }
 
     def shirt_counts(self, session):
-        # This report is now super-ridiculously wrong
-
         counts = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
         labels = ['size unknown'] + [label for val, label in c.SHIRT_OPTS][1:]
         sort = lambda d: sorted(d.items(), key=lambda tup: labels.index(tup[0]))
@@ -311,15 +309,15 @@ class Root:
         sales_by_week = OrderedDict([(i, 0) for i in range(50)])
         for attendee in session.all_attendees():
             shirt_label = attendee.shirt_label or 'size unknown'
-            if attendee.gets_free_swag_shirt:
-                counts['free'][label(shirt_label)][status(attendee.got_merch)] += 1
-                counts['all'][label(shirt_label)][status(attendee.got_merch)] += 1
+            if attendee.volunteer_swag_shirt_eligible:
+                counts['free_swag_shirts'][label(shirt_label)][status(attendee.got_merch)] += 1
+                counts['all_swag_shirts'][label(shirt_label)][status(attendee.got_merch)] += 1
             if attendee.paid_for_a_swag_shirt:
-                counts['paid'][label(shirt_label)][status(attendee.got_merch)] += 1
-                counts['all'][label(shirt_label)][status(attendee.got_merch)] += 1
+                counts['paid_swag_shirts'][label(shirt_label)][status(attendee.got_merch)] += 1
+                counts['all_swag_shirts'][label(shirt_label)][status(attendee.got_merch)] += 1
                 sales_by_week[(datetime.now(UTC) - attendee.registered).days // 7] += 1
-            if attendee.gets_free_swag_shirt and attendee.paid_for_a_swag_shirt:
-                counts['both'][label(shirt_label)][status(attendee.got_merch)] += 1
+            if attendee.gets_staff_shirt:
+                counts['staff_shirts'][label(shirt_label)][status(attendee.got_merch)] += c.SHIRTS_PER_STAFFER
         for week in range(48, -1, -1):
             sales_by_week[week] += sales_by_week[week + 1]
         return {

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -323,10 +323,10 @@ class Root:
         return {
             'sales_by_week': sales_by_week,
             'categories': [
-                ('Eligible free', sort(counts['free'])),
-                ('Paid', sort(counts['paid'])),
-                ('All pre-ordered', sort(counts['all'])),
-                ('People with both free and paid', sort(counts['both']))
+                ('Free Swag Shirts', sort(counts['free_swag_shirts'])),
+                ('Paid Swag Shirts', sort(counts['paid_swag_shirts'])),
+                ('All Swag Shirts', sort(counts['all_swag_shirts'])),
+                ('Staff Shirts', sort(counts['staff_shirts']))
             ]
         }
 

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -110,7 +110,7 @@
         <script type="text/javascript">
             var donationChanged = function () {
                 setVisible('.affiliate-row', $.val('amount_extra') > 0);
-                {% if attendee.gets_shirt %}
+                {% if attendee.gets_any_kind_of_shirt %}   {# TODO: maybe. not sure.  do we show shirt-row when staff, or swag, or both #}
                     setVisible('.shirt-row', true);
                 {% else %}
                     setVisible('.shirt-row', $.val('amount_extra') >= {{ c.SHIRT_LEVEL }});

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -110,7 +110,7 @@
         <script type="text/javascript">
             var donationChanged = function () {
                 setVisible('.affiliate-row', $.val('amount_extra') > 0);
-                {% if attendee.gets_any_kind_of_shirt %}   {# TODO: maybe. not sure.  do we show shirt-row when staff, or swag, or both #}
+                {% if attendee.gets_any_kind_of_shirt %}
                     setVisible('.shirt-row', true);
                 {% else %}
                     setVisible('.shirt-row', $.val('amount_extra') >= {{ c.SHIRT_LEVEL }});

--- a/uber/templates/summary/shirt_manufacturing_counts.html
+++ b/uber/templates/summary/shirt_manufacturing_counts.html
@@ -13,7 +13,7 @@
 </p>
 
 {% for name, category in categories %}
-    <h3>{{ name }} shirts</h3>
+    <h3>{{ name }}</h3>
     <table>
     {% for label, counts in category %}
         <tr>

--- a/uber/templates/summary/shirt_manufacturing_counts.html
+++ b/uber/templates/summary/shirt_manufacturing_counts.html
@@ -10,6 +10,10 @@
 <p>
     This report is designed to give you the correct numbers ready to be sent to the manufacturer.
     We recommend adding in a few extra shirts for safety margins to these numbers.
+    {% if c.SHIRTS_PER_STAFFER > 1 %}
+        <br/> <br/>
+        <b>NOTE:</b> The "Staff Shirts" report shows the result of each staffer receiving {{ c.SHIRTS_PER_STAFFER }} shirts.
+    {% endif %}
 </p>
 
 {% for name, category in categories %}

--- a/uber/templates/summary/shirt_manufacturing_counts.html
+++ b/uber/templates/summary/shirt_manufacturing_counts.html
@@ -9,15 +9,7 @@
 <h2>Shirt Manufacturing Reports</h2>
 <p>
     This report is designed to give you the correct numbers ready to be sent to the manufacturer.
-    We recommend adding in a extra shirts for safety margins to these numbers.
-</p>
-
-<p>
-    IMPORTANT NOTES:<br>
-    <ul>
-        <li><b>The STAFF SHIRT report shows the result of EACH staffer receiving ***{{ c.SHIRTS_PER_STAFFER }}*** shirt(s) EACH.</b></li>
-        <li><b>The SWAG SHIRT report does NOT include the count of volunteers who would qualify for shirts but aren't currently signed up for enough hours yet.</b></li>
-    </ul>
+    We recommend adding in a few extra shirts for safety margins to these numbers.
 </p>
 
 {% for name, category in categories %}

--- a/uber/templates/summary/shirt_manufacturing_counts.html
+++ b/uber/templates/summary/shirt_manufacturing_counts.html
@@ -9,11 +9,15 @@
 <h2>Shirt Manufacturing Reports</h2>
 <p>
     This report is designed to give you the correct numbers ready to be sent to the manufacturer.
-    We recommend adding in a few extra shirts for safety margins to these numbers.
+    We recommend adding in a extra shirts for safety margins to these numbers.
 </p>
 
 <p>
-    <b>IMPORTANT NOTE: The STAFF SHIRT report shows the result of EACH staffer receiving {{ c.SHIRTS_PER_STAFFER }} shirt(s).</b>
+    IMPORTANT NOTES:<br>
+    <ul>
+        <li><b>The STAFF SHIRT report shows the result of EACH staffer receiving ***{{ c.SHIRTS_PER_STAFFER }}*** shirt(s) EACH.</b></li>
+        <li><b>The SWAG SHIRT report does NOT include the count of volunteers who would qualify for shirts but aren't currently signed up for enough hours yet.</b></li>
+    </ul>
 </p>
 
 {% for name, category in categories %}

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -120,46 +120,6 @@ def test_trusted_somewhere():
     assert not Attendee(trusted_depts='').trusted_somewhere
 
 
-class TestGetsShirt:
-    def test_basics(self, monkeypatch):
-        assert not Attendee().gets_shirt
-        assert Attendee(amount_extra=c.SHIRT_LEVEL).gets_shirt
-        assert Attendee(ribbon=c.DEPT_HEAD_RIBBON).gets_shirt
-        assert Attendee(badge_type=c.STAFF_BADGE).gets_shirt
-        # assert Attendee(badge_type=c.SUPPORTER_BADGE).gets_shirt  # TODO: should this be true?
-
-    def test_shiftless_depts(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'takes_shifts', False)
-        assert not Attendee(assigned_depts='x').gets_shirt
-        assert Attendee(staffing=True, assigned_depts='x').gets_shirt
-
-    def test_shirt_hours(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'weighted_hours', 5)
-        assert not Attendee(staffing=True).gets_shirt
-        for amount in [6, 18, 24, 30]:
-            monkeypatch.setattr(Attendee, 'weighted_hours', amount)
-            assert not Attendee().gets_shirt
-            assert Attendee(staffing=True).gets_shirt
-
-
-class TestShirtEligible:
-    @pytest.fixture
-    def gets_shirt(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'gets_shirt', True)
-
-    @pytest.fixture
-    def gets_no_shirt(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'gets_shirt', False)
-
-    def test_gets_shirt_true(self, gets_shirt):
-        assert Attendee(staffing=False).shirt_eligible
-        assert Attendee(staffing=True).shirt_eligible
-
-    def test_gets_shirt_false(self, gets_no_shirt):
-        assert not Attendee(staffing=False).shirt_eligible
-        assert Attendee(staffing=True).shirt_eligible
-
-
 def test_has_personalized_badge():
     assert not Attendee().has_personalized_badge
     assert Attendee(badge_type=c.STAFF_BADGE).has_personalized_badge
@@ -203,16 +163,6 @@ class TestUnsetVolunteer:
         a = Attendee(affiliate='xxx')
         a._misc_adjustments()
         assert a.affiliate == ''
-
-    def test_gets_shirt_with_enough_extra(self):
-        a = Attendee(shirt=1, amount_extra=c.SHIRT_LEVEL)
-        a._misc_adjustments()
-        assert a.shirt == 1
-
-    def test_gets_shirt_without_enough_extra(self):
-        a = Attendee(shirt=1, amount_extra=1)
-        a._misc_adjustments()
-        assert a.shirt == c.NO_SHIRT
 
     def test_amount_refunded_when_refunded(self):
         a = Attendee(amount_refunded=123, paid=c.REFUNDED)

--- a/uber/tests/models/test_merch.py
+++ b/uber/tests/models/test_merch.py
@@ -1,0 +1,148 @@
+from uber.tests import *
+
+
+"""
+Scenario: A staffer who has not kicked in extra is picking up their merch
+Current behavior: uber reports that the staffer should receive a t-shirt bundle
+Desired behavior: uber reports that the staffer should receive two staff t-shirts, and a staffer info packet
+
+Scenario: A staffer who has kicked in for the t-shirt bundle is picking up their merch
+Current behavior: uber reports that the staffer should receive a t-shirt bundle, and a 2nd t-shirt bundle
+Desired behavior: uber reports that the staffer should receive an attendee t-shirt bundle, two staff t-shirts, and a staffer info packet
+
+Scenario: A staffer who has kicked in for the I <3 magfest is picking up their merch
+Current behavior: uber reports that the staffer should receive a t-shirt bundle, i <3 magfest, and a 2nd t-shirt bundle
+Desired behavior: uber reports that the staffer should receive an attendee t-shirt bundle, i <3 magfest, two staff t-shirts, and a staffer info packet
+"""
+
+
+class TestMerch:
+    @pytest.fixture(autouse=True)
+    def donation_tier_fixture(self, monkeypatch):
+        shirt_level = 25
+        supporter_level = 85
+
+        monkeypatch.setattr(c, 'DONATION_TIERS', {
+            0: 'No thanks',
+            shirt_level: 'RedShirt T-Shirt Bundle',
+            55: 'Cruiser',
+            supporter_level: 'Supporter Package - Battleship',
+            205: 'Aircraft Carrier',
+        })
+
+        # [integer_enums]
+        monkeypatch.setattr(c, 'SHIRT_LEVEL', shirt_level)
+        monkeypatch.setattr(c, 'SUPPORTER_LEVEL', supporter_level)
+
+        monkeypatch.setattr(c, 'SHIRTS_PER_STAFFER', 3)
+
+        monkeypatch.setattr(c, 'get_attendee_price', Mock(return_value=20))
+
+    def test_merch_setup(self):
+        assert 20 == Attendee(amount_extra=0).total_cost
+
+    def test_merch_setup(self):
+        att = Attendee(amount_extra=0)
+
+    # Scenario: A staffer who has not kicked in extra is picking up their merch
+    # Current behavior: uber reports that the staffer should receive a t-shirt bundle
+    # Desired behavior: uber reports that the staffer should receive two staff t-shirts, and a staffer info packet
+    def test_staff_shirt_merch(self):
+        staffer = Attendee(badge_type=c.STAFF_BADGE)
+        staffer._staffing_adjustments()
+
+        assert 'RedShirt T-Shirt Bundle' not in staffer.merch
+
+        assert '3 Staff Shirts' in staffer.merch
+        assert 'Staffer Info Packet' in staffer.merch
+
+    def test_staff_shirt_properties(self):
+        staffer = Attendee(badge_type=c.STAFF_BADGE)
+        staffer._staffing_adjustments()
+
+        assert staffer.gets_staff_shirt
+        assert staffer.gets_any_kind_of_shirt
+        assert not staffer.paid_for_a_swag_shirt
+        assert not staffer.eligible_for_free_swag_shirt
+
+    # att = Attendee(amount_extra=c.SHIRT_LEVEL) TODO
+
+    def test_volunteer_has_enough_hours_gets_swag_shirt(self):
+        volunteer = Attendee(ribbon=c.VOLUNTEER_RIBBON)
+        volunteer._staffing_adjustments()
+
+        assert 'RedShirt T-Shirt Bundle' in volunteer.merch
+
+    # ----------------------------------------------------------------
+
+    def test_basics(self):
+        # TODO: needs refactoring.
+        assert not Attendee().paid_for_a_swag_shirt
+        assert Attendee(amount_extra=c.SHIRT_LEVEL).paid_for_a_swag_shirt
+        assert Attendee(ribbon=c.DEPT_HEAD_RIBBON).paid_for_a_swag_shirt
+        assert Attendee(badge_type=c.STAFF_BADGE).paid_for_a_swag_shirt
+        # assert Attendee(badge_type=c.SUPPORTER_BADGE).paid_for_a_swag_shirt  # TODO: should this be true? (original comment)
+
+    def test_shiftless_depts(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'takes_shifts', False)
+        assert not Attendee(assigned_depts='x').paid_for_a_swag_shirt # TODO not sure if right property
+        assert Attendee(staffing=True, assigned_depts='x').paid_for_a_swag_shirt # TODO not sure if right property
+
+    @pytest.mark.parametrize("attendee_kwargs, weighted_hours, expected_result", [
+        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 5, False),
+        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 6, True),
+        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 18, True),
+        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 24, True),
+        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 30, True),
+
+        ({'ribbon': c.VOLUNTEER_RIBBON}, 30, True),
+
+        ({}, 5, False),
+        ({}, 30, False),
+
+        ({'badge_type': c.STAFF_BADGE, 'assigned_depts': c.CONSOLE}, 5, False),
+        ({'badge_type': c.STAFF_BADGE, 'assigned_depts': c.CONSOLE}, 30, False),
+    ])
+    def test_shirt_hours(self, monkeypatch, attendee_kwargs, weighted_hours, expected_result):
+        monkeypatch.setattr(Attendee, 'weighted_hours', weighted_hours)
+        attendee = Attendee(**attendee_kwargs)
+        attendee._staffing_adjustments()
+        assert attendee.eligible_for_free_swag_shirt == expected_result
+
+
+
+
+
+
+
+
+
+
+
+
+
+    @pytest.fixture
+    def gets_shirt(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'gets_shirt', True)
+
+    @pytest.fixture
+    def gets_no_shirt(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'gets_shirt', False)
+
+    def test_gets_shirt_true(self, gets_shirt):
+        assert Attendee(staffing=False).gets_any_kind_of_shirt
+        assert Attendee(staffing=True).gets_any_kind_of_shirt
+
+    def test_gets_shirt_false(self, gets_no_shirt):
+        assert not Attendee(staffing=False).gets_any_kind_of_shirt
+        assert Attendee(staffing=True).gets_any_kind_of_shirt
+
+    def test_gets_shirt_with_enough_extra(self):
+        a = Attendee(shirt=1, amount_extra=c.SHIRT_LEVEL)
+        a._misc_adjustments()
+        assert a.shirt == 1
+
+    def test_gets_shirt_without_enough_extra(self):
+        a = Attendee(shirt=1, amount_extra=1)
+        a._misc_adjustments()
+        assert a.shirt == c.NO_SHIRT

--- a/uber/tests/models/test_merch.py
+++ b/uber/tests/models/test_merch.py
@@ -1,148 +1,119 @@
 from uber.tests import *
 
 
-"""
-Scenario: A staffer who has not kicked in extra is picking up their merch
-Current behavior: uber reports that the staffer should receive a t-shirt bundle
-Desired behavior: uber reports that the staffer should receive two staff t-shirts, and a staffer info packet
+@pytest.fixture(autouse=True)
+def donation_tier_fixture(monkeypatch):
+    shirt_level = 25
+    supporter_level = 85
 
-Scenario: A staffer who has kicked in for the t-shirt bundle is picking up their merch
-Current behavior: uber reports that the staffer should receive a t-shirt bundle, and a 2nd t-shirt bundle
-Desired behavior: uber reports that the staffer should receive an attendee t-shirt bundle, two staff t-shirts, and a staffer info packet
+    monkeypatch.setattr(c, 'DONATION_TIERS', {
+        0: 'No thanks',
+        shirt_level: 'RedShirt',
+        55: 'Cruiser',
+        supporter_level: 'Supporter Package - Battleship',
+        205: 'Aircraft Carrier',
+    })
 
-Scenario: A staffer who has kicked in for the I <3 magfest is picking up their merch
-Current behavior: uber reports that the staffer should receive a t-shirt bundle, i <3 magfest, and a 2nd t-shirt bundle
-Desired behavior: uber reports that the staffer should receive an attendee t-shirt bundle, i <3 magfest, two staff t-shirts, and a staffer info packet
-"""
+    # [integer_enums]
+    monkeypatch.setattr(c, 'SHIRT_LEVEL', shirt_level)
+    monkeypatch.setattr(c, 'SUPPORTER_LEVEL', supporter_level)
+    monkeypatch.setattr(c, 'SHIRTS_PER_STAFFER', 3)
+
+
+class TestMerchAttrs:
+    def test_paid_for_a_swag_shirt(self):
+        assert not Attendee(amount_extra=c.SHIRT_LEVEL - 1).paid_for_a_swag_shirt
+        assert Attendee(amount_extra=c.SHIRT_LEVEL).paid_for_a_swag_shirt
+        assert Attendee(amount_extra=c.SHIRT_LEVEL + 1).paid_for_a_swag_shirt
+
+    def test_volunteer_swag_shirt_eligible(self):
+        assert not Attendee().volunteer_swag_shirt_eligible
+        assert Attendee(ribbon=c.VOLUNTEER_RIBBON).volunteer_swag_shirt_eligible
+        assert not Attendee(ribbon=c.VOLUNTEER_RIBBON, badge_type=c.STAFF_BADGE).volunteer_swag_shirt_eligible
+
+    def test_volunteer_swag_shirt_earned(self, monkeypatch):
+        for (eligible, takes_shifts, worked_hours), expected in {
+                (False, False, 5): False,
+                (False, False, 6): False,
+                (False, True, 5): False,
+                (False, True, 6): False,
+                (True, False, 5): True,
+                (True, True, 5): False,
+                (True, False, 6): True,
+                (True, True, 6): True}.items():
+            monkeypatch.setattr(Attendee, 'takes_shifts', takes_shifts)
+            monkeypatch.setattr(Attendee, 'volunteer_swag_shirt_eligible', eligible)
+            assert expected == Attendee(nonshift_hours=worked_hours).volunteer_swag_shirt_earned
+
+    def test_num_swag_shirts_owed(self, monkeypatch):
+        for paid, volunteer, owed in [
+                (False, False, 0),
+                (False, True, 1),
+                (True, False, 1),
+                (True, True, 2)]:
+            monkeypatch.setattr(Attendee, 'paid_for_a_swag_shirt', paid)
+            monkeypatch.setattr(Attendee, 'volunteer_swag_shirt_eligible', volunteer)
+            assert owed == Attendee().num_swag_shirts_owed
+
+    def test_gets_staff_shirt(self):
+        assert not Attendee().gets_staff_shirt
+        assert Attendee(badge_type=c.STAFF_BADGE).gets_staff_shirt
+
+    def test_gets_any_kind_of_shirt(self, monkeypatch):
+        for staff, swag, expected in [
+                (False, 0, False),
+                (False, 1, True),
+                (True, 0, True),
+                (True, 1, True)]:
+            monkeypatch.setattr(Attendee, 'gets_staff_shirt', staff)
+            monkeypatch.setattr(Attendee, 'num_swag_shirts_owed', swag)
+            assert expected == Attendee().gets_any_kind_of_shirt
 
 
 class TestMerch:
     @pytest.fixture(autouse=True)
-    def donation_tier_fixture(self, monkeypatch):
-        shirt_level = 25
-        supporter_level = 85
-
-        monkeypatch.setattr(c, 'DONATION_TIERS', {
-            0: 'No thanks',
-            shirt_level: 'RedShirt T-Shirt Bundle',
-            55: 'Cruiser',
-            supporter_level: 'Supporter Package - Battleship',
-            205: 'Aircraft Carrier',
-        })
-
-        # [integer_enums]
-        monkeypatch.setattr(c, 'SHIRT_LEVEL', shirt_level)
-        monkeypatch.setattr(c, 'SUPPORTER_LEVEL', supporter_level)
-
-        monkeypatch.setattr(c, 'SHIRTS_PER_STAFFER', 3)
-
-        monkeypatch.setattr(c, 'get_attendee_price', Mock(return_value=20))
-
-    def test_merch_setup(self):
-        assert 20 == Attendee(amount_extra=0).total_cost
-
-    def test_merch_setup(self):
-        att = Attendee(amount_extra=0)
-
-    # Scenario: A staffer who has not kicked in extra is picking up their merch
-    # Current behavior: uber reports that the staffer should receive a t-shirt bundle
-    # Desired behavior: uber reports that the staffer should receive two staff t-shirts, and a staffer info packet
-    def test_staff_shirt_merch(self):
-        staffer = Attendee(badge_type=c.STAFF_BADGE)
-        staffer._staffing_adjustments()
-
-        assert 'RedShirt T-Shirt Bundle' not in staffer.merch
-
-        assert '3 Staff Shirts' in staffer.merch
-        assert 'Staffer Info Packet' in staffer.merch
-
-    def test_staff_shirt_properties(self):
-        staffer = Attendee(badge_type=c.STAFF_BADGE)
-        staffer._staffing_adjustments()
-
-        assert staffer.gets_staff_shirt
-        assert staffer.gets_any_kind_of_shirt
-        assert not staffer.paid_for_a_swag_shirt
-        assert not staffer.eligible_for_free_swag_shirt
-
-    # att = Attendee(amount_extra=c.SHIRT_LEVEL) TODO
-
-    def test_volunteer_has_enough_hours_gets_swag_shirt(self):
-        volunteer = Attendee(ribbon=c.VOLUNTEER_RIBBON)
-        volunteer._staffing_adjustments()
-
-        assert 'RedShirt T-Shirt Bundle' in volunteer.merch
-
-    # ----------------------------------------------------------------
-
-    def test_basics(self):
-        # TODO: needs refactoring.
-        assert not Attendee().paid_for_a_swag_shirt
-        assert Attendee(amount_extra=c.SHIRT_LEVEL).paid_for_a_swag_shirt
-        assert Attendee(ribbon=c.DEPT_HEAD_RIBBON).paid_for_a_swag_shirt
-        assert Attendee(badge_type=c.STAFF_BADGE).paid_for_a_swag_shirt
-        # assert Attendee(badge_type=c.SUPPORTER_BADGE).paid_for_a_swag_shirt  # TODO: should this be true? (original comment)
-
-    def test_shiftless_depts(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'takes_shifts', False)
-        assert not Attendee(assigned_depts='x').paid_for_a_swag_shirt # TODO not sure if right property
-        assert Attendee(staffing=True, assigned_depts='x').paid_for_a_swag_shirt # TODO not sure if right property
-
-    @pytest.mark.parametrize("attendee_kwargs, weighted_hours, expected_result", [
-        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 5, False),
-        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 6, True),
-        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 18, True),
-        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 24, True),
-        ({'ribbon': c.VOLUNTEER_RIBBON, 'assigned_depts': c.CONSOLE}, 30, True),
-
-        ({'ribbon': c.VOLUNTEER_RIBBON}, 30, True),
-
-        ({}, 5, False),
-        ({}, 30, False),
-
-        ({'badge_type': c.STAFF_BADGE, 'assigned_depts': c.CONSOLE}, 5, False),
-        ({'badge_type': c.STAFF_BADGE, 'assigned_depts': c.CONSOLE}, 30, False),
-    ])
-    def test_shirt_hours(self, monkeypatch, attendee_kwargs, weighted_hours, expected_result):
-        monkeypatch.setattr(Attendee, 'weighted_hours', weighted_hours)
-        attendee = Attendee(**attendee_kwargs)
-        attendee._staffing_adjustments()
-        assert attendee.eligible_for_free_swag_shirt == expected_result
-
-
-
-
-
-
-
-
-
-
-
-
+    def defaults(self, monkeypatch):
+        for attr in ['volunteer_swag_shirt_eligible', 'paid_for_a_swag_shirt', 'volunteer_swag_shirt_earned', 'gets_staff_shirt']:
+            monkeypatch.setattr(Attendee, attr, False)
 
     @pytest.fixture
-    def gets_shirt(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'gets_shirt', True)
+    def paid_for_a_swag_shirt(self, monkeypatch):
+        setattr(Attendee, 'paid_for_a_swag_shirt', True)
 
     @pytest.fixture
-    def gets_no_shirt(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'gets_shirt', False)
+    def volunteer_swag_shirt_eligible(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'volunteer_swag_shirt_eligible', True)
 
-    def test_gets_shirt_true(self, gets_shirt):
-        assert Attendee(staffing=False).gets_any_kind_of_shirt
-        assert Attendee(staffing=True).gets_any_kind_of_shirt
+    @pytest.fixture
+    def volunteer_swag_shirt_earned(self, monkeypatch):
+        setattr(Attendee, 'volunteer_swag_shirt_earned', True)
 
-    def test_gets_shirt_false(self, gets_no_shirt):
-        assert not Attendee(staffing=False).gets_any_kind_of_shirt
-        assert Attendee(staffing=True).gets_any_kind_of_shirt
+    @pytest.fixture
+    def gets_staff_shirt(self, monkeypatch):
+        setattr(Attendee, 'gets_staff_shirt', True)
 
-    def test_gets_shirt_with_enough_extra(self):
-        a = Attendee(shirt=1, amount_extra=c.SHIRT_LEVEL)
-        a._misc_adjustments()
-        assert a.shirt == 1
+    def test_extra_merch(self):
+        assert 'foo' == Attendee(extra_merch='foo').merch
 
-    def test_gets_shirt_without_enough_extra(self):
-        a = Attendee(shirt=1, amount_extra=1)
-        a._misc_adjustments()
-        assert a.shirt == c.NO_SHIRT
+    def test_normal_kickins(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'donation_swag', ['some', 'stuff'])
+        assert 'some and stuff' == Attendee().merch
+
+    def test_comma_and(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'donation_swag', ['some', 'stuff'])
+        assert 'some, stuff, and more' == Attendee(extra_merch='more').merch
+
+    def test_info_packet(self):
+        assert 'Staffer Info Packet' == Attendee(staffing=True).merch
+
+    def test_staff_shirts(self, gets_staff_shirt):
+        assert '3 Staff Shirts' == Attendee().merch
+
+    def test_volunteer(self, volunteer_swag_shirt_eligible):
+        assert 'RedShirt' in Attendee().merch and 'will be reported' in Attendee().merch
+
+    def test_volunteer_worked(self, volunteer_swag_shirt_eligible, volunteer_swag_shirt_earned):
+        assert 'RedShirt' == Attendee().merch
+
+    def test_two_swag_shirts(self, volunteer_swag_shirt_eligible, volunteer_swag_shirt_earned, paid_for_a_swag_shirt):
+        assert 'RedShirt and a 2nd RedShirt' == Attendee(amount_extra=c.SHIRT_LEVEL).merch


### PR DESCRIPTION
This implements the logic which @nickthenewbie1 has requested:
- People with staff badges get a configurable number of staff shirts.
- People with volunteer ribbons get a single swag shirt (not a staff shirt).
- People who pay for a shirt get the shirt they paid for.

I added a ton of unit tests for all of this and also fixed the manufacturing reports.

fixes https://github.com/magfest/magprime/issues/188