### PR TITLE
Fixes 500 error when jinja attempts to serialize an undefined value

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -111,7 +111,8 @@ def yesno(value, arg=None):
 
 @JinjaEnv.jinja_filter
 def jsonize(x):
-    return safe_string('{}' if x is None else html.escape(json.dumps(x, cls=serializer), quote=False))
+    is_empty = x is None or isinstance(x, jinja2.runtime.Undefined)
+    return safe_string('{}' if is_empty else html.escape(json.dumps(x, cls=serializer), quote=False))
 
 
 @JinjaEnv.jinja_filter

--- a/uber/tests/test_custom_tags.py
+++ b/uber/tests/test_custom_tags.py
@@ -66,6 +66,7 @@ class TestJsonize(object):
         ([], '[]'),
         (True, 'true'),
         (False, 'false'),
+        (jinja2.runtime.Undefined(), '{}'),
     ])
     def test_jsonize(self, test_input, expected):
         assert expected == jsonize(test_input)


### PR DESCRIPTION
Fixes this error I just ran into:

```
500 Internal Server Error

The server encountered an unexpected condition which prevented it from fulfilling the request.

Traceback (most recent call last):
  File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 670, in respond
    response.body = self.handler()
  File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/lib/encoding.py", line 220, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/cherrypy/_cpdispatch.py", line 60, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 239, in with_timing
    return func(*args, **kwargs)
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 230, in with_caching
    return func(*args, **kwargs)
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 254, in with_session
    retval = func(*args, session=session, **kwargs)
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 375, in with_restrictions
    return func(*args, **kwargs)
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 340, in with_rendering
    return render(_get_template_filename(func), result)
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/decorators.py", line 275, in render
    rendered = template.render(data)
  File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/vagrant/uber/sideboard/env/lib/python3.4/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/templates/registration/register.html", line 1, in top-level template code
    {% extends "./preregistration/preregbase.html" %}
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/templates/preregistration/preregbase.html", line 1, in top-level template code
    {% extends "base.html" %}
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/templates/base.html", line 229, in top-level template code
    {% block content %}{% endblock %}
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/templates/registration/register.html", line 71, in block "content"
    {% include "regform.html" %}
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/templates/regform.html", line 235, in top-level template code
    data: {{ affiliates|jsonize }},
  File "/home/vagrant/uber/sideboard/plugins/uber/uber/custom_tags.py", line 118, in jsonize
    return safe_string('{}' if x is None else html.escape(json.dumps(x, cls=serializer), quote=False))
  File "/usr/lib/python3.4/json/__init__.py", line 237, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.4/json/encoder.py", line 192, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.4/json/encoder.py", line 250, in iterencode
    return _iterencode(o, 0)
  File "/home/vagrant/uber/sideboard/sideboard/lib/_utils.py", line 45, in default
    raise json.JSONEncoder.default(self, o)
  File "/usr/lib/python3.4/json/encoder.py", line 173, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: Undefined is not JSON serializable
```