### PR TITLE
Add "form group scaffolding" to form macros

### DIFF
--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -1,5 +1,5 @@
 {% macro ie7_compatibility_check() -%}
-    <!--[if lte IE 7]>
+  <!--[if lte IE 7]>
         <script>
             if (!document.documentMode) { //if documentMode exists, this is a later IE in compatibility mode
                 alert("This website requires IE 8 or later.");
@@ -10,45 +10,45 @@
 
 
 {% macro stripe_button(label) -%}
-    <button class="btn btn-primary stripe-button-el">
-        <span class="display: block; min-height: 30px;">{{label}}</span>
-    </button>
+  <button class="btn btn-primary stripe-button-el">
+    <span class="display: block; min-height: 30px;">{{label}}</span>
+  </button>
 {%- endmacro %}
 
 
 {% macro popup_link(href, text='<sup>?</sup>') -%}
-    <a onClick='window.open(&quot;{{ href }}&quot;, &quot;info&quot;, &quot;toolbar=no,height=500,width=375,scrollbars=yes&quot;).focus(); return false;' href='{{ href }}'>{{ text|safe }}</a>
+  <a onClick='window.open(&quot;{{ href }}&quot;, &quot;info&quot;, &quot;toolbar=no,height=500,width=375,scrollbars=yes&quot;).focus(); return false;' href='{{ href }}'>{{ text|safe }}</a>
 {%- endmacro %}
 
 
 {% macro checkbox(model, field_name, id=None, label=None, label_class=None, is_readonly=False, title=None) -%}
-    {% if label %}
-      <label
-          class="checkbox-label{% if label_class %} {{ label_class }}{% endif %}{% if is_readonly %} disabled{% endif %}"
-          {% if title %}title="{{ title }}"{% endif %}>
-    {% endif %}
-    {% if is_readonly %}
-      <input
+  {% if label %}
+    <label
+            class="checkbox-label{% if label_class %} {{ label_class }}{% endif %}{% if is_readonly %} disabled{% endif %}"
+            {% if title %}title="{{ title }}"{% endif %}>
+  {% endif %}
+{% if is_readonly %}
+  <input
           type="hidden"
           name="{{ field_name }}"
           id="{% if id %}{{ id }}{% else %}{{ field_name }}{% endif %}"
           value="{%- if model[field_name] -%}1{%- else -%}0{%- endif -%}" />
-      <input
+  <input
           type="checkbox"
           value="1"
           disabled
           {% if not label and title %}title="{{ title }}"{% endif %}
           {% if model[field_name] %}checked{% endif %} />
-    {% else %}
-      <input
+{% else %}
+  <input
           type="checkbox"
           name="{{ field_name }}"
           id="{% if id %}{{ id }}{% else %}{{ field_name }}{% endif %}"
           value="1"
           {% if not label and title %}title="{{ title }}"{% endif %}
           {% if model[field_name] %}checked{% endif %} />
-    {% endif %}
-    {% if label %}{{ label }}</label>{% endif %}
+{% endif %}
+{% if label %}{{ label }}</label>{% endif %}
 {%- endmacro %}
 
 
@@ -61,18 +61,18 @@
       {%- set has_value = num|string in defaults -%}
       {%- if not is_readonly or has_value -%}
         <label
-            class="checkbox-label{% if is_readonly %} disabled{% endif %}"
-            style="font-weight: normal;">
+                class="checkbox-label{% if is_readonly %} disabled{% endif %}"
+                style="font-weight: normal;">
           {% if is_readonly %}
             <input type="hidden" name="{{ field_name }}{{ suffix }}" value="{{ num }}"/>
             <input type="checkbox" disabled checked/>
             {{ desc }}
           {% else %}
             <input
-                type="checkbox"
-                name="{{ field_name }}{{ suffix }}"
-                value="{{ num }}"
-                {% if has_value %}checked{% endif %}/>
+                    type="checkbox"
+                    name="{{ field_name }}{{ suffix }}"
+                    value="{{ num }}"
+                    {% if has_value %}checked{% endif %}/>
             {{ desc }}
           {% endif %}
         </label>
@@ -89,26 +89,26 @@
     size=6,
     form_class='',
     static_wrap=False) -%}
