### PR TITLE
Expand definition of 'dealer' for the purpose of badge prices

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1339,7 +1339,8 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def is_dealer(self):
-        return self.ribbon == c.DEALER_RIBBON or self.badge_type == c.PSEUDO_DEALER_BADGE or self.group and self.group.is_dealer and self.paid == c.PAID_BY_GROUP
+        return self.ribbon == c.DEALER_RIBBON or self.badge_type == c.PSEUDO_DEALER_BADGE or \
+               (self.group and self.group.is_dealer and self.paid == c.PAID_BY_GROUP)
 
     @property
     def is_dept_head(self):

--- a/uber/models.py
+++ b/uber/models.py
@@ -1192,7 +1192,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     def _badge_adjustments(self):
         # _assert_badge_lock()
         from uber.badge_funcs import needs_badge_num
-        if self.is_dealer:
+        if self.badge_type == c.PSEUDO_DEALER_BADGE:
             self.ribbon = c.DEALER_RIBBON
 
         self.badge_type = get_real_badge_type(self.badge_type)
@@ -1339,7 +1339,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def is_dealer(self):
-        return self.ribbon == c.DEALER_RIBBON or self.badge_type == c.PSEUDO_DEALER_BADGE
+        return self.ribbon == c.DEALER_RIBBON or self.badge_type == c.PSEUDO_DEALER_BADGE or self.group and self.group.is_dealer and self.paid == c.PAID_BY_GROUP
 
     @property
     def is_dept_head(self):

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -251,9 +251,12 @@ class Root:
                 session.delete_from_group(attendee, attendee.group)
                 message = 'Unassigned badge removed.'
             else:
-                session.add(Attendee(**{attr: getattr(attendee, attr) for attr in [
+                replacement_attendee = Attendee(**{attr: getattr(attendee, attr) for attr in [
                     'group', 'registered', 'badge_type', 'badge_num', 'paid', 'amount_paid', 'amount_extra'
-                ]}))
+                ]})
+                if replacement_attendee.group and replacement_attendee.group.is_dealer:
+                    replacement_attendee.ribbon == c.DEALER_RIBBON
+                session.add(replacement_attendee)
                 session.delete_from_group(attendee, attendee.group)
                 message = 'Attendee deleted, but this badge is still available to be assigned to someone else in the same group'
         else:

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -62,6 +62,7 @@ def test_is_dealer():
     # not all attendees in a dealer group are necessarily dealers
     dealer_group = Group(tables=1)
     assert not Attendee(group=dealer_group).is_dealer
+    assert Attendee(group=dealer_group, paid=c.PAID_BY_GROUP)
 
 
 def test_is_dept_head():

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -62,7 +62,7 @@ def test_is_dealer():
     # not all attendees in a dealer group are necessarily dealers
     dealer_group = Group(tables=1)
     assert not Attendee(group=dealer_group).is_dealer
-    assert Attendee(group=dealer_group, paid=c.PAID_BY_GROUP)
+    assert Attendee(group=dealer_group, paid=c.PAID_BY_GROUP).is_dealer
 
 
 def test_is_dept_head():


### PR DESCRIPTION
Fixes https://github.com/magfest/magclassic/issues/52. When we changed the way group prices worked, we started inspecting attendees' status for their price instead of the group's status. This definition wasn't broad enough for dealers, who could be in a 'dealer' group but not have a Shopkeep ribbon. This fixes that, and changes our dealer ribbon auto-assignment so it doesn't override admin choices by accident now that we've broadened this definition. It also auto-assigns Shopkeep ribbons to replacement attendees when you 'unassign' an attendee, which is the bug that revealed this problem.