### PR TITLE
Add estimate for remaining # of badges at a certain price

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -156,7 +156,7 @@ class Config(_Overridable):
                                                                     sa.Group.amount_paid > 0).count()
             return individuals + group_badges
 
-    @property
+    @request_cached_property
     def BADGES_LEFT_AT_CURRENT_PRICE(self):
         """
         Returns a string representing a rough estimate of how many badges are left at the current badge price tier.

--- a/uber/config.py
+++ b/uber/config.py
@@ -157,6 +157,42 @@ class Config(_Overridable):
             return individuals + group_badges
 
     @property
+    def BADGES_LEFT_AT_CURRENT_PRICE(self):
+        """
+        Returns a string representing a rough estimate of how many badges are left at the current badge price tier.
+        """
+        if c.HARDCORE_OPTIMIZATIONS_ENABLED:
+            return 'Unknown'
+
+        current_price_tier = c.ORDERED_PRICE_LIMITS.index(c.BADGE_PRICE) if c.BADGE_PRICE in c.ORDERED_PRICE_LIMITS else -1
+        if current_price_tier != -1 and c.ORDERED_PRICE_LIMITS[current_price_tier] == c.ORDERED_PRICE_LIMITS[-1]\
+                or not c.ORDERED_PRICE_LIMITS:
+            if c.MAX_BADGE_SALES:
+                difference = c.MAX_BADGE_SALES - c.BADGES_SOLD
+            else:
+                return 'Limitless'
+        else:
+            for key, val in c.PRICE_LIMITS.items():
+                if c.ORDERED_PRICE_LIMITS[current_price_tier+1] == val:
+                    difference = key - c.BADGES_SOLD
+        if not difference:
+            return 'Unknown'
+        elif difference <= 50:
+            return 'Almost Gone'
+        elif difference <= 100:
+            return 'Very Low'
+        elif difference <= 250:
+            return 'Low'
+        elif difference <= 500:
+            return 'Medium'
+        elif difference <= 750:
+            return 'High'
+        elif difference <= 1000:
+            return 'Very High'
+        else:
+            return 'Super High'
+
+    @property
     def ONEDAY_BADGE_PRICE(self):
         return self.get_oneday_price(sa.localized_now())
 
@@ -486,6 +522,7 @@ for _opt, _val in c.BADGE_PRICES['attendee'].items():
         c.PRICE_LIMITS[int(_opt)] = _val
     else:
         c.PRICE_BUMPS[date] = _val
+c.ORDERED_PRICE_LIMITS = sorted([val for key, val in c.PRICE_LIMITS.items()])
 
 
 def _is_intstr(s):

--- a/uber/config.py
+++ b/uber/config.py
@@ -162,7 +162,7 @@ class Config(_Overridable):
         Returns a string representing a rough estimate of how many badges are left at the current badge price tier.
         """
         if c.HARDCORE_OPTIMIZATIONS_ENABLED:
-            return 'Unknown'
+            return None
 
         current_price_tier = c.ORDERED_PRICE_LIMITS.index(c.BADGE_PRICE) if c.BADGE_PRICE in c.ORDERED_PRICE_LIMITS else -1
         if current_price_tier != -1 and c.ORDERED_PRICE_LIMITS[current_price_tier] == c.ORDERED_PRICE_LIMITS[-1]\
@@ -170,27 +170,12 @@ class Config(_Overridable):
             if c.MAX_BADGE_SALES:
                 difference = c.MAX_BADGE_SALES - c.BADGES_SOLD
             else:
-                return 'Limitless'
+                return -1
         else:
             for key, val in c.PRICE_LIMITS.items():
                 if c.ORDERED_PRICE_LIMITS[current_price_tier+1] == val:
                     difference = key - c.BADGES_SOLD
-        if not difference:
-            return 'Unknown'
-        elif difference <= 50:
-            return 'Almost Gone'
-        elif difference <= 100:
-            return 'Very Low'
-        elif difference <= 250:
-            return 'Low'
-        elif difference <= 500:
-            return 'Medium'
-        elif difference <= 750:
-            return 'High'
-        elif difference <= 1000:
-            return 'Very High'
-        else:
-            return 'Super High'
+        return difference
 
     @property
     def ONEDAY_BADGE_PRICE(self):

--- a/uber/tests/models/test_config.py
+++ b/uber/tests/models/test_config.py
@@ -109,6 +109,67 @@ class TestPriceLimits:
     # todo: Test badges that are paid by group
 
 
+class TestBadgePriceEstimate:
+    @pytest.fixture(autouse=True)
+    def add_price_limits(request, monkeypatch):
+        monkeypatch.setattr(c, 'PRICE_LIMITS', {1000: 50, 2500: 55})
+        monkeypatch.setattr(c, 'ORDERED_PRICE_LIMITS', [50, 55])
+        monkeypatch.setattr(c, 'PRICE_BUMPS', {})
+
+    def test_no_limits_estimate_no_max(self, monkeypatch):
+        monkeypatch.setattr(c, 'ORDERED_PRICE_LIMITS', [])
+        monkeypatch.setattr(c, 'MAX_BADGE_SALES', 0)
+        assert 'Limitless' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_no_limits_estimate_with_max(self, monkeypatch):
+        monkeypatch.setattr(c, 'ORDERED_PRICE_LIMITS', [])
+        monkeypatch.setattr(c, 'MAX_BADGE_SALES', 100)
+        assert 'Very Low' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_last_price_estimate_no_max(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGE_PRICE', 55)
+        monkeypatch.setattr(c, 'MAX_BADGE_SALES', 0)
+        assert 'Limitless' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_last_price_estimate_with_max(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGE_PRICE', 55)
+        monkeypatch.setattr(c, 'MAX_BADGE_SALES', 100)
+        assert 'Very Low' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_hardcore_optimized_estimate(self, monkeypatch):
+        monkeypatch.setattr(c, 'HARDCORE_OPTIMIZATIONS_ENABLED', True)
+        assert 'Unknown' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_almost_gone_estimate(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGES_SOLD', 990)
+        assert 'Almost Gone' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_very_low_estimate(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGES_SOLD', 910)
+        assert 'Very Low' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_low_estimate(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGES_SOLD', 760)
+        assert 'Low' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_moderate_estimate(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGES_SOLD', 600)
+        assert 'Medium' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_high_estimate(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGES_SOLD', 260)
+        assert 'High' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_very_high_estimate(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGES_SOLD', 60)
+        assert 'Very High' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+    def test_super_high_estimate(self, monkeypatch):
+        monkeypatch.setattr(uber.config.Config, 'BADGES_SOLD', 1010)
+        monkeypatch.setattr(uber.config.Config, 'BADGE_PRICE', 50)
+        assert 'Super High' == c.BADGES_LEFT_AT_CURRENT_PRICE
+
+
 class TestBadgeOpts:
     def test_prereg_badge_opts_with_group(self, monkeypatch):
         monkeypatch.setattr(c, 'GROUP_PREREG_TAKEDOWN', localized_now() + timedelta(days=1))


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2591. We add the property to the core system because it can be useful, but it's a pretty specific use-case so we only print it in SuperMAG's registration template.

I'm currently debating whether or not the limits/wording should be a dictionary in config or if it's not really worth it.