### PR TITLE
Fixes #2991: Adds a link to checklist items to email delinquent dept heads

### DIFF
--- a/uber/site_sections/dept_checklist.py
+++ b/uber/site_sections/dept_checklist.py
@@ -148,8 +148,15 @@ class Root:
                 subqueryload(Department.checklist_admins),
                 subqueryload(Department.dept_checklist_items)) \
             .order_by(Department.name)
+
+        emails = []
+        for dept in departments:
+            if not dept.checklist_item_for_slug(conf.slug):
+                emails.extend([dh.email for dh in dept.dept_heads if dh.email])
+
         return {
             'conf': conf,
+            'delinquent_emails': emails,
             'overview': [(
                 dept,
                 dept.checklist_item_for_slug(conf.slug),

--- a/uber/templates/dept_checklist/item.html
+++ b/uber/templates/dept_checklist/item.html
@@ -6,6 +6,15 @@
 
 {{ conf.description }}
 
+{% if delinquent_emails %}
+  <p style="margin: 10px 0">
+    <a href="mailto:?bcc={{ delinquent_emails|join(',') }}&subject=Dept Checklist: {{ conf.name }}">
+      <span class="glyphicon glyphicon-envelope"></span>
+      Email Delinquent Department Heads
+    </a>
+  </p>
+{% endif %}
+
 {% for department, item, checklist_admins in overview %}
   <div style="margin-bottom: 15px;">
     <h3 style="display: inline-block;">


### PR DESCRIPTION
Super simple feature. Adds a huge bcc mailto link to checklist items for delinquent dept heads.