### PR TITLE
Fixes styling on the date field to match all the other fields

### DIFF
--- a/uber/templates/static_views/styles/main.css
+++ b/uber/templates/static_views/styles/main.css
@@ -57,6 +57,18 @@ h4 small { font-size: 65%; }
 h5 small { font-size: 70%; }
 h6 small { font-size: 75%; }
 
+span.jq-dte {
+    border-color: #ccc;
+    height: 34px;
+    margin: 0;
+    padding: 6px 2px;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+    -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+    -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s
+}
+
 .width-auto {
     width: auto;
 }


### PR DESCRIPTION
Fixes height, border color, and inner box shadow to match all our other fields.

# Old
<img width="709" alt="screen shot 2017-08-07 at 5 02 02 pm" src="https://user-images.githubusercontent.com/2592431/29045669-5630ba0e-7b92-11e7-88c4-17de61d18df5.png">

# New
<img width="700" alt="screen shot 2017-08-07 at 5 02 38 pm" src="https://user-images.githubusercontent.com/2592431/29045670-5635ecae-7b92-11e7-8881-de509584bcaa.png">