### PR TITLE
Accept badge numbers at checkin besides only numerals

### DIFF
--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -76,7 +76,7 @@
                     {{ attendee.badge_num }}
                     <input type="hidden" id="checkin-badge" name="badge_num" value="{{ attendee.badge_num }}" />
                 {% else %}
-                    # <input class="num" id="checkin-badge" name="badge_num" type="number" size="5" autofocus />
+                  # <input class="num" id="checkin-badge" name="badge_num" type="text" size="10" autofocus/>
                 {% endif %}
             </td>
         </tr>

--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -258,8 +258,8 @@
         {% else %}
             {% if c.NUMBERED_BADGES %}
                 <td>
-                    <input type="number" name="badge_num" form="new_checkin_{{ attendee.id }}" size="5"
-                           {% if attendee.paid == c.NOT_PAID %}disabled{% endif %} />
+                  <input type="tet" name="badge_num" form="new_checkin_{{ attendee.id }}" size="10"
+                         {% if attendee.paid == c.NOT_PAID %}disabled{% endif %} />
                 </td>
             {% endif %}
             <td>

--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -258,7 +258,7 @@
         {% else %}
             {% if c.NUMBERED_BADGES %}
                 <td>
-                  <input type="tet" name="badge_num" form="new_checkin_{{ attendee.id }}" size="10"
+                  <input type="text" name="badge_num" form="new_checkin_{{ attendee.id }}" size="10"
                          {% if attendee.paid == c.NOT_PAID %}disabled{% endif %} />
                 </td>
             {% endif %}


### PR DESCRIPTION
In order to decrypt badge number barcodes, we first have to accept them in the input field.