### PR TITLE
Stop normalizing the left side of email addresses.

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -149,8 +149,12 @@ def allowed_to_register(attendee):
 def email(attendee):
     if len(attendee.email) > 255:
         return 'Email addresses cannot be longer than 255 characters.'
+    elif not attendee.email and not c.AT_OR_POST_CON:
+        return 'Please enter an email address.'
 
-    if (c.AT_OR_POST_CON and attendee.email) or not c.AT_OR_POST_CON:
+@validation.Attendee
+def email_valid(attendee):
+    if attendee.email:
         try:
             validate_email(attendee.email)
         except EmailNotValidError as e:

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -152,6 +152,7 @@ def email(attendee):
     elif not attendee.email and not c.AT_OR_POST_CON:
         return 'Please enter an email address.'
 
+
 @validation.Attendee
 def email_valid(attendee):
     if attendee.email:

--- a/uber/models.py
+++ b/uber/models.py
@@ -575,8 +575,7 @@ class Session(SessionManager):
                                                      WatchList.active == True)).all()
 
         def get_account_by_email(self, email):
-            return self.query(AdminAccount).join(Attendee).filter(
-                Attendee.normalized_email == Attendee.normalize_email(email)).one()
+            return self.query(AdminAccount).join(Attendee).filter(func.lower(Attendee.email) == func.lower(email)).one()
 
         def no_email(self, subject):
             return not self.query(Email).filter_by(subject=subject).all()
@@ -754,7 +753,7 @@ class Session(SessionManager):
             if ':' in text:
                 target, term = text.split(':', 1)
                 if target == 'email':
-                    return attendees.filter(Attendee.normalized_email == Attendee.normalize_email(term)).one()
+                    return attendees.filter(Attendee.normalized_email == Attendee.normalize_email(term))
                 elif target == 'group':
                     return attendees.icontains(Group.name, term.strip())
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -581,7 +581,6 @@ class Session(SessionManager):
             return not self.query(Email).filter_by(subject=subject).all()
 
         def lookup_attendee(self, first_name, last_name, email, zip_code):
-            email = normalize_email(email)
             attendee = self.query(Attendee).iexact(first_name=first_name, last_name=last_name, email=email, zip_code=zip_code).filter(Attendee.badge_status != c.INVALID_STATUS).all()
             if attendee:
                 return attendee[0]

--- a/uber/models.py
+++ b/uber/models.py
@@ -753,7 +753,7 @@ class Session(SessionManager):
             if ':' in text:
                 target, term = text.split(':', 1)
                 if target == 'email':
-                    return attendees.filter(Attendee.normalized_email == Attendee.normalize_email(term))
+                    return attendees.icontains(Attendee.normalized_email, Attendee.normalize_email(term))
                 elif target == 'group':
                     return attendees.icontains(Group.name, term.strip())
 

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -70,7 +70,7 @@ class Root:
 
         if 'email' in params:
             try:
-                account = session.get_account_by_email(params['email'])
+                account = session.get_account_by_email(normalize_email(params['email']))
                 if not valid_password(params['password'], account):
                     message = 'Incorrect password'
             except NoResultFound:

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -70,7 +70,7 @@ class Root:
 
         if 'email' in params:
             try:
-                account = session.get_account_by_email(normalize_email(params['email']))
+                account = session.get_account_by_email(params['email'])
                 if not valid_password(params['password'], account):
                     message = 'Incorrect password'
             except NoResultFound:

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -533,14 +533,8 @@ class request_cached_context:
 
 def normalize_email(address):
     """
-    For only @gmail addresses, periods need to be parsed
-    out because they simply don't matter.
-
-    For all other addresses, they are read normally.
+    We check the validity of the email and normalize the domain using the email_validator library.
     """
-    address = address.lower()
-    if address.endswith("@gmail.com"):
-        address = address[:-10].replace(".", "") + "@gmail.com"
     try:
         validation_info = validate_email(address)
         # get normalized result

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1,5 +1,4 @@
 from uber.common import *
-from email_validator import validate_email, EmailNotValidError
 
 
 class CSRFException(Exception):
@@ -529,16 +528,3 @@ class request_cached_context:
     @staticmethod
     def _clear_cache():
         threadlocal.clear()
-
-
-def normalize_email(address):
-    """
-    We check the validity of the email and normalize the domain using the email_validator library.
-    """
-    try:
-        validation_info = validate_email(address)
-        # get normalized result
-        address = validation_info["email"]
-    except EmailNotValidError:
-        pass  # ignore invalid emails
-    return address


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2392. We don't need to normalize the left side of emails, so now we just don't. We DO normalize the domain, so we now also normalize it when someone is trying to log in -- that way we can be sure we don't introduce mismatches.