### PR TITLE
Ensures dealer reg is visible from the "Prereg not yet open" page

### DIFF
--- a/uber/templates/static_views/prereg_not_yet_open.html
+++ b/uber/templates/static_views/prereg_not_yet_open.html
@@ -1,13 +1,25 @@
+<!DOCTYPE html>
 <html>
 <head></head>
 <body style='text-align:center'>
-    <h2 style='color:red'>{{ c.EVENT_NAME_AND_YEAR }} pre-registration is not yet open.</h2>
-    {% if not c.HIDE_PREREG_OPEN_DATE %}
-        Please check back on {{ c.PREREG_OPEN|datetime("%B %d") }}.<br/>
+  <h1 style='color:red'>{{ c.EVENT_NAME_AND_YEAR }} pre-registration is not yet open.</h1>
+  <p>
+  {%- if not c.HIDE_PREREG_OPEN_DATE -%}
+    Please check back on {{ c.PREREG_OPEN|datetime("%B %d") }}!<br/>
+  {%- else -%}
+    Please check back soon!
+  {%- endif -%}
+  </p>
+  {%- if c.DEALER_REG_START and c.DEALER_REG_PUBLIC and c.BEFORE_DEALER_REG_SHUTDOWN -%}
+  <p>
+    <strong>Dealers:</strong>
+    {% if c.BEFORE_DEALER_REG_PUBLIC %}
+        Registrations for dealer memberships begin {{ c.DEALER_REG_START|datetime_local }}.
     {% else %}
-        Please check back soon.
+        Please register <a href="../preregistration/dealer_registration">here</a>.
     {% endif %}
-    <br/>
-    Please <a href="{{ c.CONTACT_URL }}">contact us</a> if you have any questions.<br/>
+  </p>
+  {%- endif -%}
+  Please <a href="{{ c.CONTACT_URL }}">contact us</a> if you have any questions.<br/>
 </body>
 </html>


### PR DESCRIPTION
This shows the link to the dealer registration page from the "Preregistration not yet open" page. We've never opened dealer reg earlier than prereg before, so it's never come up. With the changes, it looks like this:
<img width="636" alt="screen shot 2017-07-29 at 1 18 17 pm" src="https://user-images.githubusercontent.com/2592431/28746857-743cf550-7460-11e7-9f36-1829ca07265a.png">