### PR TITLE
Armor up prereg

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -192,8 +192,11 @@ def check_shutdown(func):
 def credit_card(func):
     @wraps(func)
     def charge(self, session, payment_id, stripeToken, stripeEmail='ignored', **ignored):
+        log.debug('PAYMENT: payment_id={}, stripeToken={}', payment_id or 'NONE', stripeToken or 'NONE')
+
         if ignored:
-            log.error('received unexpected stripe parameters: {}', ignored)
+            log.debug('PAYMENT: received unexpected stripe parameters: {}', ignored)
+
         try:
             return func(self, session=session, payment_id=payment_id, stripeToken=stripeToken)
         except HTTPRedirect:
@@ -203,7 +206,7 @@ def credit_card(func):
                 'Got an error while calling charge' \
                 '(self, payment_id={!r}, stripeToken={!r}, ignored={}):\n{}\n' \
                 '\n IMPORTANT: This could have resulted in an attendee paying and not being' \
-                'marked as paid in the database. Definitely double check.'\
+                'marked as paid in the database. Definitely double check this.'\
                 .format(payment_id, stripeToken, ignored, traceback.format_exc())
 
             report_critical_exception(msg=error_text, subject='ERROR: MAGFest Stripe error (Automated Message)')

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -191,7 +191,7 @@ def check_shutdown(func):
 
 def credit_card(func):
     @wraps(func)
-    def charge(self, session, payment_id, stripeToken, stripeEmail='ignored', **ignored):
+    def charge(self, session, payment_id=None, stripeToken=None, stripeEmail='ignored', **ignored):
         log.debug('PAYMENT: payment_id={}, stripeToken={}', payment_id or 'NONE', stripeToken or 'NONE')
 
         if ignored:

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -301,6 +301,10 @@ class Root:
 
     @credit_card
     def prereg_payment(self, session, payment_id, stripeToken):
+        if not payment_id or not stripeToken:
+            message = 'The payment was interrupted. Please check below to ensure you received your badge.'
+            raise HTTPRedirect('paid_preregistrations?message={}', message)
+
         charge = Charge.get(payment_id)
         if not charge.total_cost:
             message = 'Your total cost was $0. Your credit card has not been charged.'
@@ -327,7 +331,7 @@ class Root:
         Charge.paid_preregs.extend(charge.targets)
         raise HTTPRedirect('paid_preregistrations?payment_received={}', charge.dollar_amount)
 
-    def paid_preregistrations(self, session, payment_received=None):
+    def paid_preregistrations(self, session, payment_received=None, message=''):
         if not Charge.paid_preregs:
             raise HTTPRedirect('index')
         else:
@@ -339,7 +343,8 @@ class Root:
                     pass  # this badge must have subsequently been transferred or deleted
             return {
                 'preregs': preregs,
-                'total_cost': payment_received
+                'total_cost': payment_received,
+                'message': message
             }
 
     def delete(self, id, message='Preregistration deleted'):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -300,7 +300,7 @@ class Root:
             raise HTTPRedirect('index?message={}', message)
 
     @credit_card
-    def prereg_payment(self, session, payment_id, stripeToken):
+    def prereg_payment(self, session, payment_id=None, stripeToken=None):
         if not payment_id or not stripeToken:
             message = 'The payment was interrupted. Please check below to ensure you received your badge.'
             raise HTTPRedirect('paid_preregistrations?message={}', message)

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -385,6 +385,9 @@ class Charge:
 
     def charge_cc(self, session, token):
         try:
+            log.debug('PAYMENT: !!! attempting to charge stripeToken {} ${} for {}',
+                      token, self.amount, self.description)
+
             self.response = stripe.Charge.create(
                 card=token,
                 currency='usd',
@@ -392,8 +395,14 @@ class Charge:
                 description=self.description,
                 receipt_email=self.receipt_email
             )
+
+            log.info('PAYMENT: !!! SUCCESS: charged stripeToken {} ${} for {}, responseID={}',
+                     token, self.amount, self.description, self.response.id or None)
+
         except stripe.CardError as e:
-            return 'Your card was declined with the following error from our processor: ' + str(e)
+            msg = 'Your card was declined with the following error from our processor: ' + str(e)
+            log.error('PAYMENT: !!! FAIL: {}', msg)
+            return msg
         except stripe.StripeError as e:
             error_txt = 'Got an error while calling charge_cc(self, token={!r})'.format(token)
             report_critical_exception(msg=error_txt, subject='ERROR: MAGFest Stripe invalid request error')


### PR DESCRIPTION
This starts with and probably replaces Vicki's PR: https://github.com/magfest/ubersystem/pull/2810

This heavily armors up the logging around anything to do with attendee payments, to a paranoid insane level. Spam as much info as we can into the logs so if there are ever issues, we should be able to better see what's going on

Some of this is redundant with the DB logging we're also doing, but, could be helpful during audit events to understand what really happened and fix any timing-dependent issues once and for all when coupled with nginx and cherrypy access/error logs.

One thing this doesn't do is fix the end-user seeing a non-nice error message if they visit ```prereg_payment``` with a GET request.  You can see there's a check for POST in here, but it comes too late and by that point cherrypy will have rejected it because ```credit_card``` says ```payment_id``` and ```stripeToken``` are required params.