### PR TITLE
Remove 'fallback' options for at-door if prepay only is set

### DIFF
--- a/uber/templates/registration/pay.html
+++ b/uber/templates/registration/pay.html
@@ -3,19 +3,21 @@
 {% block backlink %}{% endblock %}
 {% block content %}
 
-<script type="text/javascript">
-    DISABLE_STRIPE_BUTTONS_ON_CLICK = false;
-</script>
-<script src="../static/js/servertimecheck.js" type="text/javascript"></script>
+  <script type="text/javascript">
+      DISABLE_STRIPE_BUTTONS_ON_CLICK = false;
+  </script>
+  <script src="../static/js/servertimecheck.js" type="text/javascript"></script>
 
-<h2>Payment for {{ attendee.full_name }}</h2>
+  <h2>Payment for {{ attendee.full_name }}</h2>
 
-<div class="center">
+  <div class="center">
     {{ stripe_form('take_payment',charge) }}
-    <br/>
-    <a href="register?message=Please+queue+in+the+cash+line+and+have+your+photo+ID+and+cash+ready.">{{ macros.stripe_button("Nevermind, I'll Pay Cash") }}</a>
-    <br/> <br/>
-    <a href="register?message=Please+queue+in+the+credit+card+line+and+have+your+photo+ID+and+credit+card+ready.">{{ macros.stripe_button("Nevermind, I'll Use My Credit Card at the Desk") }}</a>
-</div>
+    {% if not c.ONLY_PREPAY_AT_DOOR %}
+      <br/>
+      <a href="register?message=Please+queue+in+the+cash+line+and+have+your+photo+ID+and+cash+ready.">{{ macros.stripe_button("Nevermind, I'll Pay Cash") }}</a>
+      <br/> <br/>
+      <a href="register?message=Please+queue+in+the+credit+card+line+and+have+your+photo+ID+and+credit+card+ready.">{{ macros.stripe_button("Nevermind, I'll Use My Credit Card at the Desk") }}</a>
+    {% endif %}
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
We were removing the dropdown options for cash and pay-at-desk, but then bringing attendees to a page that let them select those anyway! This fixes that.