### PR TITLE
Fix "missing parameter" 500 errors for prereg_payment

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -301,6 +301,10 @@ class Root:
 
     @credit_card
     def prereg_payment(self, session, payment_id, stripeToken):
+        if not payment_id or not stripeToken:
+            message = 'The payment was interrupted. Please check below to ensure you received your badge.'
+            raise HTTPRedirect('paid_preregistrations?message={}', message)
+
         charge = Charge.get(payment_id)
         if not charge.total_cost:
             message = 'Your total cost was $0. Your credit card has not been charged.'
@@ -327,7 +331,7 @@ class Root:
         Charge.paid_preregs.extend(charge.targets)
         raise HTTPRedirect('paid_preregistrations?payment_received={}', charge.dollar_amount)
 
-    def paid_preregistrations(self, session, payment_received=None):
+    def paid_preregistrations(self, session, payment_received=None, message=''):
         if not Charge.paid_preregs:
             raise HTTPRedirect('index')
         else:
@@ -339,7 +343,8 @@ class Root:
                     pass  # this badge must have subsequently been transferred or deleted
             return {
                 'preregs': preregs,
-                'total_cost': payment_received
+                'total_cost': payment_received,
+                'message': message
             }
 
     def delete(self, id, message='Preregistration deleted'):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -300,7 +300,7 @@ class Root:
             raise HTTPRedirect('index?message={}', message)
 
     @credit_card
-    def prereg_payment(self, session, payment_id, stripeToken):
+    def prereg_payment(self, session, payment_id=None, stripeToken=None):
         if not payment_id or not stripeToken:
             message = 'The payment was interrupted. Please check below to ensure you received your badge.'
             raise HTTPRedirect('paid_preregistrations?message={}', message)


### PR DESCRIPTION
During the prereg rush this year, we had hundreds of people getting stuck on the POST-only page prereg_payment. When they refreshed the page, they'd get a 500 error for their troubles. This catches that and redirects them to the paid preregistrations page instead so they have a chance of knowing if their badge went through.