### PR TITLE
Clean up WatchList page for attendees

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -664,7 +664,7 @@ class Session(SessionManager):
                 if (job.required_roles
                     or frozenset(job.hours) not in restricted_hours)]
 
-        def guess_attendee_watchentry(self, attendee):
+        def guess_attendee_watchentry(self, attendee, active=True):
             or_clauses = [
                 func.lower(WatchList.first_names).contains(
                     attendee.first_name.lower()),
@@ -692,7 +692,7 @@ class Session(SessionManager):
             return self.query(WatchList).filter(and_(
                 or_(*or_clauses),
                 func.lower(WatchList.last_name) == attendee.last_name.lower(),
-                WatchList.active == True)).all()  # noqa: E712
+                WatchList.active == active)).all()  # noqa: E712
 
         def get_account_by_email(self, email):
             return self.query(AdminAccount) \

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -222,7 +222,7 @@ class Root:
                     message = 'Watchlist entry updated'
                 if 'confirm' in params:
                     attendee.watchlist_id = watchlist_id
-            
+
             session.commit()
 
             raise HTTPRedirect('watchlist?attendee_id={}&message={}', attendee.id, message or 'Attendee updated')

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -211,8 +211,10 @@ class Root:
     @log_pageview
     def watchlist(self, session, attendee_id, watchlist_id=None, message='', **params):
         attendee = session.attendee(attendee_id, allow_invalid=True)
-        if watchlist_id:
-            watchlist_entry = session.watch_list(watchlist_id)
+        if cherrypy.request.method == 'POST':
+            if watchlist_id:
+                watchlist_entry = session.watch_list(watchlist_id)
+                message = 'Watchlist entry updated'
 
             if 'active' in params:
                 watchlist_entry.active = not watchlist_entry.active
@@ -223,9 +225,12 @@ class Root:
 
             session.commit()
 
-            message = 'Watchlist entry updated'
+            raise HTTPRedirect('watchlist?attendee_id={}&message={}', attendee.id, message or 'Attendee updated')
+
         return {
             'attendee': attendee,
+            'active_entries': session.guess_attendee_watchentry(attendee, active=True),
+            'inactive_entries': session.guess_attendee_watchentry(attendee, active=False),
             'message': message
         }
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -212,17 +212,17 @@ class Root:
     def watchlist(self, session, attendee_id, watchlist_id=None, message='', **params):
         attendee = session.attendee(attendee_id, allow_invalid=True)
         if cherrypy.request.method == 'POST':
-            if watchlist_id:
-                watchlist_entry = session.watch_list(watchlist_id)
-                message = 'Watchlist entry updated'
-
-            if 'active' in params:
-                watchlist_entry.active = not watchlist_entry.active
-            if 'confirm' in params:
-                attendee.watchlist_id = watchlist_id
             if 'ignore' in params:
                 attendee.badge_status = c.COMPLETED_STATUS
+            elif watchlist_id:
+                watchlist_entry = session.watch_list(watchlist_id)
 
+                if 'active' in params:
+                    watchlist_entry.active = not watchlist_entry.active
+                    message = 'Watchlist entry updated'
+                if 'confirm' in params:
+                    attendee.watchlist_id = watchlist_id
+            
             session.commit()
 
             raise HTTPRedirect('watchlist?attendee_id={}&message={}', attendee.id, message or 'Attendee updated')

--- a/uber/templates/registration/watchlist.html
+++ b/uber/templates/registration/watchlist.html
@@ -2,71 +2,128 @@
 {% block title %}Attendee History - {{ attendee.full_name }}{% endblock %}
 {% block content %}
 
-{% include "registration/menu.html" %}
+  <script type="text/javascript">
+      $(function () {
+          $("form[name='confirm_entry']").submit(function (event) {
+              var formToSubmit = this;
+              event.preventDefault();
+              bootbox.confirm({
+                  title: 'Confirm Watchlist Entry?',
+                  message: 'When you "confirm" a watchlist entry, that entry will be permanently associated with this ' +
+                  'attendee and no other watchlist entries will be matched to this person. If there are multiple ' +
+                  'correct watchlist entries for an attendee, please choose the most recent one. This cannot be undone.',
+                  buttons: {
+                      confirm: {
+                          label: 'Confirm Entry',
+                          className: 'btn-info'
+                      },
+                      cancel: {
+                          label: 'Nevermind',
+                          className: 'btn-default'
+                      }
+                  },
+                  callback: function (result) {
+                      if (result) {
+                          formToSubmit.submit();
+                      }
+                  }
+              });
+          });
+      });
+  </script>
 
