### PR TITLE
set default number of staff shirts to 0

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -210,7 +210,7 @@ collect_extra_donation = boolean(default=False)
 out_of_shirts = boolean(default=False)
 
 # This is the number of staff shirts (i.e. the shirt that says "{EVENT_NAME} staff") that EACH staffer gets.
-shirts_per_staffer = integer(default=2)
+shirts_per_staffer = integer(default=0)
 
 # The max number of tables a dealer can apply for.  Note that the admin
 # interface allows you to give a dealer a higher number than this.


### PR DESCRIPTION
only supermag is going to want this set to non-zero, so this is a more sane default

look out for more PRs that add this as a puppet option