### PR TITLE
Stop using amount_extra in default_cost for groups

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1337,7 +1337,7 @@ class Group(MagModel, TakesPaymentMixin):
                 total += attendee.badge_cost
         return total
 
-    @cost_property
+    @property
     def amount_extra(self):
         if self.is_new:
             return sum(a.total_cost - a.badge_cost for a in self.attendees if a.paid == c.PAID_BY_GROUP)
@@ -1345,11 +1345,15 @@ class Group(MagModel, TakesPaymentMixin):
             return 0
 
     @property
+    def total_cost(self):
+        return self.default_cost + self.amount_extra
+
+    @property
     def amount_unpaid(self):
         if self.registered:
             return max(0, self.cost - self.amount_paid)
         else:
-            return self.default_cost
+            return self.total_cost
 
     @property
     def dealer_max_badges(self):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -318,7 +318,7 @@ class Root:
             session.add(attendee)
 
         for group in charge.groups:
-            group.amount_paid = group.default_cost - group.amount_extra
+            group.amount_paid = group.default_cost
             for attendee in group.attendees:
                 attendee.amount_paid = attendee.total_cost - attendee.badge_cost
             session.add(group)


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2805 by making groups closer match how attendee's costs are calculated.