### PR TITLE
Restore old css that was not replaced

### DIFF
--- a/uber/static/styles/styles.css
+++ b/uber/static/styles/styles.css
@@ -32,14 +32,6 @@ ul {
     margin: 0px;
 }
 
-table {
-    width:          100%;
-    border-spacing: 5px;
-}
-td {
-    padding: 5px;
-}
-
 table.calendar {
     width:          auto;
     border:         2px solid black;
@@ -49,41 +41,6 @@ table.calendar {
 table.calendar td {
     border:  1px solid black;
     padding: 15px;
-}
-
-table.menu {
-    border-collapse: collapse;
-    text-align:      center;
-    margin-top:      10px;
-    margin-bottom:   10px;
-}
-table.menu td {
-    border: 2px solid gray;
-}
-
-table.list {
-    width:           100%;
-    text-align:      center;
-    border-collapse: collapse;
-}
-table.list td {
-    border:  1px solid black;
-    padding: 5px;
-}
-table.list tr.header {
-    background:     #99CCFF;
-    font-weight:    bold;
-    vertical-align: bottom;
-}
-table.list tr.header a,
-table.list tr.header a:hover,
-table.list tr.header a:visited {
-    color:           black;
-    text-decoration: none;
-}
-table.list table td {
-    border:  0;
-    padding: 0;
 }
 
 table.form {
@@ -134,12 +91,4 @@ ul.select2-results {
 .select2-bolded {
     font-weight: bold;
     font-size: 16pt;
-}
-
-.pad-top-10 li {
-    padding-top: 10px;
-}
-
-.center {
-    text-align: center;
 }

--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -230,7 +230,7 @@
 
 {% macro nav_menu(model, current_page_path) -%}
   {% if not model.is_new -%}
-    <table class="menu"><tr>
+    <table class="navmenu"><tr>
       {% for href, label, display in varargs|batch(3, False) if display %}
         {% set href = href.format(**model.__dict__) %}
         <td width="{{ 100 // loop.length }}%">

--- a/uber/templates/static_views/styles/main.css
+++ b/uber/templates/static_views/styles/main.css
@@ -129,3 +129,52 @@ span.jq-dte {
     padding-left: 0;
     padding-right: 0;
 }
+
+/* imported from styles.css */
+
+table.navmenu {
+    border-spacing: 5px;
+    border-collapse: collapse;
+    text-align:      center;
+    margin-top:      10px;
+    margin-bottom:   10px;
+    width:          100%;
+
+}
+table.navmenu td {
+    border: 2px solid gray;
+    padding: 5px;
+}
+
+table.list {
+    width:           100%;
+    text-align:      center;
+    border-collapse: collapse;
+}
+table.list td {
+    border:  1px solid black;
+    padding: 5px;
+}
+table.list tr.header {
+    background:     #99CCFF;
+    font-weight:    bold;
+    vertical-align: bottom;
+}
+table.list tr.header a,
+table.list tr.header a:hover,
+table.list tr.header a:visited {
+    color:           black;
+    text-decoration: none;
+}
+table.list table td {
+    border:  0;
+    padding: 0;
+}
+
+.pad-top-10 li {
+    padding-top: 10px;
+}
+
+.center {
+    text-align: center;
+}


### PR DESCRIPTION
This PR restores some missing CSS rules by moving some classes from `styles.css`, a file that currently has no references, into `main.css`, a file which is included in many places. Presumably, some event took place which resulted in `styles.css` being removed from many pages.

The reason only some of the CSS was moved is because not all of `styles.css` should be restored at this point. For example, the `{% for attendee in charge.attendees %}` table on `preregistration\index` has since been updated with new css. Applying the old rules from `styles.css` does not look good.

However, some places appear to have NOT been updated with new css. This includes the `reg_take_report` and `registration\comments` tables, and also the `macros.nav_menu` section on many pages (registration, groups, jobs). The classes I am adding into `main.css` enable some styling which improves these pages.

I have reviewed every class that I am adding to `main.css`. As best as I can tell, these classes are only referenced by elements that are otherwise not benefiting from any styling at all.