### PR TITLE
Removes test imports from common.py

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,5 @@
 -r requirements.txt
+pytest>=3.0.1
+mock>=1.0.1,<1.1
+coverage>=3.6
 -e "git+https://github.com/magfest/sideboard#egg=sideboard"

--- a/uber/common.py
+++ b/uber/common.py
@@ -81,5 +81,4 @@ from uber import model_checks
 from uber import custom_tags
 from uber import server
 from uber import sep_commands
-from uber.tests import import_test_data
 import uber.api


### PR DESCRIPTION
Because the test requirements were removed from sideboard in magfest/sideboard/pull/82, the following line breaks in uber/common.py:
```
from uber.tests import import_test_data
```

```
[localhost] run: /home/vagrant/uber/sideboard/env/bin/sep alembic current
[localhost] out: Traceback (most recent call last):
[localhost] out:   File "/home/vagrant/uber/sideboard/env/bin/sep", line 11, in <module>
[localhost] out:     load_entry_point('sideboard', 'console_scripts', 'sep')()
[localhost] out:   File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/pkg_resources/__init__.py", line 560, in load_entry_point
[localhost] out:     return get_distribution(dist).load_entry_point(group, name)
[localhost] out:   File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2648, in load_entry_point
[localhost] out:     return ep.load()
[localhost] out:   File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2302, in load
[localhost] out:     return self.resolve()
[localhost] out:   File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2308, in resolve
[localhost] out:     module = __import__(self.module_name, fromlist=['__name__'], level=0)
[localhost] out:   File "/home/vagrant/uber/sideboard/sideboard/__init__.py", line 16, in <module>
[localhost] out:     _discover_plugins()
[localhost] out:   File "/home/vagrant/uber/sideboard/sideboard/internal/imports.py", line 34, in _discover_plugins
[localhost] out:     plugins[name] = importlib.import_module(name)
[localhost] out:   File "/home/vagrant/uber/sideboard/env/lib/python3.4/importlib/__init__.py", line 109, in import_module
[localhost] out:     return _bootstrap._gcd_import(name[level:], package, level)
[localhost] out:   File "/home/vagrant/uber/sideboard/plugins/uber/uber/__init__.py", line 4, in <module>
[localhost] out:     from uber.common import *
[localhost] out:   File "/home/vagrant/uber/sideboard/plugins/uber/uber/common.py", line 84, in <module>
[localhost] out:     from uber.tests import import_test_data
[localhost] out:   File "/home/vagrant/uber/sideboard/plugins/uber/uber/tests/__init__.py", line 1, in <module>
[localhost] out:     import pytest
[localhost] out: ImportError: No module named 'pytest'
[localhost] out: 
```