### PR TITLE
Add 'base_badge_price' to save attendee badge prices

### DIFF
--- a/alembic/versions/b6074f8ea4ab_add_base_badge_price_column.py
+++ b/alembic/versions/b6074f8ea4ab_add_base_badge_price_column.py
@@ -1,0 +1,38 @@
+"""Add base_badge_price column
+
+Revision ID: b6074f8ea4ab
+Revises: 71991162a59c
+Create Date: 2017-07-14 04:16:59.504802
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'b6074f8ea4ab'
+down_revision = '71991162a59c'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('base_badge_price', sa.Integer(), server_default='0', nullable=False))
+
+
+def downgrade():
+    op.drop_column('attendee', 'base_badge_price')

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -380,6 +380,7 @@ class Root:
 
                 attendee.badge_type = badge_being_claimed.badge_type
                 attendee.badge_num = badge_being_claimed.badge_num
+                attendee.base_badge_price = badge_being_claimed.base_badge_price
                 attendee.ribbon = badge_being_claimed.ribbon
                 attendee.paid = badge_being_claimed.paid
                 attendee.overridden_price = badge_being_claimed.overridden_price

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -296,10 +296,10 @@
 <div class="form-group">
     <label class="col-sm-3 control-label">Badge Price</label>
     <div class="checkbox col-sm-9">
-        Base Price: $<input type="text" style="width:4em" name="overridden_price" value="{{ attendee.badge_cost|round(2) }}" />
+        $<input type="text" style="width:4em" name="overridden_price" value="{{ attendee.badge_cost|round(2) }}" />
         <label>
           <input type="checkbox" name="no_override" {% if attendee.overridden_price == None %} checked {% endif %}>
-          Automatically recalculate badge price.
+          Let the system determine base badge price. (uncheck to override badge price)
         </label>
     </div>
 </div>

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -14,6 +14,7 @@ class TestCosts:
         assert 30 == Attendee(overridden_price=30).badge_cost
         assert 0 == Attendee(paid=c.NEED_NOT_PAY).badge_cost
         assert 20 == Attendee(paid=c.PAID_BY_GROUP).badge_cost
+        assert 30 == Attendee(base_badge_price=30).badge_cost
 
     def test_total_cost(self):
         assert 20 == Attendee().total_cost


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2587 by adding a new column to the attendee table and slightly reorganizing how badge prices are calculated.