### PR TITLE
Prevents admins from accidentally sending the hotel link too early

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -45,7 +45,7 @@ AutomatedEmail(Attendee, '{EVENT_NAME} extra payment received', 'reg_workflow/gr
 if c.PREREG_REQUEST_HOTEL_INFO_ENABLED:
     AutomatedEmail(Attendee, '{EVENT_NAME} hotel booking info', 'reg_workflow/hotel_booking_info.html',
         lambda a: a.requested_hotel_info,
-        when=days_after(0, c.PREREG_REQUEST_HOTEL_INFO_DEADLINE),
+        when=days_after(0, c.PREREG_HOTEL_INFO_EMAIL_DATE),
         needs_approval=True,
         sender=c.PREREG_HOTEL_INFO_EMAIL_SENDER,
         ident='hotel_booking_info')

--- a/uber/config.py
+++ b/uber/config.py
@@ -278,7 +278,15 @@ class Config(_Overridable):
         """
         if not self.PREREG_REQUEST_HOTEL_INFO_ENABLED:
             return False
-        return not c.AFTER_PREREG_REQUEST_HOTEL_INFO_DEADLINE
+        return not self.AFTER_PREREG_REQUEST_HOTEL_INFO_DEADLINE
+
+    @property
+    def PREREG_HOTEL_INFO_EMAIL_DATE(self):
+        """
+        Date at which the hotel booking link email becomes available to send.
+        """
+        return self.PREREG_REQUEST_HOTEL_INFO_DEADLINE + \
+            timedelta(hours=max(0, self.PREREG_HOTEL_INFO_EMAIL_WAIT_DURATION))
 
     @property
     def AT_THE_DOOR_BADGE_OPTS(self):

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -58,6 +58,13 @@ badge_promo_codes_enabled = boolean(default=False)
 # be omitted entirely during preregistration.
 prereg_request_hotel_info_duration = integer(default=0)
 
+# The number of hours after the prereg_request_hotel_info_duration window
+# elapses to wait before the hotel booking link email becomes available to
+# send. Set this to 0 to allow the hotel booking link email to be sent as soon
+# as the prereg_request_hotel_info_duration window elapses.
+# Defaults to 197 hours (8 days and 5 hours).
+prereg_hotel_info_email_wait_duration = integer(default=197)
+
 # This will be used as the sender for the hotel booking info email.
 prereg_hotel_info_email_sender = string(default='Do Not Reply <noreply@magfest.org>')
 


### PR DESCRIPTION
Ok, this adds an extra duration to prevent the hotel link from being sent out too early. I have hardcoded our desired duration in the `configspec.ini`, but we can puppetize it and fix the default value later. 

I just want to make sure this is deployed sometime this evening when the traffic dies down a bit, but before the hotel request window elapses.

We've pushed the hotel email date back to August 17th at 8pm, and I **really** don't want the email going out early.