### PR TITLE
fix error when exception handler context code deals with attachments

### DIFF
--- a/uber/server.py
+++ b/uber/server.py
@@ -26,7 +26,7 @@ def get_verbose_request_context():
 
     max_reporting_length = 1000   # truncate to reasonably large size in case they uploaded attachments
 
-    p = ["  %s: %s" % (k, v[:max_reporting_length]) for k, v in cherrypy.request.params.items()]
+    p = ["  %s: %s" % (k, str(v)[:max_reporting_length]) for k, v in cherrypy.request.params.items()]
     post_txt = 'Request Params:\n' + '\n'.join(p)
 
     session_txt = 'Session Params:\n' + pformat(cherrypy.session.items(), width=40)

--- a/uber/tests/test_exception_handler.py
+++ b/uber/tests/test_exception_handler.py
@@ -1,0 +1,34 @@
+from uber import config
+from uber.tests import *
+from cherrypy._cpreqbody import Part
+
+
+class MockPart(Part):
+    # fake a cherrypy attachment, make it able to create without constructor
+    def __init__(self):
+        pass
+
+
+class TestExceptionHandler:
+    @pytest.fixture(autouse=True)
+    def setup_cherrypy_fake_env(self, monkeypatch):
+        monkeypatch.setattr(AdminAccount, 'admin_name', Mock(return_value='Bruce'))
+        monkeypatch.setattr(cherrypy.request, 'request_line', "/uber/location3/hello")
+        monkeypatch.setattr(cherrypy.request, 'params', {
+            'id': '32',
+            'action': 'reload',
+            'thing': 3,                 # use a non-string
+            'attachment': MockPart(),   # add fake attachment based on cherrypy's Part() class, make sure we handle OK
+        })
+        monkeypatch.setattr(cherrypy, 'session', {'session_id': '762876'})
+        headers = [
+            ('Content-Type', 'text/html'),
+            ('Server', 'Null CherryPy'),
+            ('Date', localized_now()),
+            ('Content-Length', '80'),
+        ]
+        monkeypatch.setattr(cherrypy.request, 'header_list', headers)
+
+    def test_exception_handler(self):
+        for expected in ['Request', 'text/html', 'reload', 'Bruce', 'session_id', 'Content-Length']:
+            assert expected in server.get_verbose_request_context()


### PR DESCRIPTION
- convert everything to String type first before doing anything with
- this works fine even with objects that don't convert to string
- will return something like ''<object Part at &ffffff>'
- add some unit tests and mock data to armor this up some more

fixes #2945 

this is tested well in unit tests, but I couldn't run it locally due to an issue with running the DB migrations locally.  should be OK as the unit tests now run this code OK, but, maybe worth a quick test after deploying.

Rob, merge whenever you like