### PR TITLE
Fix #1778, make reg_take_report work again

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -783,9 +783,9 @@ class Root:
             params['endhour'] = localized_now().strftime('%H')
             params['endminute'] = localized_now().strftime('%M')
         # list all reg stations associated with attendees and sales
-        stations_attendees = session.query(Attendee.reg_station).filter(Attendee.reg_station is not None, Attendee.reg_station > 0)
-        stations_sales = session.query(Sale.reg_station).filter(Sale.reg_station is not None, Sale.reg_station > 0)
-        stations = sorted([r for (r,) in stations_attendees.union(stations_sales).distinct()])
+        stations_attendees = session.query(Attendee.reg_station).filter(Attendee.reg_station != None, Attendee.reg_station > 0)
+        stations_sales = session.query(Sale.reg_station).filter(Sale.reg_station != None, Sale.reg_station > 0)
+        stations = [r for (r,) in stations_attendees.union(stations_sales).distinct().order_by(Attendee.reg_station)]
         params['reg_stations'] = stations
         params.setdefault('reg_station', stations[0] if stations else 0)
         return params

--- a/uber/templates/registration/reg_take_report.html
+++ b/uber/templates/registration/reg_take_report.html
@@ -56,7 +56,7 @@
     {% for sale in sales %}
         <tr>
             <td>{{ sale.what }}</td>
-            <td><a href="../form?id={{ attendee.id }}">{{ sale.attendee.full_name }}</a></td>
+            <td><a href="../registration/form?id={{ sale.attendee_id }}">{{ sale.attendee.full_name }}</a></td>
             <td>{{ sale.payment_method_label }}</td>
             <td>${{ sale.cash }}</td>
             <td>{{ sale.when }}</td>

--- a/uber/templates/registration/reg_take_report.html
+++ b/uber/templates/registration/reg_take_report.html
@@ -56,7 +56,7 @@
     {% for sale in sales %}
         <tr>
             <td>{{ sale.what }}</td>
-            <td><a href="../registration/form?id={{ sale.attendee_id }}">{{ sale.attendee.full_name }}</a></td>
+            <td><a href="./form?id={{ sale.attendee_id }}">{{ sale.attendee.full_name }}</a></td>
             <td>{{ sale.payment_method_label }}</td>
             <td>${{ sale.cash }}</td>
             <td>{{ sale.when }}</td>


### PR DESCRIPTION
This should fix the query used by reg_take_report. Also, I took the liberty of including reg stations in the dropdown if they are associated with one or more sales, but no attendees. 

Fixes #1778

It looks like the table on this page is trying to access css class `list` defined in `uber/static/styles/styles.css`, but that file is not being loaded here. As a result, the report looks like a squishy mess. Should the appearance of this table be dealt with in this PR, or should I make a new one?

![image](https://user-images.githubusercontent.com/437315/30469218-4ff17d6a-99bd-11e7-9f19-ee33f563f3f7.png)
