### PR TITLE
send pending email report to individual departments

### DIFF
--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -354,9 +354,26 @@ def notify_admins_of_any_pending_emails():
     if not pending_email_categories:
         return
 
+    for sender, email_categories in pending_email_categories.items():
+        include_all_categories = sender == c.STAFF_EMAIL
+        included_categories = pending_email_categories
+
+        if not include_all_categories:
+            included_categories = {
+                c_sender: categories for c_sender, categories in pending_email_categories.items() if c_sender == sender
+            }
+
+        send_pending_email_report(included_categories, sender)
+
+
+def send_pending_email_report(pending_email_categories, sender):
+    rendering_data = {
+        'pending_email_categories': pending_email_categories,
+        'primary_sender': sender,
+    }
     subject = c.EVENT_NAME + ' Pending Emails Report for ' + localized_now().strftime('%Y-%m-%d')
-    body = render('emails/daily_checks/pending_emails.html', {'pending_email_categories': pending_email_categories})
-    send_email(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
+    body = render('emails/daily_checks/pending_emails.html', rendering_data)
+    send_email(c.STAFF_EMAIL, sender, subject, body, format='html', model='n/a')
 
 
 # 86400 seconds = 1 day = 24 hours * 60 minutes * 60 seconds
@@ -367,7 +384,7 @@ def get_pending_email_data():
     """
     Generate a list of emails which are ready to send, but need approval.
 
-    Returns: A dict of email idents -> pending counts for any email category with pending emails,
+    Returns: A dict of senders -> email idents -> pending counts for any email category with pending emails,
     or None if none are waiting to send or the email daemon service has not finished any runs yet.
     """
     has_email_daemon_run_yet = SendAllAutomatedEmailsJob.last_result.get('completed', False)
@@ -378,21 +395,24 @@ def get_pending_email_data():
     if not categories_results:
         return None
 
-    pending_emails = dict()
+    pending_emails_by_sender = defaultdict(dict)
 
     for automated_email in AutomatedEmail.instances.values():
-        category_results = categories_results.get(automated_email.ident, None)
+        sender = automated_email.sender
+        ident = automated_email.ident
+
+        category_results = categories_results.get(ident, None)
         if not category_results:
             continue
 
         unsent_because_unapproved_count = category_results.get('unsent_because_unapproved', 0)
-
         if unsent_because_unapproved_count <= 0:
             continue
 
-        pending_emails[automated_email.ident] = {
+        pending_emails_by_sender[sender][ident] = {
             'num_unsent': unsent_because_unapproved_count,
             'subject': automated_email.subject,
+            'sender': automated_email.sender,
         }
 
-    return pending_emails
+    return pending_emails_by_sender

--- a/uber/templates/emails/daily_checks/pending_emails.html
+++ b/uber/templates/emails/daily_checks/pending_emails.html
@@ -1,17 +1,28 @@
 <html>
 <head></head>
 <body>
-    <h3>{{ c.EVENT_NAME_AND_YEAR }}<br/> Emails that need approval to send:</h3>
+    <h3>{{ c.EVENT_NAME_AND_YEAR }}<br/> Emails that need approval to send on behalf of {{ primary_sender }}:</h3>
 
-    <p>The following email categories are ready to send, but still require manual approval by admins.
-        Please visit the <a href="{{ c.URL_BASE }}/emails/pending">pending email approval page</a>
-        if you would like to approve any of these.</p>
+    <p>
+        The following email categories are ready to send, but still require manual approval of their content by admins.
+        Please visit the <a href="{{ c.URL_BASE }}/emails/pending">pending email approval page</a> to approve these
+        as soon as possible.  The purpose of the approval process is to make sure departments have control over the
+        text content and the timing of emails.
+    </p>
 
     <ul style="margin-top:0px ; margin-bottom:10px">
-    {% for pending_email_ident, pending_email_category_info in pending_email_categories.items() %}
-        <li>
-            {{ pending_email_category_info.num_unsent }} pending: <b>{{ pending_email_category_info.subject }}</b>
-            [<a href="{{ c.URL_BASE }}/emails/pending_examples?ident={{ pending_email_ident }}">view examples</a>]
+    {% for sender, categories in pending_email_categories.items() %}
+        <li><b>From {{ sender }}</b>:
+        <ul style="margin-top:0px ; margin-bottom:10px">
+
+            {% for ident, category in categories.items() %}
+                <li>
+                    {{ category.num_unsent }} pending: <b>{{ category.subject }}</b>
+                    [<a href="{{ c.URL_BASE }}/emails/pending_examples?ident={{ ident }}">view examples</a>]
+                </li>
+            {% endfor %}
+
+        </ul>
         </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
We were originally sending this report just to STOPs, which is fine but individual departments are currently unaware that they have pending emails on behalf of their department.

Now, in addition to sending to STOPs, we send a subset of the report the sending email address of the email category. (i.e. we send music@magfest.org info about the music dept's pending emails that need approval)

For the STOPs report, we now group by sender to make it easier to read.

Fixes #2623 for real, phase 2.  Thanks @kitsuta for the great idea to do this, sorry it took a while to get around to :)

Here's an example of the email that would be sent to STOPs which includes all categories, grouped by sender:
![image](https://user-images.githubusercontent.com/5413064/33152959-6c941952-cfad-11e7-899f-78f8553ba096.png)

Here's an example of the smaller report sent to just one deparment (like music, guests, etc)
![image](https://user-images.githubusercontent.com/5413064/33152981-87b340fa-cfad-11e7-8b41-676dd23bfff6.png)