### PR TITLE
Make reg_notes more universal

### DIFF
--- a/uber/templates/emails/reg_workflow/reg_notes.html
+++ b/uber/templates/emails/reg_workflow/reg_notes.html
@@ -1,4 +1,4 @@
-{% if attendee.staffing %}
+{% if attendee.staffing and not attendee.assigned_depts %}
     <br/> <br/>
     Thanks for your interest in volunteering!
     {% if attendee.paid == c.HAS_PAID %}


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2276 by making the block about volunteering show only if the attendee receiving the email does not have any assigned departments. This should allow us to include reg_notes in any email without showing this message out of context.