### PR TITLE
Stop redefining dates in development-defaults

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -28,7 +28,7 @@ rooms_locked_in = True
 
 
 [dates]
-
+room_deadline = "2015-11-30"
 
 [badge_prices]
 

--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -29,19 +29,6 @@ rooms_locked_in = True
 
 [dates]
 
-shifts_created = "2015-11-14"
-
-dealer_reg_start    = "2015-08-08"
-dealer_reg_deadline = "2015-08-11"
-dealer_reg_shutdown = "2015-08-31"
-dealer_payment_due  = "2015-11-15"
-
-supporter_deadline = "2015-12-26"
-
-printed_badge_deadline = "2016-01-04"
-
-room_deadline = "2015-11-30"
-
 
 [badge_prices]
 


### PR DESCRIPTION
We already defined these dates in configspec.ini and set default values when needed. Doing it again in development-defaults is confusing.