### PR TITLE
Fixes #2770: Makes legal name label less ambiguous

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -135,7 +135,7 @@
     </div>
     {% if attendee.legal_name %}
         <div class="form-group">
-            <label for="legal_name" class="col-sm-3 control-label">Name as appears on Current Legal ID</label>
+            <label for="legal_name" class="col-sm-3 control-label">Name as appears on Legal Photo ID</label>
             <div class="col-sm-6 form-control-static">{{ attendee.legal_name }}</div>
         </div>
     {% endif %}
@@ -158,17 +158,17 @@
         <div class="col-sm-9 col-sm-offset-3">
           <label for="same_legal_name" class="checkbox-label">
             <input type="checkbox" name="same_legal_name" id="same_legal_name" value="1" {% if attendee.first_name != '' and attendee.legal_name == '' %}checked="checked"{% endif %} />
-            The above name is exactly what appears on my Current Legal ID
+            The above name is exactly what appears on my Legal Photo ID
           </label>
         </div>
     </div>
 
     <div class="form-group">
-        <label for="legal_name" class="col-sm-3 control-label">Name as appears on Current Legal ID</label>
+        <label for="legal_name" class="col-sm-3 control-label">Name as appears on Legal Photo ID</label>
         <div class="col-sm-6">
-            <input type="text" name="legal_name" value="{{ attendee.legal_name }}" class="form-control" placeholder="Your name exactly as it appears on your Photo ID" autocomplete="name" />
+            <input type="text" name="legal_name" value="{{ attendee.legal_name }}" class="form-control" placeholder="Name exactly as it appears on Photo ID" autocomplete="name" />
             <p class="help-block">
-              <span class="popup">{{ macros.popup_link("../static_views/legal_name.html", 'What does "Current Legal ID" mean?') }}</span>
+              <span class="popup">{{ macros.popup_link("../static_views/legal_name.html", 'What does "Legal Photo ID" mean?') }}</span>
             </p>
         </div>
     </div>

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -135,7 +135,7 @@
     </div>
     {% if attendee.legal_name %}
         <div class="form-group">
-            <label for="legal_name" class="col-sm-3 control-label">Name on ID</label>
+            <label for="legal_name" class="col-sm-3 control-label">Name as appears on Current Legal ID</label>
             <div class="col-sm-6 form-control-static">{{ attendee.legal_name }}</div>
         </div>
     {% endif %}
@@ -155,22 +155,22 @@
     </div>
 
     <div class="form-group">
-        <div class="col-sm-6 col-sm-offset-3">
+        <div class="col-sm-9 col-sm-offset-3">
           <label for="same_legal_name" class="checkbox-label">
             <input type="checkbox" name="same_legal_name" id="same_legal_name" value="1" {% if attendee.first_name != '' and attendee.legal_name == '' %}checked="checked"{% endif %} />
-            The above name is exactly what appears on my ID
+            The above name is exactly what appears on my Current Legal ID
           </label>
         </div>
     </div>
 
     <div class="form-group">
-        <label for="legal_name" class="col-sm-3 control-label">Name on ID</label>
+        <label for="legal_name" class="col-sm-3 control-label">Name as appears on Current Legal ID</label>
         <div class="col-sm-6">
             <input type="text" name="legal_name" value="{{ attendee.legal_name }}" class="form-control" placeholder="Your name exactly as it appears on your Photo ID" autocomplete="name" />
+            <p class="help-block">
+              <span class="popup">{{ macros.popup_link("../static_views/legal_name.html", 'What does "Current Legal ID" mean?') }}</span>
+            </p>
         </div>
-        <p class="help-block col-sm-6 col-sm-offset-3">
-            <span class="popup">{{ macros.popup_link("../static_views/legal_name.html", "What does this mean?") }}</span>
-        </p>
     </div>
 {% endif %}
 

--- a/uber/templates/static_views/legal_name.html
+++ b/uber/templates/static_views/legal_name.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title> Explanation of 'Name on ID' </title>
+    <title> Explanation of "Name as appears on Current Legal ID" </title>
 </head>
 <body>
 

--- a/uber/templates/static_views/legal_name.html
+++ b/uber/templates/static_views/legal_name.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title> Explanation of "Name as appears on Current Legal ID" </title>
+    <title> Explanation of "Name as appears on Legal Photo ID" </title>
 </head>
 <body>
 


### PR DESCRIPTION
These changes make the legal name field look like this:

<img width="628" alt="screen shot 2017-08-03 at 11 45 26 am" src="https://user-images.githubusercontent.com/2592431/28930618-83567608-7841-11e7-8e0f-de175e8b7120.png">



Fixes #2770