-<h2>{% if not attendee.watchlist_id %}Possible {% endif %}Watchlist Entry for {{ attendee.full_name }} {% if c.AT_THE_CON %}({{ attendee.badge }}){% endif %}</h2>
+  {% include "registration/menu.html" %}
 
-<div class="panel col-md-4">
-    {% for entry in attendee.banned %}
-    {% if not attendee.watchlist_id %}
-    <div class="row">
-        <label class="col-sm-2 control-label">Watchlist First Names</label>
-        <div class="col-sm-6"> {{ entry.first_names }}</div>
-    </div>
-    <div class="row">
-        <label class="col-sm-2 control-label">Watchlist Last Name: </label>
-        <div class="col-sm-6"> {{ entry.last_name }}</div>
-    </div>
-    <div class="row">
-        <label class="col-sm-2 control-label">Watchlist Email: </label>
-        <div class="col-sm-6"> {{ entry.email }}</div>
-    </div>
-    <div class="row">
-        <label class="col-sm-2 control-label">Watchlist DOB: </label>
-        <div class="col-sm-6"> {{ entry.birthdate|datetime("%Y-%m-%d") }}</div>
-    </div>
-    {% endif %}
-    <div class="row">
-        <label class="col-sm-2 control-label">Watchlist Reason: </label>
-        <div class="col-sm-6"> {{ entry.reason }} </div>
-    </div>
-    <div class="row">
-        <label class="col-sm-2 control-label">Watchlist Action: </label>
-        <div class="col-sm-6"> {{ entry.action }} </div>
-    </div>
-
-    <form class="form-inline" role="form" method="post" action="watchlist">
+  <h2>{% if not attendee.watchlist_id %}Possible Watchlist Entries{% else %}Watchlist Entry{% endif %}
+    for {{ attendee.full_name }} {% if c.AT_THE_CON %}({{ attendee.badge }}){% endif %}</h2>
+  {% if attendee.badge_status == c.WATCHED_STATUS %}
+    <div class="form-group">
+      <form class="form-inline" role="form" method="post" action="watchlist">
         {{ csrf_token() }}
-        <input type="hidden" name="attendee_id" value="{{ attendee.id }}" />
-        <input type="hidden" name="watchlist_id" value="{{ entry.id }}" />
-        <div class="form-group">
-            <label class="btn btn-success">
-                <input type="checkbox" name="active" value="{{ entry.active }}" />
-                {% if attendee.banned.active %} Deactivate Watchlist Entry {% else %} Activate Watchlist Entry {% endif %}
-            </label>
-        </div>
-        {% if not attendee.watchlist_id %}
-        <div class="form-group">
-            <label class="btn btn-info">
-                <input type="checkbox" name="confirm" />
-                Confirm Watchlist Entry
-            </label>
-            (Permanently associate watchlist entry with this attendee, ignoring any other watchlist entries.)
-        </div>
-        {% endif %}
-        {% if attendee.badge_status == c.WATCHED_STATUS %}
-        <div class="form-group">
-            <label class="btn btn-default">
-                <input type="checkbox" name="ignore" />
-                Ignore Watchlist Entry
-            </label>
-            (Set attendee to "Completed" without altering the watchlist entry.)
-        </div>
-        {% endif %}
-        <button type="submit" class="btn btn-primary">Update</button>
+        <input type="hidden" name="attendee_id" value="{{ attendee.id }}"/>
+        <button class="btn btn-success" type="submit" name="ignore">
+          Ignore Watchlist Entries
+        </button>
+        Set attendee to "Completed" status, allowing them to check in without altering any watchlist entries.
+      </form>
+    </div>
+  {% endif %}
+
+  {% if attendee.watchlist_id %}
+    Below is the confirmed watchlist entry for this attendee. All other possible watchlist entries are ignored.
+    <br/><strong>Reason</strong>: {{ attendee.watch_list.reason }}
+    <br/><strong>Action</strong>: {{ attendee.watch_list.action }}
+    <br/>
+    <form class="form-inline" role="form" method="post" action="watchlist">
+      {{ csrf_token() }}
+      <input type="hidden" name="attendee_id" value="{{ attendee.id }}"/>
+      <input type="hidden" name="watchlist_id" value="{{ attendee.watch_list.id }}"/>
+      <button class="btn btn-success" type="submit" name="active">
+        {% if attendee.watch_list.active %} Deactivate {% else %} Activate {% endif %}
+        Watchlist Entry
+      </button>
     </form>
