### PR TITLE
Show an example of an email if there are none pending

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -279,6 +279,12 @@ def render(template_name_list, data=None):
     return rendered.encode('utf-8')
 
 
+def render_empty(template_name_list):
+    env = JinjaEnv.env()
+    template = env.get_or_select_template(template_name_list)
+    return str(open(template.filename, 'r').read())
+
+
 # this is a Magfest inside joke.
 # Nick gets mad when people call Magfest a "convention".  He always says "It's not a convention, it's a festival"
 # So........ if Nick is logged in.... let's annoy him a bit :)

--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -47,6 +47,7 @@ class Root:
         count = 0
         examples = []
         email = AutomatedEmail.instances[ident]
+        example = render_empty('emails/' + email.template)
         for x in AutomatedEmail.queries[email.model](session):
             if email.filters_run(x):
                 count += 1
@@ -59,6 +60,7 @@ class Root:
 
         return {
             'count': count,
+            'example': example,
             'examples': examples,
             'subject': email.subject,
         }

--- a/uber/templates/emails/pending_examples.html
+++ b/uber/templates/emails/pending_examples.html
@@ -13,6 +13,8 @@
     The following are some examples of the {{ count }} emails that will be sent once this email is approved:
 {% else %}
     Nobody matches the email criteria.  Perhaps the email is time-based and it's not yet time for it to be sent out?
+    <br>Here's what the template looks like though:<br>
+    <pre style="white-space:pre-wrap">{{ example }}</pre>
 {% endif %}
 
 {% for url, email in examples %}

--- a/uber/tests/test_templates.py
+++ b/uber/tests/test_templates.py
@@ -32,6 +32,30 @@ def test_verify_jinja_autoescape_template():
     assert result == expected
 
 
+def test_render_empty():
+    env = JinjaEnv.env()
+    cur_dir = os.path.dirname(__file__)
+    env.loader.searchpath.append(cur_dir)
+    try:
+        template = env.get_template('autoescape_template.html')
+    finally:
+        if cur_dir in env.loader.searchpath:
+            env.loader.searchpath.remove(cur_dir)
+
+    result = str(open(template.filename, 'r').read())
+    expected = '''\
+<!DOCTYPE HTML>
+<html>
+<body>
+{{ unsafe_string }}
+{% autoescape false %}{{ safe_string }}{% endautoescape %}
+</body>
+</html>
+'''
+
+    assert result == expected
+
+
 def test_verify_jinja_autoescape_string():
     env = JinjaEnv.env()
     template = env.from_string('''\


### PR DESCRIPTION
implements the same goal of #2384 

A decorator function was added to return a template's html without rendering it.
The pending examples page was edited.
The emails.py function was modified.