### PR TITLE
Stop forcing department heads to be trusted in all their departments.

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1166,7 +1166,6 @@ class Attendee(MagModel, TakesPaymentMixin):
     def _staffing_adjustments(self):
         if self.ribbon == c.DEPT_HEAD_RIBBON:
             self.staffing = True
-            self.trusted_depts = self.assigned_depts
             if c.SHIFT_CUSTOM_BADGES or c.STAFF_BADGE not in c.PREASSIGNED_BADGE_TYPES:
                 self.badge_type = c.STAFF_BADGE
             if self.paid == c.NOT_PAID:

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -219,8 +219,6 @@ class TestStaffingAdjustments:
         a = Attendee(ribbon=c.DEPT_HEAD_RIBBON, assigned_depts=c.CONSOLE)
         a._staffing_adjustments()
         assert a.staffing
-        assert a.trusted_in(c.CONSOLE)
-        assert a.trusted_somewhere
         assert a.badge_type == c.STAFF_BADGE
 
     def test_staffing_still_trusted_assigned(self):


### PR DESCRIPTION
Fixes #2200. This is a rare use-case but an easy fix.