-    <div class="form-group {{ form_class }}">
-        <label class="col-sm-3 control-label{% if not is_required %} optional-field{% endif %}">
-            {{ label }}
-        </label>
+  <div class="form-group {{ form_class }}">
+    <label class="col-sm-3 control-label{% if not is_required %} optional-field{% endif %}">
+      {{ label }}
+    </label>
     <div class="col-sm-{{ size }}">
-        {% if static_wrap %}
-            <div class="form-control-static">
-                {{ caller() }}
-            </div>
-        {% else %}
-            {{ caller() }}
-        {% endif %}
+      {% if static_wrap %}
+        <div class="form-control-static">
+          {{ caller() }}
+        </div>
+      {% else %}
+        {{ caller() }}
+      {% endif %}
     </div>
     {% if help %}
-        <div class="clearfix"></div>
-        <p class="col-sm-{{ size }} col-sm-offset-3 help-block">
-            {{ help }}
-        </p>
+      <div class="clearfix"></div>
+      <p class="col-sm-9 col-sm-offset-3 help-block">
+        {{ help }}
+      </p>
     {% endif %}
-    </div>
+  </div>
 {% endmacro %}
 
 
@@ -128,48 +128,48 @@
     is_readonly=False,
     is_admin=False) -%}
 
-    {%- set is_class = model is class -%}
-    {%- set has_value = not is_class and model[field] -%}
-    {%- set is_url = url_field or url_text or url_is_relative or type == 'url' -%}
-    {%- set url_field = url_field if url_field else field -%}
-    {% if not is_readonly or has_value %}
-        {% call form_group_scaffolding(label if label else field|unfieldify, help if not is_readonly else False, is_required) %}
-        {%- if is_readonly -%}
-          <div class="form-control-static">
-            {%- if type == 'email' -%}
-              {{ model[field]|email_to_link }}
-            {%- elif is_url -%}
-              {{ model[url_field]|url_to_link(text=url_text or model[field], is_relative=url_is_relative) }}
-            {%- else -%}
-              {{ '' if is_class else model[field]|linebreaksbr }}
-            {%- endif -%}
-          </div>
-        {%- else -%}
-          {%- if type == 'textarea' -%}
-            <textarea
-                class="form-control"
-                name="{{ field }}{{ suffix }}"
-                rows="4"
-                placeholder="{{ placeholder }}">{{ '' if is_class else model[field] }}</textarea>
+  {%- set is_class = model is class -%}
+  {%- set has_value = not is_class and model[field] -%}
+  {%- set is_url = url_field or url_text or url_is_relative or type == 'url' -%}
+  {%- set url_field = url_field if url_field else field -%}
+  {% if not is_readonly or has_value %}
+    {% call form_group_scaffolding(label if label else field|unfieldify, help if not is_readonly else False, is_required) %}
+      {%- if is_readonly -%}
+        <div class="form-control-static">
+          {%- if type == 'email' -%}
+            {{ model[field]|email_to_link }}
+          {%- elif is_url -%}
+            {{ model[url_field]|url_to_link(text=url_text or model[field], is_relative=url_is_relative) }}
           {%- else -%}
-            <input
-                class="form-control"
-                type="{{ type }}"
-                name="{{ field }}{{ suffix }}"
-                {% if id %}id="{{ id }}"{% endif %}
-                value="{{ '' if is_class else model[field] }}"
-                placeholder="{{ placeholder }}"
-                {% if is_required %}required="required"{% endif %}/>
+            {{ '' if is_class else model[field]|linebreaksbr }}
           {%- endif -%}
-          {%- if is_admin and has_value -%}
-            {%- if type == 'email' -%}
-              {{ model[field]|email_to_link }}
-            {%- elif is_url -%}
-              {{ model[url_field]|url_to_link(text=url_text or model[field], is_relative=url_is_relative) }}
-            {%- endif -%}
+        </div>
+      {%- else -%}
+        {%- if type == 'textarea' -%}
+          <textarea
+                  class="form-control"
+                  name="{{ field }}{{ suffix }}"
+                  rows="4"
+                  placeholder="{{ placeholder }}">{{ '' if is_class else model[field] }}</textarea>
+        {%- else -%}
+          <input
+                  class="form-control"
+                  type="{{ type }}"
+                  name="{{ field }}{{ suffix }}"
+                  {% if id %}id="{{ id }}"{% endif %}
+                  value="{{ '' if is_class else model[field] }}"
+                  placeholder="{{ placeholder }}"
+                  {% if is_required %}required="required"{% endif %}/>
+        {%- endif -%}
+        {%- if is_admin and has_value -%}
+          {%- if type == 'email' -%}
+            {{ model[field]|email_to_link }}
+          {%- elif is_url -%}
+            {{ model[url_field]|url_to_link(text=url_text or model[field], is_relative=url_is_relative) }}
           {%- endif -%}
         {%- endif -%}
