### PR TITLE
Fixes template tests

### DIFF
--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -27,7 +27,7 @@
   {% if label %}
     <label
         class="checkbox-label{% if label_class %} {{ label_class }}{% endif %}{% if is_readonly %} disabled{% endif %}"
-        {% if title %}title="{{ title }}"{% endif %}>
+        {% if title %} title="{{ title }}"{% endif %}>
   {% endif %}
   {% if is_readonly %}
     <input
@@ -39,18 +39,18 @@
         type="checkbox"
         value="1"
         disabled
-        {% if not label and title %}title="{{ title }}"{% endif %}
-        {% if is_checked %}checked{% endif %} />
+        {% if not label and title %} title="{{ title }}"{% endif %}
+        {% if is_checked %} checked{% endif %} />
   {% else %}
     <input
         type="checkbox"
         name="{{ field_name }}"
         id="{% if id %}{{ id }}{% else %}{{ field_name }}{% endif %}"
         value="1"
-        {% if not label and title %}title="{{ title }}"{% endif %}
-        {% if is_checked %}checked{% endif %} />
+        {% if not label and title %} title="{{ title }}"{% endif %}
+        {% if is_checked %} checked{% endif %} />
   {% endif %}
-  {% if label %}{{ label }}</label>{% endif %}
+  {% if label %} {{ label }}</label>{% endif %}
 {%- endmacro %}
 
 
@@ -185,18 +185,18 @@
               name="{{ field }}{{ suffix }}"
               rows="4"
               placeholder="{{ placeholder }}"
-              {% if is_required %}required="required"{% endif %}
-              {% if is_focused %}autofocus{% endif %}>{{ '' if is_class else model[field] }}</textarea>
+              {% if is_required %} required="required"{% endif %}
+              {% if is_focused %} autofocus{% endif %}>{{ '' if is_class else model[field] }}</textarea>
         {%- else -%}
           <input
                   class="form-control"
                   type="{{ type }}"
                   name="{{ field }}{{ suffix }}"
-                  {% if id %}id="{{ id }}"{% endif %}
+                  {% if id %} id="{{ id }}"{% endif %}
                   value="{{ '' if is_class else model[field] }}"
                   placeholder="{{ placeholder }}"
-                  {% if is_required %}required="required"{% endif %}
-                  {% if is_focused %}autofocus{% endif %}/>
+                  {% if is_required %} required="required"{% endif %}
+                  {% if is_focused %} autofocus{% endif %}/>
         {%- endif -%}
         {%- if is_admin and has_value -%}
           {%- if type == 'email' -%}

--- a/uber/templates/preregistration/stripeForm.html
+++ b/uber/templates/preregistration/stripeForm.html
@@ -4,8 +4,8 @@
     <script
         src="https://checkout.stripe.com/v2/checkout.js" class="stripe-button"
         data-key="{{ c.STRIPE_PUBLIC_KEY }}"
-        {% if email %}data-email="{{ email }}"{% endif %}
-        {% if c.DEV_BOX %}data-bitcoin="true" {% endif %}
+        {% if email %} data-email="{{ email }}"{% endif %}
+        {% if c.DEV_BOX %} data-bitcoin="true" {% endif %}
         data-zip-code="true"
         data-allow-remember-me="false"
         data-amount="{{ charge.amount }}"

--- a/uber/templates/summary/food_eligible.xml
+++ b/uber/templates/summary/food_eligible.xml
@@ -3,8 +3,8 @@
 {% for attendee, food_categories in attendees.items() %}
     <attendee name="{{ attendee.full_name }}"
               badge_type="{{ attendee.badge_type_label }}"
-              {% if attendee.badge_num %}badge_number="{{ attendee.badge_num }}"{% endif %}
-              {% if c.VOLUNTEER_RIBBON in attendee.ribbon_ints %}now_eligible="{{ attendee.worked_hours|yesno("true,false") }}"{% endif %}
+              {% if attendee.badge_num %} badge_number="{{ attendee.badge_num }}"{% endif %}
+              {% if c.VOLUNTEER_RIBBON in attendee.ribbon_ints %} now_eligible="{{ attendee.worked_hours|yesno("true,false") }}"{% endif %}
               {% for attr, val in food_categories.items() %}
                   {% if val %}
                       {{ attr }}="true"

--- a/uber/tests/test_templates.py
+++ b/uber/tests/test_templates.py
@@ -25,8 +25,7 @@ def test_verify_jinja_autoescape_template():
 <html>
 <body>
 &lt;img src=&#34;#&#34;&gt;
-<b>bold</b>
-</body>
+<b>bold</b></body>
 </html>'''
 
     assert result == expected


### PR DESCRIPTION
Also adds some paranoid whitespace in some template tags due to the new aggressive whitespace stripping.

For example, with the new aggressive whitespace stripping, the following:
```
       {% if not label and title %}title="{{ title }}"{% endif %}
       {% if is_checked %}checked{% endif %} />
```

would be rendered as:
```
title="The title"checked />
```

With no whitespace before `checked`. I'm pretty sure most browsers will render that just fine, but I _think_ it violates the HTML spec.