### PR TITLE
Update reg_notes to use FAQ and CoC link and change under 18 reminder

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -89,10 +89,13 @@ event_venue_address = string(default="")
 consent_form_url = string(default="")
 
 # This link appears in preregistration pages and in some emails.
-code_of_conduct_url = string(default="http://magfest.org/codeofconduct")
+code_of_conduct_url = string(default="")
 
 # This link is to give users a generic way to contact your organization.
 contact_url = string(default="")
+
+# This link will be included in confirmation emails.
+prereg_faq_url = string(default="")
 
 # when you access the kiosk landing page, this is where it will redirect you
 kiosk_redirect_url = string(default="../registration/register")

--- a/uber/templates/emails/reg_workflow/reg_notes.html
+++ b/uber/templates/emails/reg_workflow/reg_notes.html
@@ -21,3 +21,15 @@
     You may <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">click here</a>
     to edit your info if you are over 18 and entered that age by mistake.
 {% endif %}
+
+{% if c.CODE_OF_CONDUCT_URL %}
+    <br/><br/>
+    Registered attendees agree to the {{ c.EVENT_NAME }} code of conduct by picking up their badge.
+    You can review the code of conduct anytime by <a href="{{ c.CODE_OF_CONDUCT_URL }}">clicking here</a>.
+{% endif %}
+
+{% if c.PREREG_FAQ_URL %}
+    <br/><br/>
+    Got a question? Most common questions are answered in our FAQ.
+    Be sure to check the FAQ by <a href="{{ c.PREREG_FAQ_URL }}">clicking here</a>!
+{% endif %}

--- a/uber/templates/emails/reg_workflow/under_18_reminder.txt
+++ b/uber/templates/emails/reg_workflow/under_18_reminder.txt
@@ -1,6 +1,6 @@
 {{ attendee.first_name }},
 
-Thanks for pre-registering for {{ c.EVENT_NAME }}.  Our records indicate that you are under the age of 18, and as such, you will need a signed parental consent waiver. If a parent/guardian will be present at {{ c.EVENT_NAME }}, then they can sign the consent waiver when you pick up your badge at the registration desk. If a parent/guardian will not be at the event, the waiver may be brought pre-signed, however it MUST be notarized. We will not accept pre-signed waivers that are not notarized. You may find the waiver at {{ c.CONSENT_FORM_URL }}
+Thanks for pre-registering for {{ c.EVENT_NAME }}.  Our records indicate that you are under the age of 18, and as such, you will need a signed parental consent form. If a parent/guardian will be present at {{ c.EVENT_NAME }}, then they can sign the consent form when you pick up your badge at the registration desk. If a parent/guardian will not be at the event, the form may be brought pre-signed, however it MUST be notarized. We will not accept pre-signed forms that are not notarized. You may find the form at {{ c.CONSENT_FORM_URL }}
 
 If you are actually over 18, you can update your age in our database at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id  }} before {{ c.UBER_TAKEDOWN|datetime_local }}.  Or you can simply ignore this email, since we'll be checking photo IDs at our registration desk.
 


### PR DESCRIPTION
Fixes part of https://github.com/magfest/ubersystem/issues/2618. While adding the prereg FAQ link, I noticed that we had a code_of_conduct_url config option that we never used anywhere, so I also added that. Reg_notes.html gets included in confirmation emails, so these changes should make it to every attendee.