### PR TITLE
Prevents the "Legal Photo ID" label on the prereg page from jumping around when it is bolded/unbolded

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -164,7 +164,7 @@
     </div>
 
     <div class="form-group">
-        <label for="legal_name" class="col-sm-3 control-label">Name as appears on Legal Photo ID</label>
+        <label for="legal_name" class="col-sm-3 control-label">Name as appears on <span style="white-space: nowrap">Legal Photo ID</span></label>
         <div class="col-sm-6">
             <input type="text" name="legal_name" value="{{ attendee.legal_name }}" class="form-control" placeholder="Name exactly as it appears on Photo ID" autocomplete="name" />
             <p class="help-block">


### PR DESCRIPTION
This is a thing that I personally find very annoying, so I am fixing it. The text wrapping algorithm breaks the label "Name as appears on Legal Photo ID" in different location based on whether or not it's bold. See screenshots for examples. 

This change simply prevents the line from breaking in the middle of the phrase "Legal Photo ID", thus preserving the break point whether or not it's bold.

# Bolded
<img width="629" alt="screen shot 2017-08-05 at 5 02 42 pm" src="https://user-images.githubusercontent.com/2592431/28998744-7d0757c0-7a00-11e7-9b4d-95f3ea00f8b0.png">

# Unbolded
<img width="653" alt="screen shot 2017-08-05 at 5 02 51 pm" src="https://user-images.githubusercontent.com/2592431/28998745-7d0dafb2-7a00-11e7-9633-b549b5588730.png">
