### PR TITLE
handle 404 errors better

### DIFF
--- a/uber/server.py
+++ b/uber/server.py
@@ -38,14 +38,25 @@ cherrypy.tools.custom_verbose_logger = cherrypy.Tool('before_error_response', lo
 
 
 class StaticViews:
-    def path_args_to_string(self, path_args):
+    @classmethod
+    def path_args_to_string(cls, path_args):
         return '/'.join(path_args)
 
-    def get_full_path_from_path_args(self, path_args):
-        return 'static_views/' + self.path_args_to_string(path_args)
+    @classmethod
+    def get_full_path_from_path_args(cls, path_args):
+        return 'static_views/' + cls.path_args_to_string(path_args)
 
-    def get_filename_from_path_args(self, path_args):
+    @classmethod
+    def get_filename_from_path_args(cls, path_args):
         return path_args[-1]
+
+    @classmethod
+    def raise_not_found(cls, path, e=None):
+        raise cherrypy.HTTPError(404, "The path '{}' was not found.".format(path)) from e
+
+    @cherrypy.expose
+    def index(self):
+        self.raise_not_found('static_views/')
 
     @cherrypy.expose
     def default(self, *path_args, **kwargs):
@@ -55,7 +66,7 @@ class StaticViews:
         try:
             content = render(template_name)
         except jinja2.exceptions.TemplateNotFound as e:
-            raise cherrypy.HTTPError(404, "Couldn't find {}".format(template_name)) from e
+            self.raise_not_found(template_name, e)
 
         guessed_content_type = mimetypes.guess_type(content_filename)[0]
         return cherrypy.lib.static.serve_fileobj(content, name=content_filename, content_type=guessed_content_type)
@@ -97,6 +108,11 @@ class Root:
     angular = AngularJavascript()
 
 mount_site_sections(c.MODULE_ROOT)
+
+def error_page_404(status, message, traceback, version):
+    return "Sorry, page not found!<br/><br/>{}<br/>{}".format(status, message)
+
+c.APPCONF['/']['error_page.404'] = error_page_404
 
 cherrypy.tree.mount(Root(), c.PATH, c.APPCONF)
 static_overrides(join(c.MODULE_ROOT, 'static'))


### PR DESCRIPTION
two unrelated parts:
1) cleanup 404 handling to be more consistent for static_views/ related section, fix harmless but ugly TupleError/IndexError on default static_views/ page
2) display a nicer looking page to end user without stacktrace for 404 errors across entire app

@RobRuana could you give my ```@classmethod``` usage a quick look here to make sure it's sane

I wanted to get this in here to 1) reduce the signal to noise ratio in our slack error reporting (which currently pukes verbosely whenever search bots trip on a 404 on static_views/) and 2) make the errors less public-facing to end users