### PR TITLE
Fix #1125, use accurate age calculation

### DIFF
--- a/uber/models.py
+++ b/uber/models.py
@@ -1708,7 +1708,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     def age_group_conf(self):
         if self.birthdate:
             day = c.EPOCH.date() if date.today() <= c.EPOCH.date() else sa.localized_now().date()
-            attendee_age = (day - self.birthdate).days // 365.2425
+            attendee_age = get_age_from_birthday(self.birthdate, day)
             for val, age_group in c.AGE_GROUP_CONFIGS.items():
                 if val != c.AGE_UNKNOWN and age_group['min_age'] <= attendee_age <= age_group['max_age']:
                     return age_group

--- a/uber/tests/models/test_utils.py
+++ b/uber/tests/models/test_utils.py
@@ -1,5 +1,5 @@
 from uber.tests import *
-from uber.utils import add_opt, remove_opt
+from uber.utils import add_opt, remove_opt, get_age_from_birthday
 
 
 @pytest.fixture
@@ -93,3 +93,38 @@ class TestCharge:
         charge = Charge(amount=1000, description="Test charge")
         Charge.charge_cc(charge, Mock(), 1)
         assert not Charge.stripe_transaction_from_charge.called
+
+
+class TestAgeCalculations:
+
+    @pytest.mark.parametrize('birthdate,today,expected', [
+        # general
+        (date(2000, 1,  1), date(2010, 1,  1), 10),
+        (date(2000, 1,  1), date(2010, 6,  1), 10),
+        (date(2000, 1,  1), date(2009, 6,  1),  9),
+        (date(2000, 7, 31), date(2010, 7, 30),  9),
+        (date(2000, 7, 31), date(2010, 7, 31), 10),
+        (date(2000, 7, 31), date(2010, 8,  1), 10),
+        # feb 29 birthday
+        (date(2000, 2, 29), date(2010, 2, 28),  9),
+        (date(2000, 2, 29), date(2010, 3,  1), 10),
+        # feb 29 birthday + feb 29 today
+        (date(2000, 2, 29), date(2008, 2, 28),  7),
+        (date(2000, 2, 29), date(2008, 2, 29),  8),
+        (date(2000, 2, 29), date(2008, 3,  1),  8),
+        # feb 29 today
+        (date(2000, 3,  1), date(2008, 2, 28),  7),
+        (date(2000, 3,  1), date(2008, 2, 29),  7),
+        (date(2000, 3,  1), date(2008, 3,  1),  8),
+        # turning 18
+        (date(2000, 1,  4), date(2018, 1,  3), 17),
+        (date(2000, 1,  4), date(2018, 1,  4), 18),
+        (date(2000, 1,  5), date(2018, 1,  4), 17),
+        # turning 21
+        (date(1997, 1,  4), date(2018, 1,  3), 20),
+        (date(1997, 1,  4), date(2018, 1,  4), 21),
+        (date(1997, 1,  5), date(2018, 1,  4), 20)
+
+    ])
+    def test_age_calculation(self, birthdate, today, expected):
+        assert expected == get_age_from_birthday(birthdate, today)

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -548,6 +548,28 @@ def remove_opt(opts, other):
     return ','.join(map(str, set(opts).difference(other)))
 
 
+def get_age_from_birthday(birthdate, today=None):
+    """
+    Determines a person's age in the US. DO NOT use this to find other timespans, like the duration of an event.
+    This function does not calculate a fully accurate timespan between two datetimes.
+    This function assumes that a person's age begins at zero, and increments when `today.day == birthdate.day`.
+    This will not be accurate for cultures which calculate age differently than the US, such as Korea.
+
+    Args:
+        birthdate: A date, should be earlier than the second parameter
+        today:  Optional, age will be found as of this date
+
+    Returns: An integer indicating the age.
+
+    """
+
+    if today == None:
+        today = date.today()
+
+    # Hint: int(True) == 1 and int(False) == 0
+    return today.year - birthdate.year - ((today.month, today.day) < (birthdate.month, birthdate.day))
+
+
 _when_dateformat = "%m/%d"
 
 


### PR DESCRIPTION
Adds a utility function to calculate a person's age given a birthdate and effective date. This doesn't return a real timespan, so this function shouldn't be used for anything other than finding the age of a person.

I used TDD to implement this function. First, I wrote unit tests to cover a variety of cases that I made up on the spot Then, with the old age code, I ran the tests and found that some of them failed. I've reproduced those results below. Finally, I wrote the new function `get_age_from_birthday` and ran the tests again.

Old code: `(day - self.birthdate).days // 365.2425`

Test failures:
```
get_age_from_birthday(datetime.date(1997, 1, 4), datetime.date(2018, 1, 4))
Expected 21 years, got 20

get_age_from_birthday(datetime.date(2000, 7, 31), datetime.date(2010, 7, 31))
Expected 10 years, got 9
```

That first one could really ruin somebody's day!

New code: `today.year - birthdate.year - ((today.month, today.day) < (birthdate.month, birthdate.day))`

All tests passed successfully.

Please let me know if there are any previously known failure cases for the old code that we can add to the unit tests (or if you just have some ideas!)

Also, I would appreciate if the test cases can be given extra scrutiny. I'm pretty sure they are all correct, but it's late and I'm afraid there might be problems with them that I just am not seeing.

Thanks for reviewing my work. 😄

Fixes #1125