### PR TITLE
Fixes #2871: Adds the group management link to the end of the group confirmation email

### DIFF
--- a/uber/templates/emails/reg_workflow/group_confirmation.html
+++ b/uber/templates/emails/reg_workflow/group_confirmation.html
@@ -49,6 +49,8 @@ registration desk when you arrive at {{ c.EVENT_NAME }}. Inform your group to br
 desk, where they'll be provided with their badge. If anyone in your group ordered bonus items such as a
 ribbon, t-shirt, or supporter package, they can pick those up at our merchandise booth. The location and
 hours of the registration desk and merchandise booth will be e-mailed prior to the event.
+<br/> <br/>
+You can always <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">use this link</a> to manage your group.
 
 </body>
 </html>


### PR DESCRIPTION
There are very rare circumstances where the group management link isn't displayed in a group confirmation email. This pull request adds the link to the end of the email, no matter what.