### PR TITLE
Fixes magclassic #70: Minor css tweaks to improve supporter options

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -193,7 +193,7 @@
                     <br>
                 {{ macros.popup_link("../static_views/givingExtra.html", "Why do this?") }}
                 </label>
-                <div class="col-sm-8">
+                <div class="col-sm-10">
                     {% if c.AFTER_SUPPORTER_DEADLINE and attendee.amount_extra >= c.SUPPORTER_LEVEL or c.AFTER_SHIRT_DEADLINE and attendee.amount_extra >= c.SHIRT_LEVEL %}
                         {{ attendee.amount_extra_label }}
                         <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" />
@@ -212,18 +212,13 @@
                                         display: flex;
                                         flex-direction: row;
                                         flex-wrap: nowrap;
-                                        justify-content: center;
-                                        margin-top: 7rem;
                                     }
 
-                                    .btn-inline {
-                                        width: 180px;
-                                        height: 340px;
-
+                                    .no-inline, .btn-inline {
+                                        margin-right: 15px;
                                     }
 
                                     .h4-inline {
-
                                         text-align: center;
                                     }
 
@@ -247,7 +242,6 @@
                                     .li-inline {
                                         padding: 0.5em;
                                         text-align: center;
-                                        border-bottom: 1px solid whitesmoke;
                                     }
 
                                     .li-inline a, #supporter_popup a {
@@ -256,19 +250,18 @@
                                     }
                                 }
 
-                            @media (max-width: 543px) {
-                                .btn-group-inline
-                                    {
-                                        flex-direction: column;
-                                        flex-wrap: wrap;
-                                        width: 100vw;
-                                    }
+                            @media (max-width: 633px) {
+                                .btn-group-inline {
+                                    flex-direction: column;
+                                    flex-wrap: wrap;
+                                    padding-left: 15px;
+                                    padding-right: 15px;
+                                }
 
-                                .btn-inline
-                                    {
-                                        width: 100%;
-                                        height: initial;
-                                    }
+                                .no-inline, .btn-inline {
+                                    margin-right: 0;
+                                    width: 100%;
+                                }
                             }
 
                                 </style>
@@ -316,7 +309,7 @@
                     {% endif %}
                 </div>
 
-                <p class="help-block col-sm-6">
+                <p class="help-block col-sm-offset-2 col-sm-10">
                     Each level includes all lower levels. <br/>
                     Supporter level and higher {% if c.BEFORE_SUPPORTER_DEADLINE %}are{% else %}were{% endif %} only available until {{ c.SUPPORTER_DEADLINE|datetime_local }}.
                 </p>


### PR DESCRIPTION
Fixes https://github.com/magfest/magclassic/issues/70

Supporter options now look like this:

![screen shot 2017-04-10 at 11 31 06 pm](https://cloud.githubusercontent.com/assets/2592431/24894209/fc3a0ae0-1e45-11e7-92fb-8680c3a84065.png)
