### PR TITLE
Fix 500 error for non-Prime personalized badge reports

### DIFF
--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -193,7 +193,10 @@ class Root:
 
     @csv_file
     def printed_badges_minor(self, out, session):
-        uber.reports.PrintedBadgeReport(badge_type=c.CHILD_BADGE, badge_type_name='Minor').run(out, session)
+        try:
+            uber.reports.PrintedBadgeReport(badge_type=c.CHILD_BADGE, badge_type_name='Minor').run(out, session)
+        except AttributeError:
+            pass
 
     @csv_file
     def printed_badges_staff(self, out, session):
@@ -230,7 +233,7 @@ class Root:
             badge_type_override='supporter')
 
     """
-    Enumerate individual CSVs here that will be intergrated into the .zip which will contain all the
+    Enumerate individual CSVs here that will be integrated into the .zip which will contain all the
     badge types.  Downstream plugins can override which items are in this list.
     """
     badge_zipfile_contents = [


### PR DESCRIPTION
A "minor badges" report was added at some point, but only MAGFest Prime has a "Minor" badge type. For other events, the related report was causing a 500 error. The 'best' fix would be to use MAGPrime's event-specific repo to override/add the minor badge report, but this isn't yet supported by Sideboard -- plugins can only _add_ site sections, not modify them. Since this feature is needed quickly, this clumsy-ish fix will have to do for now.