### PR TITLE
Remove 'disabled' attr from badge_num field when at-door is paid

### DIFF
--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -77,6 +77,7 @@
 
     var refreshRow = function(currentForm) {
         currentForm.closest('tr').find(':contains("Check In")').removeAttr('disabled');
+        currentForm.closest('tr').find('[name="badge_num"]').removeAttr('disabled');
         currentForm.closest('td').text('paid');
     };
 


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/3038. We didn't need a full page refresh -- we just needed to add the badge_num field to the function that un-disabled the check-in button.