### PR TITLE
[WIP] use schedule module for better / serialized scheduling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ treepoem==1.0.1
 email_validator==1.0.2
 phonenumbers==8.8.1
 XlsxWriter==1.0.2
+schedule==0.5.0

--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -359,7 +359,10 @@ def notify_admins_of_any_pending_emails():
     send_email(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
 
 
-uber.scheduler.schedule.every().day.at("06:00").do(notify_admins_of_any_pending_emails)
+uber.scheduler.register_task(
+    fn=lambda: uber.scheduler.schedule.every().day.at("06:00").do(notify_admins_of_any_pending_emails),
+    category="reports"
+)
 
 
 def get_pending_email_data():
@@ -395,3 +398,14 @@ def get_pending_email_data():
         }
 
     return pending_emails
+
+
+uber.scheduler.register_task(
+    lambda: uber.scheduler.schedule.every(5).minutes.do(SendAllAutomatedEmailsJob.send_all_emails),
+    category="automated_email_sending",
+)
+
+
+@entry_point
+def start_email_sending_daemon():
+    uber.scheduler.start_scheduler_and_block(include_categories="automated_email_sending")

--- a/uber/automated_emails_server.py
+++ b/uber/automated_emails_server.py
@@ -1,4 +1,5 @@
 from uber.common import *
+import uber.scheduler
 
 
 class AutomatedEmail:
@@ -197,7 +198,6 @@ class SendAllAutomatedEmailsJob:
         """ Helper method to start a run of our automated email processing """
         cls().run(raise_errors)
 
