### PR TITLE
remove some secrets

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -46,7 +46,7 @@ use_checkin_barcode = boolean(default=True)
 
 # These are used for web server configuration and for linking back to our
 # pages in emails; these definitely needs to be overridden in production.
-path = string(default="/magfest")
+path = string(default="/uber")
 hostname = string(default="localhost")
 url_root = string(default="http://localhost:8282")
 url_base = string(default="%(url_root)s%(path)s")
@@ -261,7 +261,7 @@ jerks = string_list(default=list('Nick Marinelli', 'Nicholas Marinelli', 'Matt R
 # public such as email crendtials and lists of banned attendees.
 
 # Used to connect to our Postgres database.
-sqlalchemy_url = string(default="postgresql://m13:m13@localhost:5432/m13")
+sqlalchemy_url = string(default="postgresql://db_user:db_password@localhost:5432/db_name")
 
 # Setting these to a value of -1 indicates that they won't be used when
 # constructing the SQLAlchemy session. For example, the SQLite DB engine
@@ -275,8 +275,8 @@ sqlalchemy_max_overflow = integer(default=100)
 # this purpose in mind.  You can enter any of Stripe's test credit card numbers
 # and have them work, e.g. you can use the number 4242 4242 4242 4242 which will
 # always be valid with any expiration date and security code.
-stripe_secret_key = string(default="sk_test_CvvvyHs2XnU9giMYDCUnIpF4")
-stripe_public_key = string(default="pk_test_t36jT3di98A0rnENDejBE1Vg")
+stripe_secret_key = string(default="")
+stripe_public_key = string(default="")
 
 # This list is checked when attendeees preregister and sign up as volunteers.
 # You should enter the full names including all common nicknames as separate


### PR DESCRIPTION
remove stripe keys and some magfest-specific settings in configspec.ini

These aren't particularly sensitive but, probably don't belong here.  In particular, magfest's stripe key (which is not a big deal because it's a test key so it can't any financial harm), but could be used for a denial of service attack or something.   Also, we're about to rotate it so it is going to be invalid anyway