### PR TITLE
Prevent attendees from trying to pay over $999,999

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -119,6 +119,12 @@ def total_cost_over_paid(attendee):
         return 'You have already paid ${}, you cannot reduce your extras below that.'.format(attendee.amount_paid)
 
 
+@validation.Attendee
+def reasonable_total_cost(attendee):
+    if attendee.total_cost >= 999999:
+        return 'We cannot charge ${:,.2f}. Please reduce extras so the total is below $999,999.'.format(attendee.total_cost)
+
+
 @prereg_validation.Attendee
 def promo_code_is_useful(attendee):
     if attendee.promo_code:


### PR DESCRIPTION
Stripe literally cannot charge an attendee more than eight digits ($999,999.99). Fixes https://github.com/magfest/ubersystem/issues/2257 by preventing attendees from registering a badge with a total_cost more than $999,999.