### PR TITLE
 I'd like to restrict access to the feed of database changes

### DIFF
--- a/uber/menu.py
+++ b/uber/menu.py
@@ -80,7 +80,7 @@ c.MENU = MenuItem(name='Root', submenu=[
         MenuItem(name='All Unfilled Shifts', href='../jobs/everywhere', access=c.PEOPLE),
         MenuItem(name='Departments', href='../departments/', access=c.PEOPLE),
         MenuItem(name='Department Checklists', href='../dept_checklist/overview', access=c.PEOPLE),
-        MenuItem(name='Feed of Database Changes', href='../registration/feed', access=c.PEOPLE),
+        MenuItem(name='Feed of Database Changes', href='../registration/feed', access=c.ACCOUNTS),
     ]),
 
     MenuItem(name='People', access=[c.PEOPLE, c.REG_AT_CON], submenu=[

--- a/uber/menu.py
+++ b/uber/menu.py
@@ -80,7 +80,7 @@ c.MENU = MenuItem(name='Root', submenu=[
         MenuItem(name='All Unfilled Shifts', href='../jobs/everywhere', access=c.PEOPLE),
         MenuItem(name='Departments', href='../departments/', access=c.PEOPLE),
         MenuItem(name='Department Checklists', href='../dept_checklist/overview', access=c.PEOPLE),
-        MenuItem(name='Feed of Database Changes', href='../registration/feed', access=[c.ACCOUNTS, c.REG_MANAGERS]),
+        MenuItem(name='Feed of Database Changes', href='../registration/feed', access=[c.ACCOUNTS, c.STAFF_ROOMS]),
     ]),
 
     MenuItem(name='People', access=[c.PEOPLE, c.REG_AT_CON], submenu=[

--- a/uber/menu.py
+++ b/uber/menu.py
@@ -80,7 +80,7 @@ c.MENU = MenuItem(name='Root', submenu=[
         MenuItem(name='All Unfilled Shifts', href='../jobs/everywhere', access=c.PEOPLE),
         MenuItem(name='Departments', href='../departments/', access=c.PEOPLE),
         MenuItem(name='Department Checklists', href='../dept_checklist/overview', access=c.PEOPLE),
-        MenuItem(name='Feed of Database Changes', href='../registration/feed', access=c.ACCOUNTS),
+        MenuItem(name='Feed of Database Changes', href='../registration/feed', access=[c.ACCOUNTS, c.REG_MANAGERS]),
     ]),
 
     MenuItem(name='People', access=[c.PEOPLE, c.REG_AT_CON], submenu=[

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -841,7 +841,7 @@ class Root:
         session.delete(shift)
         raise HTTPRedirect('shifts?id={}&message={}', shift.attendee.id, 'Staffer unassigned from shift')
 
-    @renderable_override(c.ACCOUNTS, c.REG_MANAGERS)
+    @renderable_override(c.ACCOUNTS, c.STAFF_ROOMS)
     def feed(self, session, message='', page='1', who='', what='', action=''):
         feed = session.query(Tracking).filter(Tracking.action != c.AUTO_BADGE_SHIFT).order_by(Tracking.when.desc())
         what = what.strip()

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -841,7 +841,7 @@ class Root:
         session.delete(shift)
         raise HTTPRedirect('shifts?id={}&message={}', shift.attendee.id, 'Staffer unassigned from shift')
 
-    @renderable_override(c.ACCOUNTS)
+    @renderable_override(c.ACCOUNTS, c.REG_MANAGERS)
     def feed(self, session, message='', page='1', who='', what='', action=''):
         feed = session.query(Tracking).filter(Tracking.action != c.AUTO_BADGE_SHIFT).order_by(Tracking.when.desc())
         what = what.strip()

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -841,6 +841,7 @@ class Root:
         session.delete(shift)
         raise HTTPRedirect('shifts?id={}&message={}', shift.attendee.id, 'Staffer unassigned from shift')
 
+    @renderable_override(c.ACCOUNTS)
     def feed(self, session, message='', page='1', who='', what='', action=''):
         feed = session.query(Tracking).filter(Tracking.action != c.AUTO_BADGE_SHIFT).order_by(Tracking.when.desc())
         what = what.strip()


### PR DESCRIPTION
I tried to do this earlier, but I rushed it out and immediately broke the preregistration page (see here https://github.com/magfest/ubersystem/pull/2998).

Now that `renderable_override()` actually works and doesn't disrupt the existing codebase (see here https://github.com/magfest/ubersystem/pull/3049), I wanna restrict access to the feed of database changes.