### PR TITLE
Fix emails never including a link to the consent form

### DIFF
--- a/uber/templates/emails/reg_workflow/reg_notes.html
+++ b/uber/templates/emails/reg_workflow/reg_notes.html
@@ -12,7 +12,7 @@
     instructions about your department assignment and how to sign up for shifts.
 {% endif %}
 
-{% if c.CONSENT_FORM_URL and attendee.consent_form %}
+{% if c.CONSENT_FORM_URL and attendee.age_group_conf['consent_form'] %}
     <br/> <br/>
     Because you are under 18, you must bring a signed and notarized parental permission
     to be granted admission to {{ c.EVENT_NAME }}.  You may download the consent form 


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2493. During testing, MFF found that confirmation emails were not actually including the consent form link for attendees under 18. It turned out to be because we had the syntax wrong for checking whether the attendee's age group needed a consent form. This fixes that.