### PR TITLE
Remove nonfunctional "Scan 2D Barcode" button

### DIFF
--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -8,41 +8,6 @@
         document.getElementById('search_bar').select();
     });
 
-    function decrypt_checkin_code(barcode) {
-        $.ajax({
-            method: 'POST',
-            url: 'qrcode_reader',
-            dataType: 'json',
-            data: {qrcode: barcode, csrf_token: csrf_token},
-            success: function (json) {
-                toastr.clear();
-                var message = json.message;
-                if (json.success) {
-                    $("#search_bar").val(json.data).parents('form').submit()
-                } else {
-                    toastr.error(message);
-                }
-            },
-            error: function () {
-                toastr.error('Unable to connect to server, please try again.');
-            }
-        });
-    }
-
-    $(function(){
-        $("#qr-scan").click(function(){
-            bootbox.prompt({
-                title: "Scan 2D Barcode",
-                backdrop: true,
-                callback: function (result) {
-                    if(result) {
-                        decrypt_checkin_code(result);
-                    }
-                }
-            });
-        });
-    });
-
 </script>
     {% include "check_in.html" %}
 
@@ -80,7 +45,6 @@
             <a class="btn btn-info" href="index?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode }}&invalid=True">Show all badge statuses</a>
         {% endif %}
 
-        <button class="btn btn-primary" id="qr-scan">Scan 2D Barcode</button>
     </div>
     <div class="panel col-md-4">
         <div class="col-md-6">{{ attendee_count }} Attendee{{ attendee_count|pluralize }}</div>


### PR DESCRIPTION
This was an oversight in https://github.com/magfest/ubersystem/pull/2344 -- we removed the `qr_code_reader` function that this button depends on, but not the button itself. Trying to use this button would result in an error.

Since #2344 lets you scan the check-in barcode directly into the searchbox, we don't need the button anymore.