### PR TITLE
Implement separate preferred/legal names

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -120,7 +120,7 @@ def full_name(attendee):
 @validation.Attendee
 @ignore_unassigned_and_placeholders
 def legal_name(attendee):
-    if attendee.legal_name_opt and attendee.full_name == attendee.legal_name_opt:
+    if attendee.legal_name and attendee.full_name == attendee.legal_name:
         return 'When entering a legal name, it must be different than your preferred name. Otherwise, leave it blank.'
 
 

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -119,6 +119,13 @@ def full_name(attendee):
 
 @validation.Attendee
 @ignore_unassigned_and_placeholders
+def legal_name(attendee):
+    if attendee.legal_name_opt and attendee.full_name == attendee.legal_name_opt:
+        return 'When entering a legal name, it must be different than your preferred name. Otherwise, leave it blank.'
+
+
+@validation.Attendee
+@ignore_unassigned_and_placeholders
 def age(attendee):
     if c.COLLECT_EXACT_BIRTHDATE:
         if not attendee.birthdate:

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -407,7 +407,7 @@ class Root:
 
         if 'first_name' in params:
             message = check(attendee, prereg=True)
-            if (old.first_name == attendee.first_name and old.last_name == attendee.last_name) or old.legal_name == attendee.legal_name:
+            if (old.first_name == attendee.first_name and old.last_name == attendee.last_name) or (old.legal_name and old.legal_name == attendee.legal_name):
                 message = 'You cannot transfer your badge to yourself.'
             elif not message and (not params['first_name'] and not params['last_name']):
                 message = check(attendee, prereg=True)

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -407,7 +407,7 @@ class Root:
 
         if 'first_name' in params:
             message = check(attendee, prereg=True)
-            if old.first_name == attendee.first_name and old.last_name == attendee.last_name:
+            if (old.first_name == attendee.first_name and old.last_name == attendee.last_name) or old.legal_name == attendee.legal_name:
                 message = 'You cannot transfer your badge to yourself.'
             elif not message and (not params['first_name'] and not params['last_name']):
                 message = check(attendee, prereg=True)

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -55,15 +55,14 @@
 
     var sameLegalNameChecked = function () {
         if ($("#same_legal_name").prop('checked')) {
-            $("#legal_name").prop('disabled', true)
-            $("#legal_name").val('')
+            $.field('legal_name').prop('readonly', true).val('').attr('required', false);
         } else {
-            $("#legal_name").prop('disabled', false)
+            $.field('legal_name').prop('readonly', false).attr('required', true);
         }
     };
     $(function () {
-        sameLegalNameChecked()
-        $('#same_legal_name').change(sameLegalNameChecked)
+        sameLegalNameChecked();
+        $('#same_legal_name').change(sameLegalNameChecked);
     })
 
 </script>
@@ -121,7 +120,7 @@
     <div class="form-group">
         <label for="legal_name" class="col-sm-2 control-label optional-field">Legal Name</label>
         <div class="col-sm-6">
-            <input type="text" name="legal_name" id="legal_name" value="{{ attendee.legal_name }}" class="form-control" placeholder="Legal Name" />
+            <input type="text" name="legal_name" value="{{ attendee.legal_name }}" class="form-control" placeholder="Legal Name" />
         </div>
         <p class="help-block col-sm-6 col-sm-offset-2">
             <span class="popup">{% popup_link "../static_views/legal_name.html" "What does legal name mean?" %}</span>

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -53,6 +53,19 @@
         }
     });
 
+    var sameLegalNameChecked = function () {
+        if ($("#same_legal_name").prop('checked')) {
+            $("#legal_name").prop('disabled', true)
+            $("#legal_name").val('')
+        } else {
+            $("#legal_name").prop('disabled', false)
+        }
+    };
+    $(function () {
+        sameLegalNameChecked()
+        $('#same_legal_name').change(sameLegalNameChecked)
+    })
+
 </script>
 
 {% if c.PAGE_PATH != '/registration/form' %}
