### PR TITLE
Remove unused email templates and emails

### DIFF
--- a/uber/templates/emails/dealers/waitlist_closed.txt
+++ b/uber/templates/emails/dealers/waitlist_closed.txt
@@ -1,7 +1,0 @@
-{{ attendee.first_name }},
-
-Thank you for applying to vend at {{ c.EVENT_NAME }} this year, and I apologize this notice is coming so late; however, it has been very hectic with the holidays.  Unfortunately, we only had 2 spots open this year for the waitlist, so you did not make it in.  Your vendor application is being removed, but your badges will remain in the system in case you would still like to attend {{ c.EVENT_NAME }} as an attendee (if you do, then please stop by and say hi to me in the Marketplace!).  Although the current badge price is $60, we've created a discounted badge price for you at the early prereg price of $40.  You can pay for your registration at the discounted price no later than {{ c.UBER_TAKEDOWN|datetime_local }} by visiting {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
-
-Again, I am sorry you did not make it in this year, but we were overwhelmed and surprised by the increased number of applications.  Please try applying again next year, as registration will open again Otakon weekend simultaneously online and in person.  Thank you and have a good day, as well as Happy Holidays!
-
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}


### PR DESCRIPTION
We had several templates with no reference to them in code. We also had a dealer email that was coded for conditions that would not ever be met -- clearly meant as a one-time automated email. Fixes https://github.com/magfest/ubersystem/issues/2106.