-      {% endcall %}
+      {%- endif -%}
+    {% endcall %}
   {% endif %}
 {%- endmacro %}
 
@@ -188,85 +188,85 @@
     is_readonly=False,
     is_admin=False) -%}
 
-    {%- set is_class = model is class -%}
-    {%- set has_value = not is_class and model[field] -%}
-    {%- set has_other_value = not is_class and other_field and model[other_field] -%}
-    {%- set is_other_value_visible = not is_readonly or has_other_value -%}
-    {%- set is_wrapped = not is_readonly or has_value or desc -%}
-    {% call form_group_scaffolding(label if label else field|unfieldify, help if not is_readonly else False, is_required, 9, form_class, is_wrapped) %}
-        {%- if desc and not is_admin -%}<p>{{ desc }}</p>{%- endif -%}
+  {%- set is_class = model is class -%}
+  {%- set has_value = not is_class and model[field] -%}
+  {%- set has_other_value = not is_class and other_field and model[other_field] -%}
+  {%- set is_other_value_visible = not is_readonly or has_other_value -%}
+  {%- set is_wrapped = not is_readonly or has_value or desc -%}
+  {% call form_group_scaffolding(label if label else field|unfieldify, help if not is_readonly else False, is_required, 9, form_class, is_wrapped) %}
+    {%- if desc and not is_admin -%}<p>{{ desc }}</p>{%- endif -%}
 
-        {% if not is_readonly or has_value %}
-          {{ checkgroup(model, field, suffix=suffix, is_readonly=is_readonly) }}
-          <div class="clearfix"></div>
-        {% endif %}
+    {% if not is_readonly or has_value %}
+      {{ checkgroup(model, field, suffix=suffix, is_readonly=is_readonly) }}
+      <div class="clearfix"></div>
+    {% endif %}
 
-        {% if is_other_value_visible %}
-          <div class="form-group" style="margin-bottom: 0;">
-            {% if is_readonly %}
-              <div class="col-sm-8">
-                {% if not is_wrapped %}<div class="form-control-static">{% endif %}
-                {{ '' if is_class else model[other_field] }}
-                {% if not is_wrapped %}</div>{% endif %}
-              </div>
-            {% else %}
-              <div class="col-sm-1">
-                <div class="form-control-static">Other:</div>
-              </div>
-              <div class="col-sm-7">
-                <input
+    {% if is_other_value_visible %}
+      <div class="form-group" style="margin-bottom: 0;">
+        {% if is_readonly %}
+          <div class="col-sm-8">
+            {% if not is_wrapped %}<div class="form-control-static">{% endif %}
+            {{ '' if is_class else model[other_field] }}
+            {% if not is_wrapped %}</div>{% endif %}
+          </div>
+        {% else %}
+          <div class="col-sm-1">
+            <div class="form-control-static">Other:</div>
+          </div>
+          <div class="col-sm-7">
+            <input
                     class="form-control"
                     type="text"
                     name="{{ other_field }}{{ suffix }}"
                     value="{{ '' if is_class else model[other_field] }}"
                     placeholder="{{ other_placeholder }}"/>
-              </div>
-            {% endif %}
           </div>
         {% endif %}
-    {% endcall %}
+      </div>
+    {% endif %}
+  {% endcall %}
 {%- endmacro %}
 
 
 {% macro nav_menu(model, current_page_path) -%}
