### PR TITLE
Add only_prepay_at_door option

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -639,6 +639,14 @@ if not c.KIOSK_CC_ENABLED:
     del _config['enums']['door_payment_method']['stripe']
     c.create_enum_val('stripe')
 
+if c.ONLY_PREPAY_AT_DOOR:
+    del _config['enums']['door_payment_method']['cash']
+    del _config['enums']['door_payment_method']['manual']
+    del _config['enums']['door_payment_method']['group']
+    c.create_enum_val('cash')
+    c.create_enum_val('manual')
+    c.create_enum_val('group')
+
 if not c.GROUPS_ENABLED:
     del _config['enums']['door_payment_method']['group']
     c.create_enum_val('group')

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -127,6 +127,10 @@ post_con = boolean(default=False)
 # to quickly pay at-door using a credit card.
 kiosk_cc_enabled = boolean(default=False)
 
+# This disables everything BUT the Stripe payment options for kiosks,
+# allowing events to open at-door reg before their payment stations exist
+only_prepay_at_door = boolean(default=False)
+
 # When this is True, the only thing anyone can do is log in as a volunteer to
 # view their shift schedule.  All other pages, including admin pages, will be
 # disabled, with the idea being that the live database will be move to on-site


### PR DESCRIPTION
Requested by registration so they can turn on at-con mode without needing payment stations set up. We do this instead of just changing the door_payment_method opts because it is impossible to take away enum options via puppet.