### PR TITLE
Allows staffers to change their printed badge name up until c.PRINTED_BADGE_DEADLINE

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -146,6 +146,9 @@ class Config(_Overridable):
         return c.PRINTED_BADGE_DEADLINE if badge_type in c.PREASSIGNED_BADGE_TYPES \
             else max(c.PRINTED_BADGE_DEADLINE, c.SUPPORTER_BADGE_DEADLINE)
 
+    def after_printed_badge_deadline_by_type(self, badge_type):
+        return sa.localized_now() > self.get_printed_badge_deadline_by_type(badge_type)
+
     @property
     def DEALER_REG_OPEN(self):
         return self.AFTER_DEALER_REG_START and self.BEFORE_DEALER_REG_SHUTDOWN

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -297,10 +297,7 @@
         {% endif %}
     {% endif %}
 
-{%- set readonly_badge_name =
-    (c.AFTER_PRINTED_BADGE_DEADLINE and attendee.badge_type in c.PREASSIGNED_BADGE_TYPES)
-    or (c.AFTER_SUPPORTER_DEADLINE and attendee.badge_type not in c.PREASSIGNED_BADGE_TYPES) -%}
-
+{%- set readonly_badge_name = c.after_printed_badge_deadline_by_type(attendee.badge_type) -%}
 <div class="badge-row extra-row form-group" style="display:none">
     <label for="badge_printed_name" class="col-sm-3 control-label optional-field">Name Printed on Badge</label>
     <div class="col-sm-6">

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -297,15 +297,19 @@
         {% endif %}
     {% endif %}
 
+{%- set readonly_badge_name =
+    (c.AFTER_PRINTED_BADGE_DEADLINE and attendee.badge_type in c.PREASSIGNED_BADGE_TYPES)
+    or (c.AFTER_SUPPORTER_DEADLINE and attendee.badge_type not in c.PREASSIGNED_BADGE_TYPES) -%}
+
 <div class="badge-row extra-row form-group" style="display:none">
     <label for="badge_printed_name" class="col-sm-3 control-label optional-field">Name Printed on Badge</label>
     <div class="col-sm-6">
-        <input type="text" class="form-control" name="badge_printed_name" maxlength="20" value="{{ attendee.badge_printed_name }}" {% if c.AFTER_PRINTED_BADGE_DEADLINE and attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or c.AFTER_SUPPORTER_DEADLINE %}readonly{% endif %} />
+        <input type="text" class="form-control" name="badge_printed_name" maxlength="20" value="{{ attendee.badge_printed_name }}" {% if readonly_badge_name %}readonly{% endif %} />
     </div>
     <p class="help-block col-sm-offset-3 col-sm-9">Badge names have a maximum of 20 characters.</p>
 </div>
 
-{% if c.AFTER_PRINTED_BADGE_DEADLINE and attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or c.AFTER_SUPPORTER_DEADLINE %}
+{% if readonly_badge_name %}
     <div class="badge-row extra-row form-group" style="display:none">
         <p class="help-block col-sm-6 col-sm-offset-3">(custom badges have already been ordered, so you can no longer set this)</p>
     </div>


### PR DESCRIPTION
The issue here is that `c.AFTER_SUPPORTER_DEADLINE` has already elapsed, so staffers could no longer change their printed badge name. We want to allow them to change their printed badge name up until `c.PRINTED_BADGE_DEADLINE`.