### PR TITLE
Adds shift signup ui explaining public shifts

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -752,7 +752,7 @@ c.WEIGHT_OPTS = (
     ('2.0', 'x2.0'),
     ('2.5', 'x2.5'),
 )
-c.JOB_DEFAULTS = ['name', 'description', 'duration', 'slots', 'weight', 'required_roles_ids', 'extra15']
+c.JOB_DEFAULTS = ['name', 'description', 'duration', 'slots', 'weight', 'visibility', 'required_roles_ids', 'extra15']
 
 c.PREREG_SHIRT_OPTS = c.SHIRT_OPTS[1:]
 c.MERCH_SHIRT_OPTS = [(c.SIZE_UNKNOWN, 'select a size')] + list(c.PREREG_SHIRT_OPTS)

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -651,7 +651,8 @@ class Session(SessionManager):
             fields = [
                 'name', 'department_name', 'description', 'weight',
                 'start_time_local', 'end_time_local', 'duration',
-                'weighted_hours', 'restricted', 'extra15', 'taken']
+                'weighted_hours', 'restricted', 'extra15', 'taken',
+                'visibility', 'is_public']
             jobs = self.logged_in_volunteer().possible_and_current
             restricted_hours = set()
             for job in jobs:

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -649,8 +649,8 @@ class Session(SessionManager):
 
         def jobs_for_signups(self):
             fields = [
-                'name', 'department_name', 'description', 'weight',
-                'start_time_local', 'end_time_local', 'duration',
+                'name', 'department_id', 'department_name', 'description',
+                'weight', 'start_time_local', 'end_time_local', 'duration',
                 'weighted_hours', 'restricted', 'extra15', 'taken',
                 'visibility', 'is_public']
             jobs = self.logged_in_volunteer().possible_and_current

--- a/uber/models/department.py
+++ b/uber/models/department.py
@@ -415,6 +415,14 @@ class Job(MagModel):
             Shift.job_id == cls.id).label('slots_taken')
 
     @hybrid_property
+    def is_public(self):
+        return self.visibility > Job.ONLY_MEMBERS
+
+    @is_public.expression
+    def is_public(cls):
+        return cls.visibility > Job.ONLY_MEMBERS
+
+    @hybrid_property
     def is_unfilled(self):
         return self.slots_taken < self.slots
 

--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -8,6 +8,8 @@ def job_dict(job, shifts=None):
         'slots': job.slots,
         'weight': job.weight,
         'restricted': job.restricted,