-    {% if not model.is_new -%}
-        <table class="menu"><tr>
-        {% for href, label, display in varargs|batch(3, False) if display %}
-            {% set href = href.format(**model.__dict__) %}
-            <td width="{{ 100 // loop.length }}%">
-                {%- if current_page_path.endswith(href.split('?')[0]) -%}
-                    {{ label }}
-                {%- else -%}
-                    <a href="{{ href }}">{{ label }}</a>
-                {%- endif -%}
-            </td>
-        {% endfor %}
-        </tr></table>
-    {%- endif %}
+  {% if not model.is_new -%}
+    <table class="menu"><tr>
+      {% for href, label, display in varargs|batch(3, False) if display %}
+        {% set href = href.format(**model.__dict__) %}
+        <td width="{{ 100 // loop.length }}%">
+          {%- if current_page_path.endswith(href.split('?')[0]) -%}
+            {{ label }}
+          {%- else -%}
+            <a href="{{ href }}">{{ label }}</a>
+          {%- endif -%}
+        </td>
+      {% endfor %}
+    </tr></table>
+  {%- endif %}
 {%- endmacro %}
 
 
 {% macro checklist_image(enabled) -%}
-    <img src="../static/images/checkbox_{% if not enabled %}un{% endif %}checked.png" style="vertical-align:top ; margin-right:5px" height="20" width="20" />
+  <img src="../static/images/checkbox_{% if not enabled %}un{% endif %}checked.png" style="vertical-align:top ; margin-right:5px" height="20" width="20" />
 {%- endmacro %}
 
 
 {% macro prereg_wizard(page_path, prereg_request_hotel_info_open) -%}
   {%- if prereg_request_hotel_info_open -%}
     {%-
-      set steps = [
-          (('form', 'post_form'), 'Enter Info'),
-          (('hotel',), 'Hotel Booking'),
-          (('index', 'preregistration', ''), 'Review & Pay'),
-          (('paid_preregistrations',), 'Done')]
-    -%}
+            set steps = [
+                (('form', 'post_form'), 'Enter Info'),
+                (('hotel',), 'Hotel Booking'),
+                (('index', 'preregistration', ''), 'Review & Pay'),
+                (('paid_preregistrations',), 'Done')]
+            -%}
   {% else %}
     {%-
-      set steps = [
-          (('form', 'post_form'), 'Enter Info'),
-          (('index', 'preregistration', ''), 'Review & Pay'),
-          (('paid_preregistrations',), 'Done')]
-    -%}
+            set steps = [
+                (('form', 'post_form'), 'Enter Info'),
+                (('index', 'preregistration', ''), 'Review & Pay'),
+                (('paid_preregistrations',), 'Done')]
+            -%}
   {%- endif -%}
   {%- set step_count = steps|length -%}
   {%- set col_size = (12 / step_count)|round(0, 'floor')|int -%}
@@ -285,103 +285,103 @@
 
 
 {% macro address_form(model, name_prefix="", update_international=False) -%}
-    {% set suffix=model.id|replace("-", "") %}
+  {% set suffix=model.id|replace("-", "") %}
 
-    <script type="text/javascript">
-        var regionChange{{ suffix }} = function() {
-            {% if update_international %}setInternational();{% endif %}
-            var regionopts = $('#region{{ suffix }}');
-            var whichCountry = $('#country{{ suffix }}').find(':selected').text();
-            switch(whichCountry) {
-                case 'United States':
-                    regionopts.replaceWith('<select name="{{ name_prefix }}region" id="region{{ suffix }}" class="form-control"></select>');
-                    $('[name="{{ name_prefix }}region"]').html(regionsforUS);
-                    break;
-                case 'Canada':
-                    regionopts.replaceWith('<select name="{{ name_prefix }}region" id="region{{ suffix }}" class="form-control"></select>');
-                    $('[name="{{ name_prefix }}region"]').html(regionsforCanada);
-                    break;
-            }
-            var optionToSelect{{ suffix }} = $('#region{{ suffix }} option[value="{{ model.region }}"]');
-            if (optionToSelect{{ suffix }}.length) {
-                optionToSelect{{ suffix }}.prop('selected', true)
-            }
-        };
+  <script type="text/javascript">
+      var regionChange{{ suffix }} = function() {
+          {% if update_international %}setInternational();{% endif %}
+          var regionopts = $('#region{{ suffix }}');
+          var whichCountry = $('#country{{ suffix }}').find(':selected').text();
+          switch(whichCountry) {
+              case 'United States':
+                  regionopts.replaceWith('<select name="{{ name_prefix }}region" id="region{{ suffix }}" class="form-control"></select>');
+                  $('[name="{{ name_prefix }}region"]').html(regionsforUS);
+                  break;
+              case 'Canada':
+                  regionopts.replaceWith('<select name="{{ name_prefix }}region" id="region{{ suffix }}" class="form-control"></select>');
+                  $('[name="{{ name_prefix }}region"]').html(regionsforCanada);
+                  break;
+          }
+          var optionToSelect{{ suffix }} = $('#region{{ suffix }} option[value="{{ model.region }}"]');
+          if (optionToSelect{{ suffix }}.length) {
+              optionToSelect{{ suffix }}.prop('selected', true)
+          }
+      };
 
