### PR TITLE
split out merch and staff merch

### DIFF
--- a/alembic/versions/23193b41cfea_added_got_staff_merch.py
+++ b/alembic/versions/23193b41cfea_added_got_staff_merch.py
@@ -1,0 +1,41 @@
+"""added Attendee.got_staff_merch column
+
+Revision ID: 23193b41cfea
+Revises: 1c87fd8da02e
+Create Date: 2018-01-01 00:43:46.450809
+"""
+revision = '23193b41cfea'
+down_revision = '1c87fd8da02e'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('got_staff_merch', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('attendee', 'got_staff_merch')

--- a/uber/config.py
+++ b/uber/config.py
@@ -686,6 +686,11 @@ for _name, _section in _config['age_groups'].items():
     _val = getattr(c, _name.upper())
     c.AGE_GROUP_CONFIGS[_val] = dict(_section.dict(), val=_val)
 
+c.DONATION_TIER_ITEMS = {}
+for _key, _items in _config['donation_tier_items'].items():
+    _key = int(_key) if _key.isdigit() else getattr(c, _key.upper())
+    c.DONATION_TIER_ITEMS[_key] = _items
+
 c.TABLE_PRICES = defaultdict(lambda: _config['table_prices']['default_price'],
                              {int(k): v for k, v in _config['table_prices'].items() if k != 'default_price'})
 c.PREREG_TABLE_OPTS = list(range(1, c.MAX_TABLES + 1))

--- a/uber/config.py
+++ b/uber/config.py
@@ -686,11 +686,6 @@ for _name, _section in _config['age_groups'].items():
     _val = getattr(c, _name.upper())
     c.AGE_GROUP_CONFIGS[_val] = dict(_section.dict(), val=_val)
 
-c.DONATION_TIER_ITEMS = {}
-for _key, _items in _config['donation_tier_items'].items():
-    _key = int(_key) if _key.isdigit() else getattr(c, _key.upper())
-    c.DONATION_TIER_ITEMS[_key] = _items
-
 c.TABLE_PRICES = defaultdict(lambda: _config['table_prices']['default_price'],
                              {int(k): v for k, v in _config['table_prices'].items() if k != 'default_price'})
 c.PREREG_TABLE_OPTS = list(range(1, c.MAX_TABLES + 1))
@@ -763,9 +758,13 @@ c.PREREG_SHIRT_OPTS = c.SHIRT_OPTS[1:]
 c.MERCH_SHIRT_OPTS = [(c.SIZE_UNKNOWN, 'select a size')] + list(c.PREREG_SHIRT_OPTS)
 c.DONATION_TIER_OPTS = [(amt, '+ ${}: {}'.format(amt, desc) if amt else desc) for amt, desc in c.DONATION_TIER_OPTS]
 
+c.DONATION_TIER_ITEMS = {}
 c.DONATION_TIER_DESCRIPTIONS = _config.get('donation_tier_descriptions', {})
-for tier in c.DONATION_TIER_DESCRIPTIONS.items():
-    tier[1]['price'] = [amt for amt, name in c.DONATION_TIERS.items() if name == tier[1]['name']][0]
+for _ident, _tier in c.DONATION_TIER_DESCRIPTIONS.items():
+    [price] = [amt for amt, name in c.DONATION_TIERS.items() if name == _tier['name']]
+    _tier['price'] = price
+    if price:  # ignore the $0 kickin level
+        c.DONATION_TIER_ITEMS[price] = _tier['merch_items'] or _tier['description'].split('|')
 
 c.STORE_ITEM_NAMES = [desc for val, desc in c.STORE_PRICE_OPTS]
 c.FEE_ITEM_NAMES = [desc for val, desc in c.FEE_PRICE_OPTS]

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -229,6 +229,12 @@ shirts_per_staffer = integer(default=0)
 # note: volunteers (not staff badges) always get a free swag shirt
 staff_eligible_for_swag_shirt = boolean(default=True)
 
+# Some events giv their staffers their special merch (such as swag shirts)
+# at a separate location from the normal merch booth.  If this setting is true,
+# then the merch page will have two separate buttons for merch and staff merch
+# but otherwise those will be combined and all distributed at once.
+separate_staff_merch = boolean(default=True)
+
 # The max number of tables a dealer can apply for.  Note that the admin
 # interface allows you to give a dealer a higher number than this.
 max_tables = integer(default=4)
@@ -572,6 +578,27 @@ discount        = integer(default=0)
 can_register    = boolean(default=True)
 can_volunteer   = boolean(default=True)
 consent_form    = boolean(default=False)
+
+
+[donation_tier_items]
+# Sometimes the items in the [[donation_tier]] subsection of [integer_enums]
+# are deliberately vague.  This can be either for brevity in our dropdowns or
+# because we've decided to not reveal all of the swag items ahead of time.
+# However, the merch booth needs to know exactly what they're giving out, since
+# just saying e.g. "supporter pack" might lead to new volunteers failing to give
+# out all of the items in that pack.
+#
+# Each option in this section should be the integer amount of a donation tier,
+# and each value is a list of the items in that tier.  Any donation tier with
+# a value here will have this value displayed for the merch booth; otherwise the
+# base tier description will be used.
+#
+# The option names may be specified as strings representing the names of config
+# options which themselves are the names of those donation tiers, e.g.
+#     [donation_tier_items]
+#     30 = "the extra large blue ribbon"
+#     supporter_level = "a supporter bag", "custom poncho"
+__many__ = force_list
 
 
 [integer_enums]

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -580,25 +580,49 @@ can_volunteer   = boolean(default=True)
 consent_form    = boolean(default=False)
 
 
-[donation_tier_items]
+[donation_tier_descriptions]
 # Sometimes the items in the [[donation_tier]] subsection of [integer_enums]
-# are deliberately vague.  This can be either for brevity in our dropdowns or
-# because we've decided to not reveal all of the swag items ahead of time.
-# However, the merch booth needs to know exactly what they're giving out, since
-# just saying e.g. "supporter pack" might lead to new volunteers failing to give
-# out all of the items in that pack.
+# need extra information beyond just the amount and name of the donation level.
+# The two fields with semantic meaning to our merch booth are the "description"
+# and "items" fields.  When someone comes to collect their merch, it's useful to
+# not just say the donation level (e.g. "Supporter Pack") but to individually
+# list the items.  This helps prevent new volunteers from accidentally failing
+# to give out all of the items in the pack.
 #
-# Each option in this section should be the integer amount of a donation tier,
-# and each value is a list of the items in that tier.  Any donation tier with
-# a value here will have this value displayed for the merch booth; otherwise the
-# base tier description will be used.
+# The subsection names here can be anything; the "name" field is used to map
+# each subsection to the donation tier.  For example, if we had the following
+# donation tiers:
+#   [integer_enums]
+#   [[donation_tier]]
+#   "No thanks" = 0
+#   "Have some money" = 10
+#   "Shirt" = SHIRT_LEVEL
+#   "Supporter Pack" = SUPPORTER_LEVEL
 #
-# The option names may be specified as strings representing the names of config
-# options which themselves are the names of those donation tiers, e.g.
-#     [donation_tier_items]
-#     30 = "the extra large blue ribbon"
-#     supporter_level = "a supporter bag", "custom poncho"
-__many__ = force_list
+# We might see the following tier descriptions:
+#   [donation_tier_descriptions]
+#   [[minimum_kickin]]
+#   name = "Have some money"
+#   description = "Our Gratitude|Cool Throw-ins"
+#   merch_items = "Friend of the Event Ribbon", "Sticker Pack" 
+#   [[supporter]]
+#   name = "Supporter Pack"
+#   description = "Supporter Bag|Custom Poncho"
+#
+# The "description" field is a "|"-separated list (TODO: replace this with an
+# actual list).  We split this and use it to show which merch items should be
+# distributed, unless the "merch_items" field is set, in which case we use that.
+# The reason these are separate is because sometimes the description might
+# contain things that we don't physically hand out at the merch booth.
+#
+# In addition to everything described above, event-specific plugins can place
+# additional information here to power custom Javascript on their registration
+# page.  For example, the "magprime" plugin adds "icon" and "link" fields to
+# each subsection.
+[[__many__]]
+name = string(default="")
+description = string(default="")
+merch_items = force_list(default=list())
 
 
 [integer_enums]

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -774,12 +774,13 @@ class Attendee(MagModel, TakesPaymentMixin):
             merch.append(c.DONATION_TIERS[c.SHIRT_LEVEL])
         elif self.num_event_shirts_owed > 1:
             shirt = 'a 2nd ' + c.DONATION_TIERS[c.SHIRT_LEVEL]
-            if self.volunteer_event_shirt_eligible \
-                    and not self.volunteer_event_shirt_earned:
-                shirt += (
-                    ' (this volunteer must work at least 6 hours or '
-                    'they will be reported for picking up their shirt)')
             merch.append(shirt)
+
+        if self.volunteer_event_shirt_eligible \
+                and not self.volunteer_event_shirt_earned:
+            merch[-1] += (
+                ' (this volunteer must work at least 6 hours or '
+                'they will be reported for picking up their shirt)')
 
         if not c.SEPARATE_STAFF_MERCH:
             merch.extend(self.staff_merch_items)

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -70,7 +70,9 @@ def _decline_and_convert_dealer_group(session, group, delete_when_able=False):
                                render('emails/dealers/badge_converted.html', {
                                    'attendee': attendee,
                                    'group': group
-                               }), model=attendee)
+                               }),
+                               format='html',
+                               model=attendee)
                     emails_sent += 1
                 except:
                     emails_failed += 1

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -481,14 +481,15 @@ class Root:
     @ajax
     def check_merch(self, session, badge_num, staff_merch=''):
         id = shirt = None
