### PR TITLE
Fix #1669, delete badge when attendee abandons their group

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -567,17 +567,16 @@ class Root:
         success_message = "Sorry you can't make it! We hope to see you next year!"
         failure_message = "You cannot abandon your badge because you are the leader of a group."
 
-        # if attendee is part of a group, we must delete attendee and remove from the group
+        # a group leader may not abandon their badge
+        if attendee.is_group_leader:
+            raise HTTPRedirect('confirm?id={}&message={}', id, failure_message)
+
+        # if attendee is part of a group, we must delete attendee and remove them from the group
         if attendee.group:
-            if attendee.group.leader != attendee:
-                # remove this attendee from the group and delete the attendee
-                session.assign_badges(attendee.group, attendee.group.badges + 1, new_badge_type=attendee.badge_type, new_ribbon_type=attendee.ribbon, registered=attendee.registered, paid=attendee.paid)
-                session.delete_from_group(attendee, attendee.group)
-                raise HTTPRedirect('not_found?id={}&message={}', attendee.id, success_message)
-            else:
-                # attendee cannot invalidate their badge, as they are the leader of a group
-                raise HTTPRedirect('confirm?id={}&message={}', id, failure_message)
-        # otherwise, we will mark as invalid
+            session.assign_badges(attendee.group, attendee.group.badges + 1, new_badge_type=attendee.badge_type, new_ribbon_type=attendee.ribbon, registered=attendee.registered, paid=attendee.paid)
+            session.delete_from_group(attendee, attendee.group)
+            raise HTTPRedirect('not_found?id={}&message={}', attendee.id, success_message)
+        # otherwise, we will mark attendee as invalid
         else:
             attendee.badge_status = c.INVALID_STATUS
             raise HTTPRedirect('invalid_badge?id={}&message={}', attendee.id, success_message)
@@ -627,7 +626,7 @@ class Root:
             'message':       message,
             'affiliates':    session.affiliates(),
             'badge_cost':    attendee.badge_cost if attendee.paid != c.PAID_BY_GROUP else 0,
-            'can_abandon':   not attendee.amount_paid and not attendee.paid == c.NEED_NOT_PAY and not (attendee.group and attendee.group.leader == attendee)
+            'can_abandon':   not attendee.amount_paid and not attendee.paid == c.NEED_NOT_PAY and not attendee.is_group_leader
         }
 
     @id_required(Attendee)

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -569,7 +569,7 @@ class Root:
 
         # if attendee is part of a group, we must delete attendee and remove from the group
         if attendee.group:
-            if attendee.group.leader_id != attendee.id:
+            if attendee.group.leader != attendee:
                 # remove this attendee from the group and delete the attendee
                 session.assign_badges(attendee.group, attendee.group.badges + 1, new_badge_type=attendee.badge_type, new_ribbon_type=attendee.ribbon, registered=attendee.registered, paid=attendee.paid)
                 session.delete_from_group(attendee, attendee.group)
@@ -627,7 +627,7 @@ class Root:
             'message':       message,
             'affiliates':    session.affiliates(),
             'badge_cost':    attendee.badge_cost if attendee.paid != c.PAID_BY_GROUP else 0,
-            'can_abandon':   not attendee.amount_paid and not attendee.paid == c.NEED_NOT_PAY and not (attendee.group and attendee.group.leader_id == attendee.id)
+            'can_abandon':   not attendee.amount_paid and not attendee.paid == c.NEED_NOT_PAY and not (attendee.group and attendee.group.leader == attendee)
         }
 
     @id_required(Attendee)

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -55,8 +55,8 @@
           {% if attendee.is_transferable %}
             <button type="button" class="btn btn-primary" onClick='location.href="transfer_badge?id={{ attendee.id }}"'>Transfer my Badge</button>
           {% endif %}
-          {% if not attendee.amount_paid and not attendee.paid == c.NEED_NOT_PAY %}
-            <button type="submit" form="invalidate" class="btn btn-danger" onClick="return confirm('Are you sure you want to delete your badge? This can\'t be undone!');">I'm not coming</button>
+          {% if can_abandon %}
+            <button type="submit" form="abandon_badge" class="btn btn-danger" onClick="return confirm('Are you sure you want to delete your badge? This can\'t be undone!');">I'm not coming</button>
           {% endif %}
         </div>
       </div>
@@ -76,8 +76,8 @@
       {% endif %}
     </form>
 
-    {% if not attendee.amount_paid or not attendee.paid == c.NEED_NOT_PAY %}
-      <form method="post" action="invalidate" id="invalidate">
+    {% if can_abandon %}
+      <form method="post" action="abandon_badge" id="abandon_badge">
         <input type="hidden" name="id" value="{{ attendee.id }}"/>
       </form>
     {% endif %}


### PR DESCRIPTION
This PR renames the `invalidate` function in `preregistration.py` to `abandon_badge`. This function will now additionally handle the case where an attendee is part of a group. In this case, the badge will be deleted and removed from the group instead of being marked as invalid. The conditions for displaying the "I'm not coming" button have also been changed to exclude any attendee who is the leader of a group.

I have some concerns about the changes so far:

1. After the user deletes their group badge, it does not appear that they can use `invalid_badge`, so they are instead being sent to `not_found`. Is there a more appropriate destination to use here?

2. There are two different conditions being replaced by `can_abandon` in `confirm.html`. One condition uses `and`, and the other uses `or`. Was that intended, or is it a bug? This change will make the two conditions equal, because there does not appear to be any reason for them to be different.

3. `abandon_badge` includes two lines of code to adjust the group badge count and remove the attendee from the group. These lines were copied directly from `unset_group_member` in the same file. Could this be extracted into a utility function? If so, how and where should it be done?

Constructive criticism welcome 😅 