### PR TITLE
Fixes #2404: Adds empty datetime check to filters

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -17,32 +17,27 @@ def safe_string(text):
 
 @JinjaEnv.jinja_filter(name='datetime')
 def datetime_filter(dt, fmt='%-I:%M%p %Z on %A, %b %e'):
-    if not dt:
-        return ''
-    return ' '.join(dt.strftime(fmt).split()).replace('AM', 'am').replace('PM', 'pm')
+    return '' if not dt else ' '.join(dt.strftime(fmt).split()).replace('AM', 'am').replace('PM', 'pm')
 
 
 @JinjaEnv.jinja_filter(name='datetime_local')
 def datetime_local_filter(dt, fmt='%-I:%M%p %Z on %A, %b %e'):
-    if not dt:
-        return ''
-    return datetime_filter(dt.astimezone(c.EVENT_TIMEZONE), fmt=fmt)
+    return '' if not dt else datetime_filter(dt.astimezone(c.EVENT_TIMEZONE), fmt=fmt)
 
 
 @JinjaEnv.jinja_filter
 def time_day_local(dt):
     if not dt:
         return ''
-    time_str = dt.astimezone(c.EVENT_TIMEZONE).strftime('%-I:%M%p').lstrip('0').lower()
-    day_str = dt.astimezone(c.EVENT_TIMEZONE).strftime('%a')
+    dt_local = dt.astimezone(c.EVENT_TIMEZONE)
+    time_str = dt_local.strftime('%-I:%M%p').lstrip('0').lower()
+    day_str = dt_local.strftime('%a')
     return safe_string('<nobr>{} {}</nobr>'.format(time_str, day_str))
 
 
 @JinjaEnv.jinja_filter
 def full_datetime_local(dt):
-    if not dt:
-        return ''
-    return dt.astimezone(c.EVENT_TIMEZONE).strftime('%H:%M on %B %d %Y')
+    return '' if not dt else dt.astimezone(c.EVENT_TIMEZONE).strftime('%H:%M on %B %d %Y')
 
 
 @JinjaEnv.jinja_export
@@ -57,17 +52,14 @@ def event_dates():
 
 @JinjaEnv.jinja_export
 def hour_day_local(dt):
-    if not dt:
-        return ''
-    return hour_day_format(dt)
+    # NOTE: hour_day_format() already localizes the given datetime object
+    return '' if not dt else hour_day_format(dt)
 
 
 @JinjaEnv.jinja_filter
 def timestamp(dt):
-    if not dt:
-        return ''
     from time import mktime
-    return str(int(mktime(dt.timetuple())))
+    return '' if not dt else str(int(mktime(dt.timetuple())))
 
 
 @JinjaEnv.jinja_filter

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -17,16 +17,22 @@ def safe_string(text):
 
 @JinjaEnv.jinja_filter(name='datetime')
 def datetime_filter(dt, fmt='%-I:%M%p %Z on %A, %b %e'):
-    return ' '.join(dt.strftime(fmt).split()).replace('AM', 'am').replace('PM', 'pm') if dt else ''
+    if not dt:
+        return ''
+    return ' '.join(dt.strftime(fmt).split()).replace('AM', 'am').replace('PM', 'pm')
 
 
 @JinjaEnv.jinja_filter(name='datetime_local')
 def datetime_local_filter(dt, fmt='%-I:%M%p %Z on %A, %b %e'):
+    if not dt:
+        return ''
     return datetime_filter(dt.astimezone(c.EVENT_TIMEZONE), fmt=fmt)
 
 
 @JinjaEnv.jinja_filter
 def time_day_local(dt):
+    if not dt:
+        return ''
     time_str = dt.astimezone(c.EVENT_TIMEZONE).strftime('%-I:%M%p').lstrip('0').lower()
     day_str = dt.astimezone(c.EVENT_TIMEZONE).strftime('%a')
     return safe_string('<nobr>{} {}</nobr>'.format(time_str, day_str))
@@ -34,6 +40,8 @@ def time_day_local(dt):
 
 @JinjaEnv.jinja_filter
 def full_datetime_local(dt):
+    if not dt:
+        return ''
     return dt.astimezone(c.EVENT_TIMEZONE).strftime('%H:%M on %B %d %Y')
 
 
@@ -49,11 +57,15 @@ def event_dates():
 
 @JinjaEnv.jinja_export
 def hour_day_local(dt):
+    if not dt:
+        return ''
     return hour_day_format(dt)
 
 
 @JinjaEnv.jinja_filter
 def timestamp(dt):
+    if not dt:
+        return ''
     from time import mktime
     return str(int(mktime(dt.timetuple())))
 

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -270,7 +270,7 @@ def renderable_data(data=None):
 def render(template_name_list, data=None):
     data = renderable_data(data)
     env = JinjaEnv.env()
-    template = env.get_template(template_name_list)
+    template = env.get_or_select_template(template_name_list)
     rendered = template.render(data)
 
     # disabled for performance optimzation.  so sad. IT SHALL RETURN

--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -55,7 +55,7 @@ class Root:
                     Attendee: '../registration/form?id={}'
                 }.get(x.__class__, '').format(x.id)
                 if len(examples) < 10:
-                    examples.append([url, email.render(x)])
+                    examples.append([url, email.render(x).decode('utf-8')])
 
         return {
             'count': count,

--- a/uber/tests/test_custom_tags.py
+++ b/uber/tests/test_custom_tags.py
@@ -1,12 +1,33 @@
 import pytest
 
 from uber.common import *
-from uber.custom_tags import jsonize, linebreaksbr
+from uber.custom_tags import (jsonize, linebreaksbr, datetime_local_filter,
+    datetime_filter, full_datetime_local, hour_day_local, time_day_local, timestamp)
+
+
+class TestDatetimeFilters(object):
+
+    @pytest.mark.parametrize('filter_function', [
+        datetime_local_filter,
+        datetime_filter,
+        full_datetime_local,
+        hour_day_local,
+        time_day_local,
+        timestamp
+    ])
+    @pytest.mark.parametrize('test_input,expected', [
+        (None, ''),
+        ('', ''),
+        ([], ''),
+        ({}, '')
+    ])
+    def test_filters_allow_empty_arg(self, filter_function, test_input, expected):
+        assert expected == filter_function(test_input)
 
 
 class TestJsonize(object):
 
-    @pytest.mark.parametrize("test_input,expected", [
+    @pytest.mark.parametrize('test_input,expected', [
         (None, '{}'),
         ('', '""'),
         ('asdf', '"asdf"'),
@@ -21,7 +42,7 @@ class TestJsonize(object):
 
 class TestLinebreaksbr(object):
 
-    @pytest.mark.parametrize("test_input,expected", [
+    @pytest.mark.parametrize('test_input,expected', [
         ('', Markup('')),
         (Markup(''), Markup('')),
         ('asdf', Markup('asdf')),


### PR DESCRIPTION
Fixes #2404

Adds empty datetime check to filters. Also utf-8 decodes email example before passing to template.