@@ -74,7 +87,7 @@
 
 {% if c.PAGE == 'confirm' %}
     <div class="form-group">
-        <label for="full_name" class="col-sm-2 control-label">Legal Name</label>
+        <label for="full_name" class="col-sm-2 control-label">Name</label>
         <div class="col-sm-6">{{ attendee.full_name }}</div>
     </div>
     <div class="form-group">
@@ -99,12 +112,18 @@
     </div>
 
     <div class="form-group">
+        <label for="same_legal_name" class="col-sm-2 control-label">The above name is exactly what appears on my ID</label>
+        <div class="col-sm-6">
+            <input type="checkbox" name="same_legal_name" id="same_legal_name" value="Yep, that's right" {% if attendee.first_name != '' and attendee.legal_name == '' %}checked="checked"{% endif %} />
+        </div>
+    </div>
+
+    <div class="form-group">
         <label for="legal_name" class="col-sm-2 control-label optional-field">Legal Name</label>
         <div class="col-sm-6">
-            <input type="text" name="legal_name" id="legal_name" value="{{ attendee.legal_name_opt }}" class="form-control" placeholder="Legal Name">
+            <input type="text" name="legal_name" id="legal_name" value="{{ attendee.legal_name }}" class="form-control" placeholder="Legal Name" />
         </div>
         <p class="help-block col-sm-6 col-sm-offset-2">
-            Only enter your legal name if it is different from your preferred name.
             <span class="popup">{% popup_link "../static_views/legal_name.html" "What does legal name mean?" %}</span>
         </p>
     </div>

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -96,12 +96,17 @@
         <div class="col-sm-6">
             <input type="text" name="last_name" id="last_name" value="{{ attendee.last_name }}" class="form-control" placeholder="Last Name">
         </div>
-        {% if c.PAGE_PATH != '/registration/form' %}
-            <p class="help-block col-sm-6 col-sm-offset-2">
-                These must be your legal name.
-                <span class="popup">{% popup_link "../static_views/legal_name.html" "What does this mean?" %}</span>
-            </p>
-        {% endif %}
+    </div>
+
+    <div class="form-group">
+        <label for="legal_name" class="col-sm-2 control-label optional-field">Legal Name</label>
+        <div class="col-sm-6">
+            <input type="text" name="legal_name" id="legal_name" value="{{ attendee.legal_name_opt }}" class="form-control" placeholder="Legal Name">
+        </div>
+        <p class="help-block col-sm-6 col-sm-offset-2">
+            Only enter your legal name if it is different from your preferred name.
+            <span class="popup">{% popup_link "../static_views/legal_name.html" "What does legal name mean?" %}</span>
+        </p>
     </div>
 {% endif %}
 

--- a/uber/templates/registration/discount.html
+++ b/uber/templates/registration/discount.html
@@ -8,6 +8,9 @@
 {% csrf_token %}
 <table class="form">
 <tr>
+    <!-- Note that this is preferred first and last name.
+    May want to change, probably by sending an attendee ID to this page as a hidden field/something,
+    instead of having to re-search for them with potentially ambiguous/problematic results. -->
     <td> <b>First and Last Name:</b> </td>
     <td>
         <input class="focus" type="text" style="width:10em" name="first_name" />

--- a/uber/templates/registration/discount.html
+++ b/uber/templates/registration/discount.html
@@ -8,9 +8,6 @@
 {% csrf_token %}
 <table class="form">
 <tr>
-    <!-- Note that this is preferred first and last name.
-    May want to change, probably by sending an attendee ID to this page as a hidden field/something,
-    instead of having to re-search for them with potentially ambiguous/problematic results. -->
     <td> <b>First and Last Name:</b> </td>
     <td>
         <input class="focus" type="text" style="width:10em" name="first_name" />

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -204,7 +204,8 @@
         <thead><tr>
             {% block tableheadings %}
             <th> <a href="index?order={{ order.group_id }}">Group Name</a> </th>
