### PR TITLE
Adds db session initialization to sep commands

### DIFF
--- a/uber/sep_commands.py
+++ b/uber/sep_commands.py
@@ -108,6 +108,7 @@ def resave_all_attendees_and_groups():
     SAFETY: This -should- be safe to run at any time, but, for safety sake, recommend turning off
     any running sideboard servers before running this command.
     """
+    Session.initialize_db(modify_tables=False, drop=False)
     with Session() as session:
         print("Re-saving all attendees....")
         [a.presave_adjustments() for a in session.query(Attendee).all()]
@@ -125,6 +126,7 @@ def resave_all_staffers():
     SAFETY: This -should- be safe to run at any time, but, for safety sake, recommend turning off
     any running sideboard servers before running this command.
     """
+    Session.initialize_db(modify_tables=False, drop=False)
     with Session() as session:
         staffers = session.query(Attendee).filter_by(badge_type=c.STAFF_BADGE).all()
 


### PR DESCRIPTION
Some DB migration code I wrote a while back broke a few `sep` commands, because they were expecting the DB Session to already be initialized.