### PR TITLE
Add 'confirmed' column for placeholder badge confirmations

### DIFF
--- a/alembic/versions/4947b38a18b1_add_confirmed_column.py
+++ b/alembic/versions/4947b38a18b1_add_confirmed_column.py
@@ -1,0 +1,63 @@
+"""Add confirmed column.
+
+Revision ID: 4947b38a18b1
+Revises: d0c15c44a031
+Create Date: 2017-08-06 12:48:43.186696
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '4947b38a18b1'
+down_revision = 'd0c15c44a031'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+import sideboard.lib.sa
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    if is_sqlite:
+        with op.batch_alter_table('attendee', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.add_column(sa.Column('confirmed', sideboard.lib.sa.UTCDateTime(), nullable=True))
+    else:
+        op.add_column('attendee', sa.Column('confirmed', sideboard.lib.sa.UTCDateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('attendee', 'confirmed')

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -22,13 +22,18 @@ AutomatedEmail(Attendee, '{EVENT_NAME} payment received', 'reg_workflow/attendee
          needs_approval=False, allow_during_con=True,
          ident='attendee_payment_received')
 
+AutomatedEmail(Attendee, '{EVENT_NAME} registration confirmed', 'reg_workflow/attendee_confirmation.html',
+                lambda a: a.paid == c.NEED_NOT_PAY and a.confirmed,
+                needs_approval=False, allow_during_con=True,
+                ident='attendee_badge_confirmed')
+
 AutomatedEmail(Group, '{EVENT_NAME} group payment received', 'reg_workflow/group_confirmation.html',
          lambda g: g.amount_paid == g.cost and g.cost != 0,
          needs_approval=False,
          ident='group_payment_received')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} group registration confirmed', 'reg_workflow/attendee_confirmation.html',
-         lambda a: a.group and a != a.group.leader and not a.placeholder,
+         lambda a: a.group and (a != a.group.leader or a.group.cost == 0) and not a.placeholder,
          needs_approval=False, allow_during_con=True,
          ident='attendee_group_reg_confirmation')
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -1432,7 +1432,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     for_review  = Column(UnicodeText, admin_only=True)
     admin_notes = Column(UnicodeText, admin_only=True)
 
-    public_id   = Column(UUID, default=lambda: str(uuid4()))
+    public_id    = Column(UUID, default=lambda: str(uuid4()))
     badge_num    = Column(Integer, default=None, nullable=True, admin_only=True)
     badge_type   = Column(Choice(c.BADGE_OPTS), default=c.ATTENDEE_BADGE)
     badge_status = Column(Choice(c.BADGE_STATUS_OPTS), default=c.NEW_STATUS, index=True, admin_only=True)
@@ -1446,8 +1446,9 @@ class Attendee(MagModel, TakesPaymentMixin):
     got_merch    = Column(Boolean, default=False, admin_only=True)
 
     reg_station   = Column(Integer, nullable=True, admin_only=True)
-    registered = Column(UTCDateTime, server_default=utcnow())
-    checked_in = Column(UTCDateTime, nullable=True)
+    registered    = Column(UTCDateTime, server_default=utcnow())
+    confirmed     = Column(UTCDateTime, nullable=True, default=None)
+    checked_in    = Column(UTCDateTime, nullable=True)
 
     paid             = Column(Choice(c.PAYMENT_OPTS), default=c.NOT_PAID, index=True, admin_only=True)
     overridden_price = Column(Integer, nullable=True, admin_only=True)

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -565,6 +565,7 @@ class Root:
             message = check(attendee, prereg=True)
             if not message:
                 if placeholder:
+                    attendee.confirmed = localized_now()
                     message = 'Your registration has been confirmed'
                 else:
                     message = 'Your information has been updated'

--- a/uber/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/uber/templates/emails/reg_workflow/attendee_confirmation.html
@@ -3,8 +3,16 @@
 <body>
 
 You ({{ attendee.full_name }}) have preregistered for {{ c.EVENT_NAME }} this coming {{ event_dates() }}
+{% if attendee.promo_code_id %}
+    using promotional code {{ attendee.promo_code.code }}
+{% endif %}
+
 {% if attendee.group %}
     by claiming one of the badges in the {{ attendee.group.name }} group.
+{% elif attendee.paid == c.NEED_NOT_PAY and attendee.promo_code_id %}
+    to claim a free badge.
+{% elif attendee.paid == c.NEED_NOT_PAY %}
+    by claiming your free badge.
 {% else %}
     and your payment of ${{ attendee.amount_paid }} has been received.
 {% endif %}
@@ -13,6 +21,11 @@ Your registration confirmation number is {{ attendee.id }}, and you can update y
     even more
 {% endif %}
 extra money <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">here</a>.
+
+{% if attendee.is_group_leader %}
+    If you don't remember claiming a badge, it may have been created for you by {{ c.EVENT_NAME }} staff. Please
+    check your information to make sure it is correct.
+{% endif %}
 
 <br/> <br/>
 


### PR DESCRIPTION
Prevents emails from going out to placeholder badges long after they were confirmed by keeping track of when they were confirmed. Also updates the email text to reflect this -- we no longer show the disclaimer about "if you don't remember claiming a badge" to non-group-leaders. Reopens https://github.com/magfest/ubersystem/issues/1709.