### PR TITLE
Revert "Fixes #2995, Related to #2909: Restricts database feed to ACCOUNTS permissions"

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -529,27 +529,13 @@ def set_renderable(func, access):
     return new_func
 
 
-def only_renderable(*needs_access):
-    """
-    Like all_renderable, but works on a single method.
-
-    Overrides access settings on a class also decorated with all_renderable.
-    """
-    def _decorator(func):
-        if getattr(func, 'exposed', False):
-            return func
-        else:
-            return set_renderable(func, needs_access)
-    return _decorator
-
-
 class all_renderable:
     def __init__(self, *needs_access):
         self.needs_access = needs_access
 
     def __call__(self, klass):
         for name, func in klass.__dict__.items():
-            if hasattr(func, '__call__') and not getattr(func, 'exposed', False):
+            if hasattr(func, '__call__'):
                 new_func = set_renderable(func, self.needs_access)
                 setattr(klass, name, new_func)
         return klass

--- a/uber/menu.py
+++ b/uber/menu.py
@@ -80,7 +80,7 @@ c.MENU = MenuItem(name='Root', submenu=[
         MenuItem(name='All Unfilled Shifts', href='../jobs/everywhere', access=c.PEOPLE),
         MenuItem(name='Departments', href='../departments/', access=c.PEOPLE),
         MenuItem(name='Department Checklists', href='../dept_checklist/overview', access=c.PEOPLE),
-        MenuItem(name='Feed of Database Changes', href='../registration/feed', access=c.ACCOUNTS),
+        MenuItem(name='Feed of Database Changes', href='../registration/feed', access=c.PEOPLE),
     ]),
 
     MenuItem(name='People', access=[c.PEOPLE, c.REG_AT_CON], submenu=[

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -841,7 +841,6 @@ class Root:
         session.delete(shift)
         raise HTTPRedirect('shifts?id={}&message={}', shift.attendee.id, 'Staffer unassigned from shift')
 
-    @only_renderable(c.ACCOUNTS)
     def feed(self, session, message='', page='1', who='', what='', action=''):
         feed = session.query(Tracking).filter(Tracking.action != c.AUTO_BADGE_SHIFT).order_by(Tracking.when.desc())
         what = what.strip()


### PR DESCRIPTION
Reverts magfest/ubersystem#2998

This pull request didn't really help, because every reg page has a database feed available in the history 😢 