### PR TITLE
Turn check-in barcodes off by default

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -42,7 +42,7 @@ event_qr_id = string(default='')
 
 # This controls whether or not we advertise check-in barcodes to attendees.
 # Events who don't have barcode scanners will want to turn this off.
-use_checkin_barcode = boolean(default=True)
+use_checkin_barcode = boolean(default=False)
 
 # This controls whether the promo code field will be visible on the
 # registration form. True to allow attendees to use promo codes when


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2487 -- now events will not be surprised by check-in codes appearing on attendees' confirmation pages.