### PR TITLE
session.lookup_attendee now uses Attendee.normalized_email

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -706,9 +706,11 @@ class Session(SessionManager):
             attendees = self.query(Attendee).iexact(
                 first_name=first_name,
                 last_name=last_name,
-                email=email,
-                zip_code=zip_code).filter(
-                    Attendee.badge_status != c.INVALID_STATUS).limit(10).all()
+                zip_code=zip_code
+            ).filter(
+                Attendee.normalized_email == Attendee.normalize_email(email),
+                Attendee.badge_status != c.INVALID_STATUS
+            ).limit(10).all()
 
             if attendees:
                 statuses = defaultdict(lambda: six.MAXSIZE, {


### PR DESCRIPTION
@kitsuta reminded me at https://github.com/magfest/panels/pull/138#discussion_r157947517 that ``session.lookup_attendee`` is a thing and noted that it should probably be using ``Attendee.normalized_email``.  I've just made this change and tested it locally.