### PR TITLE
Only check for non-standard characters before the printed badge deadline

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -647,7 +647,7 @@ c.FEE_ITEM_NAMES = [desc for val, desc in c.FEE_PRICE_OPTS]
 c.WRISTBAND_COLORS = defaultdict(lambda: c.WRISTBAND_COLORS[c.DEFAULT_WRISTBAND], c.WRISTBAND_COLORS)
 
 c.SAME_NUMBER_REPEATED = r'^(\d)\1+$'
-c.INVALID_BADGE_PRINTED_CHARS = r'[^\w!"#$%&\'()*+,\-\./:;<=>?@\[\\\]^_`\{|\}~ "]'  # Allows 0-9, a-z, A-Z, and a handful of punctuation characters
+c.INVALID_BADGE_PRINTED_CHARS = r'[^a-zA-Z0-9!"#$%&\'()*+,\-\./:;<=>?@\[\\\]^_`\{|\}~ "]'  # Allows 0-9, a-z, A-Z, and a handful of punctuation characters
 c.EVENT_QR_ID = c.EVENT_QR_ID or c.EVENT_NAME_AND_YEAR.replace(' ', '_').lower()
 
 try:

--- a/uber/config.py
+++ b/uber/config.py
@@ -647,6 +647,7 @@ c.FEE_ITEM_NAMES = [desc for val, desc in c.FEE_PRICE_OPTS]
 c.WRISTBAND_COLORS = defaultdict(lambda: c.WRISTBAND_COLORS[c.DEFAULT_WRISTBAND], c.WRISTBAND_COLORS)
 
 c.SAME_NUMBER_REPEATED = r'^(\d)\1+$'
+c.INVALID_BADGE_PRINTED_CHARS = r'[^\w!"#$%&\'()*+,\-\./:;<=>?@\[\\\]^_`\{|\}~ "]'  # Allows 0-9, a-z, A-Z, and a handful of punctuation characters
 c.EVENT_QR_ID = c.EVENT_QR_ID or c.EVENT_NAME_AND_YEAR.replace(' ', '_').lower()
 
 try:

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -417,6 +417,12 @@ def out_of_badge_type(attendee):
 
 
 @validation.Attendee
+def invalid_badge_name(attendee):
+    if attendee.badge_printed_name and re.search(c.INVALID_BADGE_PRINTED_CHARS, attendee.badge_printed_name):
+        return 'Your printed badge name has invalid characters. Please use only printable ASCII characters.'
+
+
+@validation.Attendee
 def extra_donation_valid(attendee):
     try:
         extra_donation = int(float(attendee.extra_donation if attendee.extra_donation else 0))

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -418,7 +418,8 @@ def out_of_badge_type(attendee):
 
 @validation.Attendee
 def invalid_badge_name(attendee):
-    if attendee.badge_printed_name and re.search(c.INVALID_BADGE_PRINTED_CHARS, attendee.badge_printed_name):
+    if attendee.badge_printed_name and c.BEFORE_PRINTED_BADGE_DEADLINE \
+            and re.search(c.INVALID_BADGE_PRINTED_CHARS, attendee.badge_printed_name):
         return 'Your printed badge name has invalid characters. Please use only printable ASCII characters.'
 
 


### PR DESCRIPTION
For our currently running instances, several people already have invalid names, but they can no longer edit them. This change allows them to still save their form without a validation error they can't do anything about.