+  {% else %}
+    {% for list in active_entries, inactive_entries %}
+      {% set active = loop.cycle(True, False) %}
+      <div class="panel panel-default">
+      <div class="panel-heading"><h3 class="panel-title">{{ loop.cycle('Active', 'Inactive') }} Entries</h3></div>
+      <div class="panel-body">
+        {% if active %}
+          Active watchlist entries attempt to match themselves to new attendees,
+          even if another attendee is already confirmed as matching. If an attendee
+          registers and has matching attributes to an active watchlist entry, that attendee
+          is put 'on hold' and prevented from checking in until an admin intervenes.
+        {% else %}Inactive watchlist entries do not attempt to match any new attendees.
+          Generally, entries should only be inactive if they have expired or are otherwise
+          no longer meant to affect check-in.{% endif %}</div>
+
+      <table class="table">
+      <div>
+        <table class="table">
+          <tr>
+            <th>Watchlist First Names</th>
+            <th>Watchlist Last Name</th>
+            <th>Watchlist Email</th>
+            <th>Watchlist DOB</th>
+            <th>Watchlist Reason</th>
+            <th>Watchlist Action</th>
+            <th>{{ loop.cycle('Deactivate', 'Activate') }}</th>
+            <th>Confirm as Correct Match</th>
+          </tr>
+          {% for entry in list %}
+            <tr>
+            <td>{{ entry.first_names }}</td>
+            <td>{{ entry.last_name }}</td>
+            <td>{{ entry.email }}</td>
+            <td>{{ entry.birthdate|datetime("%Y-%m-%d") }}</td>
+            <td>{{ entry.reason }}</td>
+            <td>{{ entry.action }}</td>
+            <td>
+              <form class="form-inline" role="form" method="post" action="watchlist">
+                {{ csrf_token() }}
+                <input type="hidden" name="attendee_id" value="{{ attendee.id }}"/>
+                <input type="hidden" name="watchlist_id" value="{{ entry.id }}"/>
+                <button class="btn btn-success" type="submit" name="active">
+                  {% if entry.active %} Deactivate {% else %} Activate {% endif %}
+                </button>
+              </form>
+            </td>
+            <td>
+              <form class="form-inline" role="form" method="post" name="confirm_entry" action="watchlist">
+                {{ csrf_token() }}
+                <input type="hidden" name="attendee_id" value="{{ attendee.id }}"/>
+                <input type="hidden" name="watchlist_id" value="{{ entry.id }}"/>
+                <input type="hidden" name="confirm"/>
+                <button class="btn btn-info">
+                  Confirm Watchlist Entry
+                </button>
+              </form>
+            </td>
+          {% endfor %}
+        </table>
+      </div>
     {% endfor %}
-</div>
-
-
+  </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/3066. This was meant to be a backend-only change to be merged with https://github.com/magfest/ubersystem/pull/3071, but then I ended up going a different direction with the interface. Oops.

This is what this change looks like for an attendee with unconfirmed entries: ![image](https://user-images.githubusercontent.com/7198215/34461819-1bc49dc0-ee03-11e7-8547-c3a97ff00197.png)

If you click any of the blue "Confirm" buttons, this pops up: 
![image](https://user-images.githubusercontent.com/7198215/34461840-e09652b0-ee03-11e7-9d05-7f7b66ef3dd6.png)

If you confirm the entry, the page then looks like this: ![image](https://user-images.githubusercontent.com/7198215/34461806-e8f5a60a-ee02-11e7-8b3b-8394df10587e.png)

This also makes `guess_attendee_watchentry` able to return active or inactive entries, so that we can display them on this page.