### PR TITLE
Add resend email buttons in attendee history pages

### DIFF
--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -56,7 +56,7 @@ class AutomatedEmail:
         """
         Given a model instance, return an email subject email for that instance.
         By default this just returns the default subject unmodified; this method
-        exists only to be overriden in subclasses.  For example, we might want
+        exists only to be overridden in subclasses.  For example, we might want
         our panel email subjects to contain the name of the panel.
         """
         return self.subject

--- a/uber/models.py
+++ b/uber/models.py
@@ -2631,6 +2631,13 @@ class Email(MagModel):
             return self.fk.full_name
 
     @property
+    def rcpt_current_email(self):
+        if self.model == 'Group':
+            return self.fk.leader.email
+        else:
+            return self.fk.email
+
+    @property
     def is_html(self):
         return '<body' in self.body
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -2625,17 +2625,14 @@ class Email(MagModel):
 
     @property
     def rcpt_name(self):
-        if self.model == 'Group':
-            return self.fk.leader.full_name
-        else:
-            return self.fk.full_name
+        if self.fk:
+            return self.fk.leader.full_name if self.model == 'Group' else self.fk.full_name
 
     @property
-    def rcpt_current_email(self):
-        if self.model == 'Group':
-            return self.fk.leader.email
-        else:
-            return self.fk.email
+    def rcpt_email(self):
+        if self.fk:
+            return self.fk.leader.email if self.model == 'Group' else self.fk.email
+        return self.dest or None
 
     @property
     def is_html(self):

--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -108,7 +108,7 @@ class Root:
                 body = email.html
 
             try:
-                send_email(sender, email.rcpt_current_email, email.subject, body, model=email.fk, ident=email.ident)
+                send_email(sender, email.rcpt_email, email.subject, body, model=email.fk, ident=email.ident)
             except:
                 return {'success': False, 'message': 'Email not sent: unknown error.'}
             else:

--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -88,6 +88,33 @@ class Root:
             'message': output_msg,
         }
 
+    @ajax
+    def resend_email(self, session, id):
+        """
+        Resend a particular email to the model's current email address.
+
+        This is useful for if someone had an invalid email address and did not receive an automated email.
+        """
+
+        email = session.email(id)
+        if email:
+            # If this was an automated email, we can send out an updated template with the correct 'from' address
+            if email.ident in AutomatedEmail.instances:
+                email_category = AutomatedEmail.instances[email.ident]
+                sender = email_category.sender
+                body = email_category.render(email.fk)
+            else:
+                sender = c.ADMIN_EMAIL
+                body = email.html
+
+            try:
+                send_email(sender, email.rcpt_current_email, email.subject, body, model=email.fk, ident=email.ident)
+            except:
+                return {'success': False, 'message': 'Email not sent: unknown error.'}
+            else:
+                return {'success': True, 'message': 'Email resent.'}
+        return {'success': False, 'message': 'Email not sent: no email found with that ID.'}
+
     @csrf_protected
     def approve(self, session, ident):
         session.add(ApprovedEmail(ident=ident))

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -70,7 +70,7 @@ class Root:
 
         if group.leader:
             emails = session.query(Email)\
-                .filter(or_(Email.dest == group.leader.email, and_(Email.model == 'Attendee', Email.fk_id == id)))\
+                .filter(or_(Email.dest == group.leader.email, Email.fk_id == id))\
                 .order_by(Email.when).all()
         else:
             emails = {}

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -38,6 +38,41 @@
                 <script src="{{ js }}" type="text/javascript"></script>
             {% endfor %}
         {% endif %}
+
+        {% if resend_email_form %}
+        <script type="text/javascript">
+            $(function() {
+                $("form[action='resend_email']").each(function(index) {
+                    $(this).submit(function (e) {
+                        // Prevent form submit.
+                        e.preventDefault();
+
+                        var data = $(this).serialize();
+                        var currentForm = $(this);
+
+                        $.ajax({
+                            method: 'POST',
+                            url: '../emails/resend_email',
+                            dataType: 'json',
+                            data: data,
+                            success: function (json) {
+                                toastr.clear();
+                                var message = json.message;
+                                if (json.success) {
+                                    toastr.info(message);
+                                } else {
+                                    toastr.error(message);
+                                }
+                            },
+                            error: function () {
+                                toastr.error('Unable to connect to server, please try again.');
+                            }
+                        });
+                    });
+                });
+            });
+        </script>
+        {% endif %}
     {% endblock %}
 
     <meta charset="utf-8">

