### PR TITLE
Fixes #2421: Registers Decimal type as json serializable in sideboard

### DIFF
--- a/uber/__init__.py
+++ b/uber/__init__.py
@@ -1,2 +1,10 @@
+from decimal import Decimal
+
 from uber._version import __version__
 from uber.common import *
+
+from sideboard import lib
+
+
+# NOTE: this will decrease the precision of some serialized decimal.Decimals
+lib.serializer.register(Decimal, lambda n: float(n))

--- a/uber/tests/test_sideboard_serializer.py
+++ b/uber/tests/test_sideboard_serializer.py
@@ -1,0 +1,16 @@
+from decimal import Decimal
+
+import pytest
+
+from uber.common import *
+
+
+@pytest.mark.parametrize('test_input,expected', [
+    (Decimal(), '0.0'),
+    (Decimal(0), '0.0'),
+    (Decimal(0.1), '0.1'),
+    ([Decimal(0), Decimal(0.1)], '[0.0, 0.1]'),
+    ({'d': Decimal(0.1)}, '{"d": 0.1}')
+])
+def test_decimal(test_input, expected):
+    assert expected == json.dumps(test_input, cls=serializer)


### PR DESCRIPTION
Fixes #2421. We were attempting to JSON serialize `decimal.Decimal` types, but we had not registered an appropriate serialization handler.

# NOTE
This change *could* have been made in the sideboard project. I chose to make the change in uber, because there are different approaches to serializing `decimal.Decimal`s, and I didn't want to enforce one method over the other in the base sideboard project.