### PR TITLE
Unassigned groups badges were getting erroneously deleted

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1292,7 +1292,10 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.paid == c.NOT_PAID:
             return "Not paid"
 
-        if self.badge_status != c.COMPLETED_STATUS:
+        # When someone claims an unassigned group badge on-site, they first fill out a new registration
+        # which is paid-by-group but isn't assigned to a group yet (the admin does that when they check in).
+        if self.badge_status != c.COMPLETED_STATUS \
+                and not (self.badge_status == c.NEW_STATUS and self.paid == c.PAID_BY_GROUP and not self.group_id):
             return "Badge status"
 
         if self.is_unassigned:

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -17,15 +17,8 @@ def pre_checkin_check(attendee, group):
     if group and group.amount_unpaid:
         return 'This attendee\'s group has an outstanding balance of ${}'.format(group.amount_unpaid)
 
-    if attendee.paid == c.PAID_BY_GROUP and not attendee.group_id:
-        return 'You must select a group for this attendee.'
-
     if attendee.paid == c.NOT_PAID:
         return 'You cannot check in an attendee that has not paid.'
-
-    attendee._status_adjustments()
-    if attendee.badge_status != c.COMPLETED_STATUS:
-        return 'This badge is {} and cannot be checked in.'.format(attendee.badge_status_label)
 
     return check(attendee)
 
@@ -413,18 +406,21 @@ class Root:
         }
 
     @ajax
-    def check_in(self, session, message='', **params):
+    def check_in(self, session, message='', group_id='', **params):
         attendee = session.attendee(params, allow_invalid=True)
-        group = session.group(attendee.group_id) if attendee.group_id else None
+        group = attendee.group or (session.group(group_id) if group_id else None)
 
         pre_badge = attendee.badge_num
         success, increment = False, False
 
         message = pre_checkin_check(attendee, group)
+        if not message and group_id:
+            message = session.match_to_group(attendee, group)
+
+        if not message and attendee.paid == c.PAID_BY_GROUP and not attendee.group_id:
+            message = 'You must select a group for this attendee.'
 
         if not message:
-            if group:
-                session.match_to_group(attendee, group)
             message = ''
             success = True
             attendee.checked_in = sa.localized_now()


### PR DESCRIPTION
The bug was that when someone from a group checked in, we were *always* matching them to an unassigned group badge even when they already existed in the group and weren't trying to claim an unassigned group badge for that group.

We'll go in and fix the database after this is deployed.