### PR TITLE
Add unique 'search key' for attendees and groups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ pytz==2014.4
 pep8==1.6.2
 alembic==0.8.7
 treepoem==1.0.1
-pycrypto==2.6.1
 email_validator==1.0.2

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -497,7 +497,7 @@ AutomatedEmail(Attendee, '{EVENT_NAME} parental consent form reminder', 'reg_wor
 # Emails sent out to all attendees who can check in. These emails contain useful information about the event and are
 # sent close to the event start date.
 AutomatedEmail(Attendee, 'Check in faster at {EVENT_NAME}', 'reg_workflow/attendee_qrcode.html',
-               lambda a: not a.is_not_ready_to_checkin and c.EVENT_QR_ID,
+               lambda a: not a.is_not_ready_to_checkin and c.USE_CHECKIN_BARCODE,
                when=days_before(14, c.EPOCH), ident='qrcode_for_checkin')
 
 for _conf in DeptChecklistConf.instances.values():

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -497,7 +497,7 @@ AutomatedEmail(Attendee, '{EVENT_NAME} parental consent form reminder', 'reg_wor
 # Emails sent out to all attendees who can check in. These emails contain useful information about the event and are
 # sent close to the event start date.
 AutomatedEmail(Attendee, 'Check in faster at {EVENT_NAME}', 'reg_workflow/attendee_qrcode.html',
-               lambda a: not a.is_not_ready_to_checkin and c.QR_CODE_PASSWORD,
+               lambda a: not a.is_not_ready_to_checkin and c.EVENT_QR_ID,
                when=days_before(14, c.EPOCH), ident='qrcode_for_checkin')
 
 for _conf in DeptChecklistConf.instances.values():

--- a/uber/common.py
+++ b/uber/common.py
@@ -28,7 +28,6 @@ from hashlib import sha512
 from functools import wraps
 from xml.dom import minidom
 from random import randrange
-from Crypto.Cipher import AES
 from contextlib import closing
 from time import sleep, mktime
 from io import StringIO, BytesIO

--- a/uber/config.py
+++ b/uber/config.py
@@ -501,9 +501,6 @@ c.EVENT_MONTH = c.EPOCH.strftime('%B')
 c.EVENT_START_DAY = int(c.EPOCH.strftime('%d')) % 100
 c.EVENT_END_DAY = int(c.ESCHATON.strftime('%d')) % 100
 
-c.EVENT_QR_ID = c.EVENT_QR_ID or c.EVENT_NAME_AND_YEAR.replace(' ', '_').lower()
-_secret.QR_CODE_PASSWORD = sha512(c.QR_CODE_PASSWORD.encode('UTF-8')).hexdigest()[:24] if c.QR_CODE_PASSWORD else None
-
 c.DAYS = sorted({(dt.strftime('%Y-%m-%d'), dt.strftime('%a')) for dt, desc in c.START_TIME_OPTS})
 c.HOURS = ['{:02}'.format(i) for i in range(24)]
 c.MINUTES = ['{:02}'.format(i) for i in range(60)]

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -286,10 +286,6 @@ banned_staffers = string_list(default=list())
 aws_access_key = string(default="")
 aws_secret_key = string(default="")
 
-# This is used to encrypt and decrypt attendee UUIDs for use in QR codes.
-# If not set, no QR codes are generated. Do not publish this key.
-qr_code_password = string(default="")
-
 
 [dates]
 # Dates controlling when different site features and emails are turned on and off.  Features

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -35,6 +35,10 @@ year = string(default='')
 # If not set, we generate one using the event_name and year variables above.
 event_qr_id = string(default='')
 
+# This controls whether or not we advertise check-in barcodes to attendees.
+# Events who don't have barcode scanners will want to turn this off.
+use_checkin_barcode = boolean(default=True)
+
 # These are used for web server configuration and for linking back to our
 # pages in emails; these definitely needs to be overridden in production.
 path = string(default="/magfest")

--- a/uber/models.py
+++ b/uber/models.py
@@ -742,8 +742,9 @@ class Session(SessionManager):
                                             Group.id == terms[0], Group.search_key == terms[0]))
             elif len(terms) == 1 and terms[0].startswith(c.EVENT_QR_ID):
                 search_uuid = terms[0][len(c.EVENT_QR_ID):]
