### PR TITLE
Allow attendees in unpaid groups to check-in if they are paid

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -14,7 +14,7 @@ def pre_checkin_check(attendee, group):
     if attendee.checked_in:
         return attendee.full_name + ' was already checked in!'
 
-    if group and group.amount_unpaid:
+    if group and attendee.paid == c.PAID_BY_GROUP and group.amount_unpaid:
         return 'This attendee\'s group has an outstanding balance of ${}'.format(group.amount_unpaid)
 
     if attendee.paid == c.PAID_BY_GROUP and not attendee.group_id:


### PR DESCRIPTION
Reg had a problem checking in someone even though she'd paid for her own badge (c.HAS_PAID) because she had been put into a group and they hadn't paid for their badges. This prevents that situation.