### PR TITLE
Fixes register_group_member by using existing unassigned badge instead of deleting it

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -704,13 +704,14 @@ class Session(SessionManager):
             badge_type = get_real_badge_type(badge_type)
 
             new_badge_num = self.auto_badge_num(badge_type)
+            lower_bound = c.BADGE_RANGES[badge_type][0]
+            upper_bound = c.BADGE_RANGES[badge_type][1]
             # Adjusts the badge number based on badges in the session
             for attendee in [m for m in chain(self.new, self.dirty) if isinstance(m, Attendee)]:
-                if attendee.badge_num is not None \
-                        and c.BADGE_RANGES[badge_type][0] <= attendee.badge_num <= c.BADGE_RANGES[badge_type][1]:
-                    new_badge_num = max(self.auto_badge_num(badge_type), 1 + attendee.badge_num, new_badge_num)
+                if attendee.badge_num is not None and lower_bound <= attendee.badge_num <= upper_bound:
+                    new_badge_num = max(new_badge_num, 1 + attendee.badge_num)
 
-            assert new_badge_num < c.BADGE_RANGES[badge_type][1], 'There are no more badge numbers available in this range!'
+            assert new_badge_num < upper_bound, 'There are no more badge numbers available in this range!'
 
             return new_badge_num
 
@@ -728,21 +729,27 @@ class Session(SessionManager):
             from uber.badge_funcs import needs_badge_num
 
             if c.SHIFT_CUSTOM_BADGES and c.BEFORE_PRINTED_BADGE_DEADLINE:
-                # fill in the gap from the old number, if applicable
-                badge_num_keep = attendee.badge_num
-                if old_badge_num:
-                    self.shift_badges(old_badge_type, old_badge_num + 1, down=True)
-
-                # make room for the new number, if applicable
+                badge_collision = False
                 if attendee.badge_num:
-                    offset = 1 if old_badge_type == attendee.badge_type and attendee.badge_num > (old_badge_num or 0) else 0
-                    no_gap = self.query(Attendee).filter(Attendee.badge_type == attendee.badge_type,
-                                                         Attendee.badge_num == attendee.badge_num,
-                                                         Attendee.id != attendee.id).first()
-
-                    if no_gap:
-                        self.shift_badges(attendee.badge_type, attendee.badge_num + offset, up=True)
-                attendee.badge_num = badge_num_keep
+                    badge_collision = self.query(Attendee.badge_num).filter(
+                        Attendee.badge_num == attendee.badge_num,
+                        Attendee.id != attendee.id).first()
+                desired_badge_num = attendee.badge_num
+                if old_badge_num:
+                    if attendee.badge_num and badge_collision:
+                        if old_badge_type == attendee.badge_type:
+                            if old_badge_num < attendee.badge_num:
+                                self.shift_badges(old_badge_type, old_badge_num + 1, until=attendee.badge_num, down=True)
+                            else:
+                                self.shift_badges(old_badge_type, attendee.badge_num, until=old_badge_num - 1, up=True)
+                        else:
+                            self.shift_badges(old_badge_type, old_badge_num + 1, down=True)
+                            self.shift_badges(attendee.badge_type, attendee.badge_num, up=True)
+                    else:
+                        self.shift_badges(old_badge_type, old_badge_num + 1, down=True)
+                elif attendee.badge_num and badge_collision:
+                    self.shift_badges(attendee.badge_type, attendee.badge_num, up=True)
+                attendee.badge_num = desired_badge_num
 
             if not attendee.badge_num and needs_badge_num(attendee):
                 attendee.badge_num = self.get_next_badge_num(attendee.badge_type)
