### PR TITLE
Remove base-admin.html

### DIFF
--- a/uber/templates/accounts/bulk.html
+++ b/uber/templates/accounts/bulk.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Add Admin Accounts{% endblock %}
 {% block content %}
 

--- a/uber/templates/accounts/change_password.html
+++ b/uber/templates/accounts/change_password.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Change Password {% endblock %}
 {% block content %}
 

--- a/uber/templates/accounts/homepage.html
+++ b/uber/templates/accounts/homepage.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Homepage{% endblock %}
 {% block content %}
 

--- a/uber/templates/accounts/index.html
+++ b/uber/templates/accounts/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Accounts{% endblock %}
 {% block content %}
 

--- a/uber/templates/accounts/login.html
+++ b/uber/templates/accounts/login.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Login{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/accounts/reset.html
+++ b/uber/templates/accounts/reset.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Password Reset{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/accounts/sitemap.html
+++ b/uber/templates/accounts/sitemap.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Site Map{% endblock %}
 {% block content %}
 

--- a/uber/templates/accounts/update_password_of_other.html
+++ b/uber/templates/accounts/update_password_of_other.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Change Password {% endblock %}
 {% block content %}
 

--- a/uber/templates/base-admin.html
+++ b/uber/templates/base-admin.html
@@ -1,2 +1,0 @@
-{% set admin_area=True %}
-{% extends "base.html" %}

--- a/uber/templates/budget/mpoints.html
+++ b/uber/templates/budget/mpoints.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}MPoint Uses{% endblock %}
 {% block content %}
 

--- a/uber/templates/closed.html
+++ b/uber/templates/closed.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}{{ c.EVENT_NAME }} server is being moved{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/dept_checklist/form.html
+++ b/uber/templates/dept_checklist/form.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Department Checklist - {{ item.name }}{% endblock %}
 {% block content %}
 

--- a/uber/templates/dept_checklist/index.html
+++ b/uber/templates/dept_checklist/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Department Checklist{% endblock %}
 {% block content %}
 

--- a/uber/templates/dept_checklist/item.html
+++ b/uber/templates/dept_checklist/item.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Department Checklist - {{ conf.name }}{% endblock %}
 {% block content %}
 

--- a/uber/templates/dept_checklist/overview.html
+++ b/uber/templates/dept_checklist/overview.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Department Checklist{% endblock %}
 {% block content %}
 

--- a/uber/templates/devtools/badge_number_consistency_check.html
+++ b/uber/templates/devtools/badge_number_consistency_check.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Developer Utility - Badge consistency check{% endblock %}
 {% block content %}
 

--- a/uber/templates/devtools/dump_diagnostics.html
+++ b/uber/templates/devtools/dump_diagnostics.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Developer Utility - System Diagnostics{% endblock %}
 {% block content %}
 

--- a/uber/templates/devtools/gitinfo.html
+++ b/uber/templates/devtools/gitinfo.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Developer Utility - Git info{% endblock %}
 {% block content %}
 

--- a/uber/templates/devtools/index.html
+++ b/uber/templates/devtools/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Developer Utility{% endblock %}
 {% block content %}
 

--- a/uber/templates/emails/emails_by_interest.html
+++ b/uber/templates/emails/emails_by_interest.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Email addresses by interest{% endblock %}
 {% block content %}
 

--- a/uber/templates/emails/index.html
+++ b/uber/templates/emails/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Recently Sent Automated Emails{% endblock %}
 {% block content %}
 

--- a/uber/templates/emails/pending.html
+++ b/uber/templates/emails/pending.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Automated Emails Pending Approval{% endblock %}
 {% block content %}
 

--- a/uber/templates/emails/pending_examples.html
+++ b/uber/templates/emails/pending_examples.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Example Automated Emails{% endblock %}
 {% block content %}
 

--- a/uber/templates/emails/sent.html
+++ b/uber/templates/emails/sent.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Sent Emails{% endblock %}
 {% block content %}
 

--- a/uber/templates/emails/test_email.html
+++ b/uber/templates/emails/test_email.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Test email sending{% endblock %}
 {% block content %}
 

--- a/uber/templates/groups/deletion_confirmation.html
+++ b/uber/templates/groups/deletion_confirmation.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Group Deletion Confirmation{% endblock %}
 {% block content %}
 

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Group Form{% endblock %}
 {% block content %}
 

--- a/uber/templates/groups/history.html
+++ b/uber/templates/groups/history.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Group History - {{ group.name }}{% endblock %}
 {% block content %}
 

--- a/uber/templates/groups/index.html
+++ b/uber/templates/groups/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Group Admin{% endblock %}
 {% block content %}
 

--- a/uber/templates/jobs/add_volunteers_by_dept.html
+++ b/uber/templates/jobs/add_volunteers_by_dept.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Add Volunteers{% endblock %}
 {% block content %}
 

--- a/uber/templates/jobs/all_shifts.html
+++ b/uber/templates/jobs/all_shifts.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}All Shifts for All Departments{% endblock %}
 {% block content %}
 

--- a/uber/templates/jobs/form.html
+++ b/uber/templates/jobs/form.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Job Form{% endblock %}
 {% block page_styles %}
 

--- a/uber/templates/jobs/index.html
+++ b/uber/templates/jobs/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Shifts{% endblock %}
 {% block page_styles %}
 <!--inside page_style -->

--- a/uber/templates/jobs/signups.html
+++ b/uber/templates/jobs/signups.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Shifts{% endblock %}
 {% block content %}
 

--- a/uber/templates/jobs/staffers.html
+++ b/uber/templates/jobs/staffers.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Staffer Summary{% endblock %}
 {% block content %}
 

