### PR TITLE
Add parental consent form text to more emails

### DIFF
--- a/uber/templates/emails/reg_workflow/badge_transfer.txt
+++ b/uber/templates/emails/reg_workflow/badge_transfer.txt
@@ -4,7 +4,12 @@ Our records indicate that {{ old.full_name }} ({{ old.email }}) has transferred 
 
 If {{ new.full_name }} needs to add or update the information associated with their new badge, use this link: {{ c.URL_BASE }}/preregistration/confirm?id={{ new.id }}
 
-Badges are not mailed out before the event, so your badge will be available for pickup at the registration desk when you arrive at {{ c.EVENT_NAME }}. Simply bring a photo ID to the registration desk, where you'll be provided with your badge. If you ordered bonus items such as a ribbon, t-shirt, or supporter package, you can pick those up at our merchandise booth. The location and hours of the registration desk and merchandise booth will be e-mailed prior to the event.
+Badges are not mailed out before the event, so your badge will be available for pickup at the registration desk when you arrive at {{ c.EVENT_NAME }}. Simply bring a photo ID to the registration desk, where you'll be provided with your badge. If you ordered bonus items such as a ribbon, t-shirt, or supporter package, you can pick those up at our merchandise booth. The location and hours of the registration desk and merchandise booth will be e-mailed prior to the event. {% if c.CONSENT_FORM_URL and new.age_group_conf['consent_form'] %}
+
+Our records indicate that {{ new.full_name }} is under the age of 18, and as such, will need a signed parental consent form. If a parent/guardian will be present at {{ c.EVENT_NAME }}, then they can sign the consent form when you pick up your badge at the registration desk. If a parent/guardian will not be at the event, the form may be brought pre-signed, however it MUST be notarized. We will not accept pre-signed forms that are not notarized. You may find the form at {{ c.CONSENT_FORM_URL }}.
+
+If you are actually over 18, you can update your age in our database at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id  }} before {{ c.UBER_TAKEDOWN|datetime_local }}.
+{% endif %}
 
 If this has happened in error, please contact {{ c.REGDESK_EMAIL|safe }}.  Otherwise we look forward to seeing {{ new.first_name }} on {{ event_dates() }}.
 

--- a/uber/templates/emails/reg_workflow/group_confirmation.html
+++ b/uber/templates/emails/reg_workflow/group_confirmation.html
@@ -21,12 +21,21 @@ Your {{ group.is_dealer|yesno("Dealer registration,group") }} ({{ group.name }})
     {% endif %}
     extra money <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader_id }}">here</a>.
 
-    
     {% if not group.is_dealer %}
         <br/> <br/>
         You can add badges to your group using the above link, but you must add
         at least {{ c.MIN_GROUP_ADDITION }} badges at a time.
     {% endif %}
+{% endif %}
+
+{% if c.CONSENT_FORM_URL and group.leader.age_group_conf['consent_form'] %}
+    <br/> <br/>
+    Because you are under 18, you must bring a signed and notarized parental permission
+    to be granted admission to {{ c.EVENT_NAME }}.  You may download the consent form
+    <a href="{{ c.CONSENT_FORM_URL }}">by clicking here</a>.
+    <br/> <br/>
+    You may <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">click here</a>
+    to edit your info if you are over 18.
 {% endif %}
 
 <br/> <br/>

--- a/uber/templates/emails/reg_workflow/reg_notes.html
+++ b/uber/templates/emails/reg_workflow/reg_notes.html
@@ -15,11 +15,11 @@
 {% if c.CONSENT_FORM_URL and attendee.age_group_conf['consent_form'] %}
     <br/> <br/>
     Because you are under 18, you must bring a signed and notarized parental permission
-    to be granted admission to {{ c.EVENT_NAME }}.  You may download the consent form 
+    to be granted admission to {{ c.EVENT_NAME }}. You may download the consent form
     <a href="{{ c.CONSENT_FORM_URL }}">by clicking here</a>.
     <br/> <br/>
     You may <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">click here</a>
-    to edit your info if you are over 18 and entered that age by mistake.
+    to edit your info if you are over 18.
 {% endif %}
 
 {% if c.CODE_OF_CONDUCT_URL %}

--- a/uber/templates/emails/reg_workflow/under_18_reminder.txt
+++ b/uber/templates/emails/reg_workflow/under_18_reminder.txt
@@ -2,7 +2,7 @@
 
 Thanks for pre-registering for {{ c.EVENT_NAME }}.  Our records indicate that you are under the age of 18, and as such, you will need a signed parental consent form. If a parent/guardian will be present at {{ c.EVENT_NAME }}, then they can sign the consent form when you pick up your badge at the registration desk. If a parent/guardian will not be at the event, the form may be brought pre-signed, however it MUST be notarized. We will not accept pre-signed forms that are not notarized. You may find the form at {{ c.CONSENT_FORM_URL }}
 
-If you are actually over 18, you can update your age in our database at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id  }} before {{ c.UBER_TAKEDOWN|datetime_local }}.  Or you can simply ignore this email, since we'll be checking photo IDs at our registration desk.
+If you are actually over 18, you can update your age in our database at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id  }} before {{ c.UBER_TAKEDOWN|datetime_local }}.
 
 We look forward to seeing you at {{ c.EVENT_NAME}} on {{ event_dates() }}.
 


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2618 (the rest of the way) by adding text about parental consent forms to more emails, ensuring that everyone will get notified that they need a consent form. Also slightly updates the text in some places.