+        merch_items = []
         if not (badge_num.isdigit() and 0 < int(badge_num) < 99999):
             message = 'Invalid badge number'
         else:
-            results = session.query(Attendee).filter_by(badge_num=badge_num)
-            if results.count() != 1:
+            attendee = session.query(Attendee) \
+                              .filter_by(badge_num=badge_num).first()
+            if not attendee:
                 message = 'No attendee has badge number {}'.format(badge_num)
             else:
-                attendee = results.one()
                 if staff_merch:
                     merch = attendee.staff_merch
                     got_merch = attendee.got_staff_merch
@@ -503,16 +504,19 @@ class Root:
                                 merch=merch, shirt=c.SHIRTS[attendee.shirt])
                 else:
                     id = attendee.id
+                    merch_items = attendee.staff_merch_items if staff_merch \
+                        else attendee.merch_items
                     if (staff_merch and attendee.num_staff_shirts_owed) or \
                             (not staff_merch and attendee.num_event_shirts_owed):
                         shirt = attendee.shirt or c.SIZE_UNKNOWN
                     else:
                         shirt = c.NO_SHIRT
-                    message = '{a.full_name} ({a.badge}) has not yet received {merch}'.format(a=attendee, merch=merch)
+                    message = '{a.full_name} ({a.badge}) has not yet received their merch.'.format(a=attendee)
         return {
             'id': id,
             'shirt': shirt,
-            'message': message
+            'message': message,
+            'merch_items': merch_items
         }
 
     @ajax

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -474,7 +474,7 @@ class Root:
         raise HTTPRedirect('index?message={}', 'Badge has been recorded as lost.')
 
     @ajax
