### PR TITLE
Fix #1578, use phonenumbers library for validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytz==2014.4
 alembic==0.9.1
 treepoem==1.0.1
 email_validator==1.0.2
+phonenumbers==8.8.1

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -120,10 +120,21 @@ def group_money(group):
 
 def _invalid_phone_number(s):
     try:
+        # parse input as a US number, unless a leading + is provided,
+        # in which case the input will be validated according to the country code
         parsed = phonenumbers.parse(s, 'US')
     except phonenumbers.phonenumberutil.NumberParseException:
+        # could not be parsed due to unexpected characters
         return True
-    return not phonenumbers.is_possible_number(parsed)
+
+    if not phonenumbers.is_possible_number(parsed):
+        # could not be a phone number due to length, invalid characters, etc
+        return True
+    elif parsed.country_code == 1 and phonenumbers.length_of_national_destination_code(parsed) == 0:
+        # US number does not contain area code
+        return True
+
+    return False
 
 
 def _invalid_zip_code(s):

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -13,6 +13,7 @@ on success and a string error message on validation failure.
 """
 from uber.common import *
 from email_validator import validate_email, EmailNotValidError
+import phonenumbers
 
 
 AdminAccount.required = [('attendee', 'Attendee'), ('hashed', 'Password')]
@@ -118,8 +119,11 @@ def group_money(group):
 
 
 def _invalid_phone_number(s):
-    if not s.startswith('+'):
-        return len(re.findall(r'\d', s)) != 10 or re.search(c.SAME_NUMBER_REPEATED, re.sub(r'[^0-9]', '', s))
+    try:
+        parsed = phonenumbers.parse(s, 'US')
+    except phonenumbers.phonenumberutil.NumberParseException:
+        return True
+    return not phonenumbers.is_possible_number(parsed)
 
 
 def _invalid_zip_code(s):

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -275,10 +275,8 @@ def emergency_contact(attendee):
 @ignore_unassigned_and_placeholders
 def cellphone(attendee):
     if attendee.cellphone and _invalid_phone_number(attendee.cellphone):
-        if c.COLLECT_FULL_ADDRESS:
-            return 'Enter a 10-digit US phone number or include a country code (e.g. +44) for your phone number.'
-        else:
-            return 'Your phone number was not a valid 10-digit phone number'
+        # phone number was inputted incorrectly
+        return 'Your phone number was not a valid 10-digit US phone number. Please include a country code (e.g. +44) for international numbers.'
 
     if not attendee.no_cellphone and attendee.staffing and not attendee.cellphone:
         return "Phone number is required for volunteers (unless you don't own a cellphone)"

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -1,6 +1,6 @@
 from uber import config
 from uber.tests import *
-from uber.model_checks import extra_donation_valid
+from uber.model_checks import extra_donation_valid, _invalid_phone_number
 
 
 class TestCosts:
@@ -477,3 +477,69 @@ class TestExtraDonationValidations:
 
     def test_extra_donation_valid(self):
         assert None == extra_donation_valid(Attendee(extra_donation=10))
+
+
+class TestPhoneNumberValidations:
+
+    valid_us_numbers = [
+        '7031234567',
+        '703 123 4567',
+        '(641) 123 4567',
+        '803-123-4567',
+        '(210)123-4567',
+        '12071234567',
+        '(202)fox-trot',
+        '+1 (202) 123-4567',
+    ]
+
+    invalid_us_numbers = [
+        # missing digits
+        '304123456',
+        '(864) 123 456',
+        '228-12-4567',
+        # too many digits
+        '405 123 45678',
+        '701 1234 4567',
+        # invalid characters
+        'f',
+        '404\\404 4040',
+        # normally a valid US number, but we want the area code
+        '123-4567',
+    ]
+
+    # all international numbers must have a leading +
+    valid_international_numbers = [
+        '+44 20 7946 0974',
+        '+442079460974',
+        '+44 7700 900927',
+        '+61 491 570 156',
+        '+36 55 889 752',
+        '+353 20 914 9510',
+        '+49 033933-88213'
+    ]
+
+    invalid_international_numbers = [
+        '+1234567890',
+        '+41458d98e5',
+        '+44,4930222'
+    ]
+
+    def test_phone_numbers(self):
+        # valid us numbers should pass
+        self.list_is_valid(self.valid_us_numbers)
+        # valid international numbers should pass
+        self.list_is_valid(self.valid_international_numbers)
+
+        # invalid us numbers should fail
+        self.list_is_invalid(self.invalid_us_numbers)
+        # invalid international numbers should fail
+        self.list_is_invalid(self.invalid_international_numbers)
+
+    # utility functions for testing in this class
+    def list_is_valid(self, test_list):
+        for number in test_list:
+            assert False == _invalid_phone_number(number)
+
+    def list_is_invalid(self, test_list):
+        for number in test_list:
+            assert True == _invalid_phone_number(number)


### PR DESCRIPTION
Fixes #1578.

This PR replaces the regex in `model_checks.py` for phone number validation with [this Python port](https://github.com/daviddrysdale/python-phonenumbers) of [Google's phone numbers library](https://github.com/googlei18n/libphonenumber). `phonenumbers` appears to already be accessible in this repo.

Input is parsed as a US phone number, unless a country code is provided. This library should handle international numbers correctly as long as the country code is known. Certain non-digit characters are acceptable, allowing for input like `(703) 123-4567`.

Note that I am using `is_possible_number` here instead of `is_valid_number`. The former only checks that the input is *like* a phone number (correct number of digits). The latter requires that the number is *valid* (a US number must have a valid area code).

I am merging the two validation failure messages here mostly because I don't know why there are two, especially now that we can validate international numbers. I also changed it from imperative to past tense, because this message only appears if the user has already entered something into this field.

We should be able to use this library to save inputted phone numbers in a normalized format like E.164. 