### PR TITLE
Turns out expunge_all was really important

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -254,7 +254,9 @@ def sessionized(func):
         else:
             with sa.Session() as session:
                 try:
-                    return func(*args, session=session, **kwargs)
+                    retval = func(*args, session=session, **kwargs)
+                    session.expunge_all()
+                    return retval
                 except HTTPRedirect:
                     session.commit()
                     raise


### PR DESCRIPTION
The prereg pages need the session expunged because of the weird disconnected model objects. I am going to merge this right now, because all of the preregistration pages will throw errors after anyone pays.