### PR TITLE
Show selected option for affiliates on page load

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -225,7 +225,7 @@
                             tags: true,
                             data: {{ affiliates|jsonize }},
                             width: '100%',
-                        }).val({{ attendee.affiliate|default('')|jsonize }});
+                        }).val({{ attendee.affiliate|default('')|jsonize }}).trigger('change');
                     }
                     $('form').submit(function(){
                         $(':submit').attr('value', 'Uploading Preregistration...').attr('disabled', true);


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/1632 and fixes https://github.com/magfest/ubersystem/issues/2021, which were caused by the same bug. The select2 box is apparently special and needs to have the 'change' event manually triggered when you update the value.

Fix courtesy of https://stackoverflow.com/questions/14957419/select2-doesnt-show-selected-value.