### PR TITLE
Send confirmation emails to comped attendees

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -22,13 +22,18 @@ AutomatedEmail(Attendee, '{EVENT_NAME} payment received', 'reg_workflow/attendee
          needs_approval=False, allow_during_con=True,
          ident='attendee_payment_received')
 
+AutomatedEmail(Attendee, '{EVENT_NAME} registration confirmed', 'reg_workflow/attendee_confirmation.html',
+                lambda a: a.paid == c.NEED_NOT_PAY and not a.placeholder,
+                needs_approval=False, allow_during_con=True,
+                ident='attendee_badge_confirmed')
+
 AutomatedEmail(Group, '{EVENT_NAME} group payment received', 'reg_workflow/group_confirmation.html',
          lambda g: g.amount_paid == g.cost and g.cost != 0,
          needs_approval=False,
          ident='group_payment_received')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} group registration confirmed', 'reg_workflow/attendee_confirmation.html',
-         lambda a: a.group and a != a.group.leader and not a.placeholder,
+         lambda a: a.group and (a != a.group.leader or a.group.cost == 0) and not a.placeholder,
          needs_approval=False, allow_during_con=True,
          ident='attendee_group_reg_confirmation')
 

--- a/uber/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/uber/templates/emails/reg_workflow/attendee_confirmation.html
@@ -3,8 +3,16 @@
 <body>
 
 You ({{ attendee.full_name }}) have preregistered for {{ c.EVENT_NAME }} this coming {{ event_dates() }}
+{% if attendee.promo_code_id %}
+    using promotional code {{ attendee.promo_code.code }}
+{% endif %}
+
 {% if attendee.group %}
     by claiming one of the badges in the {{ attendee.group.name }} group.
+{% elif attendee.paid == c.NEED_NOT_PAY and attendee.promo_code_id %}
+    to claim a free badge.
+{% elif attendee.paid == c.NEED_NOT_PAY %}
+    by claiming your free badge.
 {% else %}
     and your payment of ${{ attendee.amount_paid }} has been received.
 {% endif %}
@@ -13,6 +21,11 @@ Your registration confirmation number is {{ attendee.id }}, and you can update y
     even more
 {% endif %}
 extra money <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">here</a>.
+
+{% if attendee.paid == c.NEED_NOT_PAY and not attendee.promo_code_id %}
+    If you don't remember claiming a badge, it may have been created for you by {{ c.EVENT_NAME }} staff. Please
+    check your information to make sure it is correct.
+{% endif %}
 
 <br/> <br/>
 

--- a/uber/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/uber/templates/emails/reg_workflow/attendee_confirmation.html
@@ -22,7 +22,7 @@ Your registration confirmation number is {{ attendee.id }}, and you can update y
 {% endif %}
 extra money <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">here</a>.
 
-{% if attendee.paid == c.NEED_NOT_PAY and not attendee.promo_code_id %}
+{% if attendee.paid == c.NEED_NOT_PAY and not attendee.promo_code_id or attendee.is_group_leader %}
     If you don't remember claiming a badge, it may have been created for you by {{ c.EVENT_NAME }} staff. Please
     check your information to make sure it is correct.
 {% endif %}

--- a/uber/templates/emails/reg_workflow/group_confirmation.html
+++ b/uber/templates/emails/reg_workflow/group_confirmation.html
@@ -28,6 +28,11 @@ Your {{ group.is_dealer|yesno("Dealer registration,group") }} ({{ group.name }})
     {% endif %}
 {% endif %}
 
+{% if attendee.requested_hotel_info and c.PREREG_REQUEST_HOTEL_INFO_OPEN %}
+    <br/> <br/>
+    {% include "preregistration/hotel_disclaimer.html" %}
+{% endif %}
+
 {% if c.CONSENT_FORM_URL and group.leader.age_group_conf['consent_form'] %}
     <br/> <br/>
     Because you are under 18, you must bring a signed and notarized parental permission


### PR DESCRIPTION
Adds an automated email to attendees with free badges, and changes the attendee_confirmation template to accommodate that. Also adjusts the group confirmation email to go to group leaders if their groups are free (since they won't get an email otherwise). Finally, adds the hotel disclaimer to the group payment email, since it's the only email group leaders will get as confirmation of their registration. Fixes https://github.com/magfest/ubersystem/issues/2772. Fixes https://github.com/magfest/ubersystem/issues/1709. Fixes https://github.com/magfest/ubersystem/issues/1825.

Warning: Late-night coding. I probably missed something in testing.