-        $(function() {
-            {% if update_international %}setInternational();{% endif %}
-            $('#country{{ suffix }}').val('{{ model.country }}');
-            $('#country{{ suffix }}').selectToAutocomplete();
-            $('#country{{ suffix }}').change(function() {
-                $('#region{{ suffix }}').replaceWith('<input type="text" name="{{ name_prefix }}region" id="region{{ suffix }}" value="{{ model.region }}" class="form-control" placeholder="State/Province">');
-                regionChange{{ suffix }}();
-            });
+      $(function() {
+          {% if update_international %}setInternational();{% endif %}
+          $('#country{{ suffix }}').val('{{ model.country }}');
+          $('#country{{ suffix }}').selectToAutocomplete();
+          $('#country{{ suffix }}').change(function() {
+              $('#region{{ suffix }}').replaceWith('<input type="text" name="{{ name_prefix }}region" id="region{{ suffix }}" value="{{ model.region }}" class="form-control" placeholder="State/Province">');
+              regionChange{{ suffix }}();
+          });
 
-            $('#region{{ suffix }}').val('{{ model.region }}');
-            regionChange{{ suffix }}();
-        });
-    </script>
+          $('#region{{ suffix }}').val('{{ model.region }}');
+          regionChange{{ suffix }}();
+      });
+  </script>
 
-    <div class="form-group address_details{{ suffix }}">
-        <label for="country{{ suffix }}" class="col-sm-3 control-label">Country</label>
-        <div class="col-sm-6">
-            <select name="{{ name_prefix }}country" id="country{{ suffix }}" class="form-control" placeholder="Country" autocorrect="off" autocomplete="country">
-                {% include "country_opts.html" %}
-            </select>
-        </div>
+  <div class="form-group address_details{{ suffix }}">
+    <label for="country{{ suffix }}" class="col-sm-3 control-label">Country</label>
+    <div class="col-sm-6">
+      <select name="{{ name_prefix }}country" id="country{{ suffix }}" class="form-control" placeholder="Country" autocorrect="off" autocomplete="country">
+        {% include "country_opts.html" %}
+      </select>
     </div>
-    <div class="form-group address_details{{ suffix }}">
-        <label for="address1{{ suffix }}" class="col-sm-3 control-label">Street</label>
-        <div class="col-sm-6">
-            <input type="text" name="{{ name_prefix }}address1" class="form-control" placeholder="Address Line 1" value="{{ model.address1 }}" />
-        </div>
+  </div>
+  <div class="form-group address_details{{ suffix }}">
+    <label for="address1{{ suffix }}" class="col-sm-3 control-label">Street</label>
+    <div class="col-sm-6">
+      <input type="text" name="{{ name_prefix }}address1" class="form-control" placeholder="Address Line 1" value="{{ model.address1 }}" />
     </div>
-    <div class="form-group address_details{{ suffix }}">
-        <div class="col-sm-6 col-sm-offset-3">
-            <input type="text" name="{{ name_prefix }}address2" class="form-control" placeholder="Address Line 2" value="{{ model.address2 }}" />
-        </div>
+  </div>
+  <div class="form-group address_details{{ suffix }}">
+    <div class="col-sm-6 col-sm-offset-3">
+      <input type="text" name="{{ name_prefix }}address2" class="form-control" placeholder="Address Line 2" value="{{ model.address2 }}" />
     </div>
-    <div class="form-group address_details{{ suffix }}">
-        <label for="city{{ suffix }}" class="col-sm-3 control-label">City</label>
-        <div class="col-sm-6">
-            <input type="text" name="{{ name_prefix }}city" class="form-control" placeholder="City" value="{{ model.city }}" />
-        </div>
+  </div>
+  <div class="form-group address_details{{ suffix }}">
+    <label for="city{{ suffix }}" class="col-sm-3 control-label">City</label>
+    <div class="col-sm-6">
+      <input type="text" name="{{ name_prefix }}city" class="form-control" placeholder="City" value="{{ model.city }}" />
     </div>
