### PR TITLE
add support for letting people with staff badges also be eligible for swag shirts

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -209,8 +209,15 @@ collect_extra_donation = boolean(default=False)
 # their swag except a shirt, so we can contact them later.
 out_of_shirts = boolean(default=False)
 
-# This is the number of staff shirts (i.e. the shirt that says "{EVENT_NAME} staff") that EACH staffer gets.
+# This is the number of staff uniform shirts (i.e. the shirt that says "{EVENT_NAME} staff") that EACH staffer gets.
+# set this to zero if your event doesn't have staff uniform shirts.
 shirts_per_staffer = integer(default=2)
+
+# If false, staff badges will NOT earn a free swag shirt.  This shirt has nothing to do with staffing,
+# and is the same type of shirt that supporters get and are sold at the merch booth.
+# Some events will choose to give staff a staff-specific shirt and not give away a free swag shirt to staff
+# note: volunteers (not staff badges) always get a free swag shirt
+staff_eligible_for_swag_shirt = boolean(default=True)
 
 # The max number of tables a dealer can apply for.  Note that the admin
 # interface allows you to give a dealer a higher number than this.

--- a/uber/models.py
+++ b/uber/models.py
@@ -1735,7 +1735,18 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def volunteer_swag_shirt_eligible(self):
-        return self.badge_type != c.STAFF_BADGE and c.VOLUNTEER_RIBBON in self.ribbon_ints
+        """
+        Returns: True if this attendee is eligble for a swag shirt
+        *due to their status as a volunteer or staff*.  (they may,
+        in addition, be eligible for a swag shirt for other reasons too)
+        """
+
+        # some events want to exclude staff badges from getting swag shirts
+        # (typically because they are going to get staff uniform shirts instead)
+        if self.badge_type == c.STAFF_BADGE:
+            return c.STAFF_ELIGIBLE_FOR_SWAG_SHIRT
+        else:
+            return c.VOLUNTEER_RIBBON in self.ribbon_ints
 
     @property
     def volunteer_swag_shirt_earned(self):

--- a/uber/tests/models/test_merch.py
+++ b/uber/tests/models/test_merch.py
@@ -17,7 +17,9 @@ def donation_tier_fixture(monkeypatch):
     # [integer_enums]
     monkeypatch.setattr(c, 'SHIRT_LEVEL', shirt_level)
     monkeypatch.setattr(c, 'SUPPORTER_LEVEL', supporter_level)
+
     monkeypatch.setattr(c, 'SHIRTS_PER_STAFFER', 3)
+    monkeypatch.setattr(c, 'STAFF_ELIGIBLE_FOR_SWAG_SHIRT', False)
 
 
 class TestMerchAttrs:
@@ -29,7 +31,13 @@ class TestMerchAttrs:
     def test_volunteer_swag_shirt_eligible(self):
         assert not Attendee().volunteer_swag_shirt_eligible
         assert Attendee(ribbon=c.VOLUNTEER_RIBBON).volunteer_swag_shirt_eligible
+        assert not Attendee(badge_type=c.STAFF_BADGE).volunteer_swag_shirt_eligible
         assert not Attendee(ribbon=c.VOLUNTEER_RIBBON, badge_type=c.STAFF_BADGE).volunteer_swag_shirt_eligible
+
+    def test_staff_swag_shirt_eligible(self, monkeypatch):
+        monkeypatch.setattr(c, 'STAFF_ELIGIBLE_FOR_SWAG_SHIRT', True)
+        assert Attendee(badge_type=c.STAFF_BADGE).volunteer_swag_shirt_eligible
+        assert Attendee(badge_type=c.STAFF_BADGE, ribbon=c.VOLUNTEER_RIBBON).volunteer_swag_shirt_eligible
 
     def test_volunteer_swag_shirt_earned(self, monkeypatch):
         for (eligible, takes_shifts, worked_hours), expected in {


### PR DESCRIPTION
- this was the original way we did it, but supermag is now different
- add a config option to control this
- magwest and maglabs need to give staff swag shirts, so we needed to make it configurable