### PR TITLE
Add barcode scanning detection to registration pages

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -44,6 +44,11 @@ event_qr_id = string(default='')
 # Events who don't have barcode scanners will want to turn this off.
 use_checkin_barcode = boolean(default=False)
 
+# This controls whether or not we attempt to detect barcode scans
+# and decrypt them using the barcode plugin. Turn this off if
+# the scanning detection is going awry.
+reg_uses_barcodes = boolean(default=True)
+
 # This controls whether the promo code field will be visible on the
 # registration form. True to allow attendees to use promo codes when
 # registering, False to disallow promo codes.

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -188,43 +188,6 @@
             return false;
         };
 
-        var getBadgeNumFromBarcode = function(barcode, callback) {
-          // This function requires the barcode plugin
-
-          barcode = ('' + barcode).trim();
-          callback = callback || function() {}
-
-          if($.isNumeric(barcode)) {
-            // This only works because we intentionally use non-numeric barcode data
-            callback({'badge_num': barcode});
-            return;
-          }
-
-          var first = barcode.substr(0, 1),
-              last = barcode.substr(barcode.length - 1);
-          if(first === last && last.match(/\W/g)) {
-            barcode = barcode.substr(1, barcode.length - 2);
-          }
-
-          $.ajax({
-            method: 'POST',
-            url: '../barcode/get_badge_num_from_barcode',
-            data: {
-              barcode: barcode,
-              csrf_token: csrf_token
-            },
-            success: function(response, status) {
-              if(response && response['badge_num'] === -1) {
-                response['error'] = response['message'];
-              }
-              callback(response);
-            },
-            error: function(response, status, statusText) {
-              callback({'error': 'Could not decode barcode: ' + statusText});
-            }
-          });
-        };
-
         $(function() {
             $(window).load(function() {
                 $(".loader").fadeOut("fast");

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -13,13 +13,27 @@
 
   {% if c.REG_USES_BARCODES %}
     {% set detect_barcode_scan = True %}
+    <script type="text/javascript">
+        var setBarcodeField = function () {
+            if ($('input[name=badge_num]').length === 1) {
+                $barcodeField = $('input[name=badge_num]');
+            }
+        };
+
+        var useBarcode = function (barcode) {
+            if ($barcodeField.is('#search_bar')) {
+                $barcodeField.val(barcode);
+                $('#search_form').submit();
+            }
+        }
+    </script>
   {% endif %}
 
 {% endblock adminheader %}
 {% block admin_controls %}
 <div class="row">
     <div class="col-sm-6 col-md-4">
-        <form role="form" method="get" action="index">
+      <form role="form" method="get" action="index" id="search_form">
             <input type="hidden" name="order" value="{{ order }}" />
             <input type="hidden" name="invalid" value="{{ invalid }}" />
             <div class="input-group">

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -11,6 +11,10 @@
 </script>
     {% include "check_in.html" %}
 
+  {% if c.REG_USES_BARCODES %}
+    {% set detect_barcode_scan = True %}
+  {% endif %}
+
 {% endblock adminheader %}
 {% block admin_controls %}
 <div class="row">

--- a/uber/templates/registration/merch.html
+++ b/uber/templates/registration/merch.html
@@ -4,6 +4,12 @@
 
 <script type="text/javascript">
     {% set detect_barcode_scan = True %}
+    var useBarcode = function (barcode) {
+        if ($barcodeField.is(':number')) {
+            $barcodeField.val(barcode);
+        }
+    };
+
     var $shirtOpts = $('<select/>').attr('id', 'shirt');
     $.each({{ c.MERCH_SHIRT_OPTS|jsonize }}, function(i,size) {
         $shirtOpts.append($('<option/>').val(size[0]).text(size[1]));
@@ -23,11 +29,12 @@
             }
         }, 'json');
     }
+    l;
     var undoSale = function (id) {
         $.post('undo_sale', {id: id, csrf_token: csrf_token}, function(message) {
             $('#message').html(message);
         });
-    }
+    };
 
     var showOrHideWhatText = function (pageLoading) {
         $('#store_mpoints').val('0');
@@ -43,8 +50,8 @@
                 $('#store_amount').focus();
             }
         }
-    }
-    
+    };
+
     var recordMPointExchange = function () {
         $.post('record_old_mpoint_exchange', {
             badge_num:  $('#ex_badge_num').val(),
@@ -61,12 +68,12 @@
                     }));
             }
        }, 'json');
-    }
+    };
     var undoMPointExchange = function (id) {
         $.post('undo_mpoint_exchange', {'id': id, csrf_token: csrf_token}, function(s) {
             $('#message').html(s);
         });
-    }
+    };
 
     var giveMerch = function (noShirt, id, shirtSize) {
         $('#give button').attr('disabled', true);
@@ -84,12 +91,12 @@
                          }));
             }
         }, 'json');
-    }
+    };
     var takeBackMerch = function (id) {
         $.post('take_back_merch', {id: id, csrf_token: csrf_token}, function(message) {
             $('#message').html(message);
         });
-    }
+    };
 
     var checkDiscount = function () {
         var $num = $('#dis_badge_num'),

--- a/uber/templates/registration/merch.html
+++ b/uber/templates/registration/merch.html
@@ -3,6 +3,7 @@
 {% block content %}
 
 <script type="text/javascript">
+    {% set detect_barcode_scan = True %}
     var $shirtOpts = $('<select/>').attr('id', 'shirt');
     $.each({{ c.MERCH_SHIRT_OPTS|jsonize }}, function(i,size) {
         $shirtOpts.append($('<option/>').val(size[0]).text(size[1]));

--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -17,6 +17,10 @@
         }, 900000);
     {% endif %}
 
+    {% if c.REG_USES_BARCODES %}
+        {% set detect_barcode_scan = True %}
+    {% endif %}
+
     var UNASSIGNED = {{ unassigned|jsonize }};
     var toggleMarkButton = function (dropdown) {
         var $button = $(dropdown).parent().find(':submit');


### PR DESCRIPTION
Adds the ability to use barcode scanners with automatic decryption on the registration pages. This is hidden behind a new 'reg_uses_barcodes' variable, just in case something goes horribly wrong at-con and we need to turn this off for registration.

Fixes https://github.com/magfest/ubersystem/issues/2867.