### PR TITLE
Remove validation for legal_name matching full_name

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -128,13 +128,6 @@ def full_name(attendee):
 
 @validation.Attendee
 @ignore_unassigned_and_placeholders
-def legal_name(attendee):
-    if attendee.legal_name and attendee.full_name == attendee.legal_name:
-        return 'When entering a legal name, it must be different than your preferred name. Otherwise, leave it blank.'
-
-
-@validation.Attendee
-@ignore_unassigned_and_placeholders
 def age(attendee):
     if c.COLLECT_EXACT_BIRTHDATE:
         if not attendee.birthdate:

--- a/uber/models.py
+++ b/uber/models.py
@@ -1204,6 +1204,9 @@ class Attendee(MagModel, TakesPaymentMixin):
             if value.isupper() or value.islower():
                 setattr(self, attr, value.title())
 
+        if attendee.legal_name and attendee.full_name == attendee.legal_name:
+            attendee.legal_name = ''
+
     @presave_adjustment
     def _badge_adjustments(self):
         # _assert_badge_lock()

--- a/uber/models.py
+++ b/uber/models.py
@@ -1204,8 +1204,8 @@ class Attendee(MagModel, TakesPaymentMixin):
             if value.isupper() or value.islower():
                 setattr(self, attr, value.title())
 
-        if attendee.legal_name and attendee.full_name == attendee.legal_name:
-            attendee.legal_name = ''
+        if self.legal_name and self.full_name == self.legal_name:
+            self.legal_name = ''
 
     @presave_adjustment
     def _badge_adjustments(self):

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -90,6 +90,18 @@ def test_last_first(monkeypatch):
     assert 'xxx' == Attendee(first_name='x', last_name='y').last_first
 
 
+def test_legal_name_same_as_full_name():
+    same_legal_name = Attendee(first_name='First', last_name='Last', legal_name='First Last')
+    same_legal_name._misc_adjustments()
+    assert '' == same_legal_name.legal_name
+
+
+def test_legal_name_diff_from_full_name():
+    diff_legal_name = Attendee(first_name='first', last_name='last', legal_name='diff name')
+    diff_legal_name._misc_adjustments()
+    assert 'diff name' == diff_legal_name.legal_name
+
+
 def test_badge():
     assert Attendee().badge == 'Unpaid Attendee'
     assert Attendee(paid=c.HAS_PAID).badge == 'Attendee'


### PR DESCRIPTION
This was tripping a lot of people up, so we now simply set the legal_name to an empty string if it matches. Partly addresses https://github.com/magfest/ubersystem/issues/2454.