### PR TITLE
Allow unpaid attendees to decline their badges

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -590,6 +590,10 @@ class Attendee(MagModel, TakesPaymentMixin):
         return None
 
     @property
+    def can_abandon_badge(self):
+        return not self.amount_paid and not self.paid == c.NEED_NOT_PAY and not self.is_group_leader
+
+    @property
     def shirt_size_marked(self):
         return self.shirt not in [c.NO_SHIRT, c.SIZE_UNKNOWN]
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -628,7 +628,6 @@ class Root:
             'message':       message,
             'affiliates':    session.affiliates(),
             'badge_cost':    attendee.badge_cost if attendee.paid != c.PAID_BY_GROUP else 0,
-            'can_abandon':   (not attendee.amount_paid and not attendee.paid == c.NEED_NOT_PAY and not attendee.is_group_leader)
         }
 
     @id_required(Attendee)

--- a/uber/templates/preregistration/attendee_donation_form.html
+++ b/uber/templates/preregistration/attendee_donation_form.html
@@ -17,8 +17,22 @@
             <td style="width:100px ; text-align:center">or</td>
             <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Undo Extra Money") }}</a></td>
           {% endif %}
+          {% if attendee.can_abandon_badge %}
+            <td style="width:100px ; text-align:center">or</td>
+            <td>
+              <button type="submit" form="abandon_badge" class="btn btn-danger"
+                      onClick="return confirm('Are you sure you want to delete your badge? This can\'t be undone!');">
+                I'm not coming
+              </button>
+            </td>
+          {% endif %}
         </tr>
       </table>
+      {% if attendee.can_abandon_badge %}
+        <form method="post" action="abandon_badge" id="abandon_badge">
+          <input type="hidden" name="id" value="{{ attendee.id }}"/>
+        </form>
+      {% endif %}
     {% else %}
       <h2> Extra Payment for {{ attendee.full_name }} </h2>
 

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -59,7 +59,7 @@
           {% if attendee.is_transferable %}
             <button type="button" class="btn btn-primary" onClick='location.href="transfer_badge?id={{ attendee.id }}"'>Transfer my Badge</button>
           {% endif %}
-          {% if can_abandon %}
+          {% if attendee.can_abandon_badge %}
             <button type="submit" form="abandon_badge" class="btn btn-danger" onClick="return confirm('Are you sure you want to delete your badge? This can\'t be undone!');">I'm not coming</button>
           {% endif %}
         </div>
@@ -80,7 +80,7 @@
       {% endif %}
     </form>
 
-    {% if can_abandon %}
+    {% if attendee.can_abandon_badge %}
       <form method="post" action="abandon_badge" id="abandon_badge">
         <input type="hidden" name="id" value="{{ attendee.id }}"/>
       </form>


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/3082. We had an "I'm not coming" button on the confirmation page, but we were redirecting unpaid attendees to the donation form, thus preventing unpaid attendees outside of a group from using that button. This adds the button to the donation form and converts the prerequisites involved into a property.