### PR TITLE
Stop reducing group prices when badges are dropped

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -364,8 +364,7 @@ class Root:
         except:
             log.error('unable to send group unset email', exc_info=True)
 
-        session.assign_badges(attendee.group, attendee.group.badges + 1, registered=attendee.registered, paid=attendee.paid)
-        attendee.group.cost -= attendee.group.new_badge_cost  # We add this value to the group in assign_badges; undo!
+        session.assign_badges(attendee.group, attendee.group.badges + 1, new_badge_type=attendee.badge_type, new_ribbon_type=attendee.ribbon, registered=attendee.registered, paid=attendee.paid)
         session.delete_from_group(attendee, attendee.group)
         raise HTTPRedirect('group_members?id={}&message={}', attendee.group_id, 'Attendee unset; you may now assign their badge to someone else')
 


### PR DESCRIPTION
This was a change I had made earlier that I forgot to remove when I fixed group pricing -- the end result is that the group's cost would keep going down but their badge number would stay the same. Oops.
Also transfers the badge's type and ribbon to the new unassigned badge.