### PR TITLE
Add custom `url_to_link` filter

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -124,8 +124,7 @@ def subtract(x, y):
 def urlencode(s):
     if isinstance(s, Markup):
         s = s.unescape()
-    s = s.encode('utf8')
-    s = quote_plus(s)
+    s = quote_plus(s.encode('utf8'))
     return Markup(s)
 
 
@@ -139,7 +138,9 @@ def url_to_link(url=None, text=None, target=None):
     if not text:
         text = url
 
-    return safe_string('<a href="{}" {}>{}</a>'.format(url, 'target="{}"'.format(target) if target else '', text))
+    return safe_string('<a href="{}"{}>{}</a>'.format(jinja2.escape(url),
+                                                       ' target="{}"'.format(jinja2.escape(target)) if target else '',
+                                                       jinja2.escape(text)))
 
 
 @JinjaEnv.jinja_filter

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -130,6 +130,19 @@ def urlencode(s):
 
 
 @JinjaEnv.jinja_filter
+def url_to_link(url=None, text=None, target=None):
+    # Jinja2 has a 'urlize' filter but it depends on links having `.com` or `http` in the name
+    # This works with relative links and allows you to also define link text
+    if not url:
+        return ''
+
+    if not text:
+        text = url
+
+    return safe_string('<a href="{}" {}>{}</a>'.format(url, 'target="{}"'.format(target) if target else '', text))
+
+
+@JinjaEnv.jinja_filter
 def percent(numerator, denominator):
     return '0/0' if denominator == 0 else '{} / {} ({}%)'.format(numerator, denominator, int(100 * numerator / denominator))
 

--- a/uber/tests/test_custom_tags.py
+++ b/uber/tests/test_custom_tags.py
@@ -111,8 +111,8 @@ class TestLinebreaksbr(object):
 class TestUrlToLink(object):
 
     @pytest.mark.parametrize('url_args, url_kwargs, expected', [
-        ('', {}, ''),
-        ('/regular/url', {}, '<a href="/regular/url">/regular/url</a>'),
+        ([''], {}, ''),
+        (['/regular/url'], {}, '<a href="/regular/url">/regular/url</a>'),
         (['/regular/url', 'normaltext'], {}, '<a href="/regular/url">normaltext</a>'),
         (['/regular/url', 'normaltext', '_blank'], {}, '<a href="/regular/url" target="_blank">normaltext</a>'),
         (['&<>"\'', 'normaltext'], {}, '<a href="&amp;&lt;&gt;&#34;&#39;">normaltext</a>'),

--- a/uber/tests/test_custom_tags.py
+++ b/uber/tests/test_custom_tags.py
@@ -3,7 +3,7 @@ import pytest
 from uber.common import *
 from uber.custom_tags import (jsonize, linebreaksbr, datetime_local_filter,
     datetime_filter, full_datetime_local, hour_day_local, time_day_local,
-    timedelta_filter, timestamp, normalize_newlines)
+    timedelta_filter, timestamp, normalize_newlines, url_to_link)
 
 
 class TestDatetimeFilters(object):
@@ -106,3 +106,18 @@ class TestLinebreaksbr(object):
     ])
     def test_normalize_newlines(self, test_input, expected):
         assert expected == normalize_newlines(test_input)
+
+
+class TestUrlToLink(object):
+
+    @pytest.mark.parametrize('url_args, url_kwargs, expected', [
+        ('', {}, ''),
+        ('/regular/url', {}, '<a href="/regular/url">/regular/url</a>'),
+        (['/regular/url', 'normaltext'], {}, '<a href="/regular/url">normaltext</a>'),
+        (['/regular/url', 'normaltext', '_blank'], {}, '<a href="/regular/url" target="_blank">normaltext</a>'),
+        (['&<>"\'', 'normaltext'], {}, '<a href="&amp;&lt;&gt;&#34;&#39;">normaltext</a>'),
+        (['/regular/url', '&<>"\''], {}, '<a href="/regular/url">&amp;&lt;&gt;&#34;&#39;</a>'),
+        (['/regular/url', 'normaltext', '&<>"\''], {}, '<a href="/regular/url" target="&amp;&lt;&gt;&#34;&#39;">normaltext</a>')
+    ])
+    def test_urltolink(self, url_args, url_kwargs, expected):
+        assert expected == url_to_link(*url_args, **url_kwargs)


### PR DESCRIPTION
Required for https://github.com/magfest/bands/pull/70. Adds a handy filter that allows you to turn any URL into an HTML link, with custom text.