### PR TITLE
Fixes #2535: Allows wrapping of whitespace inside supporter level buttons

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -396,7 +396,7 @@ def price_notice(label, takedown, amount_extra=0, discount=0):
     if not takedown:
         takedown = c.ESCHATON
 
-    if c.PAGE_PATH not in ['/preregistration/form', '/preregistration/register_group_member']:
+    if c.PAGE_PATH not in ['/preregistration/form', '/preregistration/post_form', '/preregistration/register_group_member']:
         return ''  # we only display notices for new attendees
     else:
         badge_price = c.BADGE_PRICE  # optimization.  this call is VERY EXPENSIVE.

--- a/uber/static/theme/prereg.css
+++ b/uber/static/theme/prereg.css
@@ -7,8 +7,22 @@
     background-size: 100% auto;
 }
 
-#mainContainer{
-    max-width:840px;
+#mainContainer {
+    max-width: 840px;
+}
+
+.masthead + .panel {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
+.masthead + .panel hr {
+    margin-left: -15px;
+    margin-right: -15px;
+}
+
+.masthead + .panel > .panel-body + table.table {
+    border-top: 0 none transparent;
 }
 
 body {
@@ -16,8 +30,8 @@ body {
     background-image: url("../theme/tile-background.jpg");
 }
 
-/*Form Wizard*/
-.bs-wizard {border-bottom: solid 1px #e0e0e0; padding: 0 0 10px 0;}
+/* Form Wizard */
+.bs-wizard {border-bottom: 0; border-top: 0; padding: 0 0 30px 0;}
 .bs-wizard > .bs-wizard-step {padding: 0; position: relative;}
 .bs-wizard > .bs-wizard-step + .bs-wizard-step {}
 .bs-wizard > .bs-wizard-step .bs-wizard-stepnum {color: #595959; font-size: 16px; margin-bottom: 5px;}
@@ -35,9 +49,9 @@ body {
 .bs-wizard > .bs-wizard-step:first-child  > .progress {left: 50%; width: 50%;}
 .bs-wizard > .bs-wizard-step:last-child  > .progress {width: 50%;}
 .bs-wizard > .bs-wizard-step.disabled a.bs-wizard-dot{ pointer-events: none; }
-/*END Form Wizard*/
+/* END Form Wizard */
 
-.col-centered{
+.col-centered {
     float: none;
     margin: 0 auto;
 }
@@ -45,6 +59,7 @@ body {
 #badge-types {
     margin-bottom: 0px;
 }
+
 .reg-type-selector, .badge-type-selector {
     cursor: pointer;
 }
@@ -62,13 +77,118 @@ body {
     background-color: pink;
 }
 
-.panel.panel-default {
-    padding-top: 15px;
-}
-
 .prereg-price-notice, .prereg-type-closing {
     color: #CC0000;
 }
+
 .active .prereg-price-notice, .active .prereg-type-closing {
     color: #FFCC66;
+}
+
+#first_name { margin-bottom: 0; }
+@media (max-width: 768px) {
+    #first_name { margin-bottom: 10px; }
+}
+
+/* "Registration Type" Buttons */
+
+.form-horizontal .form-group-buttons {
+    margin-right: 0;
+}
+
+.col-btn {
+    padding-right: 0;
+    padding-bottom: 10px;
+}
+
+@media (min-width: 768px) {
+    .col-btn {
+        padding-bottom: 0;
+    }
+}
+
+/* "Want to kick in extra?" Buttons */
+
+.btn-group-inline {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: stretch;
+    margin-bottom: -10px;
+}
+
+.btn-inline {
+    margin-bottom: 10px;
+    margin-right: 15px;
+}
+
+.btn-inline:last-child {
+    margin-right: 0;
+}
+
+.btn-inline .title h4 {
+    text-align: center;
+    white-space: normal;
+}
+
+.btn-inline .title span {
+    display: block;
+    margin-right: auto;
+    margin-left: auto;
+    width: 100%;
+    text-align: center;
+    font-size: 120%;
+    font-weight: bold;
+}
+
+.btn-inline ul {
+    list-style-type: none;
+    margin-top: 10px;
+    padding-left: 0;
+    font-size: 80%
+}
+
+.btn-inline li {
+    padding-bottom: 0.5em;
+    text-align: center;
+}
+
+.btn-inline li a {
+    color: black;
+    text-decoration: underline;
+}
+
+.btn-primary li a {
+    color: #fff;
+}
+
+.btn-primary img {
+    -webkit-filter: invert(100%);
+    filter: invert(100%);
+}
+
+@media (max-width: 767px) {
+
+    .btn-group-inline {
+        flex-direction: column;
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .btn-inline {
+        margin-right: 0;
+        text-align: left;
+        width: 100%;
+    }
+
+    .btn-inline .title, .btn-inline ul {
+        display: inline-block;
+        vertical-align: top;
+        width: 50%;
+    }
+
+    .btn-inline li {
+        text-align: left;
+    }
 }

--- a/uber/static/theme/prereg.css
+++ b/uber/static/theme/prereg.css
@@ -12,8 +12,9 @@
 }
 
 .masthead + .panel {
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+    /* Uncomment to remove the rounded corners on the top of the main form */
+    /* border-top-left-radius: 0; */
+    /* border-top-right-radius: 0; */
 }
 
 .masthead + .panel hr {

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -113,6 +113,15 @@
                     errorbox_y: 28
                 });
 
+                $('.jq-dte').each(function(index, element) {
+                    var $dte = $(element),
+                        $input = $dte.find('input.date'),
+                        $fields = $dte.find('.jq-dte-inner input'),
+                        isRequired = $input.prop('required');
+                    $input.prop('required', false);
+                    $fields.prop('required', isRequired);
+                });
+
                 $('.expiration-date:not(.jq-dte .expiration-date)').datetextentry({
                     field_order: 'MDY',
                     show_tooltips: false,

--- a/uber/templates/groupform.html
+++ b/uber/templates/groupform.html
@@ -1,12 +1,12 @@
 {% set attendee_or_group = attendee if attendee else group %}
 {% if not attendee_or_group.is_dealer %}
     <div class="form-group" id="badge-types">
-        <label class="col-sm-2 control-label">Badge Level</label>
+        <label class="col-sm-3 control-label">Badge Level</label>
     </div>
 
     <div class="group_fields hide">
         <div class="form-group">
-            <label for="name" class="col-sm-2 control-label">Group Name</label>
+            <label for="name" class="col-sm-3 control-label">Group Name</label>
             <div class="col-sm-6">
                 <input type="text" name="name" class="form-control" value="{{ group.name }}" />
             </div>
@@ -16,13 +16,13 @@
     {% if attendee_or_group.is_new %}
         <div class="group_fields hide">
             <div class="form-group">
-                <label for="name" class="col-sm-2 control-label">Badges</label>
+                <label for="name" class="col-sm-3 control-label">Badges</label>
                 <div class="col-sm-6">
                     <select name="badges" class="form-control">{{ int_options(c.MIN_GROUP_SIZE, c.MAX_GROUP_SIZE, badges) }}</select>
                 </div>
                 (${{ c.GROUP_PRICE }} each)
                 {% if c.MIN_GROUP_ADDITION > 1 %}
-                <p class="help-block col-sm-6 col-sm-offset-2">
+                <p class="help-block col-sm-9 col-sm-offset-3">
                     You may add badges to your group later, but you must add at least {{ c.MIN_GROUP_ADDITION }}
                     badges at a time.
                 </p>
@@ -38,7 +38,7 @@
     </script>
 
     <div class="form-group">
-        <label for="name" class="col-sm-2 control-label">Dealer Table Name</label>
+        <label for="name" class="col-sm-3 control-label">Dealer Table Name</label>
         <div class="col-sm-6">
             <input class="form-control" type="text" class="focus" name="name" value="{{ group.name }}" maxlength="40" />
         </div>
@@ -46,25 +46,25 @@
 
     {% if attendee_or_group.is_new %}
         <div class="form-group">
-            <label for="tables" class="col-sm-2 control-label">Tables</label>
+            <label for="tables" class="col-sm-3 control-label">Tables</label>
             <div class="col-sm-6">
                 <select class="form-control" name="tables">
                     {{ options(c.PREREG_TABLE_OPTS,group.tables) }}
                 </select>
-                <span id="table_prices">({{ table_prices() }})</span>
             </div>
-        </div>
-        <div class="form-group" id="moretables">
-            <p class="help-block col-sm-6 col-sm-offset-2"><i>You may contact us via <a href='{{ c.CONTACT_URL }}'>{{ c.CONTACT_URL }}</a> to request more than {{ c.MAX_TABLES }} tables.</i></p>
+            <div class="col-sm-offset-3 col-sm-9" id="table_prices">{{ table_prices() }}</div>
+            <p class="col-sm-9 col-sm-offset-3 help-block"><i>You may contact us via <a href='{{ c.CONTACT_URL }}'>{{ c.CONTACT_URL }}</a> to request more than {{ c.MAX_TABLES }} tables.</i></p>
         </div>
 
         <div class="form-group">
-            <label for="badges" class="col-sm-2 control-label">Badges</label>
+            <label for="badges" class="col-sm-3 control-label">Badges</label>
             <div class="col-sm-6">
                 <select class="form-control" name="badges">{{ int_options(1,c.MAX_DEALERS,badges) }}</select>
-                <p class="help-block">(${{ c.DEALER_BADGE_PRICE }} per badge) <br/><br/>
-                    The number of people working your table, including yourself.</p>
             </div>
+            <div class="col-sm-offset-3 col-sm-9">${{ c.DEALER_BADGE_PRICE }} per badge</div>
+            <p class="col-sm-offset-3 col-sm-9 help-block">
+              The number of people working your table, including yourself.
+            </p>
         </div>
         <div class="form-group">
 
@@ -72,48 +72,40 @@
     {% endif %}
 
     <div class="form-group">
-        <label for="wares" class="col-sm-2 control-label">What do you sell?</label>
+        <label for="wares" class="col-sm-3 control-label">What do you sell?</label>
         <div class="col-sm-6">
             <textarea class="form-control" name="wares" rows="4">{{ group.wares }}</textarea>
         </div>
-    </div>
-    <div class="form-group">
-        <p class="help-block col-sm-6 col-sm-offset-2">Please be detailed; include a link to view your wares if possible.</p>
+        <p class="help-block col-sm-9 col-sm-offset-3">Please be detailed; include a link to view your wares if possible.</p>
     </div>
 
     <div class="form-group">
-        <label for="description" class="col-sm-2 control-label">Description</label>
+        <label for="description" class="col-sm-3 control-label">Description</label>
         <div class="col-sm-6">
             <textarea class="form-control" name="description" rows="4" maxlength="400">{{ group.description }}</textarea>
         </div>
-    </div>
-    <div class="form-group">
-        <p class="help-block col-sm-6 col-sm-offset-2">Please keep to one sentence.</p>
+        <p class="help-block col-sm-9 col-sm-offset-3">Please keep to one sentence.</p>
     </div>
 
     <div class="form-group">
-        <label for="special_needs" class="col-sm-2 control-label optional-field">Table Requests and Special Requests</label>
+        <label for="special_needs" class="col-sm-3 control-label optional-field">Table Requests and Special Requests</label>
         <div class="col-sm-6">
             <textarea class="form-control" name="special_needs" rows="4" placeholder="E.g., specific table, who you would like to sit near, who you would not like to sit near.">{{ group.special_needs }}</textarea>
         </div>
-    </div>
-    <div class="form-group">
-        <p class="help-block col-sm-6 col-sm-offset-2">No guarantees that we can accommodate any requests.</p>
+        <p class="help-block col-sm-9 col-sm-offset-3">No guarantees that we can accommodate any requests.</p>
     </div>
 
     <div class="form-group">
-        <label for="website" class="col-sm-2 control-label">Website URL</label>
+        <label for="website" class="col-sm-3 control-label">Website URL</label>
         <div class="col-sm-6">
             <input class="form-control" type="text" name="website" value="{{ group.website }}" size="40" />
         </div>
-    </div>
-    <div class="form-group">
-        <p class="help-block col-sm-6 col-sm-offset-2">The one you want us to link on our website, or n/a</p>
+        <p class="help-block col-sm-9 col-sm-offset-3">The one you want us to link on our website, or n/a</p>
     </div>
 
     {% if not c.COLLECT_FULL_ADDRESS %}
     <div class="form-group">
-        <label for="address" class="col-sm-2 control-label">Address and Phone Number</label>
+        <label for="address" class="col-sm-3 control-label">Address and Phone Number</label>
         <div class="col-sm-6">
             <textarea class="form-control" name="address" rows="4" placeholder="Your or your business' full address and phone number for tax purposes.">{{ group.address }}</textarea>
         </div>

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -55,16 +55,16 @@
 <input type="hidden" name="new_dealer" value="{{ new_dealer }}" />
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Name of Group</label>
+    <label class="col-sm-3 control-label">Name of Group</label>
     <div class="col-sm-6">
-        <input class="focus" type="text" name="name" value="{{ group.name }}" />
+        <input class="focus form-control" type="text" name="name" value="{{ group.name }}" />
     </div>
 </div>
 
 <!-- we need to register a placeholder group leader for new dealers -->
 {% if new_dealer %}
     <div class="form-group">
-        <label class="col-sm-2 control-label">Owner's First and Last Name</label>
+        <label class="col-sm-3 control-label">Owner's First and Last Name</label>
         <div class="col-sm-6">
             <input type="text" name="first_name" value="{{ first_name }}" style="width:10em" />
             <input type="text" name="last_name" value="{{ last_name }}" style="width:15em" />
@@ -72,15 +72,15 @@
     </div>
 
     <div class="form-group">
-        <label class="col-sm-2 control-label">Owner's Email Address</label>
+        <label class="col-sm-3 control-label">Owner's Email Address</label>
         <div class="col-sm-6">
-            <input type="text" name="email" value="{{ email }}" />
+            <input type="text" name="email" value="{{ email }}" class="form-control"/>
         </div>
     </div>
 {% endif %}
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Tables</label>
+    <label class="col-sm-3 control-label">Tables</label>
     <div class="col-sm-6">
         <select name="tables">
             {{ options(c.ADMIN_TABLE_OPTS,group.tables) }}
@@ -89,7 +89,7 @@
 </div>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Badges</label>
+    <label class="col-sm-3 control-label">Badges</label>
     <div class="col-sm-6">
         <select name="badges">
             {{ int_options(0, c.MAX_GROUP_SIZE, group.badges) }}
@@ -101,8 +101,8 @@
 </div>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Badge Type</label>
-    <div class="col-sm-6">
+    <label class="col-sm-3 control-label">Badge Type</label>
+    <div class="col-sm-9">
         <select name="badge_type">
             {{ options(c.BADGE_OPTS,group.leader.badge_type) }}
         </select>
@@ -112,8 +112,8 @@
 
 {% if not new_dealer and not group.is_dealer %}
 <div class="form-group">
-    <label class="col-sm-2 control-label">Ribbon Type</label>
-    <div class="col-sm-6">
+    <label class="col-sm-3 control-label">Ribbon Type</label>
+    <div class="col-sm-9">
         <select name="ribbon">
             {{ options(c.RIBBON_OPTS,group.new_ribbon) }}
         </select>
@@ -123,30 +123,30 @@
 {% endif %}
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Amount Paid</label>
+    <label class="col-sm-3 control-label">Amount Paid</label>
     <div class="col-sm-6">
         $<input type="text" style="width:4em" name="amount_paid" value="{{ group.amount_paid }}" />
     </div>
 </div>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Total Group Price</label>
-    <div class="checkbox col-sm-6">
+    <label class="col-sm-3 control-label">Total Group Price</label>
+    <div class="checkbox col-sm-9">
         $<input type="text" style="width:4em" name="cost" value="{{ group.cost }}" />
         {{ macros.checkbox(group, 'auto_recalc', label='Automatically recalculate this number') }}
     </div>
 </div>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Amount Refunded</label>
+    <label class="col-sm-3 control-label">Amount Refunded</label>
     <div class="col-sm-6">
         $<input type="text" style="width:4em" name="amount_refunded" value="{{ group.amount_refunded }}" />
     </div>
 </div>
 
     <div class="form-group">
-    <label class="col-sm-2 control-label">Can Add Badges</label>
-    <div class="checkbox col-sm-6">
+    <label class="col-sm-3 control-label">Can Add Badges</label>
+    <div class="checkbox col-sm-9">
         {{ macros.checkbox(group, 'can_add', label='Allow this group to add badges') }}
     </div>
 </div>
@@ -154,7 +154,7 @@
 {% if new_dealer or group.is_dealer %}
     {% if group.leader %}
         <div class="form-group">
-            <label class="col-sm-2 control-label">Phone Number</label>
+            <label class="col-sm-3 control-label">Phone Number</label>
             <div class="col-sm-6">
                 {{ group.leader.cellphone }}
             </div>
@@ -162,7 +162,7 @@
     {% endif %}
 
     <div class="form-group">
-        <label class="col-sm-2 control-label">Status</label>
+        <label class="col-sm-3 control-label">Status</label>
         <div id="status" class="col-sm-6">
             {% if new_dealer %}
                 <select name="status">
@@ -190,37 +190,37 @@
     </div>
 
     <div class="form-group">
-        <label class="col-sm-2 control-label">What do they sell?</label>
+        <label class="col-sm-3 control-label">What do they sell?</label>
         <div class="col-sm-6">
-            <textarea rows="3" cols="30" name="wares">{{ group.wares }}</textarea>
+            <textarea rows="3" name="wares" class="form-control">{{ group.wares }}</textarea>
         </div>
     </div>
 
     <div class="form-group">
-        <label class="col-sm-2 control-label">Website URL</label>
+        <label class="col-sm-3 control-label">Website URL</label>
         <div class="col-sm-6">
-            <input type="text" name="website" value="{{ group.website }}" />
+            <input type="text" name="website" value="{{ group.website }}" class="form-control"/>
         </div>
     </div>
 
     <div class="form-group">
-        <label class="col-sm-2 control-label">Description</label>
+        <label class="col-sm-3 control-label">Description</label>
         <div class="col-sm-6">
-            <textarea rows="3" cols="30" name="description">{{ group.description }}</textarea>
+            <textarea rows="3" name="description" class="form-control">{{ group.description }}</textarea>
         </div>
     </div>
 
     <div class="form-group">
-        <label class="col-sm-2 control-label">Special Requests</label>
+        <label class="col-sm-3 control-label">Special Requests</label>
         <div class="col-sm-6">
-            <textarea rows="3" cols="30" name="special_needs">{{ group.special_needs }}</textarea>
+            <textarea rows="3" name="special_needs" class="form-control">{{ group.special_needs }}</textarea>
         </div>
     </div>
     {% if not c.COLLECT_FULL_ADDRESS %}
     <div class="form-group">
-        <label class="col-sm-2 control-label">Address</label>
+        <label class="col-sm-3 control-label">Address</label>
         <div class="col-sm-6">
-            <textarea rows="3" cols="30" name="address">{{ group.address }}</textarea>
+            <textarea rows="3" name="address" class="form-control">{{ group.address }}</textarea>
         </div>
     </div>
     {% endif %}
@@ -229,14 +229,14 @@
 {% include "groupextra.html" %}
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Admin Notes</label>
+    <label class="col-sm-3 control-label">Admin Notes</label>
     <div class="col-sm-6">
-        <textarea name="admin_notes" rows="3" style="width:66%">{{ group.admin_notes }}</textarea>
+        <textarea name="admin_notes" rows="3" class="form-control">{{ group.admin_notes }}</textarea>
     </div>
 </div>
 
 <div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
+    <div class="col-sm-6 col-sm-offset-3">
         <button type="submit" class="btn btn-primary" value="Upload">Save</button>
     </div>
 </div>

--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -22,7 +22,7 @@
 
 
 {% macro checkbox(model, field_name, id=None, label=None, label_class=None) -%}
-    {% if label %}<label {% if label_class %}class="{{ label_class }}"{% endif %}>{% endif %}
+    {% if label %}<label class="checkbox-label{% if label_class %} {{ label_class }}{% endif %}">{% endif %}
     <input type="checkbox" name="{{ field_name }}" id="{% if id %}{{ id }}{% else %}{{ field_name }}{% endif %}" value="1" {% if model[field_name] %}checked{% endif %} />
     {% if label %}{{ label }}</label>{% endif %}
 {%- endmacro %}
@@ -32,11 +32,10 @@
     {%- set defaults = model[field_name] if not no_instance else None -%}
     {%- set defaults = defaults.split(",") if defaults else [] -%}
     {% for num, desc in model.get_field(field_name).type.choices -%}
-        <label style="font-weight: normal;">
+        <label class="checkgroup checkbox-label" style="font-weight: normal;">
             <input type="checkbox" name="{{ field_name }}" value="{{ num }}" {% if num|string in defaults %}checked{% endif %} />
             {{ desc }}
         </label>
-        {% if not loop.last %}&nbsp;&nbsp;{% endif %}
     {% endfor %}
 {%- endmacro %}
 

--- a/uber/templates/preregistration/add_group_members.html
+++ b/uber/templates/preregistration/add_group_members.html
@@ -2,17 +2,21 @@
 {% block title %}Add Members to {{ group.name }}{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-<div class="masthead">
-</div>
+<div class="masthead"></div>
 <div class="panel panel-default">
-<h2> Add Members to {{ group.name }} </h2>
+  <div class="panel-body">
+    <h2> Add Members to {{ group.name }} </h2>
 
-You've indicated you'd like to add {{ count }} {{ group.is_dealer|yesno("Dealer Assistants,group members") }}, at a cost of ${{ charge.dollar_amount }}.
+    You've indicated you'd like to add {{ count }} {{ group.is_dealer|yesno("Dealer Assistants,group members") }}, at a cost of ${{ charge.dollar_amount }}.
 
-<table style="width:auto ; margin-left:auto ; margin-right: auto"><tr>
-    <td>{{ stripe_form('pay_for_extra_members',charge) }}</td>
-    <td style="width:100px ; text-align:center">or</td>
-    <td><a href="group_members?id={{ group.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
-</tr></table>
+    <table style="width: auto; margin: 15px auto 0;">
+      <tr>
+        <td>{{ stripe_form('pay_for_extra_members',charge) }}</td>
+        <td style="width:100px ; text-align:center">or</td>
+        <td><a href="group_members?id={{ group.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
+      </tr>
+    </table>
+  </div>
 </div>
+
 {% endblock %}

--- a/uber/templates/preregistration/attendee_donation_form.html
+++ b/uber/templates/preregistration/attendee_donation_form.html
@@ -2,36 +2,41 @@
 {% block title %}Additional Donation{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-<div class="masthead">
-</div>
+<div class="masthead"></div>
 <div class="panel panel-default">
-{% if attendee.paid == c.NOT_PAID or attendee.overridden_price %}
-    <h2> Badge Payment for {{ attendee.full_name }} </h2>
+  <div class="panel-body">
+    {% if attendee.paid == c.NOT_PAID or attendee.overridden_price %}
+      <h2> Badge Payment for {{ attendee.full_name }} </h2>
 
-    You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ attendee.overridden_price|default(attendee.badge_cost|round(2)) }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra|round(2) }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|round(2) }}.
+      You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ attendee.overridden_price|default(attendee.badge_cost|round(2)) }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra|round(2) }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|round(2) }}.
 
-    <table style="width:auto ; margin-left:auto ; margin-right: auto"><tr>
-        <td>{{ stripe_form('process_attendee_donation',charge) }}</td>
-        {% if attendee.amount_extra %}
+      <table style="width:auto ; margin-left:auto ; margin-right: auto">
+        <tr>
+          <td>{{ stripe_form('process_attendee_donation',charge) }}</td>
+          {% if attendee.amount_extra %}
             <td style="width:100px ; text-align:center">or</td>
             <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Undo Extra Money") }}</a></td>
-        {% endif %}
-    </tr></table>
-{% else %}
-    <h2> Extra Payment for {{ attendee.full_name }} </h2>
+          {% endif %}
+        </tr>
+      </table>
+    {% else %}
+      <h2> Extra Payment for {{ attendee.full_name }} </h2>
 
-    Thanks for offering to kick in money to help make {{ c.EVENT_NAME }} better.  As thanks, your total donation (of which ${{ attendee.amount_unpaid|round(2) }} is outstanding) entitles you to the following:
-    <ul>
+      Thanks for offering to kick in money to help make {{ c.EVENT_NAME }} better.  As thanks, your total donation (of which ${{ attendee.amount_unpaid|round(2) }} is outstanding) entitles you to the following:
+      <ul>
         {% for swag in attendee.donation_swag|list + attendee.addons|list %}
-            <li>{{ swag }}</li>
+          <li>{{ swag }}</li>
         {% endfor %}
-    </ul>
+      </ul>
 
-    <table style="width:auto ; margin-left:auto ; margin-right: auto"><tr>
-        <td>{{ stripe_form('process_attendee_donation',charge) }}</td>
-        <td style="width:100px ; text-align:center">or</td>
-        <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
-    </tr></table>
-{% endif %}
+      <table style="width:auto ; margin-left:auto ; margin-right: auto">
+        <tr>
+          <td>{{ stripe_form('process_attendee_donation',charge) }}</td>
+          <td style="width:100px ; text-align:center">or</td>
+          <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
+        </tr>
+      </table>
+    {% endif %}
+  </div>
 </div>
 {% endblock %}

--- a/uber/templates/preregistration/badge_updated.html
+++ b/uber/templates/preregistration/badge_updated.html
@@ -2,14 +2,15 @@
 {% block title %}Badge Updated{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-<div class="masthead">
-</div>
+<div class="masthead"></div>
 <div class="panel panel-default">
+  <div class="panel-body">
     <h2>{{ message }}!</h2>
-
-    You have successfully {% if 'registered' or 'confirmed' in message %}confirmed{% else %}updated{% endif %} your registration.
-    Thank you{% if 'payment' in message %} for upgrading your badge{% endif %}!
-
-    <br/><br/><a href="confirm?id={{ id }}" class="btn btn-primary">Go Back to My Badge</a>
+    <p>
+      You have successfully {% if 'registered' or 'confirmed' in message %}confirmed{% else %}updated{% endif %} your registration.
+      Thank you{% if 'payment' in message %} for upgrading your badge{% endif %}!
+    </p>
+    <a href="confirm?id={{ id }}" class="btn btn-primary">Go Back to My Badge</a>
+  </div>
 </div>
 {% endblock %}

--- a/uber/templates/preregistration/banned.html
+++ b/uber/templates/preregistration/banned.html
@@ -5,22 +5,25 @@
 
 <div class="masthead"></div>
 <div class="panel panel-default">
+  <div class="panel-body">
+    <h2> You may be banned from {{ c.EVENT_NAME }}! </h2>
 
-<h2> You may be banned from {{ c.EVENT_NAME }}! </h2>
+    <p>
+      Our list of banned people includes someone named <b>{{ attendee.full_name }}</b>.  Every banned attendee has
+      been told they are banned, so if this is not a mistake then you should definitely know it.  However, if you
+      just happen to have the same name as someone who has been banned, then go ahead and continue.  If we see someone
+      on our banned list complete their registration then we'll contact you to validate that you're someone else.
+    </p>
 
-Our list of banned people includes someone named <b>{{ attendee.full_name }}</b>.  Every banned attendee has
-been told they are banned, so if this is not a mistake then you should definitely know it.  However, if you
-just happen to have the same name as someone who has been banned, then go ahead and continue.  If we see someone
-on our banned list complete their registration then we'll contact you to validate that you're someone else.
+    <table style="width:auto" align="center">
+      <tr>
+        <td><a href="index">I'm someone else, let me pay!</a></td>
+        <td> &nbsp;&nbsp;&nbsp;&nbsp; </td>
+        <td><a href="delete?id={{ attendee.id }}">Well never mind then!</a></td>
+      </tr>
+    </table>
 
-<br/> </br>
-
-<table style="width:auto" align="center"><tr>
-    <td><a href="index">I'm someone else, let me pay!</a></td>
-    <td> &nbsp;&nbsp;&nbsp;&nbsp; </td>
-    <td><a href="delete?id={{ attendee.id }}">Well never mind then!</a></td>
-</tr></table>
-
-    </div>
+  </div>
+</div>
 
 {% endblock %}

--- a/uber/templates/preregistration/check_if_preregistered.html
+++ b/uber/templates/preregistration/check_if_preregistered.html
@@ -5,27 +5,32 @@
 <div class="masthead"></div>
 
 <div class="panel panel-default">
-    <div align="center"><h3>Check Preregistration</h3></div>
-    <div>If for any reason you are unsure that you're preregistered for {{ c.EVENT_NAME_AND_YEAR }}, please enter your email
-        address below.
-
-    <br/><br/>If you are pre-registered, you will receive a confirmation email (usually within 5 minutes). If you do not
-        receive this email, and it is not in your Spam or Junk folder, please contact us at
-        <strong>{{ c.REGDESK_EMAIL|email_only }}</strong>.</div>
-    <br/>
+  <div class="panel-body">
+    <h2>Check Preregistration</h2>
+    <p>
+      If for any reason you are unsure that you're preregistered for {{ c.EVENT_NAME_AND_YEAR }}, please enter your email
+      address below.
+    </p>
+    <p>
+      If you are pre-registered, you will receive a confirmation email (usually within 5 minutes). If you do not
+      receive this email, and it is not in your Spam or Junk folder, please contact us at
+      <strong>{{ c.REGDESK_EMAIL|email_only }}</strong>.
+    </p>
+    <br>
     <form method="post" action="check_if_preregistered">
-        <table width="100%" cellspacing="5" cellpadding="5">
-            <tr>
-                <td> <b>Email Address:</b> </td>
-                <td> <input type="text" name="email" placeholder="Enter your email here" /> </td>
-                <td> <input type="submit" value="Check my preregistration!" /> </td>
-            </tr>
-        </table>
+      <table width="100%" cellspacing="5" cellpadding="5">
+        <tr>
+          <td><b>Email Address:</b></td>
+          <td><input type="text" name="email" placeholder="Enter your email here" /></td>
+          <td><input type="submit" value="Check my preregistration!" /></td>
+        </tr>
+      </table>
     </form>
-    <br/>
-    <div style="color:rgb(127, 127, 127);font-size:small;text-align:center">
-        <em>Please note that in order to avoid accidentally spamming people, we can only send a confirmation email once per week.</em>
-    </div>
+    <br>
+    <p style="color:rgb(127, 127, 127);font-size:small;text-align:center">
+      <em>Please note that in order to avoid accidentally spamming people, we can only send a confirmation email once per week.</em>
+    </p>
+  </div>
 </div>
 
 {% endblock %}

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -3,8 +3,6 @@
 {% block backlink %}{% endblock %}
 {% block content %}
 
-<div class="masthead"></div>
-
 <script type="text/javascript">
     $(function(){
         {% if attendee.has_personalized_badge %}
@@ -22,64 +20,68 @@
     });
 </script>
 
+<div class="masthead"></div>
 <div class="panel panel-default">
-<form method="post" action="confirm" class="form-horizontal">
-{{ csrf_token() }}
-<input type="hidden" name="id" value="{{ attendee.id }}" />
-<input type="hidden" name="return_to" value="{{ return_to }}" />
-<input type="hidden" name="undoing_extra" value="{{ undoing_extra }}" />
+  <div class="panel-body">
+    <form method="post" action="confirm" class="form-horizontal">
+      {{ csrf_token() }}
+      <input type="hidden" name="id" value="{{ attendee.id }}" />
+      <input type="hidden" name="return_to" value="{{ return_to }}" />
+      <input type="hidden" name="undoing_extra" value="{{ undoing_extra }}" />
 
-{% if attendee.amount_unpaid and c.HTTP_METHOD == 'GET' %}
-    <br/>
-    <div class="form-group">
-        <div class="col-sm-6 col-sm-offset-2 warning">
+      {% if attendee.amount_unpaid and c.HTTP_METHOD == 'GET' %}
+        <br/>
+        <div class="form-group">
+          <div class="col-sm-9 col-sm-offset-3 warning">
             You currently have an outstanding balance of ${{ attendee.amount_unpaid }}{% if attendee.amount_extra %} due to having requested
             registration add-ons and then not completing the payment form{% endif %}.  Please either
             <a href="attendee_donation_form?id={{ attendee.id }}">click here</a> to pay, or alter your registration below to
             eliminate whichever addons you've decided not to select.
+          </div>
         </div>
-    </div>
-{% endif %}
+      {% endif %}
 
-<div class="form-group" id="badge-types">
-    <label class="col-sm-2 control-label">Badge Level</label>
-</div>
+      <div class="form-group" id="badge-types">
+        <label class="col-sm-3 control-label">Badge Level</label>
+      </div>
 
-{% include "regform.html" %}
+      {% include "regform.html" %}
 
-<div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary" id="updateButton">
+      <div class="form-group">
+        <div class="col-sm-9 col-sm-offset-3">
+          <button type="submit" class="btn btn-primary" id="updateButton">
             {% if attendee.placeholder %}Register{% else %}Update My Info{% endif %}
-        </button>
-        {% if attendee.is_transferable %}
+          </button>
+          {% if attendee.is_transferable %}
             <button type="button" class="btn btn-primary" onClick='location.href="transfer_badge?id={{ attendee.id }}"'>Transfer my Badge</button>
-        {% endif %}
-        {% if not attendee.amount_paid and not attendee.paid == c.NEED_NOT_PAY %}
+          {% endif %}
+          {% if not attendee.amount_paid and not attendee.paid == c.NEED_NOT_PAY %}
             <button type="submit" form="invalidate" class="btn btn-danger" onClick="return confirm('Are you sure you want to delete your badge? This can\'t be undone!');">I'm not coming</button>
-        {% endif %}
-    </div>
-</div>
-
-{% if not attendee.is_not_ready_to_checkin and c.USE_CHECKIN_BARCODE %}
-    <div class="form-group">
-    <label class="col-sm-2 control-label">Check-in Barcode</label>
-        <div class="col-sm-6">
-        <img src="../registration/qrcode_generator?data={{ attendee.public_id }}" />
+          {% endif %}
         </div>
-    <p class="help-block col-sm-6 col-sm-offset-2">This can be shown at badge pick-up to help check in. <br/>
-        <strong>This barcode <em>does not</em> replace your Photo ID.</strong> <br/>
-        You will receive an email with this code before the event.</p>
-    </div>
-{% endif %}
+      </div>
 
-</form>
+      {% if not attendee.is_not_ready_to_checkin and c.USE_CHECKIN_BARCODE %}
+        <div class="form-group">
+        <label class="col-sm-3 control-label">Check-in Barcode</label>
+          <div class="col-sm-6">
+            <img src="../registration/qrcode_generator?data={{ attendee.public_id }}" />
+          </div>
+          <p class="help-block col-sm-9 col-sm-offset-3">
+            This can be shown at badge pick-up to help check in. <br/>
+            <strong>This barcode <em>does not</em> replace your Photo ID.</strong> <br/>
+            You will receive an email with this code before the event.
+          </p>
+        </div>
+      {% endif %}
+    </form>
 
     {% if not attendee.amount_paid or not attendee.paid == c.NEED_NOT_PAY %}
-    <form method="post" action="invalidate" id="invalidate">
+      <form method="post" action="invalidate" id="invalidate">
         <input type="hidden" name="id" value="{{ attendee.id }}"/>
-    </form>
+      </form>
     {% endif %}
+  </div>
 </div>
 
 {% endblock %}

--- a/uber/templates/preregistration/confirmation_not_found.html
+++ b/uber/templates/preregistration/confirmation_not_found.html
@@ -2,10 +2,9 @@
 {% block title %}Confirmation Not Found{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-<div class="masthead">
-</div>
-
+<div class="masthead"></div>
 <div class="panel panel-default">
+  <div class="panel-body">
     <h3>Confirmation Number Not Valid: {{ id }}</h3>
 
     <p>The confirmation number {{ id }} you are trying to access is not valid.<br/>
@@ -21,5 +20,6 @@
 
     <p>If you think you should have a valid badge, don't panic! You are probably just on the wrong page.
         Please contact us at {{ c.REGDESK_EMAIL }} and we're happy to look into it for you.</p>
+  </div>
 </div>
 {% endblock %}

--- a/uber/templates/preregistration/credit_card_retry.html
+++ b/uber/templates/preregistration/credit_card_retry.html
@@ -5,14 +5,15 @@
 
 <div class="masthead"></div>
 <div class="panel panel-default">
-
-<h2> Credit Card Retry Failed </h2>
-
-You've been redirected here because there was a problem with your credit card transaction and you (probably) hit refresh
-in your browser to retry.  To avoid any problems with accidentally double-charging anyone, our software never tries to
-make the same charge twice.  If you're sure that your original submission didn't go through (you'll receive an email
-within a few minutes if it did), you can hit the back button and re-submit the form manually.
-
+  <div class="panel-body">
+    <h2> Credit Card Retry Failed </h2>
+    <p>
+      You've been redirected here because there was a problem with your credit card transaction and you (probably) hit refresh
+      in your browser to retry.  To avoid any problems with accidentally double-charging anyone, our software never tries to
+      make the same charge twice.  If you're sure that your original submission didn't go through (you'll receive an email
+      within a few minutes if it did), you can hit the back button and re-submit the form manually.
+    </p>
+  </div>
 </div>
 
 {% endblock %}

--- a/uber/templates/preregistration/dealer_confirmation.html
+++ b/uber/templates/preregistration/dealer_confirmation.html
@@ -2,9 +2,9 @@
 {% block title %}Dealer Application Received{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-<div class="masthead">
-</div>
-<div class="panel panel-default" style="padding:15px;">
+<div class="masthead"></div>
+<div class="panel panel-default">
+  <div class="panel-body">
     <h2>{% if c.AFTER_DEALER_REG_DEADLINE %}You've been added to our waitlist!{% else %}Thanks for applying as a Dealer!{% endif %}</h2>
 
     We've received your application for {{ group.name }} to purchase a Dealer registration for {{ c.EVENT_NAME }}.
@@ -34,5 +34,6 @@
     <br/><br/>In the event we cannot accommodate your Dealership, you will receive an email.
 
     {% include "preregistration/disclaimers.html" %}
+  </div>
 </div>
 {% endblock %}

--- a/uber/templates/preregistration/disclaimers.html
+++ b/uber/templates/preregistration/disclaimers.html
@@ -3,19 +3,18 @@
 
 <div style="font-weight:bold ; color:red ; margin-bottom:5px">Disclaimers:</div>
 <ul>
-    <li> Please review our badge polices and other <a href="http://www.magfest.org/faq">frequently asked questions</a> prior to purchasing your badge for important information. </li> 
-    <li> If you don't pay for your registration, it will be deleted and you will have to pay full price at the door. </li> 
-    <li> Your registration is <a href="http://www.magfest.org/faq#-KAbbdlWaUSQd_sAxmw2">non-refundable</a> but may be <a href="http://www.magfest.org/faq#-KAbbiQUjpv0Zb11fwvw">sold/transferred</a>. </li> 
-    <li> MAGFest has a <a href="http://www.magfest.org/faq#-KAbb-J7_81rRy5jTDR1">one badge per person policy</a>. If you purchase multiple badges (for your family, as a gift), please ensure that each badge is purchased in the name of the individual who the badge is intended for. You may use the same email address for multiple badges so any surprises aren't ruined. </li> 
-    <li> Attendees (including dealers) must abide by our <a href="http://magfest.org/codeofconduct">code of conduct</a>. </li> 
+    <li> Please review our badge polices and other <a href="http://www.magfest.org/faq">frequently asked questions</a> prior to purchasing your badge for important information. </li>
+    <li> If you don't pay for your registration, it will be deleted and you will have to pay full price at the door. </li>
+    <li> Your registration is <a href="http://www.magfest.org/faq#-KAbbdlWaUSQd_sAxmw2">non-refundable</a> but may be <a href="http://www.magfest.org/faq#-KAbbiQUjpv0Zb11fwvw">sold/transferred</a>. </li>
+    <li> MAGFest has a <a href="http://www.magfest.org/faq#-KAbb-J7_81rRy5jTDR1">one badge per person policy</a>. If you purchase multiple badges (for your family, as a gift), please ensure that each badge is purchased in the name of the individual who the badge is intended for. You may use the same email address for multiple badges so any surprises aren't ruined. </li>
+    <li> Attendees (including dealers) must abide by our <a href="http://magfest.org/codeofconduct">code of conduct</a>. </li>
     {% if c.CONSENT_FORM_URL %}
-        <li> Attendees under 18 MUST bring a <a href="http://www.magfest.org/parentalconsentform">signed parental consent form</a>, which MUST be notarized if the parent is not with the minor when the badge is picked up. Also, All children 12 and under will need to be accompanied by an adult with a paid badge. </li> 
+        <li> Attendees under 18 MUST bring a <a href="http://www.magfest.org/parentalconsentform">signed parental consent form</a>, which MUST be notarized if the parent is not with the minor when the badge is picked up. Also, All children 12 and under will need to be accompanied by an adult with a paid badge. </li>
     {% endif %}
     {% if c.DEALER_REG_START %}
-        <li> Submitting this form as a Dealer does not guarantee you will be selected for the Dealers Room - it is only the application. </li> 
+        <li> Submitting this form as a Dealer does not guarantee you will be selected for the Dealers Room - it is only the application. </li>
     {% endif %}
 </ul>
-<br/>
 
 <script type="text/javascript">
     $(document).ready(function(){

--- a/uber/templates/preregistration/duplicate.html
+++ b/uber/templates/preregistration/duplicate.html
@@ -5,7 +5,8 @@
 
 <div class="masthead"></div>
 <div class="panel panel-default">
-    <h2> You are already registered </h2>
+  <div class="panel-body">
+    <h2>You are already registered</h2>
 
     We already have a {{ attendee.full_name }} with email address {{ attendee.email }} in our database with a
     {% if attendee.paid == c.PAID_BY_GROUP and attendee.group.status == c.WAITLISTED %}
@@ -53,6 +54,7 @@
         <td><a href="delete?id={% if duplicate.group %}{{ duplicate.group.id }}{% else %}{{ duplicate.id }}{% endif %}&message=Duplicate badge canceled">Well never mind then!</a></td>
     </tr>
     </table>
+  </div>
 </div>
 
 {% endblock %}

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -5,10 +5,11 @@
 <div class="masthead"></div>
 
 <div class="panel panel-default">
-{% if attendee.is_dealer %}
-    <span class="text-center"><h2>Dealer Application</h2></span>
-{% else %}
-    <div class="row bs-wizard" style="border-bottom:0;border-top:0;">
+  <div class="panel-body">
+    {% if attendee.is_dealer %}
+      <h2 class="text-center">Dealer Application</h2>
+    {% else %}
+    <div class="row bs-wizard">
         <div class="col-xs-4 bs-wizard-step active">
             <div class="text-center bs-wizard-stepnum">Step 1</div>
             <div class="progress">
@@ -35,9 +36,11 @@
         </div>
     </div>
 
+    <div class="form-horizontal">
+
     {% if c.DEV_BOX %}
         <div class="form-group row">
-            <p class="col-sm-8 col-sm-offset-2">
+            <p class="col-sm-9 col-sm-offset-3">
                 <strong> You are on a development box.
                     {% if c.BADGES_SOLD >= c.MAX_BADGE_SALES %}
                         Otherwise, you would be automatically redirected to <a href="../static_views/prereg_soldout.html">the "badges sold out" page</a>.
@@ -53,7 +56,7 @@
 
     {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC and c.BEFORE_DEALER_REG_SHUTDOWN %}
         <div class="form-group row">
-            <p class="col-sm-6 col-sm-offset-2">
+            <p class="col-sm-9 col-sm-offset-3">
                 <strong>Dealers:</strong>
                 {% if c.BEFORE_DEALER_REG_PUBLIC %}
                     Registrations for dealer memberships begin {{ c.DEALER_REG_START|datetime_local }}.
@@ -64,8 +67,9 @@
         </div>
     {% endif %}
 
-    <div class="form-group" id="reg-types">
-        <label class="col-sm-2 control-label" style="white-space:nowrap">Registration Type</label>
+      <div class="form-group form-group-buttons" id="reg-types">
+          <label class="col-sm-3 control-label">Registration Type</label>
+      </div>
     </div>
 {% endif %}
 
@@ -81,7 +85,7 @@
 {% include "regform.html" %}
 
 <div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
+    <div class="col-sm-9 col-sm-offset-3">
         {% if attendee.is_dealer %}
             <button type="submit" class="btn btn-primary" value="Submit Application">Submit Application</button>
         {% elif not edit_id %}
@@ -100,6 +104,7 @@
 
 {% include "preregistration/disclaimers.html" %}
 
+</div>
 </div>
 
 {% endblock %}

--- a/uber/templates/preregistration/group_extra_payment_form.html
+++ b/uber/templates/preregistration/group_extra_payment_form.html
@@ -2,22 +2,28 @@
 {% block title %}Preregistration{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-<div class="masthead">
-</div>
+<div class="masthead"></div>
 <div class="panel panel-default">
-<h2> Extra Payment for {{ attendee.full_name }} </h2>
+  <div class="panel-body">
+    <h2>Extra Payment for {{ attendee.full_name }}</h2>
 
-Thanks for offering to kick in ${{ charge.dollar_amount|round(2) }} extra to help make {{ c.EVENT_NAME }} better.  As thanks, this entitles you to the following:
-<ul>
-    {% for swag in attendee.donation_swag %}
-        <li>{{ swag }}</li>
-    {% endfor %}
-</ul>
+    Thanks for offering to kick in ${{ charge.dollar_amount|round(2) }} extra to help make {{ c.EVENT_NAME }} better!
+    {% if attendee.donation_swag %}
+      As thanks, this entitles you to the following:
+      <ul>
+        {% for swag in attendee.donation_swag %}
+          <li>{{ swag }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
 
-<table style="width:auto ; margin-left:auto ; margin-right: auto"><tr>
-    <td>{{ stripe_form('process_group_member_payment',charge) }}</td>
-    <td style="width:100px ; text-align:center">or</td>
-    <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
-</tr></table>
+    <table style="width: auto; margin: 15px auto 0;">
+      <tr>
+        <td>{{ stripe_form('process_group_member_payment',charge) }}</td>
+        <td style="width:100px ; text-align:center">or</td>
+        <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
+      </tr>
+    </table>
+  </div>
 </div>
 {% endblock %}

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -37,19 +37,19 @@
         });
     {% endif %}
 </script>
-<div class="masthead">
-</div>
+
+<div class="masthead"></div>
 <div class="panel panel-default">
-{% if group.is_dealer %}
-    <h2>"{{ group.name }}" Information</h2>
-    <form method="post" action="group_members" class="form-horizontal" role="form">
+  <div class="panel-body">
+    {% if group.is_dealer %}
+      <h2>"{{ group.name }}" Information</h2>
+      <form method="post" action="group_members" class="form-horizontal" role="form">
         <input type="hidden" name="id" value="{{ group.id }}" />
         {% include "groupform.html" %}
         <button type="submit" class="btn btn-primary" value="Update Application">Update Application</button>
-    </form>
-{% endif%}
-</div>
-<div class="panel panel-default">
+      </form>
+    {% endif%}
+
 <h2> Members of "{{ group.name }}" </h2>
 
 {% if group.amount_unpaid and group.status != c.WAITLISTED %}
@@ -136,7 +136,7 @@
         <input type="submit" value="{{ group.is_dealer|yesno("Add Dealer Assistants,Add Group Members") }}">
         </form>
     </div>
-    
+
     <script type="text/javascript">
         {% if group.amount_unpaid %}
             $(function(){
@@ -152,7 +152,7 @@
             });
         {% endif %}
     </script>
-    
+
 {% endif %}
 </div>
 {% endblock %}

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -30,32 +30,31 @@
     });
 </script>
 
-<div class="masthead">
-</div>
+<div class="masthead"></div>
 
 <div class="panel panel-default">
-<div class="row bs-wizard" style="border-bottom:0;border-top:0;">
-    <div class="col-xs-4 bs-wizard-step complete">
-        <div class="text-center bs-wizard-stepnum">Step 1</div>
-        <div class="progress"><div class="progress-bar"></div></div>
-        <a class="bs-wizard-dot"></a>
-        <div class="bs-wizard-info text-center">Enter Info</div>
+  <div class="panel-body">
+    <div class="row bs-wizard">
+        <div class="col-xs-4 bs-wizard-step complete">
+            <div class="text-center bs-wizard-stepnum">Step 1</div>
+            <div class="progress"><div class="progress-bar"></div></div>
+            <a class="bs-wizard-dot"></a>
+            <div class="bs-wizard-info text-center">Enter Info</div>
+        </div>
+        <div class="col-xs-4 bs-wizard-step active">
+            <div class="text-center bs-wizard-stepnum">Step 2</div>
+            <div class="progress"><div class="progress-bar"></div></div>
+            <a class="bs-wizard-dot"></a>
+            <div class="bs-wizard-info text-center">Review &amp; Pay</div>
+        </div>
+        <div class="col-xs-4 bs-wizard-step disabled">
+            <div class="text-center bs-wizard-stepnum">Step 3</div>
+            <div class="progress"><div class="progress-bar"></div></div>
+            <a class="bs-wizard-dot"></a>
+            <div class="bs-wizard-info text-center">Done</div>
+        </div>
     </div>
-    <div class="col-xs-4 bs-wizard-step active">
-        <div class="text-center bs-wizard-stepnum">Step 2</div>
-        <div class="progress"><div class="progress-bar"></div></div>
-        <a class="bs-wizard-dot"></a>
-        <div class="bs-wizard-info text-center">Review &amp; Pay</div>
-    </div>
-    <div class="col-xs-4 bs-wizard-step disabled">
-        <div class="text-center bs-wizard-stepnum">Step 3</div>
-        <div class="progress"><div class="progress-bar"></div></div>
-        <a class="bs-wizard-dot"></a>
-        <div class="bs-wizard-info text-center">Done</div>
-    </div>
-</div>
 
-<div class="row">
     <div class="row">
         <div class="col-sm-8 col-sm-offset-2">
             <div class="col-sm-5 text-center">
@@ -73,74 +72,77 @@
             </div>
         </div>
     </div>
-</div>
+  </div>
 
-<table class="charge table table-striped">
-<thead><tr>
-    <th>Preregistration</th>
-    <th data-hide="phone" data-sort-ignore="true">Details</th>
-    <th data-type="numeric">Price</th>
-    <th data-sort-ignore="true"></th>
-</tr></thead>
-{% for attendee in charge.attendees %}
-    <tr>
-        <td>{{ attendee.full_name }}</td>
-        <td>
+  <table class="charge table table-striped">
+    <thead>
+      <tr>
+        <th>Preregistration</th>
+        <th data-hide="phone" data-sort-ignore="true">Details</th>
+        <th data-type="numeric">Price</th>
+        <th data-sort-ignore="true"></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for attendee in charge.attendees %}
+        <tr>
+          <td>{{ attendee.full_name }}</td>
+          <td>
             <ul style="padding-left:15px">
-                <li>Membership for {{ c.EVENT_NAME }}</li>
-                {% if not attendee.default_cost and attendee.age_discount and not attendee.promo_code %}
-                    <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free!</li>
-                {% elif attendee.age_discount %}
-                    <li>${{ attendee.age_group_conf.discount }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>
-                {% endif %}
-                {% for swag in attendee.donation_swag|list + attendee.addons|list %}
-                    <li>{{ swag }}</li>
-                {% endfor %}
-                {% if attendee.promo_code %}
-                    <li>{{ attendee.promo_code.discount_str }} with promo code "{{ attendee.promo_code.code }}"</li>
-                {% endif %}
+              <li>Membership for {{ c.EVENT_NAME }}</li>
+              {% if not attendee.default_cost and attendee.age_discount and not attendee.promo_code %}
+                <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free!</li>
+              {% elif attendee.age_discount %}
+                <li>${{ attendee.age_group_conf.discount }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>
+              {% endif %}
+              {% for swag in attendee.donation_swag|list + attendee.addons|list %}
+                <li>{{ swag }}</li>
+              {% endfor %}
+              {% if attendee.promo_code %}
+                <li>{{ attendee.promo_code.discount_str }} with promo code "{{ attendee.promo_code.code }}"</li>
+              {% endif %}
             </ul>
-        </td>
-        <td>${{ attendee.total_cost|round(2) }}</td>
-        <td>
-            <a href="form?edit_id={{ attendee.id }}">Edit</a> /
-            <a href="delete?id={{ attendee.id }}">Delete</a>
-        </td>
-     </tr>
-{% endfor %}
-{% for group in charge.groups %}
-    <tr>
-        <td>{{ group.name }}</td>
-        <td>
+          </td>
+          <td>${{ attendee.total_cost|round(2) }}</td>
+          <td>
+            <a href="form?edit_id={{ attendee.id }}">Edit</a> / <a href="delete?id={{ attendee.id }}">Delete</a>
+          </td>
+        </tr>
+      {% endfor %}
+
+      {% for group in charge.groups %}
+        <tr>
+          <td>{{ group.name }}</td>
+          <td>
             <ul>
-                <li>{{ group.badges }} badges</li>
-                {% for swag in group.attendees.0.donation_swag|list + group.addons|list %}
-                    <li>{{ swag }}</li>
-                {% endfor %}
+              <li>{{ group.badges }} badges</li>
+              {% for swag in group.attendees.0.donation_swag|list + group.addons|list %}
+                <li>{{ swag }}</li>
+              {% endfor %}
             </ul>
-        </td>
-        <td>${{ group.default_cost|round(2) }}</td>
-        <td>
+          </td>
+          <td>${{ group.default_cost|round(2) }}</td>
+          <td>
             <a href="form?edit_id={{ group.id }}">Edit</a> /
             <a href="delete?id={{ group.id }}">Delete</a>
-        </td>
-    </tr>
-{% endfor %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    {% if charge.targets|length > 1 %}
+      <tfoot>
+        <tr>
+          <th></th>
+          <th style="text-align:right;"><i>Total:</i></th>
+          <th><b>${{ charge.dollar_amount|round(2) }}</b></th>
+          <th></th>
+        </tr>
+      </tfoot>
+    {% endif %}
+  </table>
 
-{% if charge.targets|length > 1 %}
-<tfoot>
-    <tr>
-        <th></th>
-        <th style="text-align:right;"><i>Total:</i></th>
-        <th><b>${{ charge.dollar_amount|round(2) }}</b></th>
-        <th></th>
-    </tr>
-</tfoot>
-
-</table>
-{% endif %}
-
-{% include "preregistration/disclaimers.html" %}
+  <div class="panel-body">
+    {% include "preregistration/disclaimers.html" %}
+  </div>
 </div>
-
 {% endblock %}

--- a/uber/templates/preregistration/invalid_badge.html
+++ b/uber/templates/preregistration/invalid_badge.html
@@ -2,12 +2,12 @@
 {% block title %}Confirm Your Details{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-<div class="masthead">
-</div>
-
+<div class="masthead"></div>
 <div class="panel panel-default">
-    <h3>Invalid Badge: {{ attendee.full_name }}</h3>
+  <div class="panel-body">
+    <h2>Invalid Badge: {{ attendee.full_name }}</h2>
     <p>The badge you are trying to access is no longer valid. This may be because it was a duplicate of another badge, because it was canceled before payment went through, or because you asked to no longer receive emails from us.</p>
     <p>If you think you should have a valid badge, don't panic! You are probably just on the wrong page. If you can't find your confirmation email, please contact us at {{ c.REGDESK_EMAIL }}.</p>
+  </div>
 </div>
 {% endblock %}

--- a/uber/templates/preregistration/paid_preregistrations.html
+++ b/uber/templates/preregistration/paid_preregistrations.html
@@ -2,34 +2,34 @@
 {% block title %}Preregistraton Successful{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
-<div class="masthead">
-</div>
+<div class="masthead"></div>
 
 <div class="panel panel-default">
-<div class="row bs-wizard" style="border-bottom:0;border-top:0;">
-    <div class="col-xs-4 bs-wizard-step complete">
-      <div class="text-center bs-wizard-stepnum">Step 1</div>
-      <div class="progress"><div class="progress-bar"></div></div>
-      <a class="bs-wizard-dot"></a>
-      <div class="bs-wizard-info text-center">Enter Info</div>
+  <div class="panel-body">
+    <div class="row bs-wizard">
+      <div class="col-xs-4 bs-wizard-step complete">
+        <div class="text-center bs-wizard-stepnum">Step 1</div>
+        <div class="progress"><div class="progress-bar"></div></div>
+        <a class="bs-wizard-dot"></a>
+        <div class="bs-wizard-info text-center">Enter Info</div>
+      </div>
+      <div class="col-xs-4 bs-wizard-step complete">
+        <div class="text-center bs-wizard-stepnum">Step 2</div>
+        <div class="progress"><div class="progress-bar"></div></div>
+        <a class="bs-wizard-dot"></a>
+        <div class="bs-wizard-info text-center">Review &amp; Pay</div>
+      </div>
+      <div class="col-xs-4 bs-wizard-step active">
+        <div class="text-center bs-wizard-stepnum">Step 3</div>
+        <div class="progress"><div class="progress-bar"></div></div>
+        <a class="bs-wizard-dot"></a>
+        <div class="bs-wizard-info text-center">Done</div>
+      </div>
     </div>
-    <div class="col-xs-4 bs-wizard-step complete">
-      <div class="text-center bs-wizard-stepnum">Step 2</div>
-      <div class="progress"><div class="progress-bar"></div></div>
-      <a class="bs-wizard-dot"></a>
-      <div class="bs-wizard-info text-center">Review &amp; Pay</div>
-    </div>
-    <div class="col-xs-4 bs-wizard-step active">
-      <div class="text-center bs-wizard-stepnum">Step 3</div>
-      <div class="progress"><div class="progress-bar"></div></div>
-      <a class="bs-wizard-dot"></a>
-      <div class="bs-wizard-info text-center">Done</div>
-    </div>
-</div>
 
 
-<div class="row">
-    <div class="well col-md-offset-1 col-md-10">
+    <div class="row">
+      <div class="well col-md-offset-1 col-md-10">
         <h1>Registration Complete</h1>
         <p>
             Congratulations! Your registration was successful.
@@ -47,42 +47,46 @@
                 {% if preregs|length > 1 %}All attendees will get their own confirmation email.{% endif %}
             </p>
         {% endif %}
+      </div>
     </div>
+
+    <div class="row">
+      <div class="col-md-offset-1 col-md-10">
+
+        <p>The following preregistrations have been made from this computer:</p>
+
+        <table class="table table-striped">
+          <tr>
+            <td>Name</td>
+            <td>Confirmation Link</td>
+          </tr>
+          {% for prereg in preregs %}
+            {% if prereg.first_name %}
+              <tr>
+                <td>{{ prereg.full_name }}</td>
+                <td><a href="../preregistration/confirm?id={{ prereg.id }}" target="_blank">Click Here</a></td>
+              </tr>
+            {% else %}
+              <tr>
+                <td>{{ prereg.name }}</td>
+                <td colspan="3">(<a href="group_members?id={{ prereg.id }}" target="_blank">Click Here</a> to assign your group's badges)</td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </table>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-offset-1 col-md-10">
+        <a href="index">
+          <button class="btn btn-primary">Add Another Registration</button>
+        </a>
+      </div>
+    </div>
+
+    {% include "preregistration/disclaimers.html" %}
+  </div>
 </div>
-
-<div class="row">
-  <div class="col-md-offset-1 col-md-10">
-
-<p>The following preregistrations have been made from this computer:</p>
-
-<table class="table table-striped">
-<tr>
-    <td>Name</td>
-    <td>Confirmation Link</td>
-</tr>
-{% for prereg in preregs %}
-    {% if prereg.first_name %}
-        <tr>
-            <td>{{ prereg.full_name }}</td>
-            <td><a href="../preregistration/confirm?id={{ prereg.id }}" target="_blank">Click Here</a></td>
-        </tr>
-    {% else %}
-        <tr>
-            <td>{{ prereg.name }}</td>
-            <td colspan="3">(<a href="group_members?id={{ prereg.id }}" target="_blank">Click Here</a> to assign your group's badges)</td>
-        </tr>
-    {% endif %}
-{% endfor %}
-</table>
-</div>
-</div>
-
-<div class="row">
-  <div class="col-md-offset-1 col-md-10">
-    <a href="index">
-      <button class="btn btn-primary">Add Another Registration</button>
-    </a>
-
-{% include "preregistration/disclaimers.html" %}
 
 {% endblock %}

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -76,7 +76,7 @@
             row: '#badge-types',
             selector: '.badge-type-selector',
             options: [{
-                title: '{% if c.PAGE_PATH == "/preregistration/form" or c.PAGE_PATH == "/preregistration/dealer_registration" or undoing_extra %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
+                title: '{% if c.PAGE_PATH in ["/preregistration/form", "/preregistration/post_form", "/preregistration/dealer_registration"] or undoing_extra %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
                 description: 'Allows access to the convention for its duration.',
                 extra: 0,
                 price: {{ c.BADGE_PRICE }},
@@ -122,7 +122,7 @@
         });
 
         var togglePrices = function () {
-            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' and not c.PREREG_DONATION_DESCRIPTIONS %}($.val('badge_type') != {{ c.PSEUDO_DEALER_BADGE }}){% else %}false{% endif %};
+            var showTotalPrices = {% if c.PAGE_PATH in ['/preregistration/form', '/preregistration/post_form'] and not c.PREREG_DONATION_DESCRIPTIONS %}($.val('badge_type') != {{ c.PSEUDO_DEALER_BADGE }}){% else %}false{% endif %};
             $.each(BADGE_TYPES.options, function (i, type) {
                 var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
                 var $price_notice = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price_notice').empty();
@@ -215,7 +215,7 @@
                 $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
                     $.each(types.options, function (index, type) {
                         $(types.row).append(
-                            $('<div class="col-sm-3"></div>').append(
+                            $('<div class="col-btn col-sm-3"></div>').append(
                                 $('<a class="list-group-item"></a>').addClass(types.selector.substring(1)).click(function () {
                                     setBadge(types, index);
                                     setKickinFromBadge(types, index);
@@ -226,7 +226,7 @@
                                 ).append(
                                     $('<p class="list-group-item-text"></p>').html(type.description).append('<span class="price_notice"></span>'))));
                     });
-                    $(types.row).append('<div style="clear:both">&nbsp;</div>');
+                    $(types.row).append('<div class="clearfix"></div>');
                 });
                 if (window.REG_TYPES && $(REG_TYPES.row).size()) {
                     setBadge(REG_TYPES, $.field('name') && $.val('name') ? 1 : 0);  // default to attendee or group

--- a/uber/templates/preregistration/register_group_member.html
+++ b/uber/templates/preregistration/register_group_member.html
@@ -4,25 +4,26 @@
 {% block content %}
 
 <div class="masthead"></div>
-
 <div class="panel panel-default">
-<form method="post" action="register_group_member" class="form-horizontal">
-{{ csrf_token() }}
-<input type="hidden" name="id" value="{{ attendee.db_id }}" />
-<input type="hidden" name="group_id" value="{{ group_id }}" />
+  <div class="panel-body">
+    <form method="post" action="register_group_member" class="form-horizontal">
+      {{ csrf_token() }}
+      <input type="hidden" name="id" value="{{ attendee.db_id }}" />
+      <input type="hidden" name="group_id" value="{{ group_id }}" />
 
-<div class="form-group" id="badge-types">
-    <label class="col-sm-2 control-label">Badge Level</label>
-</div>
+      <div class="form-group" id="badge-types">
+        <label class="col-sm-3 control-label">Badge Level</label>
+      </div>
 
-{% include "regform.html" %}
+      {% include "regform.html" %}
 
-<div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary" id="updateButton">Register</button>
-    </div>
-</div>
-</form>
+      <div class="form-group">
+        <div class="col-sm-6 col-sm-offset-3">
+          <button type="submit" class="btn btn-primary" id="updateButton">Register</button>
+        </div>
+      </div>
+    </form>
+  </div>
 </div>
 
 {% endblock %}

--- a/uber/templates/preregistration/repurchase.html
+++ b/uber/templates/preregistration/repurchase.html
@@ -4,18 +4,21 @@
 {% block content %}
 
 <div class="masthead"></div>
+<div class="panel panel-default">
+  <div class="panel-body">
+    <h2>Refunded Badge</h2>
 
-<h2>Refunded Badge</h2>
-
-<div class="form-group">
+    <p>
     According to our records, your badge has been refunded. You may repurchase your badge at the current price of
     ${{ c.BADGE_PRICE }} for an Attendee badge. We will pre-fill your details into the pre-registration form.
+    </p>
 
     <form method="post" action="repurchase" class="form-horizontal">
         {{ csrf_token() }}
         <input type="hidden" name="id" value="{{ id }}" />
         <button type="submit" class="btn btn-primary" value="Repurchase">Yes, I want to repurchase my badge</button>
     </form>
+  </div>
 </div>
 
 {% endblock %}}

--- a/uber/templates/preregistration/transfer_badge.html
+++ b/uber/templates/preregistration/transfer_badge.html
@@ -5,29 +5,33 @@
 
 <div class="masthead"></div>
 <div class="panel panel-default">
-<h2> Transfer {{ old.full_name }}'s Registration </h2>
+  <div class="panel-body">
+    <h2> Transfer {{ old.full_name }}'s Registration </h2>
 
-By filling out this form, you will be transferring {{ old.full_name }}'s {{ c.EVENT_NAME }} registration
-to someone else.  {{ old.full_name }} will no longer have a paid {{ c.EVENT_NAME }} badge waiting at
-our Registration Desk; that will belong to whomever the badge is transferred.
+    <p>
+      By filling out this form, you will be transferring {{ old.full_name }}'s {{ c.EVENT_NAME }} registration
+      to someone else.  {{ old.full_name }} will no longer have a paid {{ c.EVENT_NAME }} badge waiting at
+      our Registration Desk; that will belong to whomever the badge is transferred.
+    </p>
 
-<form method="POST" action="transfer_badge" class="form-horizontal">
-{{ csrf_token() }}
-<input type="hidden" name="id" value="{{ attendee.id }}" />
+    <form method="POST" action="transfer_badge" class="form-horizontal">
+      {{ csrf_token() }}
+      <input type="hidden" name="id" value="{{ attendee.id }}" />
 
-<div class="form-group" id="badge-types">
-    <label class="col-sm-2 control-label">Badge Level</label>
-</div>
+      <div class="form-group" id="badge-types">
+        <label class="col-sm-3 control-label">Badge Level</label>
+      </div>
 
-{% include "regform.html" %}
+      {% include "regform.html" %}
 
-<div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary" id="updateButton">Transfer This Badge</button>
-    </div>
-</div>
+      <div class="form-group">
+        <div class="col-sm-6 col-sm-offset-3">
+          <button type="submit" class="btn btn-primary" id="updateButton">Transfer This Badge</button>
+        </div>
+      </div>
 
-</form>
+    </form>
+  </div>
 </div>
 
 {% endblock %}

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -73,6 +73,22 @@
             regionChange();
         });
 
+    {% else %}
+        var internationalChecked = function () {
+            if ($("#international").prop('checked')) {
+                $.field('zip_code').prop('required', false);
+                $("label[for='zip_code']").addClass('optional-field');
+            } else if ($("#international").length) {
+                $.field('zip_code').prop('required', true);
+                $("label[for='zip_code']").removeClass('optional-field');
+            }
+        };
+        $(function () {
+            if ($('#international').length) {
+                internationalChecked();
+                $('#international').change(internationalChecked);
+            }
+        });
     {% endif %}
 
     var noCellphoneClicked = function () {
@@ -102,10 +118,10 @@
 
     var sameLegalNameChecked = function () {
         if ($("#same_legal_name").prop('checked')) {
-            $.field('legal_name').prop('readonly', true).val('').attr('required', false);
+            $.field('legal_name').prop('readonly', true).val('').prop('required', false);
             $("label[for='legal_name']").addClass('optional-field');
         } else if ($("#same_legal_name").length) {
-            $.field('legal_name').prop('readonly', false).attr('required', true);
+            $.field('legal_name').prop('readonly', false).prop('required', true);
             $("label[for='legal_name']").removeClass('optional-field');
         }
     };
@@ -120,13 +136,12 @@
 
 {% if c.PAGE_PATH != '/registration/form' %}
     <div id="bold-field-message" class="form-group">
-        <label class="col-sm-2 control-label">&nbsp;</label>
-        <div class="col-sm-6 heading-label">Bold fields are required</div>
+        <div class="col-sm-offset-3 col-sm-9 heading-label">Bold fields are required</div>
     </div>
 {% endif %}
 
 <div id="group-explanation" class="form-group">
-    <p class="col-sm-8 col-sm-offset-1">
+    <p class="col-sm-10 col-sm-offset-1">
         {% if attendee.is_dealer %}
             Please enter your personal information below.  Information for any additional vendors at your table can be filled out once your application is approved.
         {% else %}
@@ -137,24 +152,24 @@
 
 {% if c.PAGE == 'confirm' and not attendee.placeholder %}
     <div class="form-group">
-        <label for="full_name" class="col-sm-2 control-label">Name</label>
+        <label for="full_name" class="col-sm-3 control-label">Name</label>
         <div class="col-sm-6">{{ attendee.full_name }}</div>
     </div>
     {% if attendee.legal_name %}
         <div class="form-group">
-            <label for="legal_name" class="col-sm-2 control-label">Name on ID</label>
+            <label for="legal_name" class="col-sm-3 control-label">Name on ID</label>
             <div class="col-sm-6">{{ attendee.legal_name }}</div>
         </div>
     {% endif %}
     <div class="form-group">
-        <label for="badge_type" class="col-sm-2 control-label">Badge Type</label>
+        <label for="badge_type" class="col-sm-3 control-label">Badge Type</label>
         <div class="col-sm-6">
             {{ attendee.badge_type_label }}
         </div>
     </div>
 {% else %}
     <div class="form-group">
-        <label for="first_name" class="col-sm-2 control-label">Name</label>
+        <label for="first_name" class="col-sm-3 control-label">Name</label>
         <div class="col-sm-3">
             <input type="text" name="first_name" id="first_name" value="{{ attendee.first_name }}" class="form-control" placeholder="First Name" autocomplete="fname">
         </div>
@@ -164,17 +179,20 @@
     </div>
 
     <div class="form-group">
-        <div class="col-sm-6 col-sm-offset-2">
-            <input type="checkbox" name="same_legal_name" id="same_legal_name" value="1" {% if attendee.first_name != '' and attendee.legal_name == '' %}checked="checked"{% endif %} /> <label for="same_legal_name">The above name is exactly what appears on my ID</label>
+        <div class="col-sm-6 col-sm-offset-3">
+          <label for="same_legal_name" class="checkbox-label">
+            <input type="checkbox" name="same_legal_name" id="same_legal_name" value="1" {% if attendee.first_name != '' and attendee.legal_name == '' %}checked="checked"{% endif %} />
+            The above name is exactly what appears on my ID
+          </label>
         </div>
     </div>
 
     <div class="form-group">
-        <label for="legal_name" class="col-sm-2 control-label">Name on ID</label>
+        <label for="legal_name" class="col-sm-3 control-label">Name on ID</label>
         <div class="col-sm-6">
             <input type="text" name="legal_name" value="{{ attendee.legal_name }}" class="form-control" placeholder="Your name exactly as it appears on your Photo ID" autocomplete="name" />
         </div>
-        <p class="help-block col-sm-6 col-sm-offset-2">
+        <p class="help-block col-sm-6 col-sm-offset-3">
             <span class="popup">{{ macros.popup_link("../static_views/legal_name.html", "What does this mean?") }}</span>
         </p>
     </div>
@@ -236,113 +254,44 @@
 
         {% if c.PAGE_PATH != '/preregistration/transfer_badge' %}
             <div class="extra-row form-group">
-                <label for="amount_extra" class="col-sm-2 control-label">Want to kick in extra?
+                <label for="amount_extra" class="col-sm-3 control-label">Want to kick in extra?
                     <br>
                 {{ macros.popup_link("../static_views/givingExtra.html", "Why do this?") }}
                 </label>
-                <div class="col-sm-10">
+                <div class="col-sm-9">
                     {% if c.AFTER_SUPPORTER_DEADLINE and attendee.amount_extra >= c.SUPPORTER_LEVEL or c.AFTER_SHIRT_DEADLINE and attendee.amount_extra >= c.SHIRT_LEVEL %}
                         {{ attendee.amount_extra_label }}
                         <input type="hidden" name="amount_extra" value="{{ attendee.amount_extra }}" />
                     {% else %}
                         {% if c.PREREG_DONATION_DESCRIPTIONS %}
 
-                            <style>
-                                @media all {
-
-                                    .no-inline {
-                                        display: flex;
-                                        flex-direction: row;
-                                    }
-
-                                    .btn-group-inline {
-                                        display: flex;
-                                        flex-direction: row;
-                                        flex-wrap: nowrap;
-                                    }
-
-                                    .no-inline, .btn-inline {
-                                        margin-right: 15px;
-                                    }
-
-                                    .h4-inline {
-                                        text-align: center;
-                                    }
-
-                                    .span-inline {
-                                        display: block;
-                                        margin-right: auto;
-                                        margin-left: auto;
-                                        width: 100%;
-                                        text-align: center;
-                                        font-size: 120%;
-                                        font-weight: bold;
-                                    }
-
-                                    .ul-inline {
-                                        list-style-type: none;
-                                        margin-top: 0;
-                                        padding-left: 0;
-                                        font-size: 80%
-                                    }
-
-                                    .li-inline {
-                                        padding: 0.5em;
-                                        text-align: center;
-                                    }
-
-                                    .li-inline a, #supporter_popup a {
-                                        color: black;
-                                        text-decoration: underline;
-                                    }
-                                }
-
-                            @media (max-width: 633px) {
-                                .btn-group-inline {
-                                    flex-direction: column;
-                                    flex-wrap: wrap;
-                                    padding-left: 15px;
-                                    padding-right: 15px;
-                                }
-
-                                .no-inline, .btn-inline {
-                                    margin-right: 0;
-                                    width: 100%;
-                                }
-                            }
-
-                                </style>
-
-
                             <div data-toggle="buttons" class="btn-group-inline">
                             {% for tier in c.PREREG_DONATION_DESCRIPTIONS %}
 
-                                <label class="btn btn-default {% if tier.price == 0 %}no-inline{% else %}btn-inline{% endif %}">
+                              <label class="btn btn-default btn-inline">
                                 <input type="radio"
                                        name="amount_extra"
                                        autocomplete="off"
                                        value="{{ tier.price }}"
                                        onchange="donationChanged();"
-                                       {% if attendee.amount_extra == tier.price %}checked{% endif %}  />
-                                <h4 class="h4-inline">
-                                    {{ tier.name }}
-                                </h4>
-                                {% if tier.price %}
-                                <span class="span-inline">
-                                    <img src="{{ tier.icon }}" alt=""> + ${{ tier.price }}
-                                </span>
-                                <br>
-                                <ul class="ul-inline">
-                                    {% for desc, link in tier.all_descriptions %}
+                                       {% if attendee.amount_extra == tier.price %}checked{% endif %} />
+                                <div class="title">
+                                  <h4>{{ tier.name }}</h4>
+                                  {% if tier.price %}
+                                    <span>
+                                      <img src="{{ tier.icon }}" alt=""> + ${{ tier.price }}
+                                    </span>
+                                  {% endif %}
+                                </div>
+                                <ul>
+                                  {% for desc, link in tier.all_descriptions %}
                                     {% if link %}
-                                    <li class="li-inline">
-                                        <a onClick="window.open('{{ link }}', 'info', 'toolbar=no,height=500,width=375,scrollbars=yes').focus(); return false;"
-                     href="{{ link }}">{{ desc }}</a>
-                                    </li>
+                                      <li>
+                                        <a onClick="window.open('{{ link }}', 'info', 'toolbar=no,height=500,width=375,scrollbars=yes').focus(); return false;" href="{{ link }}">{{ desc }}</a>
+                                      </li>
                                     {% endif %}
-                                    {% endfor %}
+                                  {% endfor %}
                                 </ul>
-                                {% endif %}
                               </label>
                             {% endfor %}
                             </div>
@@ -356,7 +305,7 @@
                     {% endif %}
                 </div>
 
-                <p class="help-block col-sm-offset-2 col-sm-10">
+                <p class="help-block col-sm-offset-3 col-sm-9">
                     Each level includes all lower levels. <br/>
                     Supporter level and higher {% if c.BEFORE_SUPPORTER_DEADLINE %}are{% else %}were{% endif %} only available until {{ c.SUPPORTER_DEADLINE|datetime_local }}.
                 </p>
@@ -365,7 +314,7 @@
     {% endif %}
 
 <div class="badge-row extra-row form-group" style="display:none">
-    <label for="badge_printed_name" class="col-sm-2 control-label optional-field">Name Printed on Badge</label>
+    <label for="badge_printed_name" class="col-sm-3 control-label optional-field">Name Printed on Badge</label>
     <div class="col-sm-6">
         <input type="text" class="form-control" name="badge_printed_name" maxlength="20" value="{{ attendee.badge_printed_name }}" {% if c.AFTER_PRINTED_BADGE_DEADLINE and attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or c.AFTER_SUPPORTER_DEADLINE %}readonly{% endif %} />
     </div>
@@ -374,12 +323,12 @@
 
 {% if c.AFTER_PRINTED_BADGE_DEADLINE and attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or c.AFTER_SUPPORTER_DEADLINE %}
     <div class="badge-row extra-row form-group" style="display:none">
-        <p class="help-block col-sm-6 col-sm-offset-2">(custom badges have already been ordered, so you can no longer set this)</p>
+        <p class="help-block col-sm-6 col-sm-offset-3">(custom badges have already been ordered, so you can no longer set this)</p>
     </div>
 {% endif %}
 
 <div class="affiliate-row extra-row form-group" style="display:none">
-    <label for="affiliate" class="col-sm-2 control-label optional-field">Affiliate</label>
+    <label for="affiliate" class="col-sm-3 control-label optional-field">Affiliate</label>
     <div class="col-sm-6">
         <select name="affiliate">
             <option value="" selected="selected"></option>
@@ -389,7 +338,7 @@
 </div>
 
 <div class="shirt-row extra-row form-group" style="display:none">
-    <label for="shirt" class="col-sm-2 control-label">Shirt Size</label>
+    <label for="shirt" class="col-sm-3 control-label">Shirt Size</label>
     <div class="col-sm-6">
         <select name="shirt" class="form-control">
             <option value="{{ c.NO_SHIRT }}">Select a shirt size</option>
@@ -400,7 +349,7 @@
 {% endif %}
 
 <div class="form-group staffing">
-    <label for="staffing" class="col-sm-2 optional-field control-label">Want to Volunteer?</label>
+    <label for="staffing" class="col-sm-3 optional-field control-label">Want to Volunteer?</label>
     <div class="checkbox col-sm-6">
         <label for="staffing">
         {{ macros.checkbox(attendee, 'staffing') }}
@@ -423,8 +372,8 @@
 
 {% if c.JOB_INTEREST_OPTS %}
 <div class="form-group staffing" id="departments">
-    <label for="requested_depts" class="col-sm-2 control-label">Where do you want to help?</label>
-    <div class="col-sm-6">
+    <label for="requested_depts" class="col-sm-3 control-label">Where do you want to help?</label>
+    <div class="col-sm-9">
         {{ macros.checkgroup(attendee, 'requested_depts') }}
     </div>
 </div>
@@ -432,17 +381,15 @@
 
 <div class="form-group">
     {% if c.COLLECT_EXACT_BIRTHDATE %}
-        <label for="birthdate" class="col-sm-2 control-label">Date of Birth</label>
+        <label for="birthdate" class="col-sm-3 control-label">Date of Birth</label>
         <div class="col-sm-6">
-            <nobr>
-                <input type='text' class="form-control date" name="birthdate" value="{{ attendee.birthdate|datetime("%Y-%m-%d") }} "/>
-                {% if c.PAGE_PATH == '/registration/form' and attendee.birthdate %}
-                    ({{ attendee.age_group_conf.desc }})
-                {% endif %}
-            </nobr>
+          <input type='text' class="form-control date" name="birthdate" value="{{ attendee.birthdate|datetime("%Y-%m-%d") }}" required/>
+          {% if c.PAGE_PATH == '/registration/form' and attendee.birthdate %}
+              ({{ attendee.age_group_conf.desc }})
+          {% endif %}
         </div>
     {% else %}
-        <label for="age_group" class="col-sm-2 control-label">Age as of {{ c.EVENT_NAME }}</label>
+        <label for="age_group" class="col-sm-3 control-label">Age as of {{ c.EVENT_NAME }}</label>
         <div class="col-sm-6">
             <select name="age_group" class="form-control" onChange="ageGroupSelected()">
                 <option value="{{ c.AGE_UNKNOWN }}">Please indicate your age</option>
@@ -450,21 +397,18 @@
             </select>
         </div>
     {% endif %}
-</div>
-
-<div class="form-group" id="age_disclaimer">
-    <p class="help-block col-sm-6 col-sm-offset-2">
-        <span style="font-style:italic">
-            {% if c.CONSENT_FORM_URL %}
-                Attendees under 18 <b>MUST</b> bring a signed (and notarized if not accompanied by parent or guardian during badge pickup) parental
-                <nobr><a target="_blank" href="{{ c.CONSENT_FORM_URL }}">consent form</a></nobr>.
-            {% endif %}
-        </span>
+    <p id="age_disclaimer" class="help-block col-sm-9 col-sm-offset-3">
+      {% if c.CONSENT_FORM_URL %}
+      <i>
+        Attendees under 18 <b>MUST</b> bring a signed (and notarized if not accompanied by parent or guardian during badge pickup) parental
+        <nobr><a target="_blank" href="{{ c.CONSENT_FORM_URL }}">consent form</a></nobr>.
+      </i>
+      {% endif %}
     </p>
 </div>
 
 <div class="form-group">
-    <label for="email" class="col-sm-2 control-label">Email Address</label>
+    <label for="email" class="col-sm-3 control-label">Email Address</label>
     <div class="col-sm-6">
         <input type="email" type="email" name="email" id="email" value="{{ attendee.email }}" class="form-control" placeholder="Email Address">
     </div>
@@ -472,7 +416,7 @@
 
 {% if c.COLLECT_FULL_ADDRESS %}
     <div class="form-group address_details">
-        <label for="country" class="col-sm-2 control-label">Country</label>
+        <label for="country" class="col-sm-3 control-label">Country</label>
         <div class="col-sm-6">
             <select name="country" class="form-control" placeholder="Country" autofocus="autofocus" autocorrect="off" autocomplete="country">
                 {% include "country_opts.html" %}
@@ -480,60 +424,60 @@
         </div>
     </div>
     <div class="form-group address_details">
-        <label for="address1" class="col-sm-2 control-label">Street</label>
+        <label for="address1" class="col-sm-3 control-label">Street</label>
         <div class="col-sm-6">
             <input type="text" name="address1" class="form-control" placeholder="Address Line 1" value="{{ attendee.address1 }}" />
         </div>
     </div>
     <div class="form-group address_details">
-        <label for="address2" class="col-sm-2 control-label"></label>
+        <label for="address2" class="col-sm-3 control-label"></label>
         <div class="col-sm-6">
             <input type="text" name="address2" class="form-control" placeholder="Address Line 2" value="{{ attendee.address2 }}" />
         </div>
     </div>
     <div class="form-group address_details">
-        <label for="city" class="col-sm-2 control-label">City</label>
+        <label for="city" class="col-sm-3 control-label">City</label>
         <div class="col-sm-6">
             <input type="text" name="city" class="form-control" placeholder="City" value="{{ attendee.city }}" />
         </div>
     </div>
     <div class="form-group address_details">
-        <label for="region" class="col-sm-2 control-label">State/Region</label>
+        <label for="region" class="col-sm-3 control-label">State/Region</label>
         <div class="col-sm-6">
             <input type="text" name="region" class="form-control" placeholder="State/Province" value="{{ attendee.region }}" autocomplete="address-level1" />
         </div>
     </div>
 {% endif %}
     <div class="form-group">
-        <label for="zip_code" class="col-sm-2 control-label {% if c.AT_OR_POST_CON %}optional-field{% endif %}">ZIP/Postal Code</label>
+        <label for="zip_code" class="col-sm-3 control-label {% if c.AT_OR_POST_CON %}optional-field{% endif %}">ZIP/Postal Code</label>
         <div class="col-sm-6">
-            <input type="text" name="zip_code" class="form-control" value="{{ attendee.zip_code }}" />
+            <input type="text" name="zip_code" class="form-control" value="{{ attendee.zip_code }}"{% if not c.AT_OR_POST_CON %} {% endif %}/>
         </div>
-        <div class="checkbox col-sm-6 col-sm-offset-2">
+        <div class="checkbox col-sm-6 col-sm-offset-3">
             {{ macros.checkbox(attendee, 'international', label="I'm coming from outside the US.") }}
         </div>
     </div>
 
 <div class="form-group">
-    <label for="ec_name" class="col-sm-2 control-label">Emergency Contact</label>
+    <label for="ec_name" class="col-sm-3 control-label">Emergency Contact</label>
     <div class="col-sm-6">
-        <input type="text" name="ec_name" value="{{ attendee.ec_name }}" class="form-control" placeholder="Who we should contact if something happens to you">
+        <input type="text" name="ec_name" value="{{ attendee.ec_name }}" class="form-control" required placeholder="Who we should contact if something happens to you">
     </div>
 </div>
 <div class="form-group">
-    <label for="ec_phone" class="col-sm-2 control-label">Emergency Phone</label>
+    <label for="ec_phone" class="col-sm-3 control-label">Emergency Phone</label>
     <div class="col-sm-6">
-        <input type="text" name="ec_phone" value="{{ attendee.ec_phone }}" class="form-control" placeholder="A valid phone number for your emergency contact">
+        <input type="text" name="ec_phone" value="{{ attendee.ec_phone }}" class="form-control" required placeholder="A valid phone number for your emergency contact">
     </div>
 </div>
 
 <div class="form-group">
-    <label for="cellphone" class="col-sm-2 control-label">Your Phone Number</label>
+    <label for="cellphone" class="col-sm-3 control-label">Your Phone Number</label>
     <div class="col-sm-6">
-        <input type="text" name="cellphone" id="cellphone" value="{{ attendee.cellphone }}" class="form-control" placeholder="A phone number we can use to contact you during the event">
+        <input type="text" name="cellphone" id="cellphone" value="{{ attendee.cellphone }}" class="form-control" required placeholder="A phone number we can use to contact you during the event">
     </div>
     {% if not attendee.is_dealer or c.PAGE_PATH == '/registration/form' %}
-        <div class="checkbox col-sm-6 col-sm-offset-2">
+        <div class="checkbox col-sm-6 col-sm-offset-3">
             {{ macros.checkbox(attendee, 'no_cellphone', label="I don't own a cellphone.", label_class='cellphone-excuse') }}
         </div>
     {% endif %}
@@ -541,30 +485,30 @@
 
 {% if c.INTEREST_OPTS %}
 <div class="form-group">
-    <label class="col-sm-2 control-label optional-field">What interests you?</label>
-    <div class="col-sm-10">
+    <label class="col-sm-3 control-label optional-field">What interests you?</label>
+    <div class="col-sm-9">
         {{ macros.checkgroup(attendee, 'interests') }}
     </div>
 </div>
 {% endif %}
 
 <div class="form-group">
-    <label for="found_how" class="col-sm-2 control-label optional-field">How did you find {{ c.EVENT_NAME }}?</label>
+    <label for="found_how" class="col-sm-3 control-label optional-field">How did you find {{ c.EVENT_NAME }}?</label>
     <div class="col-sm-6">
         <input type="text" name="found_how" id="found_how" value="{{ attendee.found_how }}" class="form-control" placeholder="How did you find {{ c.EVENT_NAME }}?">
     </div>
 </div>
 
 <div class="form-group">
-    <label for="comments" class="col-sm-2 control-label optional-field">Comments</label>
+    <label for="comments" class="col-sm-3 control-label optional-field">Comments</label>
     <div class="col-sm-6">
         <input type="textarea" name="comments" id="comments" value="{{ attendee.comments }}" class="form-control" placeholder="Comments">
     </div>
 </div>
 
 <div class="form-group">
-    <label for="email_option" class="col-sm-2 control-label optional-field">Keep Me Updated</label>
-    <div class="checkbox col-sm-6">
+    <label for="email_option" class="col-sm-3 control-label optional-field">Keep Me Updated</label>
+    <div class="checkbox col-sm-9">
         {{ macros.checkbox(attendee, 'can_spam', label='Send me emails relating to ') }} {{ organization_with_event_name() }} in future years.<br/>
         <span class="popup">{{ macros.popup_link("../static_views/privacy.html", "View Our Privacy Policy") }}</span>
     </div>
@@ -572,7 +516,7 @@
 
 {% if c.BADGE_PROMO_CODES_ENABLED and not group_id %}
 <div class="non_group_fields form-group">
-    <label for="promo_code" class="col-sm-2 control-label optional-field">Promo Code</label>
+    <label for="promo_code" class="col-sm-3 control-label optional-field">Promo Code</label>
     <div class="col-sm-6">
         {% if attendee.is_unpaid %}
         <input type="textarea" name="promo_code" value="{{ attendee.promo_code_code }}" class="form-control" placeholder="Promo Code">

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -128,10 +128,10 @@
 
 {% if attendee.regdesk_info %}
     <div class="form-group">
-        <div class="col-sm-2 text-right">
+        <div class="col-sm-3 text-right">
           <span class="label label-danger">Special Regdesk Instructions:</span>
         </div>
-        <div class="col-sm-6">
+        <div class="col-sm-9">
           {{ attendee.regdesk_info }}
           <p class="help-block"><em>You can update these instructions below</em></p>
         </div>
@@ -139,8 +139,8 @@
 {% endif %}
 
     <div class="form-group">
-        <label for="first_name" class="col-sm-2 control-label">Placeholder</label>
-        <div class="checkbox col-sm-6">
+        <label for="first_name" class="col-sm-3 control-label">Placeholder</label>
+        <div class="checkbox col-sm-9">
             <label for='placeholder'>
             {{ macros.checkbox(attendee, 'placeholder') }} This attendee needs to
             {% if attendee.is_new %}
@@ -154,7 +154,7 @@
     </div>
 
     <div class="form-group">
-        <label for="badge_status" class="col-sm-2 control-label">Status</label>
+        <label for="badge_status" class="col-sm-3 control-label">Status</label>
         <div class="col-sm-6">
             <select name="badge_status">
             {{ options(c.BADGE_STATUS_OPTS,attendee.badge_status) }}
@@ -164,7 +164,7 @@
 
     {% if c.HAS_ACCOUNTS_ACCESS %}
         <div class="form-group">
-            <label for="admin_status" class="col-sm-2 control-label">Admin</label>
+            <label for="admin_status" class="col-sm-3 control-label">Admin</label>
             <div class="col-sm-6">
                 {% if attendee.admin_account %}
                     <p name="admin_status">True</p>
@@ -176,8 +176,8 @@
 
         {% if attendee.admin_account %}
             <div class="form-group">
-                <label for="admin_options" class="col-sm-2 control-label">Permissions</label>
-                <div class="col-sm-6">
+                <label for="admin_options" class="col-sm-3 control-label">Permissions</label>
+                <div class="col-sm-9">
                     {{ attendee.admin_account.access_labels|join(' / ') }}
                 </div>
             </div>
@@ -186,7 +186,7 @@
     {% endif %}
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Badge</label>
+    <label class="col-sm-3 control-label">Badge</label>
     <div class="col-sm-6">
         {% if not attendee.is_new %}
             {{ attendee.badge }}
@@ -216,7 +216,7 @@
 </div>
 
 <div class="form-group">
-    <label for="group_opt" class="col-sm-2 control-label">Group</label>
+    <label for="group_opt" class="col-sm-3 control-label">Group</label>
     <div class="col-sm-6">
         <select name="group_opt" onChange="boldOrRegular() ; setGroupLink() ; groupWarning()">
             <option value="">Choose a group, if applicable</option>
@@ -231,7 +231,7 @@
 
 {% if attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or attendee.amount_extra >= c.SUPPORTER_LEVEL %}
     <div class="form-group">
-        <label for="badge_printed_name" class="col-sm-2 control-label">Name Printed on Badge</label>
+        <label for="badge_printed_name" class="col-sm-3 control-label">Name Printed on Badge</label>
         <div class="col-sm-6">
             <input type="text" class="form-control" name="badge_printed_name" maxlength="20" value="{{ attendee.badge_printed_name }}" />
         </div>
@@ -241,23 +241,23 @@
 {% include "regform.html" %}
 
 <div class="form-group staffing staffing-checked">
-    <label class="col-sm-2 control-label">Assigned Depts</label>
-    <div class="col-sm-6">
+    <label class="col-sm-3 control-label">Assigned Depts</label>
+    <div class="col-sm-9">
         {{ macros.checkgroup(attendee, 'assigned_depts') }}
     </div>
 </div>
 
 <div class="form-group staffing staffing-checked">
-    <label class="col-sm-2 control-label">Trusted in which depts</label>
-    <div class="col-sm-6">
+    <label class="col-sm-3 control-label">Trusted in which depts</label>
+    <div class="col-sm-9">
         {{ macros.checkgroup(attendee, 'trusted_depts') }}
         <span class="popup">{{ macros.popup_link("../static_views/trustDesc.html", "What does this mean?") }}</span>
     </div>
 </div>
 
 <div class="form-group staffing staffing-checked">
-    <label class="col-sm-2 control-label">Approved for Setup/Teardown</label>
-    <div class="checkbox col-sm-6">
+    <label class="col-sm-3 control-label">Approved for Setup/Teardown</label>
+    <div class="checkbox col-sm-9">
         {{ macros.checkbox(attendee, 'can_work_setup', label='Approved for setup') }} <br/>
         {{ macros.checkbox(attendee, 'can_work_teardown', label='Approved for teardown') }}
     </div>
@@ -266,21 +266,21 @@
 {% if not attendee.is_new %}
     {% if c.AT_THE_CON %}
         <div class="form-group">
-            <label class="col-sm-2 control-label">Received Merch</label>
+            <label class="col-sm-3 control-label">Received Merch</label>
             <div class="checkbox col-sm-6">
                 {{ macros.checkbox(attendee, 'got_merch', label='Yes') }}
             </div>
         </div>
     {% endif %}
     <div class="form-group">
-        <label class="col-sm-2 control-label">Signed Up</label>
-        <div class="col-sm-6">
+        <label class="col-sm-3 control-label">Signed Up</label>
+        <div class="col-sm-9">
             <i>{{ attendee.registered_local|datetime("%B %-d, %Y, %-I:%M %p") }}</i>
         </div>
     </div>
     <div class="form-group">
-        <label class="col-sm-2 control-label">Checked In</label>
-        <div class="col-sm-6">
+        <label class="col-sm-3 control-label">Checked In</label>
+        <div class="col-sm-9">
             {% if attendee.checked_in %}
                 Checked in at {{ attendee.checked_in_local|datetime("%B %-d, %Y, %-I:%M %p") }}
             {% else %}
@@ -292,8 +292,8 @@
 
 <!-- TODO: integrate this with extra stuff -->
 <div class="form-group">
-    <label class="col-sm-2 control-label">Badge Price</label>
-    <div class="checkbox col-sm-6">
+    <label class="col-sm-3 control-label">Badge Price</label>
+    <div class="checkbox col-sm-9">
         Base Price: $<input type="text" style="width:4em" name="overridden_price" value="{{ attendee.badge_cost|round(2) }}" />
         <label>
           <input type="checkbox" name="no_override" {% if attendee.overridden_price == None %} checked {% endif %}>
@@ -304,7 +304,7 @@
 
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Paid</label>
+    <label class="col-sm-3 control-label">Paid</label>
     <div class="col-sm-6">
         <select name="paid" onChange="showOrHideAmounts(true)">
             {{ options(c.PAYMENT_OPTS,attendee.paid) }}
@@ -330,8 +330,8 @@
 </div>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Merch Owed</label>
-    <div class="col-sm-6">
+    <label class="col-sm-3 control-label">Merch Owed</label>
+    <div class="col-sm-9">
         <p class="form-control-static">{{ attendee.merch }}</p>
         {% if attendee.got_merch %} (Merch has been picked up) {% endif %}
     </div>
@@ -339,7 +339,7 @@
 
 {% if attendee.gets_any_kind_of_shirt %}
     <div class="form-group">
-        <label for="shirt" class="col-sm-2 control-label">Shirt Size</label>
+        <label for="shirt" class="col-sm-3 control-label">Shirt Size</label>
         <div class="col-sm-6">
             <select name="shirt" class="form-control">
                 {{ options(c.SHIRT_OPTS,attendee.shirt) }}
@@ -349,35 +349,35 @@
 {% endif %}
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Extra Merch</label>
+    <label class="col-sm-3 control-label">Extra Merch</label>
     <div class="col-sm-6">
         <input type="text" name="extra_merch" value="{{ attendee.extra_merch }}" style="width:80%" />
     </div>
 </div>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Special Regdesk Instructions</label>
+    <label class="col-sm-3 control-label">Special Regdesk Instructions</label>
     <div class="col-sm-6">
         <input type="text" name="regdesk_info" value="{{ attendee.regdesk_info }}" style="width:80%" />
     </div>
 </div>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Notes for Later Review</label>
+    <label class="col-sm-3 control-label">Notes for Later Review</label>
     <div class="col-sm-6">
         <textarea name="for_review" rows="3" style="width:66%">{{ attendee.for_review }}</textarea>
     </div>
 </div>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">Admin Notes</label>
+    <label class="col-sm-3 control-label">Admin Notes</label>
     <div class="col-sm-6">
         <textarea name="admin_notes" rows="3" style="width:66%">{{ attendee.admin_notes }}</textarea>
     </div>
 </div>
 
 <div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
+    <div class="col-sm-9 col-sm-offset-3">
         <button type="submit" name="save" class="btn btn-primary" value="save_return_to_search">Save + return{% if not return_to %} to search{% endif %}</button>
         <button type="submit" name="save" class="btn btn-primary" value="save">Save</button>
     </div>

--- a/uber/templates/registration/register.html
+++ b/uber/templates/registration/register.html
@@ -3,8 +3,6 @@
 {% block backlink %}{% endblock %}
 {% block content %}
 
-<div class="masthead"></div>
-
 <script>
     window.setTimeout(toastr.clear, 10000);
 
@@ -37,46 +35,47 @@
     });
 </script>
 
-<div class="panel panel-default" style="padding-top: 15px;">
+<div class="masthead"></div>
+<div class="panel panel-default">
+  <div class="panel-body">
+    <form method="post" action="register" autocomplete="off" class="form-horizontal">
+      {{ csrf_token() }}
 
-<form method="post" action="register" autocomplete="off" class="form-horizontal">
-{{ csrf_token() }}
-
-<div class="form-group">
-    <label class="col-sm-2 control-label">Payment Method</label>
-    <div class="col-sm-6">
-        {% if c.AFTER_BADGE_PRICE_WAIVED %}
+      <div class="form-group">
+        <label class="col-sm-3 control-label">Payment Method</label>
+        <div class="col-sm-6">
+          {% if c.AFTER_BADGE_PRICE_WAIVED %}
             <div style="margin-top:10px">All badge types are now free - enjoy {{ c.EVENT_NAME }}!</div>
-        {% else %}
+          {% else %}
             <select name="payment_method" class="form-control" onChange="maybeBold()">
-                <option value="">Select a payment option</option>
-                {{ options(c.DOOR_PAYMENT_METHOD_OPTS,attendee.payment_method) }}
+              <option value="">Select a payment option</option>
+              {{ options(c.DOOR_PAYMENT_METHOD_OPTS,attendee.payment_method) }}
             </select>
-        {% endif %}
-    </div>
-</div>
+          {% endif %}
+        </div>
+      </div>
 
-<div class="form-group">
-    <label class="col-sm-2 control-label">Badge Type</label>
-    <div class="col-sm-6">
-        <select name="badge_type" class="form-control">
+      <div class="form-group">
+        <label class="col-sm-3 control-label">Badge Type</label>
+        <div class="col-sm-6">
+          <select name="badge_type" class="form-control">
             {{ options(c.AT_THE_DOOR_BADGE_OPTS,attendee.badge_type) }}
-        </select>
-        <p id="day-warning" class="help-block"></p>
-    </div>
+          </select>
+          <p id="day-warning" class="help-block"></p>
+        </div>
+      </div>
+
+      {% include "regform.html" %}
+
+      <div class="form-group">
+        <div class="col-sm-6 col-sm-offset-3">
+          <button type="submit" class="btn btn-primary">Register</button>
+        </div>
+      </div>
+
+      {% include "preregistration/disclaimers.html" %}
+    </form>
+  </div>
 </div>
-
-{% include "regform.html" %}
-
-<div class="form-group">
-    <div class="col-sm-6 col-sm-offset-2">
-        <button type="submit" class="btn btn-primary">Register</button>
-    </div>
-</div>
-
-{% include "preregistration/disclaimers.html" %}
-
-</div>
-</form>
 
 {% endblock %}

--- a/uber/templates/static_views/prereg.css
+++ b/uber/templates/static_views/prereg.css
@@ -20,7 +20,7 @@ a, a:visited, a:hover, a:active {
 #header {
 	background: url('../static/theme/logo.png') no-repeat left bottom;
 	padding-left: 400px;
-	
+
 	font-size: 30px;
 	font-weight: bold;
 	line-height: 65px;

--- a/uber/templates/static_views/styles/main.css
+++ b/uber/templates/static_views/styles/main.css
@@ -23,3 +23,11 @@
     z-index: 9998;
     background: rgb(249, 249, 249);
 }
+
+.checkgroup {
+    margin-right: 1em;
+}
+
+.checkbox-label {
+    cursor: pointer;
+}


### PR DESCRIPTION
With `whitespace: normal` the supporter level buttons can squish together a little bit. As it turns out, this issue is not as important as I initially thought, because we're only going to have 3 supporter levels (as opposed to the 4 shown in the screenshot attached to issue #2535).

I did take this opportunity to fix a bunch of other layout issues that had been bothering me. Many oof the changes are just HTML formatting.