### PR TITLE
Add arbitrary_charge_form link back to at-door page

### DIFF
--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -160,6 +160,7 @@
         <a href="new?show_all=true">Click Here</a> to see all at-the-door registrations instead of only recent ones
     {% endif %}
     <br/> <a href="index{% if c.AT_THE_CON %}?invalid=True{% endif %}">Click Here</a> to view the preregistered and checked in attendee list
+    <br/> <a href="arbitrary_charge_form">Click Here</a> to create arbitrary credit card charges for fees if Square stops working
 </div>
 
 <div style="text-align:center; font-weight:bold; {% if c.REMAINING_BADGES < 50 %} font-size:18pt; {% endif %}">


### PR DESCRIPTION
Since smaller events may still want to collect money for random things at reg, we're adding this back with slightly different wording.