### PR TITLE
Escape single-quotes in pop-up macro to fix JS error

### DIFF
--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -17,14 +17,7 @@
 
 
 {% macro popup_link(href, text='<sup>?</sup>') -%}
-    <a onClick="window.open('{{ href }}', 'info', 'toolbar=no,height=500,width=375,scrollbars=yes').focus(); return false;" href="{{ href }}">{{ text|safe }}</a>
-    {#-
-    TODO: integrate these changes from upstream, if needed. they may not be needed anymore
-
-    inner_text = "window.open('{self.href}', 'info', 'toolbar=no,height=500,width=375,scrollbars=yes').focus(); return false;".format(self=self)
-    inner_text = inner_text.replace("'", "&quot;")
-    return "<a onClick='{inner_text}' href='{self.href}'>{self.text}</a>".format(inner_text=inner_text, self=self)
-    -#}
+    <a onClick="window.open(&quot;{{ href }}&quot;, &quot;info&quot;, &quot;toolbar=no,height=500,width=375,scrollbars=yes&quot;).focus(); return false;" href="{{ href }}">{{ text|safe }}</a>
 {%- endmacro %}
 
 

--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -17,7 +17,7 @@
 
 
 {% macro popup_link(href, text='<sup>?</sup>') -%}
-    <a onClick="window.open(&quot;{{ href }}&quot;, &quot;info&quot;, &quot;toolbar=no,height=500,width=375,scrollbars=yes&quot;).focus(); return false;" href="{{ href }}">{{ text|safe }}</a>
+    <a onClick='window.open(&quot;{{ href }}&quot;, &quot;info&quot;, &quot;toolbar=no,height=500,width=375,scrollbars=yes&quot;).focus(); return false;' href='{{ href }}'>{{ text|safe }}</a>
 {%- endmacro %}
 
 


### PR DESCRIPTION
Fixes https://github.com/magfest/magprime/issues/200. When we converted our Django templates to Jinja2 templates, we took out a function from the popup macro that turned `'`s into `&quot;`s. We weren't sure if we needed it, but it turns out we do -- it's the only way to properly escape quotes when including the macro inside a quoted element, as in https://github.com/magfest/magprime/issues/200. We also needed to switch the `"`s to `'`s in our magprime template to complete the fix.