### PR TITLE
Always give department heads a dept_head_ribbon

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -333,6 +333,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     def _staffing_adjustments(self):
         if self.is_dept_head:
             self.staffing = True
+            self.ribbon = add_opt(self.ribbon_ints, c.DEPT_HEAD_RIBBON)
             if c.SHIFT_CUSTOM_BADGES or \
                     c.STAFF_BADGE not in c.PREASSIGNED_BADGE_TYPES:
                 self.badge_type = c.STAFF_BADGE


### PR DESCRIPTION
There's been confusion about the status of the department head ribbon -- we may want to later remove it as a property, but for now we're just automatically adding it to anyone who has the dept_head status. We talked about this a little bit and decided that it's easier to reject a ribbon if you don't want it when you pick up your badge than to ask for a ribbon that's not recorded in the system, so even in the rare case that a department head doesn't want the ribbon, it's okay for the system to force them to have one.

This replaces https://github.com/magfest/ubersystem/pull/2994. It's not been tested yet, it's a simple enough code change but I'll try to get it tested tonight.