-    <div class="form-group address_details{{ suffix }}">
-        <label for="region{{ suffix }}" class="col-sm-3 control-label">State/Region</label>
-        <div class="col-sm-6">
-            <input type="text" name="{{ name_prefix }}region" id="region{{ suffix }}" class="form-control" placeholder="State/Province" value="{{ model.region }}" autocomplete="address-level1" />
-        </div>
+  </div>
+  <div class="form-group address_details{{ suffix }}">
+    <label for="region{{ suffix }}" class="col-sm-3 control-label">State/Region</label>
+    <div class="col-sm-6">
+      <input type="text" name="{{ name_prefix }}region" id="region{{ suffix }}" class="form-control" placeholder="State/Province" value="{{ model.region }}" autocomplete="address-level1" />
     </div>
-    <div class="form-group address_details{{ suffix }}">
-        <label for="zip_code{{ suffix }}" class="col-sm-3 control-label">ZIP/Postal Code</label>
-        <div class="col-sm-6">
-            <input type="text" name="{{ name_prefix }}zip_code" class="form-control" value="{{ model.zip_code }}"/>
-        </div>
+  </div>
+  <div class="form-group address_details{{ suffix }}">
+    <label for="zip_code{{ suffix }}" class="col-sm-3 control-label">ZIP/Postal Code</label>
+    <div class="col-sm-6">
+      <input type="text" name="{{ name_prefix }}zip_code" class="form-control" value="{{ model.zip_code }}"/>
     </div>
+  </div>
 {%- endmacro %}
 
 
 {% macro toggle_checkbox(selector, label, suffix='', name='', value='1', required_selector=False, hide_on_checked=True, checked=False) -%}
-    <script type="text/javascript">
-        var toggleVisibility{{ suffix }} = function () {
-            var isChecked = $('#toggle_visibility{{ suffix }}').prop('checked'),
-                hideOnChecked = {%- if hide_on_checked -%}true{%- else -%}false{%- endif -%},
-                isVisible = isChecked != hideOnChecked;
-            if (isVisible) {
-                $('{{ selector }}').show();
-            } else {
-                $('{{ selector }}').hide();
-            }
-            {%- if required_selector -%}$('{{ required_selector }}').prop('required', isVisible);{%- endif -%}
-        };
-        $(function () {
-            toggleVisibility{{ suffix }}();
-            $('#toggle_visibility{{ suffix }}').change(toggleVisibility{{ suffix }});
-        })
-    </script>
-    <label for="toggle_visibility{{ suffix }}" class="checkbox-label">
-        <input type="checkbox" name="{{ name }}" id="toggle_visibility{{ suffix }}" value="{{ value }}" {% if checked %}checked="checked"{% endif %} />
-        {{ label }}
-    </label>
+  <script type="text/javascript">
+      var toggleVisibility{{ suffix }} = function () {
+          var isChecked = $('#toggle_visibility{{ suffix }}').prop('checked'),
+              hideOnChecked = {%- if hide_on_checked -%}true{%- else -%}false{%- endif -%},
+              isVisible = isChecked != hideOnChecked;
+          if (isVisible) {
+              $('{{ selector }}').show();
+          } else {
+              $('{{ selector }}').hide();
+          }
+          {%- if required_selector -%}$('{{ required_selector }}').prop('required', isVisible);{%- endif -%}
+      };
+      $(function () {
+          toggleVisibility{{ suffix }}();
+          $('#toggle_visibility{{ suffix }}').change(toggleVisibility{{ suffix }});
+      })
+  </script>
+  <label for="toggle_visibility{{ suffix }}" class="checkbox-label">
+    <input type="checkbox" name="{{ name }}" id="toggle_visibility{{ suffix }}" value="{{ value }}" {% if checked %}checked="checked"{% endif %} />
+    {{ label }}
+  </label>
 {%- endmacro %}

--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -82,6 +82,36 @@
 {%- endmacro %}
 
 
