### PR TITLE
Fixes missing libcap development headers on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ matrix:
       env: TOX_ENV=pep8
     - python: "3.4"
       env: TOX_ENV=py34
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y build-essential libcap-dev
 install:
   - pip install tox
   - if [[ $TOX_ENV == py34 ]]; then


### PR DESCRIPTION
The `prctl` library added in this [pull request](https://github.com/magfest/sideboard/pull/93) requires new dependencies in each of our `.travis.yml` files to get the builds working again.