### PR TITLE
Add a more descriptive error message for badge_transfer

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -522,7 +522,7 @@ class Root:
     def transfer_badge(self, session, message='', **params):
         old = session.attendee(params['id'])
 
-        assert old.is_transferable, 'This badge is not transferrable'
+        assert old.is_transferable, 'This badge is not transferrable at this time. We hope to re-enable this feature by October 31st, 2017. Thank you for your patience.'
         session.expunge(old)
         attendee = session.attendee(params, restricted=True)
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -522,7 +522,7 @@ class Root:
     def transfer_badge(self, session, message='', **params):
         old = session.attendee(params['id'])
 
-        assert old.is_transferable, 'This badge is not transferrable at this time. We hope to re-enable this feature by October 31st, 2017. Thank you for your patience.'
+        assert old.is_transferable, 'This badge is not transferrable at this time. Badge transfers are temporarily disabled for hotel early booking. We hope to re-enable this feature as soon as we can. Thank you for your patience.'
         session.expunge(old)
         attendee = session.attendee(params, restricted=True)
 


### PR DESCRIPTION
This doesn't take into account badges that actually can't be transferred, and is a temporary fix while all badge transfers have been disabled. This PR will need to be reverted once badge transfers have been reenabled. 