### PR TITLE
Reset denied group badge price to opening price

### DIFF
--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -103,6 +103,7 @@ class Root:
                     message = 'Group declined and emails sent to attendees'
                     attendee.paid = c.NOT_PAID
                     attendee.badge_status = c.NEW_STATUS
+                    attendee..badge_cost = c.INITIAL_ATTENDEE
                     attendee.ribbon = remove_opt(attendee.ribbon_ints, c.DEALER_RIBBON)
                     try:
                         send_email(c.REGDESK_EMAIL, attendee.email, 'Do you still want to come to {EVENT_NAME}?',

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -103,8 +103,8 @@ class Root:
                     message = 'Group declined and emails sent to attendees'
                     attendee.paid = c.NOT_PAID
                     attendee.badge_status = c.NEW_STATUS
-                    attendee.overridden_price = c.INITIAL_ATTENDEE
                     attendee.ribbon = remove_opt(attendee.ribbon_ints, c.DEALER_RIBBON)
+                    attendee.overridden_price = attendee.new_badge_cost
                     try:
                         send_email(c.REGDESK_EMAIL, attendee.email, 'Do you still want to come to {EVENT_NAME}?',
                                    render('emails/dealers/badge_converted.html', {

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -103,7 +103,7 @@ class Root:
                     message = 'Group declined and emails sent to attendees'
                     attendee.paid = c.NOT_PAID
                     attendee.badge_status = c.NEW_STATUS
-                    attendee..badge_cost = c.INITIAL_ATTENDEE
+                    attendee.overridden_price = c.INITIAL_ATTENDEE
                     attendee.ribbon = remove_opt(attendee.ribbon_ints, c.DEALER_RIBBON)
                     try:
                         send_email(c.REGDESK_EMAIL, attendee.email, 'Do you still want to come to {EVENT_NAME}?',


### PR DESCRIPTION
This should reset the price of all group badges to the initial attendee price, for all groups that were denied a spot in the Marketplace.