--- a/uber/templates/emails/index.html
+++ b/uber/templates/emails/index.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% set admin_area=True %}
+{% extends "base.html" %}{% set admin_area=True %}{% set resend_email_form=True %}
 {% block title %}Recently Sent Automated Emails{% endblock %}
 {% block content %}
 
@@ -9,17 +9,25 @@
 
 {{ pages(page, count) }}
 
-<table class="list">
-<tr class="header">
-    <td>Sent</td>
-    <td>Subject</td>
-    <td>Recipient</td>
-</tr>
+<table class="table-striped table-bordered table-condensed">
+<thead><tr>
+    <th>Sent</th>
+    <th>Subject</th>
+    <th>Recipient</th>
+    <th></th>
+</tr></thead>
 {% for email in emails %}
     <tr>
-        <td>{{ email.when }}</td>
+        <td style="white-space:nowrap">{{ email.when|datetime_local("%x %X") }}</td>
         <td>{{ email.subject }}</td>
         <td><a href="sent?dest={{ email.dest }}">{{ email.dest }}</a></td>
+        <td>
+            <form method="post" action="resend_email" id="resend_email_{{ email.id }}">
+                {{ csrf_token() }}
+                <input type="hidden" name="id" value="{{ email.id }}" />
+                <button class="btn btn-primary" type="submit">Resend Email</button>
+            </form>
+        </td>
     </tr>
 {% endfor %}
 </table>

--- a/uber/templates/emails/sent.html
+++ b/uber/templates/emails/sent.html
@@ -1,14 +1,20 @@
-{% extends "base.html" %}{% set admin_area=True %}
+{% extends "base.html" %}{% set admin_area=True %}{% set resend_email_form=True %}
 {% block title %}Sent Emails{% endblock %}
 {% block content %}
 
 <h2>Emails Sent to {{ emails.0.rcpt_name }} ({{ emails.0.dest }})</h2>
 
-<div style="text-align:center"><a href="index">Go Back</a></div>
+<div><a href="index">Go Back</a></div>
 
 {% for email in emails  %}
-    <h3> {{ email.subject }} ({{ email.when|full_datetime_local }}) </h3>
-    <div style="font-family:courier">{{ email.html }}</div>
+    <h3>{{ email.subject }} ({{ email.when|full_datetime_local }})</h3>
+    <div style="font-family:courier" class="well">{{ email.html }}</div>
+    <form method="post" action="resend_email" id="resend_email_{{ email.id }}">
+        {{ csrf_token() }}
+        <input type="hidden" name="id" value="{{ email.id }}" />
+        <button class="btn btn-primary" type="submit">Resend Email</button>
+    </form>
+    <hr/>
 {% endfor %}
 
 {% endblock %}

--- a/uber/templates/groups/history.html
+++ b/uber/templates/groups/history.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% set admin_area=True %}
+{% extends "base.html" %}{% set admin_area=True %}{% set resend_email_form=True %}
 {% block title %}Group History - {{ group.name }}{% endblock %}
 {% block content %}
 
@@ -68,6 +68,24 @@
     </tr>
 {% endfor %}
 </table>
+
+{% for email in emails  %}
+    {% if loop.first %}<h2> Automated Emails </h2>{% endif %}
+    <h3> {{ email.subject }} ({{ email.when|full_datetime_local }}) </h3>
+    <div style="font-family:courier" class="well">
+    {% if email.is_html %}
+        (content of HTML email omitted; you can view the full email <a href="../emails/sent?id={{ email.id }}">here</a>)
+    {% else %}
+        {{ email.html }}
+    {% endif %}
+    </div>
+    <form method="post" action="resend_email" id="resend_email_{{ email.id }}">
+        {{ csrf_token() }}
+        <input type="hidden" name="id" value="{{ email.id }}" />
+        <button class="btn btn-primary" type="submit">Resend Email</button>
+    </form>
+    <hr/>
+{% endfor %}
 
 
 {% endblock %}

