### PR TITLE
Fixes #1882: Fixes guess_attendee_watchentry query

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -584,11 +584,16 @@ class Session(SessionManager):
             return [job.to_dict(fields) for job in jobs if job.restricted or frozenset(job.hours) not in restricted_hours]
 
         def guess_attendee_watchentry(self, attendee):
-            return self.query(WatchList).filter(and_(or_(WatchList.first_names.contains(attendee.first_name),
-                                                         and_(WatchList.email != '', WatchList.email == attendee.email),
-                                                         and_(WatchList.birthdate != None, WatchList.birthdate == attendee.birthdate)),
-                                                     WatchList.last_name == attendee.last_name,
-                                                     WatchList.active == True)).all()
+            or_clauses = [
+                func.lower(WatchList.first_names).contains(attendee.first_name.lower()),
+                and_(WatchList.email != '', func.lower(WatchList.email) == attendee.email.lower())]
+            if attendee.birthdate:
+                or_clauses.append(WatchList.birthdate == attendee.birthdate)
+
+            return self.query(WatchList).filter(and_(
+                or_(*or_clauses),
+                func.lower(WatchList.last_name) == attendee.last_name.lower(),
+                WatchList.active == True)).all()
 
         def get_account_by_email(self, email):
             return self.query(AdminAccount).join(Attendee).filter(func.lower(Attendee.email) == func.lower(email)).one()

--- a/uber/tests/models/test_watchlist.py
+++ b/uber/tests/models/test_watchlist.py
@@ -16,7 +16,7 @@ def watchlist_session():
             first_names='Martin, Marty, Calvin',
             last_name='McFly',
             email='88mph@example.com',
-            birthdate=dateparser.parse('June 12, 1968'))
+            birthdate=dateparser.parse('June 12, 1968').date())
         session.add(watch_list)
         session.commit()
         yield session
@@ -61,7 +61,30 @@ class TestGuessWatchListEntry:
         dict(
             last_name='MCFLY',
             first_name='ANONYMOUS',
-            birthdate=dateparser.parse('June 12, 1968').date())
+            email='88MPH@EXAMPLE.COM',
+            birthdate=None),
+        dict(
+            last_name='MCFLY',
+            first_name='ANONYMOUS',
+            email='88MPH@EXAMPLE.COM',
+            birthdate=''),
+        dict(
+            last_name='MCFLY',
+            first_name='ANONYMOUS',
+            email='88MPH@EXAMPLE.COM',
+            birthdate='INVALID_DATE'),
+        dict(
+            last_name='MCFLY',
+            first_name='ANONYMOUS',
+            birthdate=dateparser.parse('June 12, 1968').date()),
+        dict(
+            last_name='MCFLY',
+            first_name='ANONYMOUS',
+            birthdate=dateparser.parse('June 12, 1968')),
+        dict(
+            last_name='MCFLY',
+            first_name='ANONYMOUS',
+            birthdate='June 12, 1968')
     ])
     def test_partial_match(self, attendee_attrs, watchlist_session):
         attendee = Attendee(**attendee_attrs)
@@ -71,6 +94,12 @@ class TestGuessWatchListEntry:
 
     @pytest.mark.parametrize('attendee_attrs', [
         dict(last_name='McFly', first_name='Anonymous'),
+        dict(last_name='McFly', first_name='Anonymous', birthdate=None),
+        dict(last_name='McFly', first_name='Anonymous', birthdate=''),
+        dict(
+            last_name='McFly',
+            first_name='Anonymous',
+            birthdate='INVALID_DATE'),
         dict(
             last_name='McFly',
             first_name='Anonymous',


### PR DESCRIPTION
This pull request contains the work I originally did in this insanely messed up branch: https://github.com/magfest/ubersystem/pull/1883

All I did was rewrite the query in `SessionMixin.guess_attendee_watchentry()` and add some tests.

This fixes #1882.