-    def check_merch(self, session, badge_num):
+    def check_merch(self, session, badge_num, staff_merch=''):
         id = shirt = None
         if not (badge_num.isdigit() and 0 < int(badge_num) < 99999):
             message = 'Invalid badge number'
@@ -484,15 +484,26 @@ class Root:
                 message = 'No attendee has badge number {}'.format(badge_num)
             else:
                 attendee = results.one()
-                if not attendee.merch:
+                if staff_merch:
+                    merch = attendee.staff_merch
+                    got_merch = attendee.got_staff_merch
+                else:
+                    merch, got_merch = attendee.merch, attendee.got_merch
+
+                if not merch:
                     message = '{a.full_name} ({a.badge}) has no merch'.format(a=attendee)
-                elif attendee.got_merch:
-                    message = '{a.full_name} ({a.badge}) already got {a.merch}.' \
-                              ' Their shirt size is {shirt}'.format(a=attendee, shirt=c.SHIRTS[attendee.shirt])
+                elif got_merch:
+                    message = '{a.full_name} ({a.badge}) already got {merch}.' \
+                              ' Their shirt size is {shirt}'.format(a=attendee,
+                                merch=merch, shirt=c.SHIRTS[attendee.shirt])
                 else:
                     id = attendee.id
-                    shirt = (attendee.shirt or c.SIZE_UNKNOWN) if attendee.gets_any_kind_of_shirt else c.NO_SHIRT
-                    message = '{a.full_name} ({a.badge}) has not yet received {a.merch}'.format(a=attendee)
+                    if (staff_merch and attendee.num_staff_shirts_owed) or \
+                            (not staff_merch and attendee.num_event_shirts_owed):
+                        shirt = attendee.shirt or c.SIZE_UNKNOWN
+                    else:
+                        shirt = c.NO_SHIRT
+                    message = '{a.full_name} ({a.badge}) has not yet received {merch}'.format(a=attendee, merch=merch)
         return {
             'id': id,
             'shirt': shirt,
@@ -500,7 +511,7 @@ class Root:
         }
 
     @ajax
