### PR TITLE
Add pending email report

### DIFF
--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -358,7 +358,7 @@ def get_pending_email_data():
     if not categories_results:
         return None
 
-    pending_emails = None
+    pending_emails = dict()
 
     for automated_email in AutomatedEmail.instances.values():
         category_results = categories_results.get(automated_email.ident, None)
@@ -369,9 +369,6 @@ def get_pending_email_data():
 
         if unsent_because_unapproved_count <= 0:
             continue
-
-        if not pending_emails:
-            pending_emails = dict()
 
         pending_emails[automated_email.ident] = {
             'num_unsent': unsent_because_unapproved_count,

--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -340,7 +340,7 @@ def notify_admins_of_any_pending_emails():
     send_email(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
 
 
-DaemonTask(notify_admins_of_any_pending_emails, interval=300,        name="mail placeh")
+DaemonTask(notify_admins_of_any_pending_emails, interval=300, name="mail pending notification")
 
 
 def get_pending_email_data():

--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -320,3 +320,62 @@ class DeptChecklistEmail(AutomatedEmail):
                                 sender=c.STAFF_EMAIL,
                                 extra_data={'conf': conf})
 
+
+def notify_admins_of_any_pending_emails():
+    """
+    Generate an email a report which alerts admins that there are emails which are ready to send,
+    but won't because they need approval from an admin.
+
+    This is useful so we don't forget to let certain categories of emails send.
+    """
+    if not c.ENABLE_PENDING_EMAILS_REPORT or not c.PRE_CON or not (c.DEV_BOX or c.SEND_EMAILS):
+        return
+
+    pending_email_categories = get_pending_email_data()
+    if not pending_email_categories:
+        return
+
+    subject = c.EVENT_NAME + ' Pending Emails Report for ' + localized_now().strftime('%Y-%m-%d')
+    body = render('emails/daily_checks/pending_emails.html', {'pending_email_categories': pending_email_categories})
+    send_email(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
+
+
+DaemonTask(notify_admins_of_any_pending_emails, interval=300,        name="mail placeh")
+
+
+def get_pending_email_data():
+    """
+    Generate a list of emails which are ready to send, but need approval.
+
+    Returns: A dict of email idents -> pending counts for any email category with pending emails,
+    or None if none are waiting to send or the email daemon service has not finished any runs yet.
+    """
+    has_email_daemon_run_yet = SendAllAutomatedEmailsJob.last_result.get('completed', False)
+    if not has_email_daemon_run_yet:
+        return None
+
+    categories_results = SendAllAutomatedEmailsJob.last_result.get('categories', None)
+    if not categories_results:
+        return None
+
+    pending_emails = None
+
+    for automated_email in AutomatedEmail.instances.values():
+        category_results = categories_results.get(automated_email.ident, None)
+        if not category_results:
+            continue
+
+        unsent_because_unapproved_count = category_results.get('unsent_because_unapproved', 0)
+
+        if unsent_because_unapproved_count <= 0:
+            continue
+
+        if not pending_emails:
+            pending_emails = dict()
+
+        pending_emails[automated_email.ident] = {
+            'num_unsent': unsent_because_unapproved_count,
+            'subject': automated_email.subject,
+        }
+
+    return pending_emails

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -267,6 +267,8 @@ email_re            = string(default="^[a-zA-Z0-9_\-+.]+@[a-zA-Z0-9_\-+.]+(\.[a-
 # implemented a feature that replaces "Fest" with "Con" just for them.
 jerks = string_list(default=list('Nick Marinelli', 'Nicholas Marinelli', 'Matt Reid', 'Matthew Reid'))
 
+enable_pending_emails_report = boolean(default=True)
+
 
 [secret]
 # Config options in this section are accessible as normal through the global

--- a/uber/templates/emails/daily_checks/pending_emails.html
+++ b/uber/templates/emails/daily_checks/pending_emails.html
@@ -1,0 +1,19 @@
+<html>
+<head></head>
+<body>
+    <h3>{{ c.EVENT_NAME_AND_YEAR }}<br/> Emails that need approval to send:</h3>
+
+    <p>The following email categories are ready to send, but still require manual approval by admins.
+        Please visit the <a href="{{ c.URL_BASE }}/emails/pending">pending email approval page</a>
+        if you would like to approve any of these.</p>
+
+    <ul style="margin-top:0px ; margin-bottom:10px">
+    {% for pending_email_ident, pending_email_category_info in pending_email_categories.items() %}
+        <li>
+            {{ pending_email_category_info.num_unsent }} pending: <b>{{ pending_email_category_info.subject }}</b>
+            [<a href="{{ c.URL_BASE }}/emails/pending_examples?ident={{ pending_email_ident }}">view examples</a>]
+        </li>
+    {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
This is a new daily report sent to STOPs that highlights which email categories require approval to send. We often fail to remember to check on this often enough resulting in emails that go out a few days or weeks after the deadline.  This will help avoid that issue going forward.

If the volume of emails gets too crazy, it can be turned off via a config option.  I also structured this so the meat of the report functionality is in its own function, so it can be exposed via the API for other uses like Slack notifications

this is mostly what was talked about in https://github.com/magfest/ubersystem/issues/2431 except Vicki had some further suggestions we might want to implement.  For right now, I really wanted to get the basic version done sooner than later with so many events and so many emails happening concurrently, I am worried we will continue to miss email approvals and think we should err on the side of easily filterable spam reports vs not having this.  If it becomes intolerable, we can just turn it off.

What it looks like in action:
![image](https://user-images.githubusercontent.com/5413064/27916762-126d375c-6238-11e7-9773-1223c609d5b8.png)
