### PR TITLE
Stop showing badge_type on non-admin pages

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -592,7 +592,7 @@
 </div>
 {% endif %}
 
-{% if c.PAGE_PATH != '/registration/form' or not attendee.is_new %}
+{% if c.PAGE_PATH != '/registration/form' and not attendee.is_new %}
     <input type="hidden" name="badge_type" value="{{ attendee.badge_type }}" />
 {% endif %}
 


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/144. We had `or` in this tag so it would always show the hidden input on any non-admin page. Whoops.