### PR TITLE
fixed onsite volunteer logins

### DIFF
--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -107,7 +107,7 @@ class Root:
                 attendee = session.lookup_attendee(full_name, email, zip_code)
                 if not attendee.staffing:
                     message = SafeString('You are not signed up as a volunteer.  <a href="volunteer?id={}">Click Here</a> to sign up.'.format(attendee.id))
-                elif not attendee.assigned_depts_ints:
+                elif not attendee.assigned_depts_ints and not c.AT_THE_CON:
                     message = 'You have not been assigned to any departmemts; an admin must assign you to a department before you can log in'
             except:
                 message = 'No attendee matches that name and email address and zip code'


### PR DESCRIPTION
Stops has an onsite workflow wherein someone shows up and says, "I'd like to volunteer" and then we have them log into the signups page on their smartphone and take any non-restricted shifts from any department.

However, in order to support this we need to allow people to log in without even being assigned to any departments.