### PR TITLE
Show prices on pages without a REG_TYPES area

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -411,7 +411,8 @@ class Root:
             'group_id': group_id,
             'group': group,
             'attendee': attendee,
-            'affiliates': session.affiliates()
+            'affiliates': session.affiliates(),
+            'badge_cost': 0
         }
 
     @credit_card
@@ -572,7 +573,8 @@ class Root:
             'return_to':     return_to,
             'attendee':      attendee,
             'message':       message,
-            'affiliates':    session.affiliates()
+            'affiliates':    session.affiliates(),
+            'badge_cost':    attendee.badge_cost
         }
 
     @id_required(Attendee)

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -574,7 +574,7 @@ class Root:
             'attendee':      attendee,
             'message':       message,
             'affiliates':    session.affiliates(),
-            'badge_cost':    attendee.badge_cost
+            'badge_cost':    attendee.badge_cost if attendee.paid != c.PAID_BY_GROUP else 0
         }
 
     @id_required(Attendee)

--- a/uber/templates/preregistration/attendee_donation_form.html
+++ b/uber/templates/preregistration/attendee_donation_form.html
@@ -8,7 +8,7 @@
     {% if attendee.paid == c.NOT_PAID %}
       <h2> Badge Payment for {{ attendee.full_name }} </h2>
 
-      You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ attendee.overridden_price|default(attendee.badge_cost|round(2)) }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra|round(2) }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|round(2) }}.
+      You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ attendee.badge_cost }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra|round(2) }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|round(2) }}.
 
       <table style="width: auto; margin: 15px auto 0;">
         <tr>

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -238,8 +238,8 @@
                         $.field('amount_extra').on('change', makeBadgeMatchExtra);
                     {% endif %}
                 }
-                togglePrices();
             }
+            togglePrices();
         });
     </script>
 {% endblock head_javascript %}

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -79,7 +79,7 @@
                 title: '{% if c.PAGE_PATH in ["/preregistration/form", "/preregistration/post_form", "/preregistration/dealer_registration"] or undoing_extra %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
                 description: 'Allows access to the convention for its duration.',
                 extra: 0,
-                price: {{ c.BADGE_PRICE }},
+                price: {{ badge_cost if badge_cost is defined else c.BADGE_PRICE }},
                 onClick: function () {
                     updateBadgeTypeHiddenInput('{{ c.ATTENDEE_BADGE }}');
                 }
@@ -209,7 +209,6 @@
             }
         };
         $(function () {
-            togglePrices();
             showOrHideBadgeTypes();
             if ($(BADGE_TYPES.row).size()) {
                 $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
@@ -239,6 +238,7 @@
                         $.field('amount_extra').on('change', makeBadgeMatchExtra);
                     {% endif %}
                 }
+                togglePrices();
             }
         });
     </script>


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2433 by triggering togglePrices(); AFTER the badge_types area has been built, without depending on a click event that doesn't happen on some pages. Also tweaks when prices for the base badge are displayed, effectively turning it off for new group members (because they don't pay any money for their badge, so it's confusing to show them their badge's price) and anyone without a badge cost.