@@ -759,35 +766,43 @@ class Session(SessionManager):
             a specific range.
             :return:
             """
-            in_range = self.query(Attendee.badge_num).filter(Attendee.badge_num >= c.BADGE_RANGES[badge_type][0],
-                                                             Attendee.badge_num <= c.BADGE_RANGES[badge_type][1])
-            if in_range.count():
-                in_range_list = [int(row[0]) for row in in_range.order_by(Attendee.badge_num).all()]
+            in_range = self.query(Attendee.badge_num).filter(
+                Attendee.badge_num != None,
+                Attendee.badge_num >= c.BADGE_RANGES[badge_type][0],
+                Attendee.badge_num <= c.BADGE_RANGES[badge_type][1])
 
+            in_range_list = [int(row[0]) for row in in_range.order_by(Attendee.badge_num).all()]
+            if len(in_range_list):
                 # Searches badge range for a gap in badge numbers; if none found, returns the latest badge number + 1
                 # Doing this lets admins manually set high badge numbers without filling up the badge type's range.
                 start, end = c.BADGE_RANGES[badge_type][0], in_range_list[-1]
                 gap_nums = sorted(set(range(start, end + 1)).difference(in_range_list))
                 if not gap_nums:
-                    return in_range.order_by(Attendee.badge_num.desc()).first().badge_num + 1
+                    return end + 1
                 else:
                     return gap_nums[0]
             else:
                 return c.BADGE_RANGES[badge_type][0]
 
-        def shift_badges(self, badge_type, badge_num, *, until=None, **direction):
-            # assert_badge_locked()
-            until = until or c.BADGE_RANGES[badge_type][1]
+        def shift_badges(self, badge_type, badge_num, *, until=None, up=False, down=False):
             if not c.SHIFT_CUSTOM_BADGES or c.AFTER_PRINTED_BADGE_DEADLINE:
                 return False
-            assert not any(param for param in direction if param not in ['up', 'down']), 'unknown parameters'
-            assert len(direction) < 2, 'you cannot specify both up and down parameters'
-            down = (not direction['up']) if 'up' in direction else direction.get('down', True)
-            shift = -1 if down else 1
-            for a in self.query(Attendee).filter(Attendee.badge_num == None,
-                                                 Attendee.badge_num >= badge_num,
-                                                 Attendee.badge_num <= until):
-                a.badge_num += shift
+
+            # assert_badge_locked()
+            from uber.badge_funcs import get_badge_type
+            (calculated_badge_type, error) = get_badge_type(badge_num)
+            badge_type = calculated_badge_type or badge_type
+            until = until or c.BADGE_RANGES[badge_type][1]
+
+            shift = 1 if up else -1
+            query = self.query(Attendee).filter(
+                Attendee.badge_num != None,
+                Attendee.badge_num >= badge_num,
+                Attendee.badge_num <= until)
+
+            query.update({Attendee.badge_num: Attendee.badge_num + shift},
+                synchronize_session='evaluate')
+
             return True
 
         def valid_attendees(self):
@@ -1426,13 +1441,16 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.badge_type == c.PSEUDO_DEALER_BADGE:
             self.ribbon = c.DEALER_RIBBON
 
-        self.badge_type = get_real_badge_type(self.badge_type)
+        self.badge_type = self.badge_type_real
+
+        old_badge_type = self.orig_value_of('badge_type')
+        old_badge_num = self.orig_value_of('badge_num')
 
         if not needs_badge_num(self):
             self.badge_num = None
 
-        if self.orig_value_of('badge_type') != self.badge_type or self.orig_value_of('badge_num') != self.badge_num:
-            self.session.update_badge(self, self.orig_value_of('badge_type'), self.orig_value_of('badge_num'))
+        if old_badge_type != self.badge_type or old_badge_num != self.badge_num:
+            self.session.update_badge(self, old_badge_type, old_badge_num)
         elif needs_badge_num(self) and not self.badge_num:
             self.badge_num = self.session.get_next_badge_num(self.badge_type)
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -784,7 +784,7 @@ class Session(SessionManager):
             assert len(direction) < 2, 'you cannot specify both up and down parameters'
             down = (not direction['up']) if 'up' in direction else direction.get('down', True)
             shift = -1 if down else 1
-            for a in self.query(Attendee).filter(Attendee.badge_num is not None,
+            for a in self.query(Attendee).filter(Attendee.badge_num == None,
                                                  Attendee.badge_num >= badge_num,
                                                  Attendee.badge_num <= until):
                 a.badge_num += shift

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -381,24 +381,27 @@ class Root:
                 if not group.unassigned:
                     raise HTTPRedirect('register_group_member?group_id={}&message={}', group_id, 'No more unassigned badges exist in this group')
 
-                badge_being_claimed = group.unassigned[0]
+                attrs_to_preserve_from_unassigned_group_member = [
+                    'id',
+                    'group_id',
+                    'badge_type',
+                    'badge_num',
+                    'base_badge_price',
+                    'ribbon',
+                    'paid',
+                    'overridden_price']
 
-                # Free group badges are only considered 'registered' when they are actually claimed.
+                for attr in attrs_to_preserve_from_unassigned_group_member:
+                    if attr in params:
+                        del params[attr]
+
+                attendee = group.unassigned[0]
+                attendee.apply(params, restricted=True)
+
+                # Free group badges are considered registered' when they are actually claimed.
                 if group.cost == 0:
                     attendee.registered = localized_now()
-                else:
-                    attendee.registered = badge_being_claimed.registered
 
-                attendee.badge_type = badge_being_claimed.badge_type
-                attendee.badge_num = badge_being_claimed.badge_num
-                attendee.base_badge_price = badge_being_claimed.base_badge_price
-                attendee.ribbon = badge_being_claimed.ribbon
-                attendee.paid = badge_being_claimed.paid
-                attendee.overridden_price = badge_being_claimed.overridden_price
-
-                session.delete_from_group(badge_being_claimed, group)
-                group.attendees.append(attendee)
-                session.add(attendee)
                 if attendee.amount_unpaid:
                     raise HTTPRedirect('attendee_donation_form?id={}', attendee.id)
                 else:

--- a/uber/tests/conftest.py
+++ b/uber/tests/conftest.py
@@ -14,6 +14,10 @@ deadline_not_reached = localized_now() + timedelta(days=1)
 deadline_has_passed  = localized_now() - timedelta(days=1)
 
 
+def assert_unique(x):
+    assert len(x) == len(set(x))
+
+
 def monkeypatch_db_column(column, patched_config_value):
     column.property.columns[0].type.choices = dict(patched_config_value)
 

--- a/uber/tests/models/test_badge_funcs.py
+++ b/uber/tests/models/test_badge_funcs.py
@@ -230,10 +230,6 @@ class TestShiftBadges:
         # This loads badges from the session, which isn't reloaded, so the result is not always what you'd expect
         return sorted(a.badge_num for a in session.query(Attendee).filter(Attendee.badge_status != c.INVALID_STATUS).filter_by(badge_type=c.STAFF_BADGE).all())
 
-    def test_invalid_parameters(self, session):
-        pytest.raises(AssertionError, session.shift_badges, c.STAFF_BADGE, 1, invalid='param')
-        pytest.raises(AssertionError, session.shift_badges, c.STAFF_BADGE, 1, up=True, down=False)
-
     def test_shift_not_enabled(self, session, monkeypatch, custom_badges_ordered):
         session.shift_badges(c.STAFF_BADGE, 2)
         assert [1, 2, 3, 4, 5] == self.staff_badges(session)

--- a/uber/tests/site_sections/test_preregistration.py
+++ b/uber/tests/site_sections/test_preregistration.py
@@ -1,0 +1,176 @@
+import re
+from datetime import datetime
+
+import cherrypy
+import pytest
+from uber.common import *
+from uber.site_sections import preregistration
+from uber.tests.conftest import admin_attendee, extract_message_from_html, \
+    GET, POST
+from uber.utils import CSRFException
+
+
+next_week = datetime.utcnow().replace(tzinfo=pytz.UTC) + timedelta(days=7)
+
+
+@pytest.fixture(autouse=True)
+def patch_badge_printed_deadline(monkeypatch):
+    monkeypatch.setattr(c, 'PRINTED_BADGE_DEADLINE', next_week)
+
+
+@pytest.fixture
+def duplicate_badge_num_preconditions():
+    group_id = None
+    most_recent_attendee_id = None
+    most_recent_badge_num = 0
+    with Session() as session:
+        leader = Attendee(
+            first_name='Fearless',
+            last_name='Leader',
+            email='fearless@example.com',
+            zip_code='21211',
+            ec_name='Nana Fearless',
+            ec_phone='555-555-1234',
+            cellphone='555-555-2345',
+            birthdate=date(1964, 12, 30),
+            registered=localized_now(),
+            paid=c.PAID_BY_GROUP,
+            ribbon=c.NO_RIBBON,
+            staffing=True,
+            badge_status=c.COMPLETED_STATUS,
+            badge_type=c.PSEUDO_GROUP_BADGE)
+
+        group = Group(
+            name='Too Many Badges!',
+            auto_recalc=False,
+            attendees=[leader])
+
+        session.add(leader)
+        session.add(group)
+        assert session.assign_badges(
+            group,
+            15,
+            new_badge_type=c.STAFF_BADGE,
+            new_ribbon_type=c.NO_RIBBON,
+            paid=c.NEED_NOT_PAY) is None
+        session.flush()
+
+        group_id = group.id
+        most_recent_attendee_id = leader.id
+
+    with Session() as session:
+        leader = session.query(Attendee).get(most_recent_attendee_id)
+        leader.paid = c.NEED_NOT_PAY
+        leader.badge_printed_name = 'Fearmore'
+        leader.badge_type = c.STAFF_BADGE
+        leader.assigned_depts = str(c.CONSOLE)
+
+    with Session() as session:
+        attendee = session.query(Attendee).get(most_recent_attendee_id)
+
+    for i in range(10):
+        with Session() as session:
+            group = session.query(Group).get(group_id)
+
+            is_staff = (i < 9)
+            attendee = Attendee(
+                first_name='Doubtful',
+                last_name='Follower{}'.format(i),
+                email='fearsome{}@example.com'.format(i),
+                zip_code='21211',
+                ec_name='Nana Fearless',
+                ec_phone='555-555-1234',
+                cellphone='555-555-321{}'.format(i),
+                birthdate=date(1964, 12, 30),
+                paid=c.PAID_BY_GROUP,
+                registered=localized_now(),
+                ribbon=c.NO_RIBBON,
+                staffing=is_staff,
+                badge_status=c.COMPLETED_STATUS,
+                badge_printed_name='Fearsome{}'.format(i) if is_staff else '',
+                badge_type=c.STAFF_BADGE if is_staff else c.ATTENDEE_BADGE,
+                assigned_depts=str(c.CONSOLE) if is_staff else '')
+
+            badge_being_claimed = group.unassigned[0]
+
+            attendee.badge_type = badge_being_claimed.badge_type
+            attendee.badge_num = badge_being_claimed.badge_num
+            attendee.base_badge_price = badge_being_claimed.base_badge_price
+            attendee.ribbon = badge_being_claimed.ribbon
+            attendee.paid = badge_being_claimed.paid
+            attendee.overridden_price = badge_being_claimed.overridden_price
+
+            session.delete_from_group(badge_being_claimed, group)
+            group.attendees.append(attendee)
+            session.add(attendee)
+
+            session.flush()
+            most_recent_attendee_id = attendee.id
+
+        with Session() as session:
+            group = session.query(Group).get(group_id)
+            badge_nums = [a.badge_num for a in group.attendees]
+            # SQLite doesn't support deferred constraints, so our test database
+            # doesn't actually have a unique constraint on the badge_num
+            # column. So we have to manually check for duplicate badge numbers.
+            assert len(badge_nums) == len(set(badge_nums))
+
+    yield group_id
+
+    with Session() as session:
+        session.query(Group).filter(Group.id==group_id).delete(
+            synchronize_session=False)
+
+
+class TestRegisterGroupMember(object):
+
+    def _register_group_member_response(self, **params):
+        with pytest.raises(HTTPRedirect) as excinfo:
+            preregistration.Root().register_group_member(**params)
+
+        redirect = excinfo.value
+        assert isinstance(redirect, HTTPRedirect)
+        assert 303 == redirect.status
+        assert 'message=Badge%20registered%20successfully' in redirect.urls[0]
+
+        return redirect
+
+    def test_register_group_member_duplicate_badge_num(
+            self,
+            POST,
+            csrf_token,
+            admin_attendee,
+            duplicate_badge_num_preconditions):
+
+        response = self._register_group_member_response(
+            group_id=duplicate_badge_num_preconditions,
+            first_name='Duplicate',
+            last_name='Follower',
+            legal_name='Duplicate Follower',
+            ec_name='Nana Fearless',
+            ec_phone='555-555-1234',
+            requested_hotel_info='0',
+            can_spam='1',
+            badge_type=str(c.ATTENDEE_BADGE),
+            shirt='0',
+            zip_code='21211',
+            affiliate='',
+            requested_depts=['80341158', '224685583'],
+            amount_extra='0',
+            email='duplicate@example.com',
+            found_how='Followed my fearless leader',
+            cellphone='555-555-4321',
+            staffing='1',
+            birthdate='1964-12-30',
+            comments='What is even happening?',
+            interests=[str(c.ARCADE), str(c.CONSOLE)],
+            badge_printed_name='',
+            id='None')
+
+        with Session() as session:
+            group = session.query(Group).get(duplicate_badge_num_preconditions)
+            badge_nums = [a.badge_num for a in group.attendees]
+            # SQLite doesn't support deferred constraints, so our test database
+            # doesn't actually have a unique constraint on the badge_num
+            # column. So we have to manually check for duplicate badge numbers.
+            assert len(badge_nums) == len(set(badge_nums))

--- a/uber/tests/site_sections/test_preregistration.py
+++ b/uber/tests/site_sections/test_preregistration.py
@@ -5,8 +5,8 @@ import cherrypy
 import pytest
 from uber.common import *
 from uber.site_sections import preregistration
-from uber.tests.conftest import admin_attendee, extract_message_from_html, \
-    GET, POST
+from uber.tests.conftest import admin_attendee, assert_unique, \
+    extract_message_from_html, GET, POST
 from uber.utils import CSRFException
 
 
@@ -21,8 +21,7 @@ def patch_badge_printed_deadline(monkeypatch):
 @pytest.fixture
 def duplicate_badge_num_preconditions():
     group_id = None
-    most_recent_attendee_id = None
-    most_recent_badge_num = 0
+    leader_id = None
     with Session() as session:
         leader = Attendee(
             first_name='Fearless',
@@ -37,14 +36,11 @@ def duplicate_badge_num_preconditions():
             paid=c.PAID_BY_GROUP,
             ribbon=c.NO_RIBBON,
             staffing=True,
-            badge_status=c.COMPLETED_STATUS,
             badge_type=c.PSEUDO_GROUP_BADGE)
 
-        group = Group(
-            name='Too Many Badges!',
-            auto_recalc=False,
-            attendees=[leader])
-
+        group = Group(name='Too Many Badges!')
+        group.attendees = [leader]
+        group.leader = leader
         session.add(leader)
         session.add(group)
         assert session.assign_badges(
@@ -56,56 +52,40 @@ def duplicate_badge_num_preconditions():
         session.flush()
 
         group_id = group.id
-        most_recent_attendee_id = leader.id
+        leader_id = leader.id
 
     with Session() as session:
-        leader = session.query(Attendee).get(most_recent_attendee_id)
+        leader = session.query(Attendee).get(leader_id)
         leader.paid = c.NEED_NOT_PAY
         leader.badge_printed_name = 'Fearmore'
         leader.badge_type = c.STAFF_BADGE
         leader.assigned_depts = str(c.CONSOLE)
 
-    with Session() as session:
-        attendee = session.query(Attendee).get(most_recent_attendee_id)
+        group = session.query(Group).get(group_id)
+        group.auto_recalc = False
 
     for i in range(10):
         with Session() as session:
             group = session.query(Group).get(group_id)
 
             is_staff = (i < 9)
-            attendee = Attendee(
-                first_name='Doubtful',
-                last_name='Follower{}'.format(i),
-                email='fearsome{}@example.com'.format(i),
-                zip_code='21211',
-                ec_name='Nana Fearless',
-                ec_phone='555-555-1234',
-                cellphone='555-555-321{}'.format(i),
-                birthdate=date(1964, 12, 30),
-                paid=c.PAID_BY_GROUP,
-                registered=localized_now(),
-                ribbon=c.NO_RIBBON,
-                staffing=is_staff,
-                badge_status=c.COMPLETED_STATUS,
-                badge_printed_name='Fearsome{}'.format(i) if is_staff else '',
-                badge_type=c.STAFF_BADGE if is_staff else c.ATTENDEE_BADGE,
-                assigned_depts=str(c.CONSOLE) if is_staff else '')
+            params = {
+                'first_name': 'Doubtful',
+                'last_name': 'Follower{}'.format(i),
+                'email': 'fearsome{}@example.com'.format(i),
+                'zip_code': '21211',
+                'ec_name': 'Nana Fearless',
+                'ec_phone': '555-555-1234',
+                'cellphone': '555-555-321{}'.format(i),
+                'birthdate': date(1964, 12, 30),
+                'registered': localized_now(),
+                'staffing': is_staff,
+                'badge_status': str(c.COMPLETED_STATUS),
+                'badge_printed_name': 'Fearsome{}'.format(i) if is_staff else '',
+                'assigned_depts': str(c.CONSOLE) if is_staff else ''}
 
-            badge_being_claimed = group.unassigned[0]
-
-            attendee.badge_type = badge_being_claimed.badge_type
-            attendee.badge_num = badge_being_claimed.badge_num
-            attendee.base_badge_price = badge_being_claimed.base_badge_price
-            attendee.ribbon = badge_being_claimed.ribbon
-            attendee.paid = badge_being_claimed.paid
-            attendee.overridden_price = badge_being_claimed.overridden_price
-
-            session.delete_from_group(badge_being_claimed, group)
-            group.attendees.append(attendee)
-            session.add(attendee)
-
-            session.flush()
-            most_recent_attendee_id = attendee.id
+            attendee = group.unassigned[0]
+            attendee.apply(params, restricted=False)
 
         with Session() as session:
             group = session.query(Group).get(group_id)
@@ -113,12 +93,12 @@ def duplicate_badge_num_preconditions():
             # SQLite doesn't support deferred constraints, so our test database
             # doesn't actually have a unique constraint on the badge_num
             # column. So we have to manually check for duplicate badge numbers.
-            assert len(badge_nums) == len(set(badge_nums))
+            assert_unique(badge_nums)
 
     yield group_id
 
     with Session() as session:
-        session.query(Group).filter(Group.id==group_id).delete(
+        session.query(Group).filter(Group.id == group_id).delete(
             synchronize_session=False)
 
 
@@ -173,4 +153,4 @@ class TestRegisterGroupMember(object):
             # SQLite doesn't support deferred constraints, so our test database
             # doesn't actually have a unique constraint on the badge_num
             # column. So we have to manually check for duplicate badge numbers.
-            assert len(badge_nums) == len(set(badge_nums))
+            assert_unique(badge_nums)


### PR DESCRIPTION
Fixes #2675, also fixes #2703 (GET TO DA BADGE NUMBA!)

* Fixes NULL SQL conditional in `shift_badges`
* Fixes register_group_member by using existing unassigned badge instead of deleting it
* Removes many redundant SQL queries from badge shifting code
* Improves performance of certain SQL queries in badge shifting code