### PR TITLE
provide more accurate error handling in email thread

### DIFF
--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -87,8 +87,8 @@ class AutomatedEmail:
 
         Do any error handling in the client functions we call
         """
-        if self._should_send(model_inst):
-            self.really_send(model_inst)
+        if self._should_send(model_inst, raise_errors=raise_errors):
+            self.really_send(model_inst, raise_errors=raise_errors)
 
     def _should_send(self, model_inst, raise_errors=False):
         """


### PR DESCRIPTION
- would say 'error while sending email' when it really means
  'error while either determining if to send this email or sending it'
- separated these two error states out (so, say, we don't freak people out thinking uber is trying to send thousands of emails when our error handler freaks out and spams us for a while during a deploy)

This one I couldn't test at all due to DB migrations stuff on local box that I'm fixing.  definitely worth a run locally to make sure it's OK before merging.