### PR TITLE
Fixes email resending for model objects from plugins other than uber

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -2705,7 +2705,7 @@ class Email(MagModel):
     @cached_property
     def fk(self):
         try:
-            return getattr(self.session, globals()[self.model].__tablename__)(self.fk_id)
+            return self.session.query(Session.resolve_model(self.model)).filter_by(id=self.fk_id).first()
         except:
             return None
 


### PR DESCRIPTION
The `PanelApplicant` class is not available in `globals()` at the time the resend action happens.