### PR TITLE
Fix unique badge constraint errors in two cases

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -574,10 +574,9 @@ class Session(SessionManager):
             new_badge_num = self.auto_badge_num(badge_type)
             # Adjusts the badge number based on badges in the session
             for attendee in [m for m in chain(self.new, self.dirty) if isinstance(m, Attendee)]:
-                if attendee.badge_type == badge_type and attendee.badge_num is not None\
-                        and attendee.badge_num <= c.BADGE_RANGES[badge_type][1]\
-                        and attendee.badge_num <= self.auto_badge_num(badge_type):
-                    new_badge_num = max(self.auto_badge_num(badge_type), 1 + attendee.badge_num)
+                if attendee.badge_num is not None \
+                        and c.BADGE_RANGES[badge_type][0] <= attendee.badge_num <= c.BADGE_RANGES[badge_type][1]:
+                    new_badge_num = max(self.auto_badge_num(badge_type), 1 + attendee.badge_num, new_badge_num)
 
             assert new_badge_num < c.BADGE_RANGES[badge_type][1], 'There are no more badge numbers available in this range!'
 
@@ -636,18 +635,17 @@ class Session(SessionManager):
             a specific range.
             :return:
             """
-            sametype = self.query(Attendee.badge_num).filter(Attendee.badge_type == badge_type,
-                                                   Attendee.badge_num >= c.BADGE_RANGES[badge_type][0],
-                                                   Attendee.badge_num <= c.BADGE_RANGES[badge_type][1])
-            if sametype.count():
-                sametype_list = [int(row[0]) for row in sametype.order_by(Attendee.badge_num).all()]
+            in_range = self.query(Attendee.badge_num).filter(Attendee.badge_num >= c.BADGE_RANGES[badge_type][0],
+                                                             Attendee.badge_num <= c.BADGE_RANGES[badge_type][1])
+            if in_range.count():
+                in_range_list = [int(row[0]) for row in in_range.order_by(Attendee.badge_num).all()]
 
                 # Searches badge range for a gap in badge numbers; if none found, returns the latest badge number + 1
                 # Doing this lets admins manually set high badge numbers without filling up the badge type's range.
-                start, end = c.BADGE_RANGES[badge_type][0], sametype_list[-1]
-                gap_nums = sorted(set(range(start, end + 1)).difference(sametype_list))
+                start, end = c.BADGE_RANGES[badge_type][0], in_range_list[-1]
+                gap_nums = sorted(set(range(start, end + 1)).difference(in_range_list))
                 if not gap_nums:
-                    return sametype.order_by(Attendee.badge_num.desc()).first().badge_num + 1
+                    return in_range.order_by(Attendee.badge_num.desc()).first().badge_num + 1
                 else:
                     return gap_nums[0]
             else:


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2436. Also fixes a unique badge constraint error that would come up if a badge of a different type had a number in the same range -- there's no need to filter by badge type since we explicitly don't support the use case of having, e.g., 'staff 1' and 'attendee 1'.