### PR TITLE
Make Dept Head Checklist emails sendable in POST_CON mode

### DIFF
--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -322,7 +322,8 @@ class DeptChecklistEmail(AutomatedEmail):
                                 ident='department_checklist_{}'.format(conf.name),
                                 when=days_before(7, conf.deadline),
                                 sender=c.STAFF_EMAIL,
-                                extra_data={'conf': conf})
+                                extra_data={'conf': conf},
+                                post_con = True)
 
 
 def notify_admins_of_any_pending_emails():

--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -323,7 +323,7 @@ class DeptChecklistEmail(AutomatedEmail):
                                 when=days_before(7, conf.deadline),
                                 sender=c.STAFF_EMAIL,
                                 extra_data={'conf': conf},
-                                post_con = conf.email_post_con or False)
+                                post_con=conf.email_post_con or False)
 
 
 def notify_admins_of_any_pending_emails():

--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -323,7 +323,7 @@ class DeptChecklistEmail(AutomatedEmail):
                                 when=days_before(7, conf.deadline),
                                 sender=c.STAFF_EMAIL,
                                 extra_data={'conf': conf},
-                                post_con = True)
+                                post_con = conf.email_post_con or False)
 
 
 def notify_admins_of_any_pending_emails():

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -716,6 +716,7 @@ deadline = string
 description = string
 name = string(default="")
 path = string(default="")
+email_post_con = boolean(default=False)
 
 
 [volunteer_checklist]


### PR DESCRIPTION
We have a department head checklist email that's meant to be sent after the event, but refuses to send any emails because we're in post_con mode now. This enables all the emails during post con mode.