-            <th> <a href="index?order={{ order.last_first }}">Legal Name</a> </th>
+            <th> <a href="index?order={{ order.last_first }}">Preferred Name</a> </th>
+            <th> <a href="index?order={{ order.legal_name }}">Legal Name</a> </th>
             {% if c.PREASSIGNED_BADGE_TYPES %}<th> <a href="index?order={{ order.badge_printed_name }}">Badge Name</a> </th>{% endif %}
             <th> <a href="index?order={{ order.badge_type }}">Membership Type</a></th>
             {% if c.NUMBERED_BADGES %}<th> <a href="index?order={{ order.badge_num }}">Badge #</a> </th> {% endif %}
@@ -227,6 +228,9 @@
                 <td id="name_{{ attendee.id }}" style="text-align:left">
                     <a href="form?id={{ attendee.id }}">{{ attendee.last_first }}</a>
                 </td>
+                    <td id="name_{{ attendee.id }}" style="text-align:left">
+                        <a href="form?id={{ attendee.id }}">{{ attendee.legal_name_opt }}</a>
+                    </td>
                 {% if c.PREASSIGNED_BADGE_TYPES %}<td>{{ attendee.badge_printed_name }}</td>{% endif %}
                 <td><nobr>{{ attendee.badge_type_label }}</nobr></td>
                 {% if c.NUMBERED_BADGES %}<td>{{ attendee.badge_num }}</td>{% endif %}

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -229,7 +229,7 @@
                     <a href="form?id={{ attendee.id }}">{{ attendee.last_first }}</a>
                 </td>
                     <td id="name_{{ attendee.id }}" style="text-align:left">
-                        <a href="form?id={{ attendee.id }}">{{ attendee.legal_name_opt }}</a>
+                        <a href="form?id={{ attendee.id }}">{{ attendee.legal_name }}</a>
                     </td>
                 {% if c.PREASSIGNED_BADGE_TYPES %}<td>{{ attendee.badge_printed_name }}</td>{% endif %}
                 <td><nobr>{{ attendee.badge_type_label }}</nobr></td>

--- a/uber/templates/static_views/legal_name.html
+++ b/uber/templates/static_views/legal_name.html
@@ -14,7 +14,11 @@ If you are unsure what name to use, or if your legal name is in flux, simply ent
 
 <br/> <br/>
 
-Your legal name is for internal use only and will not be printed on public materials (e.g. badges, swag, etc).
+If you do not enter a separate legal name, which is the likely case for most people, we will assume your preferred name is also what will appear on your photo ID.
+
+<br/> <br/>
+
+Both your preferred and legal name are for internal use only and will not be printed on public materials (e.g. badges, swag, etc). We will use your preferred name in emails and when interacting with you, but we still need your legal name to check you in.
 
 </body>
 </html>

--- a/uber/templates/static_views/legal_name.html
+++ b/uber/templates/static_views/legal_name.html
@@ -18,7 +18,7 @@ If you do not enter a separate legal name, which is the likely case for most peo
 
 <br/> <br/>
 
-Both your preferred and legal name are for internal use only and will not be printed on public materials (e.g. badges, swag, etc). We will use your preferred name in emails and when interacting with you, but we still need your legal name to check you in.
+Your legal name is for internal use only and will not be printed on public materials, but is needed to check you in. We will use your preferred name in emails and when interacting with you, and may print it in cases such as when you do not enter a badge name (for personalized swag, staff badges, etc.)
 
 </body>
 </html>


### PR DESCRIPTION
Fixes #1894

This might need some review, but I've tested it manually a fair amount and it doesn't break much, and I think most of the review items are part of larger issues that shouldn't be tackled with this one (e.g. discount.html).

This *does* require a database schema change, however (addition of the `legal_name` column)

---

The basic overview of this change is that it adds a `legal_name` override in attendees, which is nullable and falls back to first_name+last_name if null, but can be used to add a separate legal_name. Hotel export and other plugins should be updated accordingly.

Search also displays both preferred and legal name (as well as searching both names). An example is in this image:

![preferred name](http://i.imgur.com/Fef12HU.png).