### PR TITLE
refactor verbose logging

### DIFF
--- a/uber/server.py
+++ b/uber/server.py
@@ -11,12 +11,14 @@ def _add_email():
 cherrypy.tools.add_email_to_error_page = cherrypy.Tool('after_error_response', _add_email)
 
 
-def log_exception_with_verbose_context(debug=False, msg=''):
+def get_verbose_request_context():
     """
-    Write the request headers, session params, page location, and the last error's traceback to the cherrypy error log.
-    Do this all one line so all the information can be collected by external log collectors and easily displayed.
-    """
+    Return a string with lots of information about the current cherrypy request such as
+    request headers, session params, and page location.
 
+    Returns:
+
+    """
     page_location = 'Request: ' + cherrypy.request.request_line
 
     admin_name = AdminAccount.admin_name()
@@ -32,8 +34,22 @@ def log_exception_with_verbose_context(debug=False, msg=''):
     h = ["  %s: %s" % (k, v) for k, v in cherrypy.request.header_list]
     headers_txt = 'Request Headers:\n' + '\n'.join(h)
 
-    full_msg = '\n'.join([msg, 'Exception encountered', page_location, admin_txt, post_txt, session_txt, headers_txt])
-    log.error(full_msg, exc_info=True)
+    return '\n'.join([page_location, admin_txt, post_txt, session_txt, headers_txt])
+
+
+def log_with_verbose_context(msg, exc_info=False):
+    full_msg = '\n'.join([msg, get_verbose_request_context()])
+    log.error(full_msg, exc_info=exc_info)
+
+
+def log_exception_with_verbose_context(debug=False, msg=''):
+    """
+    Write the request headers, session params, page location, and the last error's traceback to the cherrypy error log.
+    Do this all one line so all the information can be collected by external log collectors and easily displayed.
+    """
+    log_with_verbose_context('\n'.join([msg, 'Exception encountered']), exc_info=True)
+
+
 cherrypy.tools.custom_verbose_logger = cherrypy.Tool('before_error_response', log_exception_with_verbose_context)
 
 


### PR DESCRIPTION
Add new get_verbose_request_context() and log_with_verbose_context(msg)

These allow you to obtain detailed info about the executing request without needing to be in an exception

This is super-useful for armor'ing up chunks of code with as much info about the request/context as possible, without having to be in the context of an exception handler.

(Was originally using this for the CSRF fixing but turned out not to be necessary)

Prints out stuff like:

```Request: POST /uber/registration/form HTTP/1.0
Current admin user is: Test Developer
Request Params:
  group_opt: 
  assigned_depts_ids: ['', 'ce643801-b1dd-4116-aff5-7eab3ed3eb99']
  save: save
  found_how: 
  first_name: Test
  last_name: Developer
  got_merch: 0
  csrf_token: 8423de5e2e8e4b50b6a50353a1964520
  requested_hotel_info: 0
  extra_donation: 
  birthdate: 1978-12-31
  requested_depts_ids: 
  email: magfest@example.co
  extra_merch: 
  cellphone: 1231231235
  badge_printed_name: testbro
  ec_name: 123123
  zip_code: 87383
  badge_type: 16863825
  staffing: 1
  amount_paid: 0
  id: a643e1b1-9406-4e59-bc18-0cd2e06b5d10
  for_review: 
  shirt: 0
  amount_extra: 0
  amount_refunded: 0
  regdesk_info: 
  paid: 231980499
  return_to: 
  comments: 
  ec_phone: 1231231234
  overridden_price: 0
  same_legal_name: 1
  legal_name: 
  admin_notes: 
  badge_status: 215389669
Session Params:
dict_items([('csrf_token', '8423de5e2e8e4b50b6a50353a1964520'), ('staffer_id', 'a643e1b1-9406-4e59-bc18-0cd2e06b5d10'), ('account_id', '57201f59-7ed6-43c0-b0d0-f9d4fd2a4ade'), ('unpaid_preregs', OrderedDict())])
Request Headers:
  Content-Type: application/x-www-form-urlencoded
  X-FORWARDED-FOR: 10.0.2.2
  Content-Length: 692
  ACCEPT: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
  REFERER: https://localhost:4443/uber/registration/form?id=a643e1b1-9406-4e59-bc18-0cd2e06b5d10
  X-FORWARDED-PROTO: https
  X-REAL-IP: 10.0.2.2
  Remote-Addr: 127.0.0.1
  COOKIE: session_id=4948d7ab019e267e145e4358d64274e45cdb9257
  UPGRADE-INSECURE-REQUESTS: 1
  ACCEPT-ENCODING: gzip, deflate, br
  USER-AGENT: Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36
  CACHE-CONTROL: max-age=0
  HOST: localhost
  X-FORWARDED-HOST: localhost:4443
  ORIGIN: https://localhost:4443
  CONNECTION: close
  ACCEPT-LANGUAGE: en-US,en;q=0.8```