+{% macro form_group_scaffolding(
+    label=False,
+    help=False,
+    is_required=False,
+    size=6,
+    form_class='',
+    static_wrap=False) -%}
+    <div class="form-group {{ form_class }}">
+        <label class="col-sm-3 control-label{% if not is_required %} optional-field{% endif %}">
+            {{ label }}
+        </label>
+    <div class="col-sm-{{ size }}">
+        {% if static_wrap %}
+            <div class="form-control-static">
+                {{ caller() }}
+            </div>
+        {% else %}
+            {{ caller() }}
+        {% endif %}
+    </div>
+    {% if help %}
+        <div class="clearfix"></div>
+        <p class="col-sm-{{ size }} col-sm-offset-3 help-block">
+            {{ help }}
+        </p>
+    {% endif %}
+    </div>
+{% endmacro %}
+
+
 {% macro form_group(
     model,
     field,
@@ -98,16 +128,12 @@
     is_readonly=False,
     is_admin=False) -%}
 
-  {%- set is_class = model is class -%}
-  {%- set has_value = not is_class and model[field] -%}
-  {%- set is_url = url_field or url_text or url_is_relative or type == 'url' -%}
-  {%- set url_field = url_field if url_field else field -%}
-  {% if not is_readonly or has_value %}
-    <div class="form-group">
-      <label class="col-sm-3 control-label{% if not is_required %} optional-field{% endif %}">
-        {{ label if label else field|unfieldify }}
-      </label>
-      <div class="col-sm-6">
+    {%- set is_class = model is class -%}
+    {%- set has_value = not is_class and model[field] -%}
+    {%- set is_url = url_field or url_text or url_is_relative or type == 'url' -%}
+    {%- set url_field = url_field if url_field else field -%}
+    {% if not is_readonly or has_value %}
+        {% call form_group_scaffolding(label if label else field|unfieldify, help if not is_readonly else False, is_required) %}
         {%- if is_readonly -%}
           <div class="form-control-static">
             {%- if type == 'email' -%}
@@ -143,14 +169,7 @@
             {%- endif -%}
           {%- endif -%}
         {%- endif -%}
-      </div>
-      {%- if not is_readonly and help -%}
-        <div class="clearfix"></div>
-        <p class="col-sm-9 col-sm-offset-3 help-block">
-          {{ help }}
-        </p>
-      {%- endif -%}
-    </div>
+      {% endcall %}
   {% endif %}
 {%- endmacro %}
 
@@ -169,18 +188,12 @@
     is_readonly=False,
     is_admin=False) -%}
 
-  {%- set is_class = model is class -%}
-  {%- set has_value = not is_class and model[field] -%}
-  {%- set has_other_value = not is_class and other_field and model[other_field] -%}
-  {%- set is_other_value_visible = not is_readonly or has_other_value -%}
-  <div class="form-group {{ form_class }}">
-    <label class="col-sm-3 control-label{% if not is_required %} optional-field{% endif %}">
-      {{ label if label else field|unfieldify }}
-    </label>
-    <div class="col-sm-9">
-      {%- set is_wrapped = not is_readonly or has_value or desc -%}
-      {% if is_wrapped %}<div class="form-control-static">{% endif %}
-
+    {%- set is_class = model is class -%}
+    {%- set has_value = not is_class and model[field] -%}
+    {%- set has_other_value = not is_class and other_field and model[other_field] -%}
+    {%- set is_other_value_visible = not is_readonly or has_other_value -%}
+    {%- set is_wrapped = not is_readonly or has_value or desc -%}
+    {% call form_group_scaffolding(label if label else field|unfieldify, help if not is_readonly else False, is_required, 9, form_class, is_wrapped) %}
         {%- if desc and not is_admin -%}<p>{{ desc }}</p>{%- endif -%}
 
         {% if not is_readonly or has_value %}
@@ -211,16 +224,7 @@
             {% endif %}
           </div>
         {% endif %}
-
-      {% if is_wrapped %}</div>{% endif %}
-    </div>
-    {%- if not is_readonly and help -%}
-      <div class="clearfix"></div>
-      <p class="col-sm-9 col-sm-offset-3 help-block">
-        {{ help }}
-      </p>
-    {%- endif -%}
-  </div>
+    {% endcall %}
 {%- endmacro %}
 
 


### PR DESCRIPTION
This isn't 100% necessary, it's just a small refactor to pull out some of the common elements from our form macros into a single macro.

I'm not committed on this change, it was partly an exercise to see if we could combine form_checkgroup and checkgroup into one macro. Now that I've done this refactor I don't think it'd help much -- even if we combined them, we'd still have to call checkgroup with like eighteen different flags.