### PR TITLE
Fixes renderable decorator merge error (renderable defined twice)

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -343,19 +343,6 @@ def renderable(func):
     return with_rendering
 
 
-def renderable(func):
-    @wraps(func)
-    def with_rendering(*args, **kwargs):
-        result = func(*args, **kwargs)
-        if c.UBER_SHUT_DOWN and not cherrypy.request.path_info.startswith('/schedule'):
-            return render('closed.html')
-        elif isinstance(result, dict):
-            return render(_get_template_filename(func), result)
-        else:
-            return result
-    return with_rendering
-
-
 def unrestricted(func):
     func.restricted = False
     return func


### PR DESCRIPTION
There was a error during the great jinja merge, and inside `decorators.py` the `renderable()` function was defined twice, with the old wrong version defined after the new correct version.

This is one reason why I prefer flake8 over pep8, because flake8 catches this kind of thing. But there's no way were getting flake8 to run against this codebase anytime soon.