### PR TITLE
Fixes badge type reversion after submitting an invalid form

### DIFF
--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -39,9 +39,7 @@
                 onClick: function () {
                     $('.group_fields').addClass('hide');
                     $('.non_group_fields').removeClass('hide');
-                    if ($.field('badge_type').val() == '{{ c.PSEUDO_GROUP_BADGE }}') {
-                        updateBadgeTypeHiddenInput('{{ c.ATTENDEE_BADGE }}');
-                    }
+                    updateBadgeTypeHiddenInput('{{ c.ATTENDEE_BADGE }}');
                     if ($.field('first_name')) {
                         $('#bold-field-message').insertBefore($.field('first_name').parents('.form-group'));
                     }
@@ -81,10 +79,7 @@
                 title: '{% if c.PAGE_PATH in ["/preregistration/form", "/preregistration/post_form", "/preregistration/dealer_registration"] or undoing_extra %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
                 description: 'Allows access to the convention for its duration.',
                 extra: 0,
-                price: {{ badge_cost if badge_cost is defined else c.BADGE_PRICE }},
-                onClick: function () {
-                    updateBadgeTypeHiddenInput('{{ c.ATTENDEE_BADGE }}');
-                }
+                price: {{ badge_cost if badge_cost is defined else c.BADGE_PRICE }}
             }]
         };
         {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS and c.SHIRT_AVAILABLE %}


### PR DESCRIPTION
Prevents PSEUDO_GROUP_BADGE from reverting to ATTENDEE_BADGE when an invalid form is submitted.

Steps to reproduce:
1. Navigate to the preregistration page (/uber/preregistration/form)
2. Select Group Badge
3. Fill out everything except date of birth
4. Submit the form
5. The page will refresh with a message saying "please fill out date of birth"
6. Note: everything LOOKS correct, i.e. the Group Badge is still selected
7. Fill out date of birth and click submit
8. On the confirmation page (/uber/preregistration/index), the preregistration will be listed as a regular attendee without the group badges

This also fixes a second issue where clicking "No Thanks" will revert a Group Badge to an Attendee Badge. Steps to reproduce:
1. Navigate to the preregistration page (/uber/preregistration/form)
2. Select Group Badge
3. Fill out everything (including date of birth)
4. Click "T-Shirt Bundle" button
5. Click "No Thanks" button and click submit
8. On the confirmation page (/uber/preregistration/index), the preregistration will be listed as a regular attendee without the group badges