### PR TITLE
Stop requiring first and last name for placeholder emails

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -102,17 +102,17 @@ MarketplaceEmail('{EVENT_NAME} Dealer waitlist has been exhausted', 'dealers/wai
 # creates a "placeholder" registration.
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Panelist Badge Confirmation', 'placeholders/panelist.txt',
-               lambda a: a.placeholder and a.first_name and a.last_name and c.PANELIST_RIBBON in a.ribbon_ints,
+               lambda a: a.placeholder and c.PANELIST_RIBBON in a.ribbon_ints,
                sender=c.PANELS_EMAIL,
                ident='panelist_badge_confirmation')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Guest Badge Confirmation', 'placeholders/guest.txt',
-               lambda a: a.placeholder and a.first_name and a.last_name and a.badge_type == c.GUEST_BADGE,
+               lambda a: a.placeholder and a.badge_type == c.GUEST_BADGE,
                sender=c.GUEST_EMAIL,
                ident='guest_badge_confirmation')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Dealer Information Required', 'placeholders/dealer.txt',
-               lambda a: a.placeholder and a.is_dealer and a.group.status == c.APPROVED,
+               lambda a: a.placeholder and a.group.status == c.APPROVED,
                sender=c.MARKETPLACE_EMAIL,
                ident='dealer_info_required')
 
@@ -121,23 +121,22 @@ StopsEmail('Want to staff {EVENT_NAME} again?', 'placeholders/imported_volunteer
            ident='volunteer_again_inquiry')
 
 StopsEmail('{EVENT_NAME} Volunteer Badge Confirmation', 'placeholders/volunteer.txt',
-           lambda a: a.placeholder and a.first_name and a.last_name
-                                      and a.registered_local > c.PREREG_OPEN,
+           lambda a: a.placeholder and a.registered_local > c.PREREG_OPEN,
            ident='volunteer_badge_confirmation')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Badge Confirmation', 'placeholders/regular.txt',
-               lambda a: a.placeholder and a.first_name and a.last_name
+               lambda a: a.placeholder
                                        and (c.AT_THE_CON or a.badge_type not in [c.GUEST_BADGE, c.STAFF_BADGE]
                                        and not set([c.DEALER_RIBBON, c.PANELIST_RIBBON, c.VOLUNTEER_RIBBON]).intersection(a.ribbon_ints)),
                allow_during_con=True,
                ident='regular_badge_confirmation')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Badge Confirmation Reminder', 'placeholders/reminder.txt',
-               lambda a: days_after(7, a.registered)() and a.placeholder and a.first_name and a.last_name and not a.is_dealer,
+               lambda a: days_after(7, a.registered)() and a.placeholder and not a.is_dealer,
                ident='badge_confirmation_reminder')
 
 AutomatedEmail(Attendee, 'Last Chance to Accept Your {EVENT_NAME} {EVENT_DATE} Badge', 'placeholders/reminder.txt',
-               lambda a: a.placeholder and a.first_name and a.last_name and not a.is_dealer,
+               lambda a: a.placeholder and not a.is_dealer,
                when=days_before(7, c.PLACEHOLDER_DEADLINE),
                ident='badge_confirmation_reminder_last_chance')
 

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -112,7 +112,7 @@ AutomatedEmail(Attendee, '{EVENT_NAME} Guest Badge Confirmation', 'placeholders/
                ident='guest_badge_confirmation')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Dealer Information Required', 'placeholders/dealer.txt',
-               lambda a: a.placeholder and is_dealer and a.group.status == c.APPROVED,
+               lambda a: a.placeholder and a.is_dealer and a.group.status == c.APPROVED,
                sender=c.MARKETPLACE_EMAIL,
                ident='dealer_info_required')
 

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -112,7 +112,7 @@ AutomatedEmail(Attendee, '{EVENT_NAME} Guest Badge Confirmation', 'placeholders/
                ident='guest_badge_confirmation')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Dealer Information Required', 'placeholders/dealer.txt',
