### PR TITLE
Prevent attendees from unvolunteering in some cases

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -26,6 +26,8 @@
     $(function () {
         staffingClicked();
         if ($.field('staffing')) {
+            {% if c.AT_THE_CON %} $.field('staffing').prop('disabled', true).prop('title', 'Please see Staffing Operations to change your volunteer status.'); {% endif %}
+            {% if attendee.shifts %} $.field('staffing').prop('disabled', true).prop('title', 'Please {{ c.AT_THE_CON|yesno:"contact your department head to drop shifts,unassign yourself from shifts" }} before changing your volunteer status.'); {% endif %}
             $.field('staffing').on('click', staffingClicked);
         }
     });
@@ -343,7 +345,7 @@
                 <a href='goto_volunteer_checklist?id={{ attendee.id }}'>volunteering</a>
             {% endif %}
         {% else %}
-            Sign me up! &nbsp;
+            {% if attendee.badge_type == c.STAFF_BADGE %} Yes, I want to staff {{ c.EVENT_NAME }}. {% else %} Sign me up! {% endif %}
             <span class="popup">{% popup_link "../static_views/stafferComps.html" "What do I get for volunteering?" %}</span>
         {% endif %}
     </div>


### PR DESCRIPTION
Addresses a comment made in https://github.com/magfest/ubersystem/issues/970 where attendees being able to 'unvolunteer' is undesirable while at-the-con. Instructs attendees to either drop their shifts explicitly, contact their dept head to drop their shifts, or see staffing ops based on if we're at-the-con and if the attendee has shifts. Also tries to address wording around the 'volunteering' checkbox so contracted staff are less likely to get confused (https://github.com/magfest/ubersystem/issues/2050).