-                return attendees.filter(or_(Attendee.search_key == search_uuid,
-                                            Group.search_key == search_uuid))
+                if re.match('[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}', search_uuid):
+                    return attendees.filter(or_(Attendee.search_key == search_uuid,
+                                                Group.search_key == search_uuid))
 
             checks = [Group.name.ilike('%' + text + '%')]
             for attr in ['first_name', 'last_name', 'badge_printed_name', 'email', 'comments', 'admin_notes', 'for_review']:

--- a/uber/models.py
+++ b/uber/models.py
@@ -738,13 +738,13 @@ class Session(SessionManager):
                 elif int(terms[0]) <= sorted(c.BADGE_RANGES.items(), key=lambda badge_range: badge_range[1][0])[-1][1][1]:
                     return attendees.filter(Attendee.badge_num == terms[0])
             elif len(terms) == 1 and re.match('[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}', terms[0]):
-                return attendees.filter(or_(Attendee.id == terms[0], Attendee.search_key == terms[0],
-                                            Group.id == terms[0], Group.search_key == terms[0]))
+                return attendees.filter(or_(Attendee.id == terms[0], Attendee.public_id == terms[0],
+                                            Group.id == terms[0], Group.public_id == terms[0]))
             elif len(terms) == 1 and terms[0].startswith(c.EVENT_QR_ID):
                 search_uuid = terms[0][len(c.EVENT_QR_ID):]
                 if re.match('[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}', search_uuid):
-                    return attendees.filter(or_(Attendee.search_key == search_uuid,
-                                                Group.search_key == search_uuid))
+                    return attendees.filter(or_(Attendee.public_id == search_uuid,
+                                                Group.public_id == search_uuid))
 
             checks = [Group.name.ilike('%' + text + '%')]
             for attr in ['first_name', 'last_name', 'badge_printed_name', 'email', 'comments', 'admin_notes', 'for_review']:
@@ -862,7 +862,7 @@ class Session(SessionManager):
 
 
 class Group(MagModel, TakesPaymentMixin):
-    search_key    = Column(UUID, default=lambda: str(uuid4()))
+    public_id    = Column(UUID, default=lambda: str(uuid4()))
     name          = Column(UnicodeText)
     tables        = Column(Numeric, default=0)
     address       = Column(UnicodeText)
@@ -1046,7 +1046,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     for_review  = Column(UnicodeText, admin_only=True)
     admin_notes = Column(UnicodeText, admin_only=True)
 
-    search_key   = Column(UUID, default=lambda: str(uuid4()))
+    public_id   = Column(UUID, default=lambda: str(uuid4()))
     badge_num    = Column(Integer, default=None, nullable=True, admin_only=True)
     badge_type   = Column(Choice(c.BADGE_OPTS), default=c.ATTENDEE_BADGE)
     badge_status = Column(Choice(c.BADGE_STATUS_OPTS), default=c.NEW_STATUS, admin_only=True)

--- a/uber/models.py
+++ b/uber/models.py
@@ -738,7 +738,12 @@ class Session(SessionManager):
                 elif int(terms[0]) <= sorted(c.BADGE_RANGES.items(), key=lambda badge_range: badge_range[1][0])[-1][1][1]:
                     return attendees.filter(Attendee.badge_num == terms[0])
             elif len(terms) == 1 and re.match('[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}', terms[0]):
-                return attendees.filter(or_(Attendee.id == terms[0], Group.id == terms[0]))
+                return attendees.filter(or_(Attendee.id == terms[0], Attendee.search_key == terms[0],
+                                            Group.id == terms[0], Group.search_key == terms[0]))
+            elif len(terms) == 1 and terms[0].startswith(c.EVENT_QR_ID):
+                search_uuid = terms[0][len(c.EVENT_QR_ID):]
+                return attendees.filter(or_(Attendee.search_key == search_uuid,
+                                            Group.search_key == search_uuid))
 
             checks = [Group.name.ilike('%' + text + '%')]
             for attr in ['first_name', 'last_name', 'badge_printed_name', 'email', 'comments', 'admin_notes', 'for_review']:
@@ -856,6 +861,7 @@ class Session(SessionManager):
 
 
 class Group(MagModel, TakesPaymentMixin):
+    search_key    = Column(UUID, default=lambda: str(uuid4()))
     name          = Column(UnicodeText)
     tables        = Column(Numeric, default=0)
     address       = Column(UnicodeText)
