### PR TITLE
Fix Jinja2 template errors for at-door workflow

### DIFF
--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -128,7 +128,7 @@
                                 {% if attendee.paid == c.LOST_BADGE %}
                                     <strong>Badge reported as lost!</strong>
                                 {% else %}
-                                    {{ attendee.checked_in_local.strftime('fA')|lower }} {{ attendee.checked_in_local.strftime('D') }} <br/>
+                                    {{ hour_day_local(attendee.checked_in) }} <br/>
                                     <form method="post" action="lost_badge">
                                         <input type="hidden" name="id" value="{{ attendee.id }}" />
                                         <input type="submit" value="Report Lost Badge">

--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -142,7 +142,7 @@
 <tbody>
 {% for attendee in recent %}
     <tr>
-        {% block tablerows %}
+        {% block tablerows scoped %}
         <td>{{ attendee.registered|datetime_local("%b %-d %-H:%M (%-I:%M%p)") }}</td>
         <td align="left">
             <a href="form?return_to=new%3f&id={{ attendee.id }}">{{ attendee.full_name }}</a>


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2527 and fixes https://github.com/magfest/ubersystem/issues/2528. Also fixes a minor display error for checked in time -- it was displaying as 'fA D' for all attendees.