--- a/uber/templates/registration/history.html
+++ b/uber/templates/registration/history.html
@@ -1,6 +1,42 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Attendee History - {{ attendee.full_name }}{% endblock %}
 {% block content %}
+{% block adminheader %}
+<head>
+<script type="text/javascript">
+    $(function() {
+        $("form[action='resend_email']").each(function(index) {
+            $(this).submit(function (e) {
+                // Prevent form submit.
+                e.preventDefault();
+
+                var data = $(this).serialize();
+                var currentForm = $(this);
+
+                $.ajax({
+                    method: 'POST',
+                    url: '../emails/resend_email',
+                    dataType: 'json',
+                    data: data,
+                    success: function (json) {
+                        toastr.clear();
+                        var message = json.message;
+                        if (json.success) {
+                            toastr.info(message);
+                        } else {
+                            toastr.error(message);
+                        }
+                    },
+                    error: function () {
+                        toastr.error('Unable to connect to server, please try again.');
+                    }
+                });
+            });
+        });
+    });
+</script>
+</head>
+{% endblock %}
 
 {% include "registration/menu.html" %}
 
@@ -99,6 +135,11 @@
 {% for email in emails  %}
     {% if loop.first %}<h2> Automated Emails </h2>{% endif %}
     <h3> {{ email.subject }} ({{ email.when|full_datetime_local }}) </h3>
+    <form method="post" action="resend_email">
+    {{ csrf_token() }}
+    <input type="hidden" name="id" value="{{ email.id }}" />
+    <button class="btn btn-primary" type="submit">Resend Email</button>
+    </form>
     {% if email.is_html %}
         (content of HTML email omitted; you can view the full email <a href="../emails/sent?id={{ email.id }}">here</a>)
     {% else %}

--- a/uber/templates/registration/history.html
+++ b/uber/templates/registration/history.html
@@ -1,43 +1,6 @@
-{% extends "base.html" %}{% set admin_area=True %}
+{% extends "base.html" %}{% set admin_area=True %}{% set resend_email_form=True %}
 {% block title %}Attendee History - {{ attendee.full_name }}{% endblock %}
 {% block content %}
-{% block adminheader %}
-<head>
-<script type="text/javascript">
-    $(function() {
-        $("form[action='resend_email']").each(function(index) {
-            $(this).submit(function (e) {
-                // Prevent form submit.
-                e.preventDefault();
-
-                var data = $(this).serialize();
-                var currentForm = $(this);
-
-                $.ajax({
-                    method: 'POST',
-                    url: '../emails/resend_email',
-                    dataType: 'json',
-                    data: data,
-                    success: function (json) {
-                        toastr.clear();
-                        var message = json.message;
-                        if (json.success) {
-                            toastr.info(message);
-                        } else {
-                            toastr.error(message);
-                        }
-                    },
-                    error: function () {
-                        toastr.error('Unable to connect to server, please try again.');
-                    }
-                });
-            });
-        });
-    });
-</script>
-</head>
-{% endblock %}
-
 {% include "registration/menu.html" %}
 
 <h2>Changelog for {{ attendee.full_name }} {% if c.AT_THE_CON %}({{ attendee.badge }}){% endif %}</h2>
@@ -135,16 +98,19 @@
 {% for email in emails  %}
     {% if loop.first %}<h2> Automated Emails </h2>{% endif %}
     <h3> {{ email.subject }} ({{ email.when|full_datetime_local }}) </h3>
-    <form method="post" action="resend_email">
-    {{ csrf_token() }}
-    <input type="hidden" name="id" value="{{ email.id }}" />
-    <button class="btn btn-primary" type="submit">Resend Email</button>
-    </form>
+    <div style="font-family:courier" class="well">
     {% if email.is_html %}
         (content of HTML email omitted; you can view the full email <a href="../emails/sent?id={{ email.id }}">here</a>)
     {% else %}
