### PR TITLE
Updates transferable_badge_types to disable badge transfers

### DIFF
--- a/test-defaults.ini
+++ b/test-defaults.ini
@@ -45,6 +45,8 @@ shiftless_depts = "con_ops",
 # set these even though Supporter isn't really a badge type anymore
 preassigned_badge_types = "staff_badge", "supporter_badge"
 
+transferable_badge_types = "attendee_badge",
+
 
 [badge_prices]
 one_days_enabled = True

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -160,7 +160,10 @@ preassigned_badge_types = string_list(default=list())
 
 # Some badge types should not be transferable because of privilege (Guest badges) or
 # access level (Staff badges). This lists which badge types can be transferred, if any.
-transferable_badge_types = string_list(default=list('attendee_badge'))
+# transferable_badge_types = string_list(default=list('attendee_badge'))
+
+# Temporarily disable badge transfers
+transferable_badge_types = string_list(default=list())
 
 # When transfering a badge, we need to persist certain attributes such as the original
 # date someone preregistered and their badge type, but we need to reset most other


### PR DESCRIPTION
I'd prefer to do this in production-config, but this particular variable is not puppetized. Also, we're only running one event at the moment, so we don't have to worry about affecting other events.