--- a/uber/templates/jobs/staffers_by_job.html
+++ b/uber/templates/jobs/staffers_by_job.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Staffer Signups{% endblock %}
 {% block content %}
 

--- a/uber/templates/jobs/summary.html
+++ b/uber/templates/jobs/summary.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Shift Signup Summary{% endblock %}
 {% block content %}
 

--- a/uber/templates/preregistration/shirt_reorder.html
+++ b/uber/templates/preregistration/shirt_reorder.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Get Your {{ c.EVENT_NAME }} Shirt{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/registration/arbitrary_charge_form.html
+++ b/uber/templates/registration/arbitrary_charge_form.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Create Credit Card Charges{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/change_badge.html
+++ b/uber/templates/registration/change_badge.html
@@ -1,4 +1,5 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}
+{% set admin_area=True %}
 {% block title %}Badge Change{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/comments.html
+++ b/uber/templates/registration/comments.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Attendee Comments{% endblock %}}
 {% block content %}
 

--- a/uber/templates/registration/discount.html
+++ b/uber/templates/registration/discount.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Discount a Badge{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/feed.html
+++ b/uber/templates/registration/feed.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Recent Changes{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Attendee Form - {{ attendee.full_name }}{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/history.html
+++ b/uber/templates/registration/history.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Attendee History - {{ attendee.full_name }}{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/inactive.html
+++ b/uber/templates/registration/inactive.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Inactive Attendees{% endblock %}}
 {% block content %}
 

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Attendee Admin{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/manual_reg_charge_form.html
+++ b/uber/templates/registration/manual_reg_charge_form.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Manual Credit Card Payment{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/merch.html
+++ b/uber/templates/registration/merch.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Merch Booth{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/multi_merch_pickup.html
+++ b/uber/templates/registration/multi_merch_pickup.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Merch Booth{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Recent At-the-Door Registrations{% endblock %}
 {% block content %}
 {% block adminheader %}

--- a/uber/templates/registration/new_reg_station.html
+++ b/uber/templates/registration/new_reg_station.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Enter Your Registration Station Number{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/pay.html
+++ b/uber/templates/registration/pay.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Pay For Your At-the-Door Registration{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/registration/placeholders.html
+++ b/uber/templates/registration/placeholders.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Placeholder Attendees{% endblock %}}
 {% block content %}
 

--- a/uber/templates/registration/recent.html
+++ b/uber/templates/registration/recent.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Recent Preregs{% endblock %}}
 {% block content %}
 

--- a/uber/templates/registration/reg_take_report.html
+++ b/uber/templates/registration/reg_take_report.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Reg Money Take By Station{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/review-base.html
+++ b/uber/templates/registration/review-base.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Recent Changes{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/shifts.html
+++ b/uber/templates/registration/shifts.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Staffing Shifts - {{ attendee.full_name }}{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/staffers.html
+++ b/uber/templates/registration/staffers.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Staffing Admin{% endblock %}
 {% block content %}
 <ol class="breadcrumb">

--- a/uber/templates/registration/watchlist.html
+++ b/uber/templates/registration/watchlist.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Attendee History - {{ attendee.full_name }}{% endblock %}
 {% block content %}
 

--- a/uber/templates/registration/watchlist_entries.html
+++ b/uber/templates/registration/watchlist_entries.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Watch List{% endblock %}
 {% block message %}
 {% endblock %}

--- a/uber/templates/signups/food_restrictions.html
+++ b/uber/templates/signups/food_restrictions.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Dietary Restrictions{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/signups/index.html
+++ b/uber/templates/signups/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Volunteer Checklist{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/signups/login.html
+++ b/uber/templates/signups/login.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Volunteer Login{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/signups/onsite_jobs.html
+++ b/uber/templates/signups/onsite_jobs.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}On-Site Shifts{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/signups/printable.html
+++ b/uber/templates/signups/printable.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}{{ attendee.full_name}}'s Schedules{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/signups/shirt_size.html
+++ b/uber/templates/signups/shirt_size.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Shirt Size{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/signups/volunteer.html
+++ b/uber/templates/signups/volunteer.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Sign up to Volunteer{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/summary/affiliates.html
+++ b/uber/templates/summary/affiliates.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Affiliates{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/all_schedules.html
+++ b/uber/templates/summary/all_schedules.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}All Schedules{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/uber/templates/summary/consecutive_threshold.html
+++ b/uber/templates/summary/consecutive_threshold.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Volunteers With Alarming Hours{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/departments.html
+++ b/uber/templates/summary/departments.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Volunteer Requests{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/extra_merch.html
+++ b/uber/templates/summary/extra_merch.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Extra Merch{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/food_restrictions.html
+++ b/uber/templates/summary/food_restrictions.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Dietary Restrictions{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/found_how.html
+++ b/uber/templates/summary/found_how.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}How do our attendees find us?{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/index.html
+++ b/uber/templates/summary/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Registration Stats{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/ratings.html
+++ b/uber/templates/summary/ratings.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Negative Ratings{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/restricted_untaken.html
+++ b/uber/templates/summary/restricted_untaken.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Trusted Volunteers and Untaken Trusted Shifts{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/setup_teardown_neglect.html
+++ b/uber/templates/summary/setup_teardown_neglect.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Setup/Teardown Shifts{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/shirt_counts.html
+++ b/uber/templates/summary/shirt_counts.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Shirt Counts{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/shirt_manufacturing_counts.html
+++ b/uber/templates/summary/shirt_manufacturing_counts.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Shirt Counts{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/staffing_overview.html
+++ b/uber/templates/summary/staffing_overview.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Staffing Overview{% endblock %}
 {% block content %}
 

--- a/uber/templates/summary/volunteers_owed_refunds.html
+++ b/uber/templates/summary/volunteers_owed_refunds.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Volunteers Owed Refunds{% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.