### PR TITLE
Stop shifting badges twice in a row

### DIFF
--- a/uber/badge_funcs.py
+++ b/uber/badge_funcs.py
@@ -14,6 +14,15 @@ def check_range(badge_num, badge_type):
                 return '{} badge numbers must fall within the range {} - {}'.format(dict(c.BADGE_OPTS)[badge_type], min_num, max_num)
 
 
+def is_badge_the_same(attendee, old_badge_type, old_badge_num):
+    old_badge_num = int(old_badge_num or 0) or None
+
+    if old_badge_type == attendee.badge_type and \
+            (not attendee.badge_num or old_badge_num == attendee.badge_num):
+        attendee.badge_num = old_badge_num
+        return 'Attendee is already {} with badge {}'.format(c.BADGES[old_badge_type], old_badge_num)
+
+
 # TODO: returning (result, error) is not a convention we're using anywhere else,
 #       so maybe change this to be more idiomatic if convenient, but not a big deal
 def get_badge_type(badge_num):

--- a/uber/badge_funcs.py
+++ b/uber/badge_funcs.py
@@ -14,6 +14,23 @@ def check_range(badge_num, badge_type):
                 return '{} badge numbers must fall within the range {} - {}'.format(dict(c.BADGE_OPTS)[badge_type], min_num, max_num)
 
 
+def is_badge_unchanged(attendee, old_badge_type, old_badge_num):
+    old_badge_num = int(old_badge_num or 0) or None
+    return old_badge_type == attendee.badge_type and \
+            (not attendee.badge_num or old_badge_num == attendee.badge_num)
+
+
+def reset_badge_if_unchanged(attendee, old_badge_type, old_badge_num):
+    """
+    The "change badge" page can pass an empty string for the badge number,
+    but if nothing actually changed about the attendee's badge, we need the
+    old number back!
+    """
+    if is_badge_unchanged(attendee, old_badge_type, old_badge_num):
+        attendee.badge_num = old_badge_num
+        return 'Attendee is already {} with badge {}'.format(c.BADGES[old_badge_type], old_badge_num)
+
+
 def is_badge_the_same(attendee, old_badge_type, old_badge_num):
     old_badge_num = int(old_badge_num or 0) or None
 

--- a/uber/badge_funcs.py
+++ b/uber/badge_funcs.py
@@ -31,15 +31,6 @@ def reset_badge_if_unchanged(attendee, old_badge_type, old_badge_num):
         return 'Attendee is already {} with badge {}'.format(c.BADGES[old_badge_type], old_badge_num)
 
 
-def is_badge_the_same(attendee, old_badge_type, old_badge_num):
-    old_badge_num = int(old_badge_num or 0) or None
-
-    if old_badge_type == attendee.badge_type and \
-            (not attendee.badge_num or old_badge_num == attendee.badge_num):
-        attendee.badge_num = old_badge_num
-        return 'Attendee is already {} with badge {}'.format(c.BADGES[old_badge_type], old_badge_num)
-
-
 # TODO: returning (result, error) is not a convention we're using anywhere else,
 #       so maybe change this to be more idiomatic if convenient, but not a big deal
 def get_badge_type(badge_num):

--- a/uber/models.py
+++ b/uber/models.py
@@ -631,16 +631,12 @@ class Session(SessionManager):
                 return 'Attendee is already {} with badge {}'.format(c.BADGES[old_badge_type], old_badge_num)
 
             if c.SHIFT_CUSTOM_BADGES:
-                # fill in the gap from the old number, if applicable
                 badge_num_keep = attendee.badge_num
-                if old_badge_num and not was_dupe_num:
-                    self.shift_badges(old_badge_type, old_badge_num + 1, down=True)
 
                 # make room for the new number, if applicable
                 if attendee.badge_num:
                     offset = 1 if old_badge_type == attendee.badge_type and attendee.badge_num > (old_badge_num or 0) else 0
