### PR TITLE
import dateparser here to fix unit test runs

### DIFF
--- a/uber/tests/models/test_watchlist.py
+++ b/uber/tests/models/test_watchlist.py
@@ -1,4 +1,5 @@
 from uber.tests import *
+import dateparser
 
 
 @pytest.fixture()


### PR DESCRIPTION
we checked in a fix to https://github.com/magfest/ubersystem/issues/2536
here:
https://github.com/magfest/ubersystem/commit/0aa82128c7b49fa7de12b12f9bb110c36e4fbbe9

the (stopgap, temporary) solution was to move dateparser import out of common.py and into the modules actually using it.  while not ideal, this unbreaks pycharm debugger users and fixes #2536 

that fix was accidentally checked into master, and this is a followup which fixes the unit tests