### PR TITLE
Display age discounts correctly

### DIFF
--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -75,7 +75,7 @@
                 <li>Requested hotel booking info</li>
               {% endif %}
               {% if not attendee.badge_cost and attendee.age_discount and not attendee.promo_code_id %}
-                <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free! </li>
+                <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free!</li>
               {% elif attendee.age_discount and attendee.age_group_conf.discount != 0 %}
                 <li>${{ attendee.age_group_conf.discount }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>
               {% endif %}

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -74,9 +74,9 @@
               {% if attendee.requested_hotel_info %}
                 <li>Requested hotel booking info</li>
               {% endif %}
-              {% if not attendee.default_cost and attendee.age_discount and not attendee.promo_code %}
-                <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free!</li>
-              {% elif attendee.age_discount %}
+              {% if not attendee.badge_cost and attendee.age_discount and not attendee.promo_code_id %}
+                <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free! </li>
+              {% elif attendee.age_discount and attendee.age_group_conf.discount != 0 %}
                 <li>${{ attendee.age_group_conf.discount }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>
               {% endif %}
               {% for swag in attendee.donation_swag|list + attendee.addons|list %}


### PR DESCRIPTION
This is a minor bug that was found right before registration opened. Our badge cost now takes age_discounts into account by default, which made this text display incorrectly in some cases. It was even telling people that there was a $0 discount for attendees 6 to 13!