-                    no_gap = self.query(Attendee).filter(Attendee.badge_type == attendee.badge_type,
-                                                         Attendee.badge_num == attendee.badge_num,
+                    no_gap = self.query(Attendee).filter(Attendee.badge_num == attendee.badge_num,
                                                          Attendee.id != attendee.id).first()
 
                     if no_gap:
@@ -1195,6 +1191,10 @@ class Attendee(MagModel, TakesPaymentMixin):
             self.ribbon = c.DEALER_RIBBON
 
         self.badge_type = get_real_badge_type(self.badge_type)
+
+        if c.SHIFT_CUSTOM_BADGES and self.orig_value_of('badge_num'):
+            if self.orig_value_of('badge_type') != self.badge_type or not needs_badge_num(self):
+                self.session.shift_badges(self.orig_value_of('badge_type'), self.orig_value_of('badge_num') + 1, down=True)
 
         if not needs_badge_num(self):
             self.badge_num = None

--- a/uber/models.py
+++ b/uber/models.py
@@ -623,7 +623,7 @@ class Session(SessionManager):
             """
             from uber.badge_funcs import needs_badge_num
 
-            if c.SHIFT_CUSTOM_BADGES:
+            if c.SHIFT_CUSTOM_BADGES and c.BEFORE_PRINTED_BADGE_DEADLINE:
                 # fill in the gap from the old number, if applicable
                 badge_num_keep = attendee.badge_num
                 if old_badge_num:

--- a/uber/models.py
+++ b/uber/models.py
@@ -693,53 +693,6 @@ class Session(SessionManager):
                 a.badge_num += shift
             return True
 
-        def change_badge(self, attendee, badge_type, badge_num=None):
-            """
-            Badges should always be assigned a number if they're marked as
-            pre-assigned or if they've been checked in.  If auto-shifting is
-            also turned off, badge numbers cannot clobber other numbers,
-            otherwise we'll shift all the other badge numbers around the old
-            and new numbers.
-            """
-            # assert_badge_locked()
-            from uber.badge_funcs import check_range
-            badge_type = int(badge_type)
-            old_badge_type, old_badge_num = attendee.badge_type, attendee.badge_num
-
-            out_of_range = check_range(badge_num, badge_type)
-            next = self.next_badge_num(badge_type, old_badge_num)
-            if out_of_range:
-                return out_of_range
-            elif not badge_num and next > c.BADGE_RANGES[badge_type][1]:
-                return 'There are no more badges available for that type'
-            elif badge_type in c.PREASSIGNED_BADGE_TYPES and c.AFTER_PRINTED_BADGE_DEADLINE:
-                return 'Custom badges have already been ordered'
-
-            if not c.SHIFT_CUSTOM_BADGES:
-                badge_num = badge_num or next
-                if badge_num != 0:
-                    existing = self.query(Attendee).filter_by(badge_type=badge_type, badge_num=badge_num) \
-                                                   .filter(Attendee.id != attendee.id)
-                    if existing.count():
-                        return 'That badge number already belongs to {!r}'.format(existing.first().full_name)
-            else:
-                # fill in the gap from the old number, if applicable
-                if old_badge_num:
-                    self.shift_badges(old_badge_type, old_badge_num + 1, down=True)
-
-                # determine the new badge number now that the badges have shifted
-                next = self.next_badge_num(badge_type, old_badge_num)
-                badge_num = min(int(badge_num) or next, next)
-
-                # make room for the new number, if applicable
-                if badge_num:
-                    offset = 1 if badge_type == old_badge_type and old_badge_num and badge_num > old_badge_num else 0
-                    self.shift_badges(badge_type, badge_num + offset, up=True)
-
-            attendee.badge_num = badge_num
-            attendee.badge_type = badge_type
-            return 'Badge updated'
-
         def valid_attendees(self):
             return self.query(Attendee).filter(Attendee.badge_status != c.INVALID_STATUS)
 
@@ -1244,8 +1197,6 @@ class Attendee(MagModel, TakesPaymentMixin):
         self.badge_type = get_real_badge_type(self.badge_type)
 
         if not needs_badge_num(self):
-            if self.orig_value_of('badge_num') and c.SHIFT_CUSTOM_BADGES:
-                self.session.shift_badges(self.orig_value_of('badge_type'), self.orig_value_of('badge_num') + 1, down=True)
             self.badge_num = None
         elif needs_badge_num(self) and not self.badge_num:
             self.badge_num = self.session.get_next_badge_num(self.badge_type)

--- a/uber/models.py
+++ b/uber/models.py
@@ -1181,23 +1181,6 @@ class Attendee(MagModel, TakesPaymentMixin):
             self.legal_name = ''
 
     @presave_adjustment
-    def _badge_adjustments(self):
-        # _assert_badge_lock()
-        from uber.badge_funcs import needs_badge_num
-        if self.badge_type == c.PSEUDO_DEALER_BADGE:
-            self.ribbon = c.DEALER_RIBBON
-
-        self.badge_type = get_real_badge_type(self.badge_type)
-
-        if not needs_badge_num(self):
-            self.badge_num = None
-
-        if self.orig_value_of('badge_type') != self.badge_type or self.orig_value_of('badge_num') != self.badge_num:
-            self.session.update_badge(self, self.orig_value_of('badge_type'), self.orig_value_of('badge_num'))
-        elif needs_badge_num(self) and not self.badge_num:
-            self.badge_num = self.session.get_next_badge_num(self.badge_type)
-
-    @presave_adjustment
     def _status_adjustments(self):
         if self.badge_status == c.NEW_STATUS and self.banned:
             self.badge_status = c.WATCHED_STATUS
@@ -1244,6 +1227,23 @@ class Attendee(MagModel, TakesPaymentMixin):
         self.trusted_depts = ','.join(str(td) for td in self.trusted_depts_ints if td in self.assigned_depts_ints)
 
     @presave_adjustment
+    def _badge_adjustments(self):
+        # _assert_badge_lock()
+        from uber.badge_funcs import needs_badge_num
+        if self.badge_type == c.PSEUDO_DEALER_BADGE:
+            self.ribbon = c.DEALER_RIBBON
+
+        self.badge_type = get_real_badge_type(self.badge_type)
+
+        if not needs_badge_num(self):
+            self.badge_num = None
+
+        if self.orig_value_of('badge_type') != self.badge_type or self.orig_value_of('badge_num') != self.badge_num:
+            self.session.update_badge(self, self.orig_value_of('badge_type'), self.orig_value_of('badge_num'))
+        elif needs_badge_num(self) and not self.badge_num:
+            self.badge_num = self.session.get_next_badge_num(self.badge_type)
+
+    @presave_adjustment
     def _email_adjustment(self):
         self.email = normalize_email(self.email)
 
@@ -1255,7 +1255,6 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.badge_type == c.STAFF_BADGE:
             self.badge_type = c.ATTENDEE_BADGE
             self.badge_num = None
-            self.session.update_badge(self, c.STAFF_BADGE, self.orig_value_of('badge_num'))
         del self.shifts[:]
 
     @property

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -129,7 +129,7 @@ class Root:
     def change_badge(self, session, id, message='', **params):
         attendee = session.attendee(id, allow_invalid=True)
         if 'badge_type' in params:
-            from uber.badge_funcs import is_badge_the_same
+            from uber.badge_funcs import reset_badge_if_unchanged
             old_badge_type, old_badge_num = attendee.badge_type, attendee.badge_num
             attendee.badge_type = int(params['badge_type'])
             try:
@@ -140,7 +140,7 @@ class Root:
             message = check(attendee)
 
             if not message:
-                message = is_badge_the_same(attendee, old_badge_type, old_badge_num) or "Badge updated."
+                message = reset_badge_if_unchanged(attendee, old_badge_type, old_badge_num) or "Badge updated."
                 raise HTTPRedirect('form?id={}&message={}', attendee.id, message or '')
 
         return {

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -129,6 +129,7 @@ class Root:
     def change_badge(self, session, id, message='', **params):
         attendee = session.attendee(id, allow_invalid=True)
         if 'badge_type' in params:
+            from uber.badge_funcs import is_badge_the_same
             old_badge_type, old_badge_num = attendee.badge_type, attendee.badge_num
             attendee.badge_type = int(params['badge_type'])
             try:
@@ -139,7 +140,7 @@ class Root:
             message = check(attendee)
 
             if not message:
-                message = session.update_badge(attendee, old_badge_type, old_badge_num)
+                message = is_badge_the_same(attendee, old_badge_type, old_badge_num) or "Badge updated."
                 raise HTTPRedirect('form?id={}&message={}', attendee.id, message or '')
 
         return {

--- a/uber/tests/models/test_badge_funcs.py
+++ b/uber/tests/models/test_badge_funcs.py
@@ -1,5 +1,5 @@
 from uber.tests import *
-from uber.badge_funcs import needs_badge_num, is_badge_the_same
+from uber.badge_funcs import needs_badge_num, reset_badge_if_unchanged
 
 
 @pytest.fixture
@@ -41,7 +41,7 @@ def check_ranges(session):
 def change_badge(session, attendee, new_type, new_num=None, expected_num=None):
     old_type, old_num = attendee.badge_type, attendee.badge_num
     attendee.badge_type, attendee.badge_num = new_type, new_num
-    is_badge_the_same(attendee, old_type, old_num)
+    reset_badge_if_unchanged(attendee, old_type, old_num)
     session.commit()
     session.refresh(attendee)
     assert new_type == attendee.badge_type
@@ -339,9 +339,9 @@ class TestInternalBadgeChange:
         change_badge(session, session.staff_four, c.STAFF_BADGE, new_num=2)
 
     def test_self_assignment(self, session):
-        assert 'Attendee is already Staff with badge 1' == is_badge_the_same(session.staff_one, c.STAFF_BADGE, 1)
-        assert 'Attendee is already Staff with badge 3' == is_badge_the_same(session.staff_three, c.STAFF_BADGE, 3)
-        assert 'Attendee is already Staff with badge 5' == is_badge_the_same(session.staff_five, c.STAFF_BADGE, 5)
+        assert 'Attendee is already Staff with badge 1' == reset_badge_if_unchanged(session.staff_one, c.STAFF_BADGE, 1)
+        assert 'Attendee is already Staff with badge 3' == reset_badge_if_unchanged(session.staff_three, c.STAFF_BADGE, 3)
+        assert 'Attendee is already Staff with badge 5' == reset_badge_if_unchanged(session.staff_five, c.STAFF_BADGE, 5)
 
 
 class TestBadgeDeletion:

--- a/uber/tests/models/test_badge_funcs.py
+++ b/uber/tests/models/test_badge_funcs.py
@@ -303,13 +303,6 @@ class TestBadgeTypeChange:
     def test_from_non_preassigned(self, session):
         change_badge(session, session.regular_attendee, c.STAFF_BADGE, expected_num=6)
 
-    def test_no_double_shift(self, session):
-        # Regression test -- presave adjustments used to try shifting badges
-        # after they'd already been shifted by update_badge()
-        change_badge(session, session.staff_three, c.ATTENDEE_BADGE)
-        assert session.staff_four.badge_num == 3
-        assert session.staff_five.badge_num == 4
-
 
 class TestInternalBadgeChange:
     def test_beginning_to_end(self, session):
@@ -427,6 +420,13 @@ class TestShiftOnChange:
         session.update_badge(Attendee(first_name='NewStaff', paid=c.NEED_NOT_PAY, badge_type=c.STAFF_BADGE, badge_num=5), None, None)
         session.commit()
         assert [1, 2, 3, 4, 10] == self.staff_badges(session)
+
+    def test_no_double_shift(self, session):
+        # Regression test -- presave adjustments used to try shifting badges
+        # after they'd already been shifted by update_badge()
+        change_badge(session, session.staff_three, c.ATTENDEE_BADGE)
+        assert session.staff_four.badge_num == 3
+        assert session.staff_five.badge_num == 4
 
 
 class TestBadgeValidations:

--- a/uber/tests/models/test_badge_funcs.py
+++ b/uber/tests/models/test_badge_funcs.py
@@ -407,13 +407,6 @@ class TestShiftOnChange:
         assert session.staff_two.badge_num == 1
         assert [1, 2, 3, 4] == self.staff_badges(session)
 
-    def test_shift_on_invalidate(self, session):
-        session.staff_one.badge_status = c.INVALID_STATUS
-        session.commit()
-        assert not session.staff_one.badge_num
-        assert session.staff_two.badge_num == 1
-        assert [1, 2, 3, 4] == self.staff_badges(session)
-
     def test_dont_shift_if_gap(self, session):
         session.staff_five.badge_num = 10
         session.commit()

--- a/uber/tests/models/test_badge_funcs.py
+++ b/uber/tests/models/test_badge_funcs.py
@@ -452,4 +452,3 @@ class TestBadgeValidations:
         session.regular_attendee.badge_type = c.STAFF_BADGE
         session.regular_attendee.badge_num = None
         assert 'There are no more badges available for that type' == check(session.regular_attendee)
-


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2472. We were calling shift_badges during a presave adjustment in certain cases; however, this would 'stack' with the update_badge function and badge numbers would get shifted twice, resulting in a unique-constraint violation. This fixes that. Also removes the change_badge function, which was somehow left in after being fully replaced by the update_badge function.