### PR TITLE
Fixes magstock #119: Leaves check constraints unnamed in SQLite

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -131,14 +131,17 @@ class MultiChoice(TypeDecorator):
 # Consistent naming conventions are necessary for alembic to be able to
 # reliably upgrade and downgrade versions. For more details, see:
 # http://alembic.zzzcomputing.com/en/latest/naming.html
-default_metadata = MetaData(
-    naming_convention=immutabledict({
-        'unnamed_ck': check_constraint_naming_convention,
-        'ix': 'ix_%(column_0_label)s',
-        'uq': 'uq_%(table_name)s_%(column_0_name)s',
-        'ck': 'ck_%(table_name)s_%(unnamed_ck)s',
-        'fk': 'fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s',
-        'pk': 'pk_%(table_name)s'}))
+default_naming_convention = {
+    'ix': 'ix_%(column_0_label)s',
+    'uq': 'uq_%(table_name)s_%(column_0_name)s',
+    'fk': 'fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s',
+    'pk': 'pk_%(table_name)s'}
+
+if not c.SQLALCHEMY_URL.startswith('sqlite'):
+    default_naming_convention['unnamed_ck'] = check_constraint_naming_convention
+    default_naming_convention['ck'] = 'ck_%(table_name)s_%(unnamed_ck)s',
+
+default_metadata = MetaData(naming_convention=immutabledict(default_naming_convention))
 
 
 @declarative_base(metadata=default_metadata)


### PR DESCRIPTION
Fixes https://github.com/magfest/magstock/issues/119

SQLite doesn't support `ALTER` statements, so the way alembic handles table migrations in SQLite is to:
1. create a temporary table with the new schema
2. copy the data from the original table to the temporary table
3. drop the original table
4. rename the temporary table to the original table name

Because of this, it doesn't matter if the implicit check constraints for Boolean columns have names, and alembic seems incapable of correctly generating the check constraint names for the new table, so we just don't even bother naming them if we're using SQLite.

Phew!