### PR TITLE
Fixes error when unsetting volunteer that has been assigned dept roles

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -401,7 +401,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         self.staffing = False
         self.dept_membership_requests = []
         self.requested_depts = []
-        self.assigned_depts = []
+        self.dept_memberships = []
         self.ribbon = remove_opt(self.ribbon_ints, c.VOLUNTEER_RIBBON)
         if self.badge_type == c.STAFF_BADGE:
             self.badge_type = c.ATTENDEE_BADGE


### PR DESCRIPTION
Fixes the following error:
```
   Traceback (most recent call last):
      File "/usr/local/uber/env/lib/python3.4/site-packages/sqlalchemy/engine/base.py", line 1182, in _execute_context
        context)
      File "/usr/local/uber/env/lib/python3.4/site-packages/sqlalchemy/engine/default.py", line 470, in do_execute
        cursor.execute(statement, parameters)
    psycopg2.IntegrityError: update or delete on table "dept_membership" violates foreign key constraint "fk_dept_membership_dept_role_dept_membership_id_dept_membership" on table "dept_membership_dept_role"
    DETAIL:  Key (id)=(5b47f323-0dbe-5e05-afce-fab3af21e3c9) is still referenced from table "dept_membership_dept_role".
```