### PR TITLE
Reverts requested_any_dept design to use nullable department_id column on dept_membership_request table

### DIFF
--- a/alembic/versions/d3da548acd2e_drops_requested_any_dept_column.py
+++ b/alembic/versions/d3da548acd2e_drops_requested_any_dept_column.py
@@ -1,0 +1,149 @@
+"""Drops requested_any_dept column
+
+Revision ID: d3da548acd2e
+Revises: 29b1b9a4e601
+Create Date: 2017-11-06 09:33:21.963533
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'd3da548acd2e'
+down_revision = '29b1b9a4e601'
+branch_labels = None
+depends_on = None
+
+
+import uuid
+
+import sideboard.lib.sa
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import func
+from sqlalchemy.schema import ForeignKey
+from sqlalchemy.sql import and_, or_, table
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+attendee_table = table(
+    'attendee',
+    sa.Column('id', sideboard.lib.sa.UUID()),
+    sa.Column('requested_any_dept', sa.Boolean()),
+)
+
+
+dept_membership_request_table = table(
+    'dept_membership_request',
+    sa.Column('id', sideboard.lib.sa.UUID()),
+    sa.Column('attendee_id', sideboard.lib.sa.UUID(), ForeignKey('attendee.id')),
+    sa.Column('department_id', sideboard.lib.sa.UUID(), ForeignKey('department.id')),
+)
+
+
+def upgrade():
+    if is_sqlite:
+        with op.batch_alter_table('dept_membership_request', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.add_column(sa.Column('id', sideboard.lib.sa.UUID(), nullable=True))
+            batch_op.alter_column('department_id', existing_type=sideboard.lib.sa.UUID(), nullable=True)
+    else:
+        op.add_column('dept_membership_request', sa.Column('id', sideboard.lib.sa.UUID(), nullable=True))
+        op.alter_column('dept_membership_request', 'department_id', existing_type=sideboard.lib.sa.UUID(), nullable=True)
+
+    connection = op.get_bind()
+    all_requests = connection.execute(dept_membership_request_table.select())
+    for request in all_requests:
+        connection.execute(
+            dept_membership_request_table.update().where(and_(
+                dept_membership_request_table.c.attendee_id == request.attendee_id,
+                dept_membership_request_table.c.department_id == request.department_id
+            )).values({
+                'id': str(uuid.uuid4())
+            })
+        )
+
+    attendees_requesting_any = connection.execute(attendee_table.select().where(
+        attendee_table.c.requested_any_dept == True
+    ))
+    for attendee in attendees_requesting_any:
+        connection.execute(
+            dept_membership_request_table.insert().values({
+                'id': str(uuid.uuid4()),
+                'attendee_id': attendee.id,
+                'department_id': None
+            })
+        )
+
+    if is_sqlite:
+        with op.batch_alter_table('dept_membership_request', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.alter_column('id', existing_type=sideboard.lib.sa.UUID(), nullable=False)
+            batch_op.create_primary_key('pk_dept_membership_request', ['id', ])
+        with op.batch_alter_table('attendee', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.drop_column('requested_any_dept')
+    else:
+        op.alter_column('dept_membership_request', 'id', existing_type=sideboard.lib.sa.UUID(), nullable=False)
+        op.create_primary_key('pk_dept_membership_request', 'dept_membership_request', ['id', ])
+        op.drop_column('attendee', 'requested_any_dept')
+
+
+def downgrade():
+    if is_sqlite:
+        with op.batch_alter_table('attendee', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.add_column(sa.Column('requested_any_dept', sa.BOOLEAN(), server_default=sa.text('false'), autoincrement=False, nullable=False))
+    else:
+        op.add_column('attendee', sa.Column('requested_any_dept', sa.BOOLEAN(), server_default=sa.text('false'), autoincrement=False, nullable=False))
+
+    connection = op.get_bind()
+    requests_for_any = connection.execute(dept_membership_request_table.select().where(
+        dept_membership_request_table.c.department_id == None))
+    for request in requests_for_any:
+        connection.execute(
+            attendee_table.update().where(attendee_table.c.id == request.attendee_id).values({
+                'requested_any_dept': True
+            })
+        )
+
+    connection.execute(
+        dept_membership_request_table.delete().where(
+            dept_membership_request_table.c.department_id == None
+        )
+    )
+
+    if is_sqlite:
+        with op.batch_alter_table('dept_membership_request', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.drop_column('id')
+            batch_op.alter_column('department_id', existing_type=sideboard.lib.sa.UUID(), nullable=False)
+    else:
+        op.drop_column('dept_membership_request', 'id')
+        op.alter_column('dept_membership_request', 'department_id', existing_type=sideboard.lib.sa.UUID(), nullable=False)

--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -19,7 +19,7 @@ class AutomatedEmail:
             subqueryload(Attendee.shifts)
                 .subqueryload(Shift.job),
             subqueryload(Attendee.assigned_depts),
-            subqueryload(Attendee.requested_depts),
+            subqueryload(Attendee.dept_membership_requests),
             subqueryload(Attendee.checklist_admin_depts)
                 .subqueryload(Department.dept_checklist_items),
             subqueryload(Attendee.dept_memberships),

--- a/uber/site_sections/departments.py
+++ b/uber/site_sections/departments.py
@@ -138,7 +138,7 @@ class Root:
             }
 
     @department_id_adapter
-    def requests(self, session, department_id=None, message='', **params):
+    def requests(self, session, department_id=None, requested_any=False, message='', **params):
         if not department_id:
             raise HTTPRedirect('index')
 
@@ -162,7 +162,8 @@ class Root:
 
         return {
             'department': department,
-            'message': message
+            'message': message,
+            'requested_any': requested_any
         }
 
     @department_id_adapter

--- a/uber/templates/departments/requests.html
+++ b/uber/templates/departments/requests.html
@@ -41,9 +41,20 @@
 <h2>
   <span class="glyphicon glyphicon-cog"></span>
   Membership Requests for {{ department|form_link }}
+  {% if requested_any %}
+    <a class="btn btn-xs btn-plain" href="requests?department_id={{ department.id }}">
+  {% else %}
+    <a class="btn btn-xs btn-default" href="requests?department_id={{ department.id }}&requested_any=1">
+  {% endif %}
+      <span class="glyphicon glyphicon-filter"></span>
+      Include volunteers willing to help Anywhere
+    </a>
 </h2>
 
-{% if department.unassigned_requesting_attendees %}
+{%- set requesting_attendees = department.unassigned_requesting_attendees
+    if requested_any else department.unassigned_explicitly_requesting_attendees -%}
+
+{% if requesting_attendees %}
   <form method="post" action="requests" class="form-horizontal" role="form">
     {{ csrf_token() }}
     <input type="hidden" name="department_id" value="{{ department.id }}" />
@@ -61,7 +72,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for attendee in department.unassigned_requesting_attendees %}
+              {% for attendee in requesting_attendees %}
                 <tr>
                   <td>
                     <input type="checkbox" name="attendee_ids" value="{{ attendee.id }}">

--- a/uber/tests/models/test_attendee.py
+++ b/uber/tests/models/test_attendee.py
@@ -214,15 +214,15 @@ def test_requested_any_dept():
     dept1 = Department(name='Dept1', description='Dept1')
     dept2 = Department(name='Dept2', description='Dept2')
     volunteer = Attendee(paid=c.HAS_PAID, first_name='V', last_name='One')
-    volunteer.requested_any_dept = True
+    volunteer.dept_membership_requests = [
+        DeptMembershipRequest(attendee=volunteer)]
 
     with Session() as session:
         session.add_all([dept1, dept2, volunteer])
         session.commit()
-        session.refresh(dept1)
-        session.refresh(dept2)
-        assert dept1.all_requesting_attendees == [volunteer]
-        assert dept2.all_requesting_attendees == [volunteer]
+        session.refresh(volunteer)
+        all_depts = session.query(Department).order_by(Department.name).all()
+        assert all_depts == volunteer.requested_depts
 
 
 def test_must_contact():
@@ -356,12 +356,12 @@ class TestUnsetVolunteer:
             dept_roles=[trusted_role])
         a.assigned_depts = [dept]
         a.unset_volunteering()
-        assert not a.staffing \
-            and not a.has_role_somewhere \
-            and not a.requested_depts \
-            and not a.assigned_depts \
-            and not a.shifts \
-            and a.ribbon == ''
+        assert not a.staffing
+        assert not a.has_role_somewhere
+        assert not a.requested_depts
+        assert not a.assigned_depts
+        assert not a.shifts
+        assert a.ribbon == ''
 
     def test_different_ribbon(self):
         a = Attendee(ribbon=c.DEALER_RIBBON)


### PR DESCRIPTION
This pull request reverts the `requested_any_dept` boolean column in favor of using a nullable `department_id` column on the `dept_membership_request` table to indicate a request to help anywhere.

It turns out that a nullable `department_id` column results in far simpler and far more efficient SQL queries when we're trying to get all the unassigned attendees that want to volunteer for a department.

I don't feel bad about spending the time to try the other approach, because I wouldn't have known the technical pros/cons of both designs until trying them :smile: