### PR TITLE
fix some/all CSRF token errors

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -362,6 +362,7 @@ class Config(_Overridable):
 
     @property
     def CSRF_TOKEN(self):
+        uber.utils.ensure_csrf_token_exists()
         return cherrypy.session['csrf_token'] if 'csrf_token' in cherrypy.session else ''
 
     @property

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -423,8 +423,7 @@ def normalize_newlines(text):
 
 @JinjaEnv.jinja_export
 def csrf_token():
-    if not cherrypy.session.get('csrf_token'):
-        cherrypy.session['csrf_token'] = uuid4().hex
+    ensure_csrf_token_exists()
     return safe_string('<input type="hidden" name="csrf_token" value="{}" />'.format(cherrypy.session["csrf_token"]))
 
 

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -83,7 +83,7 @@ class Root:
 
             if not message:
                 cherrypy.session['account_id'] = account.id
-                cherrypy.session['csrf_token'] = uuid4().hex
+                ensure_csrf_token_exists()
                 raise HTTPRedirect(original_location)
 
         return {

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -131,7 +131,7 @@ class Root:
                 message = 'No attendee matches that name and email address and zip code'
 
             if not message:
-                cherrypy.session['csrf_token'] = uuid4().hex
+                ensure_csrf_token_exists()
                 cherrypy.session['staffer_id'] = attendee.id
                 raise HTTPRedirect(original_location)
 

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -108,13 +108,23 @@ def check_csrf(csrf_token):
     """
     if csrf_token is None:
         csrf_token = cherrypy.request.headers.get('CSRF-Token')
+
     if not csrf_token:
         raise CSRFException("CSRF token missing")
+
     if csrf_token != cherrypy.session['csrf_token']:
-        log.error("csrf tokens don't match: {!r} != {!r}", csrf_token, cherrypy.session['csrf_token'])
-        raise CSRFException('CSRF check failed')
+        raise CSRFException("CSRF check failed: csrf tokens don't match: {!r} != {!r}"
+                            .format(csrf_token, cherrypy.session['csrf_token']))
     else:
         cherrypy.request.headers['CSRF-Token'] = csrf_token
+
+
+def ensure_csrf_token_exists():
+    """
+    Generate a new CSRF token if none exists in our session already.
+    """
+    if not cherrypy.session.get('csrf_token'):
+        cherrypy.session['csrf_token'] = uuid4().hex
 
 
 def check(model, *, prereg=False):


### PR DESCRIPTION
- in certain multiple login situations, we were overwriting CSRF tokens
- if you were to go back to other tabs or forms, these would have
  caused our CSRF trips to incorrectly tripped
- now we generate the token one time per-session and never overwrite it
- fixes #2934 for certain

I think this might really fix pretty much all of the sporadic CSRF errors we see, more discussion to come in #2919 

#2934 has all the details on why this PR does what it does