### PR TITLE
Fixes #2536: Removes dateparser in favor of dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dateparser==0.6.0
+python-dateutil==2.6.0
 psycopg2==2.5.2
 py3k-bcrypt==0.3
 stripe==1.11.0

--- a/uber/common.py
+++ b/uber/common.py
@@ -45,6 +45,7 @@ import bcrypt
 import stripe
 import jinja2
 import cherrypy
+from dateutil import parser as dateparser
 from markupsafe import text_type, Markup
 from pytz import UTC
 from six.moves import urllib

--- a/uber/models.py
+++ b/uber/models.py
@@ -380,13 +380,6 @@ class MagModel:
             restricted (bool): if true, restrict any changes only to fields which we allow attendees to set on their own
                 if false, allow changes to any fields.
         """
-
-        # NOTE: slight hack. we put this import here instead of common.py due to
-        # having path issues with settings.yaml from dateparser.  this is due to some kind of
-        # sideboard include path problem during early initialization, and we should look into
-        # why this is happening and fix it.
-        import dateparser
-
         bools = self.regform_bools if restricted else bools
         checkgroups = self.regform_checkgroups if restricted else checkgroups
         for column in self.__table__.columns:
@@ -592,12 +585,6 @@ class Session(SessionManager):
             return [job.to_dict(fields) for job in jobs if job.restricted or frozenset(job.hours) not in restricted_hours]
 
         def guess_attendee_watchentry(self, attendee):
-            # NOTE: slight hack. we put this import here instead of common.py due to
-            # having path issues with settings.yaml from dateparser.  this is due to some kind of
-            # sideboard include path problem during early initialization, and we should look into
-            # why this is happening and fix it.
-            import dateparser
-
             or_clauses = [
                 func.lower(WatchList.first_names).contains(attendee.first_name.lower()),
                 and_(WatchList.email != '', func.lower(WatchList.email) == attendee.email.lower())]

--- a/uber/tests/models/test_watchlist.py
+++ b/uber/tests/models/test_watchlist.py
@@ -1,5 +1,4 @@
 from uber.tests import *
-import dateparser
 
 
 @pytest.fixture()


### PR DESCRIPTION
`dateutil` is actually the library that `dateparser` wraps. Hopefully this will fix our weird PyCharm import issues.