### PR TITLE
Removes two extraneous </div> tags from groups and accounts templates

### DIFF
--- a/uber/templates/accounts/index.html
+++ b/uber/templates/accounts/index.html
@@ -30,7 +30,6 @@
     </div>
     <input type="password" class="form-control" id="check-password" name="check-password" placeholder="Re-enter Password"
            {% if not c.AT_OR_POST_CON %}disabled{% endif %}>
-    </div>
 </div>
 <div class="form-group">
     {% checkgroup AdminAccount.access %}

--- a/uber/templates/groups/index.html
+++ b/uber/templates/groups/index.html
@@ -30,7 +30,7 @@
     <a class="btn btn-default" href="form?id=None">Add a group</a>
     <a class="btn btn-default" href="form?id=None&new_dealer=true">Add a dealer</a>
     </div>
-	</div>
+
 <ul class="nav nav-tabs" role="tablist">
   <li {% if show == "all" %}class="active"{% endif %}><a href="index?order=name&show=all">All</a></li>
   <li {% if show == "tables" %}class="active"{% endif %}><a href="index?order=name&show=tables">Tables</a></li>


### PR DESCRIPTION
There were two extra closing </div> tags in the groups and accounts templates that were absolutely KILLING me!

In the long term I'd like to introduce some template style guides and automated HTML template linting (if that's even possible) to hopefully prevent things like this in the future.