-    def give_merch(self, session, id, shirt_size, no_shirt):
+    def give_merch(self, session, id, shirt_size, no_shirt, staff_merch):
         try:
             shirt_size = int(shirt_size)
         except:
@@ -508,10 +519,12 @@ class Root:
 
         success = False
         attendee = session.attendee(id, allow_invalid=True)
-        if not attendee.merch:
+        merch = attendee.staff_merch if staff_merch else attendee.merch
+        got = attendee.got_staff_merch if staff_merch else attendee.got_merch
+        if not merch:
             message = '{} has no merch'.format(attendee.full_name)
-        elif attendee.got_merch:
-            message = '{} already got {}'.format(attendee.full_name, attendee.merch)
+        elif got:
+            message = '{} already got {}'.format(attendee.full_name, merch)
         elif shirt_size == c.SIZE_UNKNOWN:
             message = 'You must select a shirt size'
         else:
@@ -519,8 +532,9 @@ class Root:
                 message = '{} is now marked as having received all of the following (EXCEPT FOR THE SHIRT): {}'
             else:
                 message = '{} is now marked as having received {}'
-            message = message.format(attendee.full_name, attendee.merch)
-            attendee.got_merch = True
+            message = message.format(attendee.full_name, merch)
+            setattr(attendee,
+                    'got_staff_merch' if staff_merch else 'got_merch', True)
             if shirt_size:
                 attendee.shirt = shirt_size
             if no_shirt:

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -347,6 +347,8 @@
     <div class="col-sm-9">
         <p class="form-control-static">{{ attendee.merch }}</p>
         {% if attendee.got_merch %} (Merch has been picked up) {% endif %}
+        <p class="form-control-static">{{ attendee.staff_merch }}</p>
+        {% if attendee.got_merch %} (Staff merch has been picked up) {% endif %}
     </div>
 </div>
 

--- a/uber/templates/registration/merch.html
+++ b/uber/templates/registration/merch.html
@@ -2,6 +2,10 @@
 {% block title %}Merch Booth{% endblock %}
 {% block content %}
 
+<style type="text/css">
+    #give .merch-list { color: red; }
+</style>
+
 <script type="text/javascript">
     var $shirtOpts = $('<select/>').attr('id', 'shirt');
     $.each({{ c.MERCH_SHIRT_OPTS|jsonize }}, function(i,size) {
@@ -67,9 +71,16 @@
         });
     }
 
