### PR TITLE
Stop redirecting on click 'Save' for attendees

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -111,7 +111,7 @@ class Root:
                         raise HTTPRedirect('index?uploaded_id={}&message={}&search_text={}', attendee.id, msg_text,
                             '{} {}'.format(attendee.first_name, attendee.last_name) if c.AT_THE_CON else '')
                 else:
-                    raise HTTPRedirect('form?id={}&message={}', attendee.id, msg_text)
+                    raise HTTPRedirect('form?id={}&message={}&return_to={}', attendee.id, msg_text, return_to)
 
         return {
             'message':    message,

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -102,15 +102,16 @@ class Root:
                 if check_in:
                     attendee.checked_in = localized_now()
                 session.add(attendee)
-                if return_to:
-                    raise HTTPRedirect(return_to + '&message={}', 'Attendee data saved')
-                else:
-                    msg_text = '{} has been saved'.format(attendee.full_name)
-                    if params.get('save') == 'save_return_to_search':
+
+                msg_text = '{} has been saved'.format(attendee.full_name)
+                if params.get('save') == 'save_return_to_search':
+                    if return_to:
+                        raise HTTPRedirect(return_to + '&message={}', 'Attendee data saved')
+                    else:
                         raise HTTPRedirect('index?uploaded_id={}&message={}&search_text={}', attendee.id, msg_text,
                             '{} {}'.format(attendee.first_name, attendee.last_name) if c.AT_THE_CON else '')
-                    else:
-                        raise HTTPRedirect('form?id={}&message={}', attendee.id, msg_text)
+                else:
+                    raise HTTPRedirect('form?id={}&message={}', attendee.id, msg_text)
 
         return {
             'message':    message,

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -351,7 +351,7 @@
 
 <div class="form-group">
     <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" name="save" class="btn btn-primary" value="save_return_to_search">Save + return to search</button>
+        <button type="submit" name="save" class="btn btn-primary" value="save_return_to_search">Save + return{% if not return_to %} to search{% endif %}</button>
         <button type="submit" name="save" class="btn btn-primary" value="save">Save</button>
     </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2294. The "Save" button will always stay on the attendee page, and the "Save + return" button will use return_to if it exists.

I couldn't test this because my development environment is messed up.