-               lambda a: a.placeholder and a.group.status == c.APPROVED,
+               lambda a: a.placeholder and is_dealer and a.group.status == c.APPROVED,
                sender=c.MARKETPLACE_EMAIL,
                ident='dealer_info_required')
 
@@ -125,9 +125,8 @@ StopsEmail('{EVENT_NAME} Volunteer Badge Confirmation', 'placeholders/volunteer.
            ident='volunteer_badge_confirmation')
 
 AutomatedEmail(Attendee, '{EVENT_NAME} Badge Confirmation', 'placeholders/regular.txt',
-               lambda a: a.placeholder
-                                       and (c.AT_THE_CON or a.badge_type not in [c.GUEST_BADGE, c.STAFF_BADGE]
-                                       and not set([c.DEALER_RIBBON, c.PANELIST_RIBBON, c.VOLUNTEER_RIBBON]).intersection(a.ribbon_ints)),
+               lambda a: a.placeholder and (c.AT_THE_CON or a.badge_type not in [c.GUEST_BADGE, c.STAFF_BADGE]
+                                            and not set([c.DEALER_RIBBON, c.PANELIST_RIBBON, c.VOLUNTEER_RIBBON]).intersection(a.ribbon_ints)),
                allow_during_con=True,
                ident='regular_badge_confirmation')
 

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -117,7 +117,7 @@ AutomatedEmail(Attendee, '{EVENT_NAME} Dealer Information Required', 'placeholde
                ident='dealer_info_required')
 
 StopsEmail('Want to staff {EVENT_NAME} again?', 'placeholders/imported_volunteer.txt',
-           lambda a: a.placeholder and a.staffing and a.registered_local <= c.PREREG_OPEN,
+           lambda a: a.placeholder and a.registered_local <= c.PREREG_OPEN,
            ident='volunteer_again_inquiry')
 
 StopsEmail('{EVENT_NAME} Volunteer Badge Confirmation', 'placeholders/volunteer.txt',

--- a/uber/templates/emails/placeholders/dealer.txt
+++ b/uber/templates/emails/placeholders/dealer.txt
@@ -1,6 +1,6 @@
-{{ attendee.first_name }},
+{% if attendee.first_name %}{{ attendee.first_name }},
 
-You've been registered for a badge as part of the {{ c.EVENT_NAME }} Marketplace as part of "{{ attendee.group.name }}", but we're still missing some of your information, such as an emergency contact phone number.  It'll save time when checking in at our registration desk if you fill out that information now, which you can do at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
+{% endif %}You've been registered for a badge as part of the {{ c.EVENT_NAME }} Marketplace as part of "{{ attendee.group.name }}", but we're still missing some of your information, such as an emergency contact phone number.  It'll save time when checking in at our registration desk if you fill out that information now, which you can do at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
 
 Please let us know if you have any questions.
 

--- a/uber/templates/emails/placeholders/guest.txt
+++ b/uber/templates/emails/placeholders/guest.txt
@@ -1,6 +1,6 @@
-{{ attendee.first_name }},
+{% if attendee.first_name %}{{ attendee.first_name }},
 
-Thanks for coming out to {{ c.EVENT_NAME }} as a Guest!  We've added you to our registration database for your complimentary badge, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
+{% endif %}Thanks for coming out to {{ c.EVENT_NAME }} as a Guest!  We've added you to our registration database for your complimentary badge, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
 
 Please let us know if you have any questions.
 

--- a/uber/templates/emails/placeholders/imported_volunteer.txt
+++ b/uber/templates/emails/placeholders/imported_volunteer.txt
@@ -1,6 +1,6 @@
-{{ attendee.first_name }},
+{% if attendee.first_name %}{{ attendee.first_name }},
 
-{% if c.DEPT_HEAD_RIBBON in attendee.ribbon_ints %}NOTE: This is an automated email, but even though you are a Department Head you should still pay attention to it, since you DO need to fill out the form linked below.
+{% endif %}{% if c.DEPT_HEAD_RIBBON in attendee.ribbon_ints %}NOTE: This is an automated email, but even though you are a Department Head you should still pay attention to it, since you DO need to fill out the form linked below.
 
 {% endif %}Thanks so much for helping run {{ c.EVENT_NAME }} last year, we couldn't have pulled it off without so much help from our wonderful volunteers.  As thanks for your help, you're eligible for a complementary Staff badge for the next {{ c.EVENT_NAME }}, which will be {{ c.EPOCH|datetime_local("%b %e") }} - {{ c.ESCHATON|datetime_local("%e") }}.  You can accept your badge by visiting {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
 

--- a/uber/templates/emails/placeholders/panelist.txt
+++ b/uber/templates/emails/placeholders/panelist.txt
@@ -1,6 +1,6 @@
-{{ attendee.first_name }},
+{% if attendee.first_name %}{{ attendee.first_name }},
 
-Thanks for coming out to {{ c.EVENT_NAME }} as a Panelist!  We've added you to our registration database for your complementary badge, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
+{% endif %}Thanks for coming out to {{ c.EVENT_NAME }} as a Panelist!  We've added you to our registration database for your complementary badge, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
 
 Please let us know if you have any questions.
 

--- a/uber/templates/emails/placeholders/regular.txt
+++ b/uber/templates/emails/placeholders/regular.txt
@@ -1,6 +1,6 @@
-{{ attendee.first_name }},
+{% if attendee.first_name %}{{ attendee.first_name }},
 
-You've been added to the {{ c.EVENT_NAME }} registration database, but we don't have all of your personal information{% if attendee.amount_unpaid %} and you have not yet paid your outstanding balance of ${{ attendee.amount_unpaid }}{% endif %}.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info{% if attendee.amount_unpaid %} and pay{% endif %} at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
+{% endif %}You've been added to the {{ c.EVENT_NAME }} registration database, but we don't have all of your personal information{% if attendee.amount_unpaid %} and you have not yet paid your outstanding balance of ${{ attendee.amount_unpaid }}{% endif %}.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info{% if attendee.amount_unpaid %} and pay{% endif %} at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
 
 Please let us know if you have any questions.
 

--- a/uber/templates/emails/placeholders/reminder.txt
+++ b/uber/templates/emails/placeholders/reminder.txt
@@ -1,6 +1,6 @@
-{{ attendee.first_name }},
+{% if attendee.first_name %}{{ attendee.first_name }},
 
-You still haven't accepted the {{ attendee.badge_type_label }} badge{% if attendee.ribbon %} with a {{ attendee.ribbon_labels|join(" / ") }} ribbon{% endif %} for this year's {{ c.EVENT_NAME }}.  We need to know whether you're coming, so please let us know by filling out the form at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
+{% endif %}You still haven't accepted the {{ attendee.badge_type_label }} badge{% if attendee.ribbon %} with a {{ attendee.ribbon_labels|join(" / ") }} ribbon{% endif %} for this year's {{ c.EVENT_NAME }}.  We need to know whether you're coming, so please let us know by filling out the form at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
 
 We're going to delete all un-accepted preregistrations at {{ c.PLACEHOLDER_DEADLINE|datetime_local }}, so please make sure to fill out the form before then.
 

--- a/uber/templates/emails/placeholders/volunteer.txt
+++ b/uber/templates/emails/placeholders/volunteer.txt
@@ -1,6 +1,6 @@
-{{ attendee.first_name }},
+{% if attendee.first_name %}{{ attendee.first_name }},
 
-Thanks for volunteering to help run {{ c.EVENT_NAME }}!  You've been added to our registration database, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
+{% endif %}Thanks for volunteering to help run {{ c.EVENT_NAME }}!  You've been added to our registration database, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
 
 After entering the rest of your information, we'll assign you to the appropriate department and you'll be able to sign up for shifts.
 


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2904 by first removing the requirement for placeholder badges to have first and last names, and then modifying all placeholder email templates to only try to print the first name if it in fact exists.