### PR TITLE
 Adds new timedelta filter required by #185 in the magprime repo

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -16,12 +16,12 @@ def safe_string(text):
 
 
 @JinjaEnv.jinja_filter(name='datetime')
-def datetime_filter(dt, fmt='%-I:%M%p %Z on %A, %b %e'):
+def datetime_filter(dt, fmt='%-I:%M%p %Z on %A, %b %-e'):
     return '' if not dt else ' '.join(dt.strftime(fmt).split()).replace('AM', 'am').replace('PM', 'pm')
 
 
 @JinjaEnv.jinja_filter(name='datetime_local')
-def datetime_local_filter(dt, fmt='%-I:%M%p %Z on %A, %b %e'):
+def datetime_local_filter(dt, fmt='%-I:%M%p %Z on %A, %b %-e'):
     return '' if not dt else datetime_filter(dt.astimezone(c.EVENT_TIMEZONE), fmt=fmt)
 
 
@@ -33,6 +33,13 @@ def time_day_local(dt):
     time_str = dt_local.strftime('%-I:%M%p').lstrip('0').lower()
     day_str = dt_local.strftime('%a')
     return safe_string('<nobr>{} {}</nobr>'.format(time_str, day_str))
+
+
+@JinjaEnv.jinja_filter(name='timedelta')
+def timedelta_filter(dt, *args, **kwargs):
+    if not dt:
+        return None
+    return dt + timedelta(*args, **kwargs)
 
 
 @JinjaEnv.jinja_filter

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -37,6 +37,11 @@ def time_day_local(dt):
 
 @JinjaEnv.jinja_filter(name='timedelta')
 def timedelta_filter(dt, *args, **kwargs):
+    """Returns a datetime object offset by a timedelta specified by the given arguments.
+
+    Takes the same arguments as the standard library's datetime.timedelta class.
+    Returns None if an empty datetime object is given.
+    """
     if not dt:
         return None
     return dt + timedelta(*args, **kwargs)

--- a/uber/tests/test_custom_tags.py
+++ b/uber/tests/test_custom_tags.py
@@ -45,13 +45,13 @@ class TestDatetimeFilters(object):
     def test_timedelta_filter_in_template(self):
         dt = datetime.utcnow()
         env = JinjaEnv.env()
-        template = env.from_string('{{ dt|timedelta(days=5)|datetime("%A, %b %-e") }}')
-        expected = (dt + timedelta(days=5)).strftime("%A, %b %-e")
+        template = env.from_string('{{ dt|timedelta(days=-5)|datetime("%A, %B %-e") }}')
+        expected = (dt + timedelta(days=-5)).strftime("%A, %B %-e")
         assert expected == template.render(dt=dt)
 
     def test_timedelta_filter_in_template_with_empty_date(self):
         env = JinjaEnv.env()
-        template = env.from_string('{{ dt|timedelta(days=5)|datetime("%A, %b %-e") }}')
+        template = env.from_string('{{ dt|timedelta(days=-5)|datetime("%A, %B %-e") }}')
         expected = ''
         assert expected == template.render(dt=None)
 

--- a/uber/tests/test_custom_tags.py
+++ b/uber/tests/test_custom_tags.py
@@ -2,7 +2,8 @@ import pytest
 
 from uber.common import *
 from uber.custom_tags import (jsonize, linebreaksbr, datetime_local_filter,
-    datetime_filter, full_datetime_local, hour_day_local, time_day_local, timestamp)
+    datetime_filter, full_datetime_local, hour_day_local, time_day_local,
+    timedelta_filter, timestamp)
 
 
 class TestDatetimeFilters(object):
@@ -23,6 +24,36 @@ class TestDatetimeFilters(object):
     ])
     def test_filters_allow_empty_arg(self, filter_function, test_input, expected):
         assert expected == filter_function(test_input)
+
+    @pytest.mark.parametrize('timedelta_args,timedelta_kwargs', [
+        ([], {}),
+        ([], dict(days=1, seconds=30, microseconds=100, milliseconds=100, minutes=20, hours=12, weeks=2)),
+        ([1, 30, 100, 100, 20, 12, 2], {}),
+    ])
+    def test_timedelta_filter(self, timedelta_args, timedelta_kwargs):
+        dt = datetime.utcnow()
+        td = timedelta(*timedelta_args, **timedelta_kwargs)
+        expected = dt + td
+        assert expected == timedelta_filter(dt, *timedelta_args, **timedelta_kwargs)
+
+    def test_timedelta_filter_with_empty_date(self):
+        assert timedelta_filter(dt=None, days=1, seconds=3600) is None
+        assert timedelta_filter(dt='', days=1, seconds=3600) is None
+        assert timedelta_filter(None, 1, 3600) is None
+        assert timedelta_filter('', 1, 3600) is None
+
+    def test_timedelta_filter_in_template(self):
+        dt = datetime.utcnow()
+        env = JinjaEnv.env()
+        template = env.from_string('{{ dt|timedelta(days=5)|datetime("%A, %b %-e") }}')
+        expected = (dt + timedelta(days=5)).strftime("%A, %b %-e")
+        assert expected == template.render(dt=dt)
+
+    def test_timedelta_filter_in_template_with_empty_date(self):
+        env = JinjaEnv.env()
+        template = env.from_string('{{ dt|timedelta(days=5)|datetime("%A, %b %-e") }}')
+        expected = ''
+        assert expected == template.render(dt=None)
 
 
 class TestJsonize(object):


### PR DESCRIPTION
This pull request adds a new `timedelta()` Jinja filter, allowing `datetime()` addition and subtraction in our Jinja templates. This is required to fix https://github.com/magfest/magprime/issues/185.