### PR TITLE
Add duplicate confirmation for admins

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -110,6 +110,12 @@ class Root:
                     attendee.checked_in = localized_now()
                 session.add(attendee)
 
+                if attendee.is_new and \
+                        session.attendees_with_badges().filter_by(first_name=attendee.first_name,
+                                                                  last_name=attendee.last_name,
+                                                                  email=attendee.email).count():
+                    raise HTTPRedirect('duplicate?id={}&return_to={}', attendee.id, return_to or 'index')
+
                 msg_text = '{} has been saved'.format(attendee.full_name)
                 if params.get('save') == 'save_return_to_search':
                     if return_to:
@@ -247,6 +253,13 @@ class Root:
             'new_watch': watch_entry,
             'watchlist_entries': session.query(WatchList).order_by(WatchList.last_name).all(),
             'message': message
+        }
+
+    def duplicate(self, session, id, return_to='index'):
+        attendee = session.attendee(id)
+        return {
+            'attendee': attendee,
+            'return_to': return_to
         }
 
     @csrf_protected

--- a/uber/templates/registration/duplicate.html
+++ b/uber/templates/registration/duplicate.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}That attendee already has a badge{% endblock %}
+{% block content %}
+<div class="panel panel-default">
+    <div class="panel-body">
+    <h2>This attendee already has a badge!</h2>
+
+      We already have a <a href="form?id={{ attendee.id }}">{{ attendee.full_name }}</a> with email address {{ attendee.email }} in our database with a
+    {% if attendee.paid == c.PAID_BY_GROUP and attendee.group.status == c.WAITLISTED %}
+        waitlisted
+    {% elif attendee.paid == c.HAS_PAID or attendee.paid == c.PAID_BY_GROUP %}
+        paid
+    {% elif attendee.paid == c.NEED_NOT_PAY %}
+        complementary
+    {% elif attendee.paid == c.NOT_PAID %}
+        unpaid
+    {% else %}
+        {{ attendee.paid_label }}
+    {% endif %}
+    {{ attendee.badge_type_label }}
+    {% if attendee.ribbon != c.NO_RIBBON %}
+        ({{ attendee.ribbon_label }})
+    {% endif %}
+    badge{% if attendee.group %}
+        (with the group <a href="./group/form?id={{ attendee.group.id }}">{{ attendee.group.name }}</a>)
+    {% endif %}.
+
+    <br/> <br/>
+
+    If you're <strong>absolutely</strong> sure that this is someone else, please confirm this. We highly recommend
+    editing the attendee's name if at all possible, as badges with duplicate names may be picked up by the wrong
+    person.
+    {% if attendee.paid == c.PAID_BY_GROUP and attendee.group.status == c.WAITLISTED %}
+        Please keep in mind that dealers have an option to buy their badge once the Marketplace fills up, so you
+        normally do not need to create an additional badge for them.
+    {% endif %}
+    If you are at all not sure what to do, contact your Registration department at {{ c.REGDESK_EMAIL }}.
+
+    <br/> <br/>
+
+    <table style="width:auto" align="center">
+    <tr>
+        <td class="btn-group">
+            <a class="btn btn-default" href="form?id={{ attendee.id }}">Let me go back and edit their info!</a>
+            <a class="btn btn-default" href="{{ return_to }}">Take me back to where I was going!</a>
+        </td>
+        <td> &nbsp;&nbsp;&nbsp;&nbsp; </td>
+        <td>
+            <form method="post" action="delete">
+            <input type="hidden" name="id" value="{{ attendee.id }}"/>
+            {{ csrf_token() }}
+            <button class="btn btn-danger" type="submit">Whoops, undo this badge!</button>
+            </form>
+        </td>
+    </tr>
+    </table>
+    </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/943. We cheat a little in that the badge gets created before we ask for confirmation, but at least this way admins get a chance to immediately undo their mistake.