### PR TITLE
Changes prereg wizard url indexes to use tuples instead of strings

### DIFF
--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -92,16 +92,16 @@
     {%-
       set steps = [
           (('form', 'post_form'), 'Enter Info'),
-          ('hotel', 'Hotel Booking'),
+          (('hotel',), 'Hotel Booking'),
           (('index', 'preregistration', ''), 'Review & Pay'),
-          ('paid_preregistrations', 'Done')]
+          (('paid_preregistrations',), 'Done')]
     -%}
   {% else %}
     {%-
       set steps = [
           (('form', 'post_form'), 'Enter Info'),
           (('index', 'preregistration', ''), 'Review & Pay'),
-          ('paid_preregistrations', 'Done')]
+          (('paid_preregistrations',), 'Done')]
     -%}
   {%- endif -%}
   {%- set step_count = steps|length -%}


### PR DESCRIPTION
`os.path.basename("/url/with/trailing/slash/")` evaluates to an empty string `""`.

`"" in "any string"` will always evaluate to `True`.

Thus `os.path.basename("/url/with/trailing/slash/") in "paid_preregistrations"` will always be true, so the wizard used to think any url with a trailing slash was actually the "paid_preregistrations" page.