### PR TITLE
Improve attendee/group AutomatedEmails

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -28,12 +28,12 @@ AutomatedEmail(Attendee, '{EVENT_NAME} registration confirmed', 'reg_workflow/at
                 ident='attendee_badge_confirmed')
 
 AutomatedEmail(Group, '{EVENT_NAME} group payment received', 'reg_workflow/group_confirmation.html',
-         lambda g: g.amount_paid == g.cost and g.cost != 0,
+         lambda g: g.amount_paid == g.cost and g.cost != 0 and g.leader_id,
          needs_approval=False,
          ident='group_payment_received')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} group registration confirmed', 'reg_workflow/attendee_confirmation.html',
-         lambda a: a.group and (a != a.group.leader or a.group.cost == 0) and not a.placeholder,
+         lambda a: a.group and (a.id != a.group.leader_id or a.group.cost == 0) and not a.placeholder,
          needs_approval=False, allow_during_con=True,
          ident='attendee_group_reg_confirmation')
 

--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -15,7 +15,8 @@ class AutomatedEmail:
     queries = {
         Attendee: lambda session: session.all_attendees().options(
             subqueryload(Attendee.admin_account)).options(
-            subqueryload(Attendee.dept_checklist_items)),
+            subqueryload(Attendee.dept_checklist_items)).options(
+            subqueryload(Attendee.group)),
         Group: lambda session: session.query(Group).options(
             subqueryload(Group.attendees))
     }


### PR DESCRIPTION
This pull request does three things:
1. Checks that groups have assigned leader before attempting to send the group confirmation email
    * This prevents an error when rendering the email template because it references `group.leader.age_group_conf`
    * Further, it doesn't make sense to send the email to a non-leader group member, because it has specific instructions for the group leader
    * Non-leader group members will receive emails anyway when they're badge is assigned
2. Uses group.leader_id to compare attendee to group leader
    * This prevents an additional SQL query to pull up the leader's attendee record
3. Eagerly loads attendee.group relationship for automated emails
    * This prevents an additional SQL query for each attendee in the system