@@ -1039,6 +1045,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     for_review  = Column(UnicodeText, admin_only=True)
     admin_notes = Column(UnicodeText, admin_only=True)
 
+    search_key   = Column(UUID, default=lambda: str(uuid4()))
     badge_num    = Column(Integer, default=None, nullable=True, admin_only=True)
     badge_type   = Column(Choice(c.BADGE_OPTS), default=c.ATTENDEE_BADGE)
     badge_status = Column(Choice(c.BADGE_STATUS_OPTS), default=c.NEW_STATUS, admin_only=True)

--- a/uber/templates/emails/reg_workflow/attendee_qrcode.html
+++ b/uber/templates/emails/reg_workflow/attendee_qrcode.html
@@ -10,7 +10,7 @@
 <br/><br/>Please note, however, that this code is <strong>not</strong> a replacement for your photo ID. You must still present your photo ID when picking up your badge.
 You cannot pick up badges on behalf of other attendees, even if you have a copy of their barcode.
 
-<br/><br/><img src="{{ c.URL_BASE }}/registration/qrcode_generator?data={{ attendee.search_key }}" />
+<br/><br/><img src="{{ c.URL_BASE }}/registration/qrcode_generator?data={{ attendee.public_id }}" />
 
 <br/> <br/>
 {% include "emails/reg_workflow/reg_notes.html" %}

--- a/uber/templates/emails/reg_workflow/attendee_qrcode.html
+++ b/uber/templates/emails/reg_workflow/attendee_qrcode.html
@@ -10,7 +10,7 @@
 <br/><br/>Please note, however, that this code is <strong>not</strong> a replacement for your photo ID. You must still present your photo ID when picking up your badge.
 You cannot pick up badges on behalf of other attendees, even if you have a copy of their barcode.
 
-<br/><br/><img src="{{ c.URL_BASE }}/registration/qrcode_generator?data={{ attendee.id }}" />
+<br/><br/><img src="{{ c.URL_BASE }}/registration/qrcode_generator?data={{ attendee.search_key }}" />
 
 <br/> <br/>
 {% include "emails/reg_workflow/reg_notes.html" %}

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -65,7 +65,7 @@
     <div class="form-group">
     <label class="col-sm-2 control-label">Check-in Barcode</label>
         <div class="col-sm-6">
-        <img src="../registration/qrcode_generator?data={{ attendee.search_key }}" />
+        <img src="../registration/qrcode_generator?data={{ attendee.public_id }}" />
         </div>
     <p class="help-block col-sm-6 col-sm-offset-2">This can be shown at badge pick-up to help check in. <br/>
         <strong>This barcode <em>does not</em> replace your Photo ID.</strong> <br/>

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -61,7 +61,7 @@
     </div>
 </div>
 
-{% if not attendee.is_not_ready_to_checkin and c.EVENT_QR_ID %}
+{% if not attendee.is_not_ready_to_checkin and c.USE_CHECKIN_BARCODE %}
     <div class="form-group">
     <label class="col-sm-2 control-label">Check-in Barcode</label>
         <div class="col-sm-6">

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -61,11 +61,11 @@
     </div>
 </div>
 
-{% if not attendee.is_not_ready_to_checkin and c.QR_CODE_PASSWORD %}
+{% if not attendee.is_not_ready_to_checkin and c.EVENT_QR_ID %}
     <div class="form-group">
     <label class="col-sm-2 control-label">Check-in Barcode</label>
         <div class="col-sm-6">
-        <img src="../registration/qrcode_generator?data={{ attendee.id }}" />
+        <img src="../registration/qrcode_generator?data={{ attendee.search_key }}" />
         </div>
     <p class="help-block col-sm-6 col-sm-offset-2">This can be shown at badge pick-up to help check in. <br/>
         <strong>This barcode <em>does not</em> replace your Photo ID.</strong> <br/>

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -2,9 +2,6 @@ from uber.common import *
 from email_validator import validate_email, EmailNotValidError
 
 
-qr_cipher = AES.new(c.QR_CODE_PASSWORD, AES.MODE_ECB) if c.QR_CODE_PASSWORD else None
-
-
 class HTTPRedirect(cherrypy.HTTPRedirect):
     """
     CherryPy uses exceptions to indicate things like HTTP 303 redirects.  This


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2343 by adding a new UUID used only for search. Changes the check-in barcodes to use that UUID, preventing all security issues with using the primary key id. Also removes the encryption that is no longer needed.