### PR TITLE
Allow multiple printed_badge_deadlines

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -136,7 +136,7 @@ class Config(_Overridable):
     def get_printed_badge_deadline_by_type(self, badge_type):
         """
         Returns either PRINTED_BADGE_DEADLINE for custom badge types or the latter of PRINTED_BADGE_DEADLINE and
-        SUPPORTER_BADGE_DEADLINE if the badge type is an attendee (who only has a badge name if they're a supporter)
+        SUPPORTER_BADGE_DEADLINE if the badge type is not preassigned (and only has a badge name if they're a supporter)
         """
         return c.PRINTED_BADGE_DEADLINE if badge_type in c.PREASSIGNED_BADGE_TYPES \
             else max(c.PRINTED_BADGE_DEADLINE, c.SUPPORTER_BADGE_DEADLINE)

--- a/uber/config.py
+++ b/uber/config.py
@@ -133,6 +133,14 @@ class Config(_Overridable):
         with sa.Session() as session:
             return session.query(sa.Attendee).filter_by(badge_type=badge_type, badge_status=c.COMPLETED_STATUS).count()
 
+    def get_printed_badge_deadline_by_type(self, badge_type):
+        """
+        Returns either PRINTED_BADGE_DEADLINE for custom badge types or the latter of PRINTED_BADGE_DEADLINE and
+        SUPPORTER_BADGE_DEADLINE if the badge type is an attendee (who only has a badge name if they're a supporter)
+        """
+        return c.PRINTED_BADGE_DEADLINE if badge_type in c.PREASSIGNED_BADGE_TYPES \
+            else max(c.PRINTED_BADGE_DEADLINE, c.SUPPORTER_BADGE_DEADLINE)
+
     @property
     def DEALER_REG_OPEN(self):
         return self.AFTER_DEALER_REG_START and self.BEFORE_DEALER_REG_SHUTDOWN

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -176,15 +176,9 @@ hours_for_refund = integer(default=24)
 # This setting determines how many days in advance we begin tracking setup shifts.
 setup_shift_days = integer(default=5)
 
-# There are two separate deadlines for custom badges; the one after which it's
-# too late for attendees to edit their custom badge submissions, and the one
-# where it's too late for an admin to shift badge numbers on the backend.  The
-# former is controlled by the PRINTED_BADGE_DEADLINE field, which is what we
-# advertise in our emails and such.
-#
-# Once the shift option is set to False, custom badge numbers are never changed
-# automatically.  This is a bool instead of a date since we don't usually
-# know the cutoff in advance.
+# Some events wish to be able to freely edit badge numbers throughout the year,
+# without worrying about number collisions. Others want to restrict number
+# changes. Set this to True for the former, and False for the latter.
 shift_custom_badges = boolean(default=True)
 
 # Some events may want to store an exact birthdate for attendees. If this option
@@ -383,6 +377,9 @@ prereg_hotel_info_link = string(default='http://magfest.org/bookhotel/')
 #
 # Settings in this section are automatically converted to global variable datetime objects,
 # locatized to the timezone specified in the above EVENT_TIMEZONE setting.
+#
+# Dates are in YYYY-MM-DD format. Time may also be specified by using YYYY-MM-DD HH. If a
+# time is not specified, the system defaults to YYYY-MM-DD 11:59pm in the event's timezone.
 
 # Prereg pages will automatically start letting people preregister on this day.
 prereg_open = string(default="2014-08-08")
@@ -421,8 +418,14 @@ shirt_deadline = string(default="")
 # If printed badges are enabled (in other words, if PREASSIGNED_BADGE_TYPES is not an
 # empty list), this is the date by which attendees must enter what they want printed
 # on their badge; after this date we lock in whatever they entered or their full name
-# if they didn't provide anything.
+# if they didn't provide anything. This also controls when admins can no longer
+# edit badge numbers freely, assuming shift_custom_badges is True.
 printed_badge_deadline = string(default="2015-12-26")
+
+# Many MAGFest events print custom supporter badges later than other custom badge types
+# due to the lower number of supporters vs staff. Attendees with supporter badges
+# can edit their badge names up to this or printed_badge_deadline, whichever is later.
+supporter_badge_deadline = string(default="%(supporter_deadline)s")
 
 # Users can no longer create groups after this date, though admins can. Set this
 # blank to keep the group registration open through the event's end date (eschaton).

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -298,7 +298,7 @@ def printed_badge_change(attendee):
     if attendee.badge_printed_name != attendee.orig_value_of('badge_printed_name') and not AdminAccount.admin_name() and \
                     localized_now() > c.get_printed_badge_deadline_by_type(attendee.badge_type):
             return '{} badges have already been ordered, so you cannot change the badge printed name.'\
