### PR TITLE
Fixes department list for dept checklist emails

### DIFF
--- a/uber/templates/emails/shifts/dept_checklist.txt
+++ b/uber/templates/emails/shifts/dept_checklist.txt
@@ -1,6 +1,6 @@
 {{ attendee.first_name }},
 
-As a department head for {{ attendee.assigned_depts_labels|join('') }} we need some information from you about: {{ conf.name|safe }}
+As a department head for {{ attendee.assigned_depts_labels|comma_and }} we need some information from you about: {{ conf.name|safe }}
 
 {{ conf.description|safe }}
 


### PR DESCRIPTION
Now looks like:
> As a department head for Arcade, Arcade_Crew, Attendee Services, Autographs, and Music we need some information from you about

Instead of:
> As a department head for ArcadeArcade_CrewAttendee ServicesAutographsMusic we need some information from you about