### PR TITLE
Fixes csrf_token key error

### DIFF
--- a/uber/tests/test_api.py
+++ b/uber/tests/test_api.py
@@ -218,8 +218,7 @@ class TestAuthBySession(object):
 
     def test_check_csrf_missing_from_session(self, monkeypatch):
         monkeypatch.setitem(cherrypy.request.headers, 'CSRF-Token', 'XXXX')
-        with pytest.raises(KeyError) as error:
-            auth_by_session(set())
+        assert auth_by_session(set()) == (403, 'Your CSRF token is invalid. Please go back and try again.')
 
     def test_check_csrf_invalid(self, monkeypatch):
         monkeypatch.setitem(cherrypy.session, 'csrf_token', '74c18d5c-1a92-40f0-b5f3-924d46efafe4')

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -136,9 +136,10 @@ def check_csrf(csrf_token=None):
     if not csrf_token:
         raise CSRFException("CSRF token missing")
 
-    if csrf_token != cherrypy.session['csrf_token']:
+    session_csrf_token = cherrypy.session.get('csrf_token', None)
+    if csrf_token != session_csrf_token:
         raise CSRFException("CSRF check failed: csrf tokens don't match: {!r} != {!r}"
-                            .format(csrf_token, cherrypy.session['csrf_token']))
+                            .format(csrf_token, session_csrf_token))
     else:
         cherrypy.request.headers['CSRF-Token'] = csrf_token
 


### PR DESCRIPTION
We keep seeing the following error in production. This happens if you load the confirmation page, then click "Clear All Browsing Data" in your browser, then click the "Update My Info" button:
```
Traceback (most recent call last):
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 670, in respond
       response.body = self.handler()
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/lib/encoding.py", line 221, in __call__
       self.body = self.oldhandler(*args, **kwargs)
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/_cpdispatch.py", line 60, in __call__
       return self.callable(*self.args, **self.kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 382, in with_timing
       return func(*args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 397, in with_session
       retval = func(*args, session=session, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 518, in with_restrictions
       return func(*args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 458, in with_rendering
       result = func(*args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/site_sections/preregistration.py", line 23, in wrapped
       return func(self, *args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 667, in check_id
       return func(*args, **params)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 34, in with_check
       return func(*args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/site_sections/preregistration.py", line 592, in confirm
       attendee = session.attendee(params, restricted=True)
     File "/usr/local/uber/plugins/uber/uber/models/__init__.py", line 1395, in with_validity_check
       attendee = orig_getter(self, *args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/models/__init__.py", line 1340, in getter
       restricted=restricted, ignore_csrf=ignore_csrf)
     File "/usr/local/uber/plugins/uber/uber/models/__init__.py", line 446, in apply
       check_csrf(params.get('csrf_token'))
     File "/usr/local/uber/plugins/uber/uber/utils.py", line 139, in check_csrf
       if csrf_token != cherrypy.session['csrf_token']:
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/__init__.py", line 254, in __getitem__
       return child[key]
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/lib/sessions.py", line 308, in __getitem__
       return self._data[key]
   KeyError: 'csrf_token'
```