### PR TITLE
Update test and alembic instructions

### DIFF
--- a/alembic/README.md
+++ b/alembic/README.md
@@ -8,16 +8,17 @@ normally do.
 commands:
 ```
 sep drop_uber_db
-sep alembic upgrade head
+sep alembic upgrade heads
+# If you have only the uber plugin installed, use `alembic update head` instead of `heads`
 sep alembic --plugin myplugin revision --autogenerate -m "Migration description"
-sep alembic upgrade head
+sep alembic upgrade heads
 ```
 3. Though it is unusual, alembic will sometimes miss `ALTER` statements when
 the initial migration is created. To make sure alembic recognizes every change
 to the database, try generating new revisions again:
 ```
 sep alembic --plugin myplugin revision --autogenerate -m "Additional alter statements"
-sep alembic upgrade head
+sep alembic upgrade heads
 ```
 4. Verify the new migrations manually by inspecting the generated revision
 scripts and editing them as necessary; auto-generation is not perfect and may

--- a/alembic/README.md
+++ b/alembic/README.md
@@ -9,7 +9,6 @@ commands:
 ```
 sep drop_uber_db
 sep alembic upgrade heads
-# If you have only the uber plugin installed, use `alembic upgrade head` instead of `heads`
 sep alembic --plugin myplugin revision --autogenerate -m "Migration description"
 sep alembic upgrade heads
 ```

--- a/alembic/README.md
+++ b/alembic/README.md
@@ -9,7 +9,7 @@ commands:
 ```
 sep drop_uber_db
 sep alembic upgrade heads
-# If you have only the uber plugin installed, use `alembic update head` instead of `heads`
+# If you have only the uber plugin installed, use `alembic upgrade head` instead of `heads`
 sep alembic --plugin myplugin revision --autogenerate -m "Migration description"
 sep alembic upgrade heads
 ```

--- a/uber/tests/README.md
+++ b/uber/tests/README.md
@@ -72,8 +72,8 @@ SIDEBOARD_CONFIG_OVERRIDES='development-defaults.ini;test-defaults.ini' pytest u
 ```
 
 
-## Potential pitfalls
-
+## Troubleshooting
+### No test-defaults.ini
 You will see errors like the following if the tests are run without loading
 `test-defaults.ini`:
 ```
@@ -86,6 +86,11 @@ E       sqlite3.OperationalError: near "DEFERRABLE": syntax error
 
 Make sure `SIDEBOARD_CONFIG_OVERRIDES` is set to
 `development-defaults.ini;test-defaults.ini`.
+
+### Tox using old code
+In some cases, you may see errors that look like you have old code even though you're on the latest master.
+For example, tox may report being unable to import a module recently added to Sideboard. In these cases, tox's 
+environment needs to be refreshed by add the `-r` flag to a command. Try running `tox -r`!
 
 The easiest way to make sure everything is set up correctly is to use tox as
 described above. Use tox! Tox is great!


### PR DESCRIPTION
Following the Alembic instructions resulted in an error because we always have multiple plugins installed. Additionally, we found that updating Sideboard could cause local unit tests to start failing. This updates the relevant docs in both cases to be more helpful.