### PR TITLE
Fixes int_options() custom tag to select the right value whether it's given a string or an int

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -367,8 +367,9 @@ def options(options, default='""'):
 @JinjaEnv.jinja_export
 def int_options(minval, maxval, default=1):
     results = []
+    default = str(default)
     for i in range(minval, maxval+1):
-        selected = 'selected="selected"' if str(i) == str(default) else ''
+        selected = 'selected="selected"' if str(i) == default else ''
         results.append('<option value="{val}" {selected}>{val}</option>'.format(val=i, selected=selected))
     return safe_string('\n'.join(results))
 

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -368,7 +368,7 @@ def options(options, default='""'):
 def int_options(minval, maxval, default=1):
     results = []
     for i in range(minval, maxval+1):
-        selected = 'selected="selected"' if i == default else ''
+        selected = 'selected="selected"' if str(i) == str(default) else ''
         results.append('<option value="{val}" {selected}>{val}</option>'.format(val=i, selected=selected))
     return safe_string('\n'.join(results))
 


### PR DESCRIPTION
Steps to reproduce issue:
1. Click Group Badge button
2. Change number of badges to 20
3. Click t-shirt supporter button
4. Fill out prereg form, except for t-shirt size
5. Click submit
6. Page will reload with error about missing t-shirt size
7. **Note**: the number of badges will be set to 8 (the default)