### PR TITLE
Fixes #2834: Changes Jinja2's default() filter to use falsey/truthy values instead of undef

### DIFF
--- a/uber/templates/accounts/reset.html
+++ b/uber/templates/accounts/reset.html
@@ -15,7 +15,7 @@ Your old password will still work in the meantime, in case you remember it befor
 
 <b>Email Address:</b>
 &nbsp;&nbsp;&nbsp;&nbsp;
-<input class="focus" type="text" name="email" value="{{ email|default('') }}" />
+<input class="focus" type="text" name="email" value="{{ email|default('', boolean=True) }}" />
 &nbsp;&nbsp;&nbsp;&nbsp;
 <input type="submit" value="Send Reminder" />
 

--- a/uber/templates/dept_checklist/form.html
+++ b/uber/templates/dept_checklist/form.html
@@ -9,7 +9,7 @@
 <br/> <br/>
 <input type="hidden" name="slug" value="{{ item.slug }}" />
 {{ csrf_token() }}
-<textarea name="comments" rows="5" cols="80">{{ item.comments|default('') }}</textarea>
+<textarea name="comments" rows="5" cols="80">{{ item.comments|default('', boolean=True) }}</textarea>
 <br/>
 <input type="submit" value="Upload" />
 {% if item.is_new %}

--- a/uber/templates/groups/index.html
+++ b/uber/templates/groups/index.html
@@ -53,7 +53,7 @@
 {% for group in groups %}
   <tbody>
     <tr>
-        <td style="text-align:left" data-order="{{ group.name }}" data-search="{{ group.name }}"> <a href="form?id={{ group.id }}">{{ group.name|default("?????") }}</a> </td>
+        <td style="text-align:left" data-order="{{ group.name }}" data-search="{{ group.name }}"> <a href="form?id={{ group.id }}">{{ group.name|default('?????', boolean=True) }}</a> </td>
         <td>
             {% if group.is_dealer %}
                 {{ group.status_label }}

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -220,7 +220,7 @@
                             tags: true,
                             data: {{ affiliates|jsonize }},
                             width: '100%',
-                        }).val({{ attendee.affiliate|default('')|jsonize }}).trigger('change');
+                        }).val({{ attendee.affiliate|default('', boolean=True)|jsonize }}).trigger('change');
                     }
                 }
             });
@@ -579,7 +579,7 @@
             while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].extra < {{ attendee.amount_extra }}) {
                 BADGE_TYPES.options.splice(0, 1);
             }
-            while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].price && BADGE_TYPES.options[0].price < {{ c.BADGE_TYPE_PRICES[attendee.badge_type]|default(c.BADGE_PRICE) }}) {
+            while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].price && BADGE_TYPES.options[0].price < {{ c.BADGE_TYPE_PRICES[attendee.badge_type]|default(c.BADGE_PRICE, boolean=True) }}) {
                 BADGE_TYPES.options.splice(0, 1);
             }
         }

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -201,7 +201,7 @@
                 {{ options(c.BADGE_OPTS,attendee.badge_type) }}
             </select>
             {% if c.AT_THE_CON and c.NUMBERED_BADGES %}
-                #<input class="focus" type="text" style="width:4em" name="badge_num" value='{{ attendee.badge_num|default('') }}' />
+                #<input class="focus" type="text" style="width:4em" name="badge_num" value="{{ attendee.badge_num|default('', boolean=True) }}" />
             {% else %}
                 <span id="badge_message" style="font-style:italic"></span>
             {% endif %}


### PR DESCRIPTION
The great Jinja merge strikes again!

Django's `default()` filter works slightly differently from Jinja2's `default()` filter. Jinja2's `default()` filter only considers whether the variable is defined, not whether it is Truthy or Falsey. You can make Jinja2's `default()` filter work the same way as Django's by passing the second parameter as `boolean=True`.

See the Jinja2 source code [here](https://github.com/pallets/jinja/blob/8a49e066af3d88d1edb34aa1680b668c959dfcf7/jinja2/filters.py#L284)

Fixes #2834