### PR TITLE
Add a link to email volunteers with shifts in a dept

### DIFF
--- a/uber/site_sections/jobs.py
+++ b/uber/site_sections/jobs.py
@@ -121,6 +121,7 @@ class Root:
             'department_id': department_id,
             'attendees': attendees,
             'emails': ','.join(a.email for a in attendees),
+            'emails_with_shifts': ','.join([a.email for a in attendees if a.hours_here]),
             'checklist': session.checklist_status('assigned_volunteers', department_id)
         }
 

--- a/uber/templates/jobs/staffers.html
+++ b/uber/templates/jobs/staffers.html
@@ -34,7 +34,8 @@
 
 <br/>
 <span style="font-size:14pt ; font-weight:bold"> Staffers Assigned to This Area</span>
-(<a href="mailto:eli@courtwright.org?bcc={{ emails }}">email these staffers</a>)<b>:</b>
+  (<a href="mailto:{{ c.ADMIN_EMAIL }}?bcc={{ emails }}">email these staffers</a>
+  or <a href="mailto:{{ c.ADMIN_EMAIL }}?bcc={{ emails_with_shifts }}">email staffers with shifts here</a>)<b>:</b>
 <br/> <br/>
 
 <table class="table table-striped datatable">


### PR DESCRIPTION
Several departments have a lot of volunteers assigned to them who don't actually take shifts in that department. We now have a link to only email staffers with shifts in a department, so department heads can send better-targeted emails.