### PR TITLE
Don't refer to staff food if there is no staff suite

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -261,7 +261,7 @@ class Config(_Overridable):
     def STAFF_GET_FOOD(self):
         """
         Certain events may run a complimentary consuite for staff and guests. Whether or not the consuite exists changes
-        a lot of little things, like whether we collect food restrictions or describe free food as a benefit to 
+        a lot of little things, like whether we collect food restrictions or describe free food as a benefit to
         staffing. To turn this on, add a department with the variable name `staff_suite` to [[job_location]].
         Returns:
             Boolean, true if staff_suite is in job_location config

--- a/uber/config.py
+++ b/uber/config.py
@@ -258,6 +258,17 @@ class Config(_Overridable):
         return not self.AT_OR_POST_CON
 
     @property
+    def STAFF_GET_FOOD(self):
+        """
+        Certain events may run a complimentary consuite for staff and guests. Whether or not the consuite exists changes
+        a lot of little things, like whether we collect food restrictions or describe free food as a benefit to 
+        staffing. To turn this on, add a department with the variable name `staff_suite` to [[job_location]].
+        Returns:
+            Boolean, true if staff_suite is in job_location config
+        """
+        return getattr(c, 'STAFF_SUITE', None) in c.JOB_LOCATIONS
+
+    @property
     def FINAL_EMAIL_DEADLINE(self):
         return min(c.UBER_TAKEDOWN, c.EPOCH)
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -1621,8 +1621,12 @@ class Attendee(MagModel, TakesPaymentMixin):
         return any(shift.job.location == department for shift in self.shifts)
 
     @property
+    def food_restrictions_filled_out(self):
+        return self.food_restrictions if c.STAFF_GET_FOOD else True
+
+    @property
     def shift_prereqs_complete(self):
-        return not self.placeholder and self.food_restrictions and self.shirt_size_marked
+        return not self.placeholder and self.food_restrictions_filled_out and self.shirt_size_marked
 
     @property
     def past_years_json(self):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -487,12 +487,6 @@ class Root:
             'affiliates':    session.affiliates()
         }
 
-    def guest_food(self, session, id):
-        attendee = session.attendee(id)
-        assert attendee.badge_type == c.GUEST_BADGE, 'This form is for guests only'
-        cherrypy.session['staffer_id'] = attendee.id
-        raise HTTPRedirect('../signups/food_restrictions')
-
     @attendee_id_required
     def attendee_donation_form(self, session, id, message=''):
         attendee = session.attendee(id)

--- a/uber/templates/signups/printable_schedule.html
+++ b/uber/templates/signups/printable_schedule.html
@@ -10,7 +10,7 @@
     get a free badge or free hotel room space next year.
 {% endif %}
 
-{% include "signups/food_info.html" %}
+{% if c.STAFF_GET_FOOD %}{% include "signups/food_info.html" %}{% endif %}
 
 {% if attendee.shifts %}
     <i>You should report to a Department Chair for each department you're working before the start of your first shift:</i>

--- a/uber/templates/static_views/howToStaff.html
+++ b/uber/templates/static_views/howToStaff.html
@@ -23,7 +23,7 @@ on the login form on the Volunteer Login page, and you'll be presented with a li
 
 <br/> <br/>
 
-Volunteers are rewarded with tshirts, badge refunds, and even food!  <a href="stafferComps.html">Click here</a> to
+Volunteers are rewarded with tshirts, badge refunds, and more!  <a href="stafferComps.html">Click here</a> to
 see a list of volunteer perks.
 
 </body>

--- a/uber/templates/static_views/stafferComps.html
+++ b/uber/templates/static_views/stafferComps.html
@@ -9,7 +9,7 @@
 The more hours you work, the more you get (don't forget about <a href="weightDesc.html">weighted hours</a>):
 <ul>
     <li> Working at least 6 hours gets you a {{ c.EVENT_NAME }} t-shirt. <br/><br/> </li>
-    <li> Working at least 12 hours gets you food in addition to the shirt.  We have professional chefs preparing 3 meals per day throughout the event. <br/><br/> </li>
+    {% if c.STAFF_GET_FOOD %}<li> Working at least 12 hours gets you food in addition to the shirt.  We have professional chefs preparing 3 meals per day throughout the event. <br/><br/> </li>{% endif %}
     <li> Working at least 18 hours gets you a complementary Staff badge for next year's {{ c.EVENT_NAME }}, which will make you eligible for space in one of our staff hotel rooms. <br/><br/> </li>
     <li> Working at least {{ c.HOURS_FOR_REFUND }} hours gets you a refund on your badge for this year. <br/><br/> </li>
     <li> Working at least 30 hours <b>ONLY IF</b> you're a returning Staffer gets you space in one of our staff hotel rooms. <br/><br/> </li>


### PR DESCRIPTION
Adds a new STAFF_GETS_FOOD option that checks if there is a department named staff_suite -- if not, we count food restrictions as 'filled out' for the purposes of showing volunteer checklist steps, and we remove references to free food elsewhere. Part of the fix for https://github.com/magfest/magclassic/issues/64.