+        'visibility': job.visibility,
+        'is_public': job.is_public,
         'required_roles_ids': job.required_roles_ids,
         'timespan': job.timespan(),
         'department_id': job.department_id,

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -88,6 +88,7 @@ class Root:
             cal_length = con_days
         return {
             'jobs': joblist,
+            'has_public_jobs': any(j['is_public'] for j in joblist),
             'name': session.logged_in_volunteer().full_name,
             'hours': session.logged_in_volunteer().weighted_hours,
             'assigned_depts_labels': volunteer.assigned_depts_labels,

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -76,6 +76,13 @@ class Root:
         con_days = -(-c.CON_LENGTH // 24)  # Equivalent to ceil(c.CON_LENGTH / 24)
 
         volunteer = session.logged_in_volunteer()
+        assigned_dept_ids = set(volunteer.assigned_depts_ids)
+        has_public_jobs = False
+        for job in joblist:
+            job['is_public_to_volunteer'] = job['is_public'] and job['department_id'] not in assigned_dept_ids
+            if job['is_public_to_volunteer']:
+                has_public_jobs = True
+
         has_setup = volunteer.can_work_setup or any(d.is_setup_approval_exempt for d in volunteer.assigned_depts)
         has_teardown = volunteer.can_work_teardown or any(d.is_teardown_approval_exempt for d in volunteer.assigned_depts)
         if has_setup and has_teardown:
@@ -88,7 +95,7 @@ class Root:
             cal_length = con_days
         return {
             'jobs': joblist,
-            'has_public_jobs': any(j['is_public'] for j in joblist),
+            'has_public_jobs': has_public_jobs,
             'name': session.logged_in_volunteer().full_name,
             'hours': session.logged_in_volunteer().weighted_hours,
             'assigned_depts_labels': volunteer.assigned_depts_labels,

--- a/uber/templates/signups/shifts.html
+++ b/uber/templates/signups/shifts.html
@@ -22,7 +22,8 @@
 	color:white;
 	float:right;
 }
-
+.text-public {
+  color: #40c000;
 }
 </style> {% endblock %} {% block main_content %} <div class="hidden csrf_token"> {{ csrf_token() }} </div>
 
@@ -50,7 +51,7 @@
    {% if has_public_jobs %}
      <br><br>
      Some of the listed jobs are for departments you are not assigned to
-     (marked like this<sup class="text-success"> public</sup>).
+     (marked like this<sup class="text-public"> public</sup>).
      <br>
      You may sign up any of the listed jobs, but you'll be prevented from
      working in more than {{ c.MAX_DEPTS_WHERE_WORKING }}
@@ -177,7 +178,8 @@
                 buttonTag += '</a>';
 
                 if(event.is_public_to_volunteer) {
-                  element.find('.fc-list-item-title').append($('<sup class="text-success"> public</sup>'));
+                  element.find('.fc-list-item-title').append($('<sup class="text-public"> public</sup>'));
+                  element.find('.fc-title').append($('<sup class="text-public"> public</sup>'));
                 }
                 element.find('.fc-list-item-title').append(eventDesc + buttonTag);
                 element.find('.fc-title').append(" " + buttonTag + '<br/>' + eventDesc);

--- a/uber/templates/signups/shifts.html
+++ b/uber/templates/signups/shifts.html
@@ -47,6 +47,16 @@
    </tbody></table>
    <br>
    You are assigned to the following departments: {{ assigned_depts_labels|join(' / ') }}.
+   {% if has_public_jobs %}
+     <br><br>
+     Some of the listed jobs are for departments you are not assigned to
+     (marked like this<sup class="text-success"> public</sup>).
+     <br>
+     You may sign up any of the listed jobs, but you'll be prevented from
+     working in more than {{ c.MAX_DEPTS_WHERE_WORKING }}
+     department{{ c.MAX_DEPTS_WHERE_WORKING|pluralize }}.
+     <br>
+   {% endif %}
    <br>
         <a href="#" class="toggle-cal" state="all">Click Here</a>
 	<span class="all-state-text state-text"> to see the {{hours}} weighted hours worth of shifts you are signed up for</span>
@@ -84,6 +94,7 @@
                     start : "{{ job.start_time_local|datetime("%Y-%m-%dT%H:%M:%S") }}",
                     end : "{{ job.end_time_local|datetime("%Y-%m-%dT%H:%M:%S") }}",
                     id : "{{ job.id }}",
+                    is_public: {{ job.is_public|string|lower }},
                     description: "{{ job.description }}",
                     extra15: {{ job.extra15|string|lower }},
                     backgroundColor: "#239875",
@@ -95,6 +106,7 @@
                 start : "{{ job.start_time_local|datetime("%Y-%m-%dT%H:%M:%S") }}",
                 end : "{{ job.end_time_local|datetime("%Y-%m-%dT%H:%M:%S") }}",
                 id : "{{ job.id }}",
+                is_public: {{ job.is_public|string|lower }},
                 description: "{{ job.description }}",
                 extra15: {{ job.extra15|string|lower }},
                 {% if job.taken %}
@@ -113,7 +125,7 @@
                 center: 'title',
                 right: 'agendaDay,agendaConWeek,listConDuration'
             },
-			views: {
+            views: {
                 agendaDay: { buttonText: 'Day' },
                 agendaConWeek: {
                     type: 'agenda',
@@ -161,6 +173,10 @@
                     buttonTag += 'Sign up';
                 }
                 buttonTag += '</a>';
+
+                if(event.is_public) {
+                  element.find('.fc-list-item-title').append($('<sup class="text-success"> public</sup>'));
+                }
                 element.find('.fc-list-item-title').append(eventDesc + buttonTag);
                 element.find('.fc-title').append(" " + buttonTag + '<br/>' + eventDesc);
             }

--- a/uber/templates/signups/shifts.html
+++ b/uber/templates/signups/shifts.html
@@ -95,6 +95,7 @@
                     end : "{{ job.end_time_local|datetime("%Y-%m-%dT%H:%M:%S") }}",
                     id : "{{ job.id }}",
                     is_public: {{ job.is_public|string|lower }},
+                    is_public_to_volunteer: {{ job.is_public_to_volunteer|string|lower }},
                     description: "{{ job.description }}",
                     extra15: {{ job.extra15|string|lower }},
                     backgroundColor: "#239875",
@@ -107,6 +108,7 @@
                 end : "{{ job.end_time_local|datetime("%Y-%m-%dT%H:%M:%S") }}",
                 id : "{{ job.id }}",
                 is_public: {{ job.is_public|string|lower }},
+                is_public_to_volunteer: {{ job.is_public_to_volunteer|string|lower }},
                 description: "{{ job.description }}",
                 extra15: {{ job.extra15|string|lower }},
                 {% if job.taken %}
@@ -174,7 +176,7 @@
                 }
                 buttonTag += '</a>';
 
-                if(event.is_public) {
+                if(event.is_public_to_volunteer) {
                   element.find('.fc-list-item-title').append($('<sup class="text-success"> public</sup>'));
                 }
                 element.find('.fc-list-item-title').append(eventDesc + buttonTag);

--- a/uber/templates/signups/shifts.html
+++ b/uber/templates/signups/shifts.html
@@ -47,16 +47,18 @@
    </tr>
    </tbody></table>
    <br>
-   You are assigned to the following departments: {{ assigned_depts_labels|join(' / ') }}.
+   You are assigned to the following department{{ assigned_depts_labels|length|pluralize }}: {{ assigned_depts_labels|join(' / ') }}.
    {% if has_public_jobs %}
      <br><br>
      Some of the listed jobs are for departments you are not assigned to
      (marked like this<sup class="text-public"> public</sup>).
      <br>
-     You may sign up any of the listed jobs, but you'll be prevented from
-     working in more than {{ c.MAX_DEPTS_WHERE_WORKING }}
-     department{{ c.MAX_DEPTS_WHERE_WORKING|pluralize }}.
-     <br>
+     {% if c.MAX_DEPTS_WHERE_WORKING > 0 %}
+       You may sign up any of the listed jobs, but you'll be prevented from
+       working in more than {{ c.MAX_DEPTS_WHERE_WORKING }}
+       department{{ c.MAX_DEPTS_WHERE_WORKING|pluralize }}.
+       <br>
+     {% endif %}
    {% endif %}
    <br>
         <a href="#" class="toggle-cal" state="all">Click Here</a>


### PR DESCRIPTION
**NOTE**: The new verbiage will only be displayed if there are public shifts shown that wouldn't otherwise be visible to the volunteer.

# Shift Signup UI
<img width="842" alt="screen shot 2017-12-18 at 5 58 47 pm" src="https://user-images.githubusercontent.com/2592431/34132369-78d09086-e41d-11e7-9cdd-23176513187c.png">
