### PR TITLE
Add "Merch Owed" to Attendee Details page

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1690,7 +1690,7 @@ class Attendee(MagModel, TakesPaymentMixin):
             if self.paid_for_a_swag_shirt:
                 shirt = 'a 2nd ' + shirt
             if not self.volunteer_swag_shirt_earned:
-                shirt += ' (tell them they will be reported if they take their shirt then do not work their shifts)'
+                shirt += ' (this volunteer must work at least 6 hours or they will be reported for picking up their shirt)'
             merch.append(shirt)
 
         if self.gets_staff_shirt:

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -317,7 +317,15 @@
     </div>
 </div>
 
-{% if attendee.amount_extra >= c.SHIRT_LEVEL %}
+<div class="form-group">
+    <label class="col-sm-2 control-label">Merch Owed</label>
+    <div class="col-sm-6">
+        <p class="form-control-static">{{ attendee.merch }}</p>
+        {% if attendee.got_merch %} (Merch has been picked up) {% endif %}
+    </div>
+</div>
+
+{% if attendee.gets_any_kind_of_shirt %}
     <div class="form-group">
         <label for="shirt" class="col-sm-2 control-label">Shirt Size</label>
         <div class="col-sm-6">


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2507 by printing attendee.merch on their details page, above their shirt size, along with info on if they have picked up their merch. Also fixes a bug where an attendee's shirt size would only display if they kicked in for a shirt.