### PR TITLE
Fix attendee-facing kick-in levels

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -108,7 +108,7 @@
 {% endif %}
 
 {% if c.DONATIONS_ENABLED and c.PAGE_PATH != '/registration/form' %}
-    {% if c.PREREG_DONATION_OPTS.length > 1 or attendee.amount_extra %}
+    {% if c.PREREG_DONATION_OPTS|length > 1 or attendee.amount_extra %}
         <script type="text/javascript">
             var donationChanged = function () {
                 setVisible('.affiliate-row', $.val('amount_extra') > 0);


### PR DESCRIPTION
An if statement in the regform template would always evaluate to false unless an attendee already had a kick-in. Looks like it was a typo that was just never caught. Fixes https://github.com/magfest/ubersystem/issues/2374.