-    @timed
     def run(self, raise_errors=False):
         """
         Do one run of our automated email service.  Call this periodically to send any emails that should go out
@@ -359,8 +359,7 @@ def notify_admins_of_any_pending_emails():
     send_email(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
 
 
-# 86400 seconds = 1 day = 24 hours * 60 minutes * 60 seconds
-DaemonTask(notify_admins_of_any_pending_emails, interval=86400, name="mail pending notification")
+uber.scheduler.schedule.every().day.at("06:00").do(notify_admins_of_any_pending_emails)
 
 
 def get_pending_email_data():

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -17,7 +17,7 @@ def swallow_exceptions(func):
         try:
             return func(*args, **kwargs)
         except:
-            log.error("Exception raised, but we're going to ignore it and continue.", exc_info=True)
+            log.error("unexpected error", exc_info=True)
     return swallow_exception
 
 

--- a/uber/scheduler.py
+++ b/uber/scheduler.py
@@ -1,8 +1,15 @@
-from sideboard.lib import DaemonTask
+from sideboard.lib import DaemonTask, on_startup
 from uber.decorators import timed, swallow_exceptions
 from datetime import datetime
 import time
 import schedule
+from collections import defaultdict
+
+# don't start the email sending in the main thread. everything else is cool.
+# NOTE: only applies to cherrypy process ONLY, doesn't apply when started via 'sep' or other processes.
+# uncomment this if you want to do email sending in its own process
+# _default_cherrypy_exclude_categories = ["automated_email_sending"]
+_default_cherrypy_exclude_categories = None
 
 
 class UberSchedulerJob(schedule.Job):
@@ -15,7 +22,7 @@ class UberSchedulerJob(schedule.Job):
 
 class UberScheduler(schedule.Scheduler):
     def every(self, interval=1):
-        # use our custom jobs class
+        # use our custom jobs class so we can override do()
         job = UberSchedulerJob(interval, self)
         return job
 
@@ -37,17 +44,83 @@ class TimePassed:
 _startup_time = TimePassed(2)
 
 
+def schedule_N_times_per_day(times_per_day, fn, *args, **kwargs):
+    # slightly hacky.
+    # issue: what we want to say something like "run these every 6 hours starting at midnight"
+    # schedule module only supports saying "run every 6 hours from server startup" so the scheduling
+    # is dependent on the server runtime, and the schedule isn't consistent based on server start time.
+    #
+    # work around this by creating multiple copies of the same task, scheduled for different times.
+    # CAUTION: if tasks are extremely long-running (more than 1 hour each), they can overlap each other
+
+    hourly_interval = divmod(24, times_per_day)
+    assert hourly_interval[1] == 0, "times_per_day must be evenly divisble by 24 hours"
+    hourly_interval = hourly_interval[0]
+
+    for hour in range(0,24,int(24/times_per_day)):
+        assert 0 <= hour < 24
+        _time = "{:02d}:00".format(hour)
+        schedule.every().day.at(_time).do(fn, *args, **kwargs)
+
+
 def run_pending_tasks():
     # we wait a couple minutes after system startup to allow any scheduled tasks to run
-    # this is because starting up is CPU intensive and we want the web interface to be responsiv first
-    global _startup_time
-    if not _startup_time.enough_time_passed():
+    # this is because starting up is CPU intensive and we want the web interface to be responsive first
+    global _startup_time, _started_from_cherrypy
+    if _started_from_cherrypy and not _startup_time.enough_time_passed():
         return
 
     schedule.run_pending()
     time.sleep(1)
 
 
-DaemonTask(run_pending_tasks, interval=1, name="scheduled tasks")
+_task_registrations = defaultdict(list)
+_scheduler_daemon = None
+_started_from_cherrypy = False
+
+@on_startup
+def scheduler_on_cherrypy_startup():
+    global _started_from_cherrypy
+    _started_from_cherrypy = True
+    _start_scheduler(exclude_categories=_default_cherrypy_exclude_categories)
+
+
+def register_task(fn, category):
+    _task_registrations[category].append(fn)
+
+
+def start_scheduler_and_block(include_categories=None, exclude_categories=None):
+    """
+    Starts up the scheduler thread and blocks until its finished running.
+    Don't use from Cherrypy, only use when starting scheduler from another process
+    """
+    _start_scheduler(include_categories, exclude_categories)
+    while _scheduler_daemon.running:
+        time.sleep(1)
+
+
+def _start_scheduler(include_categories=None, exclude_categories=None):
+    """
+    Args:
+        include_categories: If not None, then only schedule tasks that match these categories
+        exclude_categories: List of schedule task categories to exclude
+
+    Returns:
+
+    """
+    global _scheduler_daemon
+    assert not _scheduler_daemon
+
+    for category, register_fns in _task_registrations.items():
+        if all([
+            include_categories is None or category in include_categories,
+            exclude_categories is None or category not in exclude_categories
+        ]):
+            for register_fn in register_fns:
+                register_fn()
+
+    _scheduler_daemon = DaemonTask(run_pending_tasks, interval=1, name="scheduled tasks")
+    _scheduler_daemon.start()  # not needed if called after cherrypy startup event. needed if called before that.
+
 
 

--- a/uber/scheduler.py
+++ b/uber/scheduler.py
@@ -1,0 +1,53 @@
+from sideboard.lib import DaemonTask
+from uber.decorators import timed, swallow_exceptions
+from datetime import datetime
+import time
+import schedule
+
+
+class UberSchedulerJob(schedule.Job):
+    def do(self, job_func, *args, **kwargs):
+        # our scheduler needs to not let individual tasks throw exceptions, so wrap it here
+        wrapped_fn = timed(swallow_exceptions(job_func))
+
+        return super().do(wrapped_fn, *args, **kwargs)
+
+
+class UberScheduler(schedule.Scheduler):
+    def every(self, interval=1):
+        # use our custom jobs class
+        job = UberSchedulerJob(interval, self)
+        return job
+
+
+schedule.default_scheduler = UberScheduler()
+
+
+class TimePassed:
+    def __init__(self, minutes_to_wait):
+        assert minutes_to_wait > 0
+        self.minutes_to_wait = minutes_to_wait
+        self.create_time = datetime.utcnow()
+
+    def enough_time_passed(self):
+        assert self.create_time
+        return (datetime.utcnow() - self.create_time).seconds > self.minutes_to_wait*60
+
+
+_startup_time = TimePassed(2)
+
+
+def run_pending_tasks():
+    # we wait a couple minutes after system startup to allow any scheduled tasks to run
+    # this is because starting up is CPU intensive and we want the web interface to be responsiv first
+    global _startup_time
+    if not _startup_time.enough_time_passed():
+        return
+
+    schedule.run_pending()
+    time.sleep(1)
+
+
+DaemonTask(run_pending_tasks, interval=1, name="scheduled tasks")
+
+

--- a/uber/server.py
+++ b/uber/server.py
@@ -146,14 +146,25 @@ def register_jsonrpc(service, name=None):
     assert name not in jsonrpc_services, '{} has already been registered'.format(name)
     jsonrpc_services[name] = service
 
+
 jsonrpc_handler = _make_jsonrpc_handler(jsonrpc_services, precall=jsonrpc_reset)
 cherrypy.tree.mount(jsonrpc_handler, join(c.PATH, 'jsonrpc'), c.APPCONF)
 
-
-uber.scheduler.schedule.every(6).hours.do(check_unassigned)
-uber.scheduler.schedule.every(6).hours.do(detect_duplicates)
-uber.scheduler.schedule.every(6).hours.do(check_placeholders)
-uber.scheduler.schedule.every(5).minutes.do(SendAllAutomatedEmailsJob.send_all_emails)
+uber.scheduler.register_task(
+    lambda: uber.scheduler.schedule_N_times_per_day(4, check_unassigned),
+    category="reports"
+)
+uber.scheduler.register_task(
+    lambda: uber.scheduler.schedule_N_times_per_day(4, detect_duplicates),
+    category="reports"
+)
+uber.scheduler.register_task(
+    lambda: uber.scheduler.schedule_N_times_per_day(4, check_placeholders),
+    category="reports"
+)
 
 # enable debug logging if you need it for desperate situations
-# uber.scheduler.schedule.every(5).minutes.do(lambda: log.error(Session.engine.pool.status()))
+# uber.scheduler.register_task(
+#     lambda: uber.scheduler.schedule.every(5).minutes.do(lambda: log.error(Session.engine.pool.status())),
+#     category="debug",
+# )


### PR DESCRIPTION
- replace our current system of kicking off tons of threads for each job with schedule module
- this is fully functional but probably needs a little more iteration before merging
- allows certain reports to happen at certain times of day vs every 24hrs

Don't merge just yet.  This PR is fully functional and works fine, but, could probably use a few tweaks.

The big win of this is instead of saying 'run a report every 24 hours' which requires no deploys and the system to run continuously for 24hrs, you can now do stuff like:

```
uber.scheduler.schedule.every().day.at("06:00").do(notify_admins_of_any_pending_emails)
```

TODO:
- all tasks are now serial, but the email sending stuff should probably still kick out its own thread
- would be cool to have more refined control over certain things like instead of "run every 6hrs" we say instead "run at these specific 3 times per day" so if the server restarts, the time is still consistent.