-        <div style="font-family:courier">{{ email.html }}</div>
+        {{ email.html }}
     {% endif %}
+    </div>
+    <form method="post" action="resend_email" id="resend_email_{{ email.id }}">
+        {{ csrf_token() }}
+        <input type="hidden" name="id" value="{{ email.id }}" />
+        <button class="btn btn-primary" type="submit">Resend Email</button>
+    </form>
+    <hr/>
 {% endfor %}
 
 {% endblock %}

--- a/uber/tests/email/email_fixtures.py
+++ b/uber/tests/email/email_fixtures.py
@@ -172,7 +172,7 @@ def email_subsystem_sane_setup(
         remove_approved_idents,
         amazon_send_email_mock):
     """
-    Catch-all test for setting up all email subsytem tests.  This fixture is a catch-all container of all relevant
+    Catch-all test for setting up all email subsystem tests.  This fixture is a catch-all container of all relevant
     email testing fixtures.
 
     We will reset a bunch of global state and fake database data in each test run

--- a/uber/tests/models/test_email.py
+++ b/uber/tests/models/test_email.py
@@ -1,0 +1,68 @@
+from uber.tests import *
+from uber.tests.conftest import *
+
+
+@pytest.fixture
+def session(request, monkeypatch):
+    session = Session().session
+    request.addfinalizer(session.close)
+    monkeypatch.setattr(session, 'add', Mock())
+    monkeypatch.setattr(session, 'delete', Mock())
+    return session
+
+
+def test_get_fk_from_id():
+    a = Attendee()
+    assert a == Email(fk_id=a.id).fk
+
+
+def test_get_fk_no_id():
+    assert None == Email().fk
+
+
+def test_get_fk_fake_id():
+    assert None == Email(fk_id="blah").fk
+
+
+def test_group_name():
+    assert "Test Leader" == Email(fk_id=Group(leader=Attendee(first_name="Test", last_name="Leader")).id).rcpt_name
+
+
+def test_attendee_name():
+    assert "Test Attendee" == Email(fk_id=Attendee(first_name="Test", last_name="Attendee").id).rcpt_name
+
+
+def test_no_name():
+    assert None == Email().rcpt_name
+
+
+def test_group_email():
+    assert "testleader@example.com" == Email(fk_id=Group(leader=Attendee(email="testleader@example.com")).id).rcpt_email
+
+
+def test_attendee_email():
+    assert "testattendee@example.com" == Email(fk_id=Attendee(email="testattendee@example.com").id).rcpt_email
+
+
+def test_no_email():
+    assert None == Email().rcpt_email
+
+
+def test_email_from_dest():
+    assert "testattendee@example.com" == Email(dest="testattendee@example.com").rcpt_email
+
+
+def test_is_html():
+    assert True == Email(body="<body").is_html
+
+
+def test_is_not_html():
+    assert False == Email().is_html
+
+
+def test_html_from_html():
+    assert "HTML Content" == Email(body="<body>HTML Content</body>").html
+
+
+def test_html_from_text():
+    assert "Test<br/>Content" == Email(body="Test\nContent").html

--- a/uber/tests/site_sections/test_emails.py
+++ b/uber/tests/site_sections/test_emails.py
@@ -1,0 +1,12 @@
+import re
+from datetime import datetime, date
+
+import cherrypy
+import pytest
+from uber.common import *
+from uber.site_sections import emails
+from uber.tests.conftest import *
+
+
+class TestResendEmail():
+    pass


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2104 by adding a "resend email" button to every automated email listed in an attendee's history page.

This has been manually tested and works like a charm; however, there's still some things missing:

- [x] No unit tests. The function depends on specific items in the database, and I don't know how to set up scaffolding for that for unit testing.
- [x] The backend functionality can theoretically handle any email, but we only give admins access to resend automated emails. It'd be even better if we add similar buttons to the 'sent emails' pages.
- [x] The UI could stand to be nicer. Not sure what the best way to improve it is, though. 
See below:

![image](https://user-images.githubusercontent.com/7198215/28098877-cbc6649c-6686-11e7-9afb-c23eb771358d.png) (this image is now out of date)
