### PR TITLE
Adds support for attractions tab bar at the top of the prereg confirm form

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -43,7 +43,7 @@ def _attendee_fields_and_query(full, query):
 
 def _parse_datetime(d):
     if isinstance(d, six.string_types) and d.strip().lower() == 'now':
-        d = datetime.utcnow().replace(tzinfo=pytz.UTC)
+        d = datetime.now(pytz.UTC)
     else:
         d = dateparser.parse(d)
     try:

--- a/uber/site_sections/api.py
+++ b/uber/site_sections/api.py
@@ -79,6 +79,6 @@ class Root:
             raise HTTPRedirect('index')
 
         api_token = session.api_token(id)
-        api_token.revoked_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
+        api_token.revoked_time = datetime.now(pytz.UTC)
         raise HTTPRedirect(
             'index?message={}', 'Successfully revoked API token')

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -23,11 +23,15 @@
 <div class="masthead"></div>
 <div class="panel panel-default">
   <div class="panel-body">
+    {% block panel_top %}{% endblock %}
+
     <form method="post" action="confirm" class="form-horizontal">
       {{ csrf_token() }}
       <input type="hidden" name="id" value="{{ attendee.id }}" />
       <input type="hidden" name="return_to" value="{{ return_to }}" />
       <input type="hidden" name="undoing_extra" value="{{ undoing_extra }}" />
+
+      {% block form_top %}{% endblock %}
 
       {% if attendee.amount_unpaid and c.HTTP_METHOD == 'GET' %}
         <br/>

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -570,14 +570,15 @@
     </div>
 </div>
 
-{% if c.BADGE_PROMO_CODES_ENABLED and not group_id %}
+{% if c.BADGE_PROMO_CODES_ENABLED and not group_id and (attendee.is_unpaid or attendee.promo_code_code) %}
 <div class="non_group_fields form-group">
     <label for="promo_code" class="col-sm-3 control-label optional-field">Promo Code</label>
     <div class="col-sm-6">
         {% if attendee.is_unpaid %}
         <input type="textarea" name="promo_code" value="{{ attendee.promo_code_code }}" class="form-control" placeholder="Promo Code">
         {% else %}
-        <p name="promo_code" class="form-control-static">{{ attendee.promo_code_code }}</p>
+        <input type="hidden" name="promo_code" value="{{ attendee.promo_code_code }}">
+        <p class="form-control-static">{{ attendee.promo_code_code }}</p>
         {% endif %}
     </div>
 </div>

--- a/uber/tests/models/test_promo_code.py
+++ b/uber/tests/models/test_promo_code.py
@@ -1,7 +1,7 @@
 from uber.tests import *
 
 
-next_week = datetime.utcnow().replace(tzinfo=pytz.UTC) + timedelta(days=7)
+next_week = datetime.now(pytz.UTC) + timedelta(days=7)
 
 
 class TestPromoCodeAdjustments:
@@ -178,7 +178,7 @@ class TestAttendeePromoCodeModelChecks:
             "You may already have other discounts."
 
     def test_promo_code_not_is_expired(self):
-        expire = datetime.utcnow().replace(tzinfo=pytz.UTC) - timedelta(days=9)
+        expire = datetime.now(pytz.UTC) - timedelta(days=9)
         promo_code = PromoCode(discount=1, expiration_date=expire)
         attendee = Attendee(
             promo_code=promo_code,

--- a/uber/tests/models/test_session.py
+++ b/uber/tests/models/test_session.py
@@ -2,7 +2,7 @@ from uber.common import *
 from uber.tests import *
 
 
-next_week = datetime.utcnow().replace(tzinfo=pytz.UTC) + timedelta(days=7)
+next_week = datetime.now(pytz.UTC) + timedelta(days=7)
 
 
 @pytest.fixture(autouse=True)

--- a/uber/tests/site_sections/test_preregistration.py
+++ b/uber/tests/site_sections/test_preregistration.py
@@ -10,7 +10,7 @@ from uber.tests.conftest import admin_attendee, assert_unique, \
 from uber.utils import CSRFException
 
 
-next_week = datetime.utcnow().replace(tzinfo=pytz.UTC) + timedelta(days=7)
+next_week = datetime.now(pytz.UTC) + timedelta(days=7)
 
 
 @pytest.fixture(autouse=True)

--- a/uber/tests/site_sections/test_registration.py
+++ b/uber/tests/site_sections/test_registration.py
@@ -12,7 +12,7 @@ from uber.utils import CSRFException
 from uber.models import _attendee_validity_check
 
 
-next_week = datetime.utcnow().replace(tzinfo=pytz.UTC) + timedelta(days=7)
+next_week = datetime.now(pytz.UTC) + timedelta(days=7)
 
 
 @pytest.fixture(autouse=True)

--- a/uber/tests/test_api.py
+++ b/uber/tests/test_api.py
@@ -184,7 +184,7 @@ class TestAuthByToken(object):
         assert auth_by_token(set()) == expected
 
     def test_revoked(self, monkeypatch, session, api_token):
-        api_token.revoked_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
+        api_token.revoked_time = datetime.now(pytz.UTC)
         session.commit()
         session.refresh(api_token)
         monkeypatch.setitem(cherrypy.request.headers, 'X-Auth-Token', api_token.token)


### PR DESCRIPTION
Required by https://github.com/magfest/panels/pull/140

This pull request has a bunch of minor unrelated changes. The following line in `confirm.html` is the only thing required by attractions:
```
{% block panel_top %}{% endblock %}
```