-    var giveMerch = function (noShirt, id, shirtSize) {
+    var giveMerch = function (noShirt, id, staffMerch, shirtSize) {
         $('#give button').attr('disabled', true);
-        $.post('give_merch', {id: id, csrf_token: csrf_token, no_shirt: noShirt, shirt_size: shirtSize || null}, function(json) {
+        var params = {
+            id: id,
+            no_shirt: noShirt,
+            csrf_token: csrf_token,
+            staff_merch: staffMerch,
+            shirt_size: shirtSize || null
+        };
+        $.post('give_merch', params, function(json) {
             $('#give').html('');
             $('#badge_num').val('');
             $('#message').html(json.message);
@@ -125,7 +136,7 @@
             }
         });
     };
-    
+
     $(function(){
         $('#message').ajaxError(function () {
             toastr.error('Oh noes - the web server is down or something!!!!!');
@@ -153,38 +164,46 @@
             }
         });
 
-        $('#swag').on('submit', function(e){
-            $('#give,#message').html('');
-            $.post('check_merch', {csrf_token: csrf_token, badge_num: $('#badge_num').val()}, function(resp) {
-                if (!resp.id) {
-                    $('#message').html(resp.message);
-                } else {
-                    $('#give').html(resp.message.replace(' and ', ',')
-                                        .replace(' received ', ' received<br/>- ')
-                                        .replace(/,/g, '<br/>- ')
-                                        .replace('<br/>- <br/>- ', '<br/>- ')
-                                  + '<br/>');
-                    if (resp.shirt != {{ c.NO_SHIRT }}) {
-                        $('#give').append('Choose a shirt size:').append($shirtOpts);
-                        $('#give select').val(resp.shirt);
-                    }
-                    $('#give').append(
-                        $('<button>Give Merch</button>').click(function() {
-                            giveMerch('', resp.id, $("#shirt").val());
-                            return false;
-                        })
-                    );
-                    {% if c.OUT_OF_SHIRTS %}
-                        $("#give").append(
-                            $('<button>Give Merch Without Shirt</button>').click(function() {
-                                giveMerch('no_shirt', resp.id, $('#shirt').val());
+        $.each(['#check_merch', '#check_staff_merch'], function (i, id) {
+            $(id).on('click', function() {
+                var staffMerch = id == '#check_staff_merch' ? 'true' : '';
+                var params = {
+                    csrf_token: csrf_token,
+                    staff_merch: staffMerch,
+                    badge_num: $('#badge_num').val(),
+                };
+                $('#give,#message').html('');
+                $.post('check_merch', params, function (resp) {
+                    if (!resp.id) {
+                        $('#message').html(resp.message);
+                    } else {
+                        $('#give').empty().append(
+                            $('<div class="merch-list"></div>').html(
+                                resp.message.replace(' and ', ',')
+                                            .replace(' received ', ' received<br/>- ')
+                                            .replace(/,/g, '<br/>- ')
+                                            .replace('<br/>- <br/>- ', '<br/>- ')));
+                        if (resp.shirt != {{ c.NO_SHIRT }}) {
+                            $('#give').append('Choose a shirt size:').append($shirtOpts);
+                            $('#give select').val(resp.shirt);
+                        }
+                        $('#give').append(
+                            $('<button>Give Merch</button>').click(function () {
+                                giveMerch('', resp.id, staffMerch, $("#shirt").val());
                                 return false;
                             })
                         );
-                    {% endif %}
-                }
-            }, 'json');
-            return false;
+                        {% if c.OUT_OF_SHIRTS %}
+                            $("#give").append(
+                                $('<button>Give Merch Without Shirt</button>').click(function () {
+                                    giveMerch('no_shirt', resp.id, staffMerch, $('#shirt').val());
+                                    return false;
+                                })
+                            );
+                        {% endif %}
+                    }
+                }, 'json');
+            });
         });
     });
 </script>
@@ -231,16 +250,17 @@
 <tr>
     <td> Give Merch </td>
     <td colspan="2">
-        <form id="swag">
         Badge Number: <input type="number" id="badge_num" min="1" max="99999" />
-        <input type="submit" id="give_merch" value="Check Merch" />
-        </form>
+        <input type="submit" id="check_merch" value="Check Merch" />
+        {% if c.SEPARATE_STAFF_MERCH %}
+            <input type="submit" id="check_staff_merch" value="Check Staff Merch" />
+        {% endif %}
     </td>
     <td colspan="2"></td>
 </tr>
 <tr>
     <td></td>
-    <td id="give" colspan="4" style="color:red"></td>
+    <td id="give" colspan="4"></td>
 </tr>
 </table>
 

--- a/uber/templates/registration/merch.html
+++ b/uber/templates/registration/merch.html
@@ -15,6 +15,30 @@
         $shirtOpts.append($('<option/>').val(size[0]).text(size[1]));
     });
 
+    /**
+     * Given the list of items returned by Attendee.merch_list, return a nested
+     * list of those items for display when that attendee's merch is checked.
+     */
+    var createMerchList = function (message, merchItems) {
+        var $merchList = $('<ul></ul>');
+        $.each(merchItems, function (i, item) {
+            if ($.isArray(item)) {
+                var $subList = $('<ul></ul>');
+                $.each(item, function (j, subItem) {
+                    $subList.append(
+                        $('<li></li>').text(subItem));
+                });
+                $merchList.append($subList);
+            } else {
+                $merchList.append(
+                    $('<li></li>').text(item));
+            }
+        });
+        return $('<div class="merch-list"></div>')
+            .append(message)
+            .append($merchList);
+    };
+
     var recordSale = function () {
         $.post('record_sale', {
             id:         'None',
@@ -190,11 +214,8 @@
                         $('#message').html(resp.message);
                     } else {
                         $('#give').empty().append(
-                            $('<div class="merch-list"></div>').html(
-                                resp.message.replace(' and ', ',')
-                                            .replace(' received ', ' received<br/>- ')
-                                            .replace(/,/g, '<br/>- ')
-                                            .replace('<br/>- <br/>- ', '<br/>- ')));
+                            createMerchList(resp.message, resp.merch_items)
+                        );
                         if (resp.shirt != {{ c.NO_SHIRT }}) {
                             $('#give').append('Choose a shirt size:').append($shirtOpts);
                             $('#give select').val(resp.shirt);

--- a/uber/tests/models/test_merch.py
+++ b/uber/tests/models/test_merch.py
@@ -165,19 +165,26 @@ class TestMerch:
         assert 'foo' == Attendee(extra_merch='foo').merch
 
     def test_normal_kickins(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'donation_swag', ['some', 'stuff'])
+        monkeypatch.setattr(Attendee, 'merch_items', ['some', 'stuff'])
+        assert 'some and stuff' == Attendee().merch
+
+    def test_nested_kickins(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'merch_items', ['some', ['mildly', 'nested'], 'stuff'])
         assert 'some and stuff' == Attendee().merch
 
     def test_comma_and(self, monkeypatch):
-        monkeypatch.setattr(Attendee, 'donation_swag', ['some', 'stuff'])
-        assert 'some, stuff, and more' == Attendee(extra_merch='more').merch
+        monkeypatch.setattr(Attendee, 'merch_items', ['some', 'stuff', 'more'])
+        assert 'some, stuff, and more' == Attendee().merch
+
+    def test_extra_merch(self):
+        assert 'more' == Attendee(extra_merch='more').merch
 
     def test_info_packet(self):
         assert '' == Attendee(staffing=True).merch
         assert 'Staffer Info Packet' == Attendee(staffing=True).staff_merch
 
     def test_staff_shirts(self, gets_staff_shirt):
-        assert 'RedShirt' in Attendee().merch
+        assert 'tshirt' in Attendee().merch
         assert '2 Staff Shirts' in Attendee().staff_merch
 
         a = Attendee(second_shirt=c.TWO_STAFF_SHIRTS)
@@ -185,10 +192,14 @@ class TestMerch:
         assert '3 Staff Shirts' in a.staff_merch
 
     def test_volunteer(self, volunteer_event_shirt_eligible):
-        assert 'RedShirt' in Attendee().merch and 'will be reported' in Attendee().merch
+        assert 'tshirt' in Attendee().merch and 'will be reported' in Attendee().merch
+
+    def test_paid_volunteer(self, paid_for_a_shirt, volunteer_event_shirt_eligible):
+        assert 'RedShirt' in Attendee(amount_extra=c.SHIRT_LEVEL).merch
+        assert '2nd tshirt' in Attendee(amount_extra=c.SHIRT_LEVEL).merch
 
     def test_volunteer_worked(self, volunteer_event_shirt_eligible, volunteer_event_shirt_earned):
-        assert 'RedShirt' == Attendee().merch
+        assert 'tshirt' in Attendee().merch
 
     def test_two_swag_shirts(self, volunteer_event_shirt_eligible, volunteer_event_shirt_earned, paid_for_a_shirt):
-        assert 'RedShirt and a 2nd RedShirt' == Attendee(amount_extra=c.SHIRT_LEVEL).merch
+        assert 'RedShirt and a 2nd tshirt' == Attendee(amount_extra=c.SHIRT_LEVEL).merch

--- a/uber/tests/models/test_merch.py
+++ b/uber/tests/models/test_merch.py
@@ -141,6 +141,7 @@ class TestMerchAttrs:
 class TestMerch:
     @pytest.fixture(autouse=True)
     def defaults(self, monkeypatch):
+        monkeypatch.setattr(c, 'SEPARATE_STAFF_MERCH', True)
         for attr in ['volunteer_event_shirt_eligible', 'paid_for_a_shirt', 'volunteer_event_shirt_earned', 'gets_staff_shirt']:
             monkeypatch.setattr(Attendee, attr, False)
 
@@ -172,10 +173,16 @@ class TestMerch:
         assert 'some, stuff, and more' == Attendee(extra_merch='more').merch
 
     def test_info_packet(self):
-        assert 'Staffer Info Packet' == Attendee(staffing=True).merch
+        assert '' == Attendee(staffing=True).merch
+        assert 'Staffer Info Packet' == Attendee(staffing=True).staff_merch
 
     def test_staff_shirts(self, gets_staff_shirt):
-        assert '3 Staff Shirts' == Attendee().merch
+        assert 'RedShirt' in Attendee().merch
+        assert '2 Staff Shirts' in Attendee().staff_merch
+
+        a = Attendee(second_shirt=c.TWO_STAFF_SHIRTS)
+        assert '' == a.merch
+        assert '3 Staff Shirts' in a.staff_merch
 
     def test_volunteer(self, volunteer_event_shirt_eligible):
         assert 'RedShirt' in Attendee().merch and 'will be reported' in Attendee().merch


### PR DESCRIPTION
This implements everything in #3052 
- There are now two buttons on the Merch page, one for checking for Merch and the other for checking for Staff Merch and the "got merch" states are tracked separately for each.
- This behavior is configurable so other events with a single merch location can turn it off and revert to the original behavior of all merch being combined.
- These two merch sections now reflect the staffer preference given for 2 staff shirts vs 1 event shirt.
- Donation tiers can now be expanded into their component items with a new optional config section called ``[donation_tier_items]``.  (We already have a ``[donation_tier_descriptions]`` section, but it doesn't quite do what we need.)

I still need to make additional PRs in the ``ubersystem-puppet`` and ``production-config`` repos to add support for the new ``[donation_tier_items]`` section.  Until that time, the last item above won't actually do anything for our deployments since we won't have the necessary option configured.  I should be bale to do that on Monday.