### PR TITLE
Update attendee_qrcode.html

### DIFF
--- a/uber/templates/emails/reg_workflow/attendee_qrcode.html
+++ b/uber/templates/emails/reg_workflow/attendee_qrcode.html
@@ -8,7 +8,7 @@
 
 <br/><br/>To help speed up check-in, please bring the 2D barcode below with you when you pick up your badge. You can print it out or display it on your phone.
 <br/><br/>Please note, however, that this code is <strong>not</strong> a replacement for your photo ID. You must still present your photo ID when picking up your badge.
-You cannot pick up badges on behalf of other attendees, even if you have a copy of their barcode.
+You may not pick up badges on behalf of other attendees, even if you have a copy of their barcode.
 
 <br/><br/><img src="{{ c.URL_BASE }}/registration/qrcode_generator?data={{ attendee.public_id }}" />
 


### PR DESCRIPTION
Changes the wording from 'cannot' to 'may not,' since it's not like attendees are physically unable to pick up badges -- we just don't allow it. Requested by the Labs 2 reg dept.