-                .format(attendee.badge_type_label if attendee.badge_type != c.ATTENDEE_BADGE else "Supporter")
+                .format(attendee.badge_type_label if attendee.badge_type in c.PREASSIGNED_BADGE_TYPES else "Supporter")
 
 
 @validation.Attendee

--- a/uber/tests/models/test_badge_funcs.py
+++ b/uber/tests/models/test_badge_funcs.py
@@ -440,7 +440,7 @@ class TestBadgeValidations:
         session.regular_attendee.badge_type = session.regular_attendee.badge_type
         session.regular_attendee.badge_type = c.STAFF_BADGE
         session.regular_attendee.badge_num = None
-        assert 'Custom badges have already been ordered' == check(session.regular_attendee)
+        assert 'Custom badges have already been ordered so you cannot use this badge type' == check(session.regular_attendee)
 
     def test_out_of_badge_type(self, session, monkeypatch, before_printed_badge_deadline):
         monkeypatch.setitem(c.BADGE_RANGES, c.STAFF_BADGE, [1, 5])

--- a/uber/tests/models/test_config.py
+++ b/uber/tests/models/test_config.py
@@ -2,6 +2,19 @@ from uber import config
 from uber.tests import *
 
 
+class TestBadgeDeadlines:
+    def test_staff_badge_deadline(self):
+        assert c.PRINTED_BADGE_DEADLINE == c.get_printed_badge_deadline_by_type(c.STAFF_BADGE)
+
+    def test_supporter_badge_deadline_earlier(self, monkeypatch):
+        monkeypatch.setattr(c, 'SUPPORTER_BADGE_DEADLINE', (c.PRINTED_BADGE_DEADLINE - timedelta(days=1)))
+        assert c.PRINTED_BADGE_DEADLINE == c.get_printed_badge_deadline_by_type(c.ATTENDEE_BADGE)
+
+    def test_supporter_badge_deadline_later(self, monkeypatch):
+        monkeypatch.setattr(c, 'SUPPORTER_BADGE_DEADLINE', (c.PRINTED_BADGE_DEADLINE + timedelta(days=1)))
+        assert c.SUPPORTER_BADGE_DEADLINE == c.get_printed_badge_deadline_by_type(c.ATTENDEE_BADGE)
+
+
 class TestPrices:
     def test_initial_attendee(self, clear_price_bumps):
         assert 40 == c.get_attendee_price(datetime.now(UTC))

--- a/uber/tests/models/test_config.py
+++ b/uber/tests/models/test_config.py
@@ -14,6 +14,14 @@ class TestBadgeDeadlines:
         monkeypatch.setattr(c, 'SUPPORTER_BADGE_DEADLINE', (c.PRINTED_BADGE_DEADLINE + timedelta(days=1)))
         assert c.SUPPORTER_BADGE_DEADLINE == c.get_printed_badge_deadline_by_type(c.ATTENDEE_BADGE)
 
+    def test_group_leader_supporter_deadline(self, monkeypatch):
+        monkeypatch.setattr(c, 'SUPPORTER_BADGE_DEADLINE', (c.PRINTED_BADGE_DEADLINE + timedelta(days=1)))
+        assert c.SUPPORTER_BADGE_DEADLINE == c.get_printed_badge_deadline_by_type(c.PSEUDO_GROUP_BADGE)
+
+    def test_new_dealer_supporter_deadline(self, monkeypatch):
+        monkeypatch.setattr(c, 'SUPPORTER_BADGE_DEADLINE', (c.PRINTED_BADGE_DEADLINE + timedelta(days=1)))
+        assert c.SUPPORTER_BADGE_DEADLINE == c.get_printed_badge_deadline_by_type(c.PSEUDO_DEALER_BADGE)
+
 
 class TestPrices:
     def test_initial_attendee(self, clear_price_bumps):


### PR DESCRIPTION
This PR does three major things:
1. Improve various bits of documentation in configspec.ini
2. Adds a SUPPORTER_BADGE_DEADLINE config option that defaults to the same date as SUPPORTER_DEADLINE
3. Adds a get_printed_badge_deadline_by_type function to our config that returns the deadlines that work for MAGFest.

This codifies a kinda-hacky change we made last year to allow supporter badge names to be editable after the printed_badge_deadline while allowing other events to easily modify the business logic involved. I wanted to make it less hacky this year.