### PR TITLE
Prevent JS error caused by new legal_name code

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -63,8 +63,10 @@
         }
     };
     $(function () {
-        sameLegalNameChecked();
-        $('#same_legal_name').change(sameLegalNameChecked);
+        if ($('#same_legal_name').length) {
+            sameLegalNameChecked();
+            $('#same_legal_name').change(sameLegalNameChecked);
+        }
     })
 
 </script>


### PR DESCRIPTION
This was actually part of https://github.com/magfest/magclassic/issues/67 -- the Javascript on the confirmation page broke because we don't let people edit their name there, which then caused our amount_extra hiding script in the magclassic repo to stop working. The legal_name Javascript now checks to make sure the field exists.