### PR TITLE
Stop hiding shirt size box if there are no prereg_donation_opts

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -190,7 +190,7 @@
 {% endif %}
 
 {% if c.DONATIONS_ENABLED and c.PAGE_PATH != '/registration/form' %}
-    {% if c.PREREG_DONATION_OPTS and c.PREREG_DONATION_OPTS|length > 1 or attendee.amount_extra %}
+    {% if c.PREREG_DONATION_OPTS and c.PREREG_DONATION_OPTS|length > 1 or attendee.amount_extra or attendee.gets_any_kind_of_shirt %}
         <script type="text/javascript">
             var donationChanged = function () {
                 setVisible('.affiliate-row', $.val('amount_extra') > 0);


### PR DESCRIPTION
Staff always get a shirt, but they weren't able to change their shirt size if an event had no donation opts available. This was particularly affecting Magstock, so it needs to be a quick-ish fix.