### PR TITLE
Fixes form_link tag used by import results template

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -166,8 +166,12 @@ def form_link(model):
         return safe_string('<a href="../groups/form?id={}">{}</a>'.format(model.id, jinja2.escape(model.name)))
     elif isinstance(model, uber.models.Job):
         return safe_string('<a href="../jobs/form?id={}">{}</a>'.format(model.id, jinja2.escape(model.name)))
+    elif hasattr(model, 'name'):
+        return model.name
+    elif hasattr(model, 'full_name'):
+        return model.full_name
     else:
-        return model.name or model.full_name
+        return repr(model)
 
 
 @JinjaEnv.jinja_filter

--- a/uber/tests/test_custom_tags.py
+++ b/uber/tests/test_custom_tags.py
@@ -3,7 +3,8 @@ import pytest
 from uber.common import *
 from uber.custom_tags import (jsonize, linebreaksbr, datetime_local_filter,
     datetime_filter, full_datetime_local, hour_day_local, time_day_local,
-    timedelta_filter, timestamp, normalize_newlines, url_to_link, basename)
+    timedelta_filter, timestamp, normalize_newlines, url_to_link, basename,
+    form_link)
 
 
 class TestDatetimeFilters(object):
@@ -56,6 +57,14 @@ class TestDatetimeFilters(object):
         template = env.from_string('{{ dt|timedelta(days=-5)|datetime("%A, %B %-e") }}')
         expected = ''
         assert expected == template.render(dt=None)
+
+
+class TestFormLink(object):
+
+    def test_watch_list(self):
+        watch_list = WatchList(id='c4c29b35-a1cf-4662-a577-041d8be63edf')
+        assert form_link(watch_list) == \
+            "<WatchList id='c4c29b35-a1cf-4662-a577-041d8be63edf'>"
 
 
 class TestJsonize(object):


### PR DESCRIPTION
Was blowing up on watchlist import, because the watchlist class doesn't have a `name` attribute.