### PR TITLE
Clarify code around assigning new group badges

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -430,7 +430,7 @@ class Root:
                 for attr in attrs_to_preserve_from_unassigned_group_member:
                     params[attr] = getattr(attendee, attr)
 
-                attendee.apply(params, restricted=True)
+                attendee.apply(params, restricted=False)
 
                 # Free group badges are considered registered' when they are actually claimed.
                 if group.cost == 0:

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -428,9 +428,10 @@ class Root:
 
                 attendee = group.unassigned[0]
                 for attr in attrs_to_preserve_from_unassigned_group_member:
-                    params[attr] = getattr(attendee, attr)
+                    if attr in params:
+                        del params[attr]
 
-                attendee.apply(params, restricted=False)
+                attendee.apply(params, restricted=True)
 
                 # Free group badges are considered registered' when they are actually claimed.
                 if group.cost == 0:


### PR DESCRIPTION
~~Attempts to resolve https://github.com/magfest/ubersystem/issues/3019 by applying ALL the parameters, so that the restricted parameters from the old badge (like base_badge_price) actually get moved over.~~

This code was working just fine, but the way it did things was convoluted enough that it made me think it was broken. This PR is now largely an aesthetic change to make the code's intentions clearer.