### PR TITLE
Add amount_refunded to groups

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -62,7 +62,7 @@ def dealer_address(group):
 
 
 @validation.Group
-def group_paid(group):
+def group_money(group):
     try:
         amount = int(float(group.amount_paid))
         if amount < 0:
@@ -70,6 +70,14 @@ def group_paid(group):
     except:
         return "What you entered for Amount Paid ({}) isn't even a number".format(group.amount_paid)
 
+    try:
+        amount_refunded = int(float(group.amount_refunded))
+        if amount_refunded < 0:
+            return 'Amount Refunded must be positive'
+        elif amount_refunded > amount_paid:
+            return 'Amount Refunded cannot be greater than Amount Paid'
+    except:
+        return "What you entered for Amount Refunded ({}) wasn't even a number".format(group.amount_refunded)
 
 def _invalid_phone_number(s):
     if not s.startswith('+'):

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -79,6 +79,7 @@ def group_money(group):
     except:
         return "What you entered for Amount Refunded ({}) wasn't even a number".format(group.amount_refunded)
 
+
 def _invalid_phone_number(s):
     if not s.startswith('+'):
         return len(re.findall(r'\d', s)) != 10 or re.search(c.SAME_NUMBER_REPEATED, re.sub(r'[^0-9]', '', s))

--- a/uber/models.py
+++ b/uber/models.py
@@ -862,24 +862,25 @@ class Session(SessionManager):
 
 
 class Group(MagModel, TakesPaymentMixin):
-    public_id    = Column(UUID, default=lambda: str(uuid4()))
-    name          = Column(UnicodeText)
-    tables        = Column(Numeric, default=0)
-    address       = Column(UnicodeText)
-    website       = Column(UnicodeText)
-    wares         = Column(UnicodeText)
-    description   = Column(UnicodeText)
-    special_needs = Column(UnicodeText)
-    amount_paid   = Column(Integer, default=0, admin_only=True)
-    cost          = Column(Integer, default=0, admin_only=True)
-    auto_recalc   = Column(Boolean, default=True, admin_only=True)
-    can_add       = Column(Boolean, default=False, admin_only=True)
-    admin_notes   = Column(UnicodeText, admin_only=True)
-    status        = Column(Choice(c.DEALER_STATUS_OPTS), default=c.UNAPPROVED, admin_only=True)
-    registered    = Column(UTCDateTime, server_default=utcnow())
-    approved      = Column(UTCDateTime, nullable=True)
-    leader_id     = Column(UUID, ForeignKey('attendee.id', use_alter=True, name='fk_leader'), nullable=True)
-    leader        = relationship('Attendee', foreign_keys=leader_id, post_update=True, cascade='all')
+    public_id       = Column(UUID, default=lambda: str(uuid4()))
+    name            = Column(UnicodeText)
+    tables          = Column(Numeric, default=0)
+    address         = Column(UnicodeText)
+    website         = Column(UnicodeText)
+    wares           = Column(UnicodeText)
+    description     = Column(UnicodeText)
+    special_needs   = Column(UnicodeText)
+    amount_paid     = Column(Integer, default=0, admin_only=True)
+    amount_refunded = Column(Integer, default=0, admin_only=True)
+    cost            = Column(Integer, default=0, admin_only=True)
+    auto_recalc     = Column(Boolean, default=True, admin_only=True)
+    can_add         = Column(Boolean, default=False, admin_only=True)
+    admin_notes     = Column(UnicodeText, admin_only=True)
+    status          = Column(Choice(c.DEALER_STATUS_OPTS), default=c.UNAPPROVED, admin_only=True)
+    registered      = Column(UTCDateTime, server_default=utcnow())
+    approved        = Column(UTCDateTime, nullable=True)
+    leader_id       = Column(UUID, ForeignKey('attendee.id', use_alter=True, name='fk_leader'), nullable=True)
+    leader          = relationship('Attendee', foreign_keys=leader_id, post_update=True, cascade='all')
 
     _repr_attr_names = ['name']
 
@@ -1067,8 +1068,8 @@ class Attendee(MagModel, TakesPaymentMixin):
     overridden_price = Column(Integer, nullable=True, admin_only=True)
     amount_paid      = Column(Integer, default=0, admin_only=True)
     amount_extra     = Column(Choice(c.DONATION_TIER_OPTS, allow_unspecified=True), default=0)
-    amount_refunded  = Column(Integer, default=0, admin_only=True)
     payment_method   = Column(Choice(c.PAYMENT_METHOD_OPTS), nullable=True)
+    amount_refunded  = Column(Integer, default=0, admin_only=True)
 
     badge_printed_name = Column(UnicodeText)
 

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -377,14 +377,15 @@ class Root:
 
     def volunteers_owed_refunds(self, session):
         attendees = session.all_attendees().filter(Attendee.paid.in_([c.HAS_PAID, c.PAID_BY_GROUP, c.REFUNDED])).all()
-        is_unrefunded = lambda a: a.paid == c.HAS_PAID or a.paid == c.PAID_BY_GROUP and a.group and a.group.amount_paid
+        is_unrefunded = lambda a: a.paid == c.HAS_PAID or a.paid == c.PAID_BY_GROUP and a.group and a.group.amount_paid\
+                                                          and not a.group.amount_refunded
         return {
             'attendees': [(
                 'Volunteers Owed Refunds',
                 [a for a in attendees if is_unrefunded(a) and a.worked_hours >= c.HOURS_FOR_REFUND]
             ), (
                 'Volunteers Already Refunded',
-                [a for a in attendees if a.paid == c.REFUNDED and a.staffing]
+                [a for a in attendees if not is_unrefunded(a) and a.staffing]
             ), (
                 'Volunteers Who Can Be Refunded Once Their Shifts Are Marked',
                 [a for a in attendees if is_unrefunded(a) and a.worked_hours < c.HOURS_FOR_REFUND

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -130,6 +130,13 @@
 </div>
 
 <div class="form-group">
+    <label class="col-sm-2 control-label">Amount Refunded</label>
+    <div class="col-sm-6">
+        $<input type="text" style="width:4em" name="amount_refunded" value="{{ group.amount_refunded }}" />
+    </div>
+</div>
+
+    <div class="form-group">
     <label class="col-sm-2 control-label">Can Add Badges</label>
     <div class="col-sm-6">
         {% checkbox group.can_add %} Allow this group to add badges


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/1509 by letting admins mark down how much a group itself was refunded. This bypasses a lot of workflow issues with refunding group payments. Also fixes https://github.com/magfest/ubersystem/issues/1799 by modifying the output of volunteers_owed_refunds accordingly.