### PR TITLE
Change delete group member button to read "delete"

### DIFF
--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -360,11 +360,11 @@
 
 {% if not attendee.is_new %}
     <div style="margin-left:25%">  
-        <form method="post" action="delete" onSubmit="return confirm('{% if attendee.group %}Are you sure you want to unassign this badge?{% else %}Are you sure you want to delete this attendee?{% endif %}');" />
+        <form method="post" action="delete" onSubmit="return confirm('{% if attendee.group and attendee.is_unassigned %}Are you sure you want to delete this unassigned badge?{% elif attendee.group %}Are you sure you want to unassign this badge?{% else %}Are you sure you want to delete this attendee?{% endif %}');" />
             {% csrf_token %}
             <input type="hidden" name="id" value="{{ attendee.id }}" />
             {% if return_to %}<input type="hidden" name="return_to" value="{{ return_to }}" />{% endif %}
-            <br/><input type="submit" value="{% if attendee.group %}Unassign this group badge{% else %}Delete Attendee{% endif %}"
+            <br/><input type="submit" value="{% if attendee.group and attendee.is_unassigned %}Delete this group badge{% elif attendee.group %}Unassign this group badge{% else %}Delete Attendee{% endif %}"
                         {% if attendee.paid == c.HAS_PAID %} style="background-color:#BCBCBC" title="Cannot delete a paid badge." disabled {% endif %}/>
         </form>
     </div>


### PR DESCRIPTION
"Unassign", the old wording, was incorrect.

Fixes #2309

Ping @ShevaDas to make sure the wording on the "are you sure about this" is correct.