### PR TITLE
Fixes #2823: Prevents duplicate badge num error with a _skip_badge_shift_on_delete flag

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -254,7 +254,8 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @predelete_adjustment
     def _shift_badges(self):
-        if self.badge_num:
+        is_skipped = getattr(self, '_skip_badge_shift_on_delete', False)
+        if self.badge_num and not is_skipped:
             self.session.shift_badges(
                 self.badge_type, self.badge_num + 1, down=True)
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -278,6 +278,7 @@ class Root:
                 if replacement_attendee.group and replacement_attendee.group.is_dealer:
                     replacement_attendee.ribbon = add_opt(replacement_attendee.ribbon_ints, c.DEALER_RIBBON)
                 session.add(replacement_attendee)
+                attendee._skip_badge_shift_on_delete = True
                 session.delete_from_group(attendee, attendee.group)
                 message = 'Attendee deleted, but this badge is still available to be assigned to someone else in the same group'
         else:

--- a/uber/tests/site_sections/test_registration.py
+++ b/uber/tests/site_sections/test_registration.py
@@ -1,0 +1,146 @@
+import re
+from datetime import datetime
+
+import cherrypy
+import pytest
+import six
+from uber.common import *
+from uber.site_sections import registration
+from uber.tests.conftest import admin_attendee, assert_unique, \
+    extract_message_from_html, GET, POST
+from uber.utils import CSRFException
+from uber.models import _attendee_validity_check
+
+
+next_week = datetime.utcnow().replace(tzinfo=pytz.UTC) + timedelta(days=7)
+
+
+@pytest.fixture(autouse=True)
+def patch_badge_printed_deadline(monkeypatch):
+    monkeypatch.setattr(c, 'PRINTED_BADGE_DEADLINE', next_week)
+
+
+@pytest.fixture
+def duplicate_badge_num_preconditions():
+    group_id = None
+    leader_id = None
+    with Session() as session:
+        leader = Attendee(
+            first_name='Fearless',
+            last_name='Leader',
+            email='fearless@example.com',
+            zip_code='21211',
+            ec_name='Nana Fearless',
+            ec_phone='555-555-1234',
+            cellphone='555-555-2345',
+            birthdate=date(1964, 12, 30),
+            registered=localized_now(),
+            paid=c.PAID_BY_GROUP,
+            ribbon='',
+            staffing=True,
+            badge_type=c.PSEUDO_GROUP_BADGE)
+
+        group = Group(name='Too Many Badges!')
+        group.attendees = [leader]
+        group.leader = leader
+        session.add(leader)
+        session.add(group)
+        assert session.assign_badges(
+            group,
+            15,
+            new_badge_type=c.STAFF_BADGE,
+            new_ribbon_type='',
+            paid=c.NEED_NOT_PAY) is None
+        session.flush()
+
+        group_id = group.id
+        leader_id = leader.id
+
+    with Session() as session:
+        console = Department(name='DEPT_01', description='DEPT_01')
+        leader = session.query(Attendee).get(leader_id)
+        leader.paid = c.NEED_NOT_PAY
+        leader.badge_printed_name = 'Fearmore'
+        leader.badge_type = c.STAFF_BADGE
+        leader.assigned_depts = [console]
+
+        group = session.query(Group).get(group_id)
+        group.auto_recalc = False
+
+    for i in range(10):
+        with Session() as session:
+            console = session.query(Department).filter_by(name='DEPT_01').one()
+            group = session.query(Group).get(group_id)
+
+            is_staff = (i < 9)
+            params = {
+                'first_name': 'Doubtful',
+                'last_name': 'Follower{}'.format(i),
+                'email': 'fearsome{}@example.com'.format(i),
+                'zip_code': '21211',
+                'ec_name': 'Nana Fearless',
+                'ec_phone': '555-555-1234',
+                'cellphone': '555-555-321{}'.format(i),
+                'birthdate': date(1964, 12, 30),
+                'registered': localized_now(),
+                'staffing': is_staff,
+                'badge_status': str(c.COMPLETED_STATUS),
+                'badge_printed_name': 'Fears{}'.format(i) if is_staff else '',
+                'assigned_depts': [console] if is_staff else ''}
+
+            attendee = group.unassigned[0]
+            attendee.apply(params, restricted=False)
+
+        with Session() as session:
+            group = session.query(Group).get(group_id)
+            badge_nums = [a.badge_num for a in group.attendees]
+            # SQLite doesn't support deferred constraints, so our test database
+            # doesn't actually have a unique constraint on the badge_num
+            # column. So we have to manually check for duplicate badge numbers.
+            assert_unique(badge_nums)
+
+    yield group_id
+
+    with Session() as session:
+        session.query(Group).filter(Group.id == group_id).delete(
+            synchronize_session=False)
+
+
+class TestRegisterGroupMember(object):
+
+    def _delete_response(self, **params):
+        _attendee_validity_check()
+        with pytest.raises(HTTPRedirect) as excinfo:
+            registration.Root().delete(**params)
+
+        redirect = excinfo.value
+        assert isinstance(redirect, HTTPRedirect)
+        assert 303 == redirect.status
+        assert 'message=Attendee%20deleted' in redirect.urls[0]
+
+        return redirect
+
+    def test_delete_duplicate_badge_num(
+            self,
+            POST,
+            csrf_token,
+            admin_attendee,
+            duplicate_badge_num_preconditions):
+
+        attendee_id = None
+        with Session() as session:
+            group = session.query(Group).get(duplicate_badge_num_preconditions)
+            for attendee in sorted(group.attendees, key=lambda a: a.badge_num or six.MAXSIZE):
+                if attendee.id != group.leader.id:
+                    attendee_id = attendee.id
+                    break
+
+        response = self._delete_response(id=attendee_id, csrf_token=csrf_token)
+
+        with Session() as session:
+            group = session.query(Group).get(duplicate_badge_num_preconditions)
+            badge_nums = [a.badge_num for a in group.attendees]
+            # SQLite doesn't support deferred constraints, so our test database
+            # doesn't actually have a unique constraint on the badge_num
+            # column. So we have to manually check for duplicate badge numbers.
+            assert_unique(badge_nums)


### PR DESCRIPTION
Added a test to reproduce the bug, and a `_skip_badge_shift_on_delete` flag as described in the comments here: https://github.com/magfest/ubersystem/issues/2823#issuecomment-341485619.

The fix is super short (2 added lines, 1 modified line). Although, I am happy to consider alternative solutions 😄 