### PR TITLE
Fix #431, show "(Add new)" when user enters a new affiliate

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -220,6 +220,16 @@
                             tags: true,
                             data: {{ affiliates|jsonize }},
                             width: '100%',
+                            createTag: function(params) {
+                                var term = $.trim(params.term);
+
+                                if (params.term === '') return null;
+
+                                return {
+                                    id: params.term,
+                                    text: params.term + ' (Add new)'
+                                }
+                            }
                         }).val({{ attendee.affiliate|default('', boolean=True)|jsonize }}).trigger('change');
                     }
                 }


### PR DESCRIPTION
Are we happy with the text "Add new"?

Fixes #431

### When typing: 
![image](https://user-images.githubusercontent.com/437315/30237307-5b9c9d6c-94fd-11e7-9429-8bec50693475.png)

### Selected:
![image](https://user-images.githubusercontent.com/437315/30237312-6ea6cf36-94fd-11e7-949d-6b01e84bb158.png)


### Opening the list again:
![image](https://user-images.githubusercontent.com/437315/30237316-7e267998-94fd-11e7-8726-f11d15d2ed4b.png)