### PR TITLE
added special swadge handling

### DIFF
--- a/alembic/versions/c49ddb5a4845_added_temporary_got_swadge_column.py
+++ b/alembic/versions/c49ddb5a4845_added_temporary_got_swadge_column.py
@@ -1,0 +1,45 @@
+"""added temporary got_swadge column
+
+Revision ID: c49ddb5a4845
+Revises: 23193b41cfea
+Create Date: 2018-01-04 18:29:07.159553
+"""
+revision = 'c49ddb5a4845'
+down_revision = '23193b41cfea'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+
+def upgrade():
+    if is_sqlite:
+        with op.batch_alter_table('attendee', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.alter_column('got_swadge', type_=sa.Boolean(), server_default=False, nullable=False)
+    else:
+        op.add_column('attendee', sa.Column('got_swadge', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('attendee', 'got_swadge')

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -105,6 +105,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     extra_merch = Column(UnicodeText, admin_only=True)
     got_merch = Column(Boolean, default=False, admin_only=True)
     got_staff_merch = Column(Boolean, default=False, admin_only=True)
+    got_swadge = Column(Boolean, default=False, admin_only=True)
 
     reg_station = Column(Integer, nullable=True, admin_only=True)
     registered = Column(UTCDateTime, server_default=utcnow())
@@ -686,6 +687,11 @@ class Attendee(MagModel, TakesPaymentMixin):
             self.badge_type in c.TRANSFERABLE_BADGE_TYPES and \
             not self.admin_account and \
             not self.has_role_somewhere
+
+    # TODO: delete this after Super MAGFest 2018
+    @property
+    def gets_swadge(self):
+        return self.amount_extra >= c.SUPPORTER_LEVEL
 
     @property
     def paid_for_a_shirt(self):

--- a/uber/templates/registration/merch.html
+++ b/uber/templates/registration/merch.html
@@ -99,14 +99,15 @@
         });
     };
 
-    var giveMerch = function (noShirt, id, staffMerch, shirtSize) {
+    var giveMerch = function (noShirt, id, staffMerch, shirtSize, giveSwadge) {
         $('#give button').attr('disabled', true);
         var params = {
             id: id,
             no_shirt: noShirt,
             csrf_token: csrf_token,
             staff_merch: staffMerch,
-            shirt_size: shirtSize || null
+            shirt_size: shirtSize || null,
+            give_swadge: giveSwadge ? 'true' : ''
         };
         $.post('give_merch', params, function(json) {
             $('#give').html('');
@@ -117,14 +118,19 @@
                     .append(' &nbsp; ')
                     .append(
                         $('<a href="#">Undo</a>').click(function(){
-                            takeBackMerch(id);
+                            takeBackMerch(id, staffMerch);
                             return false;
                          }));
             }
         }, 'json');
     };
-    var takeBackMerch = function (id) {
-        $.post('take_back_merch', {id: id, csrf_token: csrf_token}, function(message) {
+    var takeBackMerch = function (id, staffMerch) {
+        var params = {
+            id: id,
+            csrf_token: csrf_token,
+            staff_merch: staffMerch
+        };
+        $.post('take_back_merch', params, function (message) {
             $('#message').html(message);
         });
     };
@@ -220,17 +226,30 @@
                             $('#give').append('Choose a shirt size:').append($shirtOpts);
                             $('#give select').val(resp.shirt);
                         }
-                        $('#give').append(
-                            $('<button>Give Merch</button>').click(function () {
-                                giveMerch('', resp.id, staffMerch, $("#shirt").val());
-                                return false;
-                            })
-                        );
+
+                        if (resp.swadges_available || !resp.gets_swadge) {
+                            $('#give').append(
+                                $('<button>Give Merch</button>').click(function () {
+                                    giveMerch('', resp.id, staffMerch, $("#shirt").val(), resp.gets_swadge);
+                                })
+                            );
+                        } else {
+                            $('#give').append(
+                                $('<button>Give Merch WITH Swadge</button>').click(function () {
+                                    giveMerch('', resp.id, staffMerch, $("#shirt").val(), true);
+                                })
+                            );
+                            $('#give').append(
+                                $('<button>Give Merch WITHOUT Swadge</button>').click(function () {
+                                    giveMerch('', resp.id, staffMerch, $("#shirt").val(), false);
+                                })
+                            );
+                        }
+
                         {% if c.OUT_OF_SHIRTS %}
                             $("#give").append(
                                 $('<button>Give Merch Without Shirt</button>').click(function () {
                                     giveMerch('no_shirt', resp.id, staffMerch, $('#shirt').val());
-                                    return false;
                                 })
                             );
                         {% endif %}


### PR DESCRIPTION
Our swadges are late!  But we now have a bunch of people who have already received merch without the swadge.  As a weird on-site fix, I'm temporarily adding swadge logic into the core ``uber`` plugin:

1) People who have already received their merch are marked as not having received their swadge.

2) Until the swadges arrive, instead of the "Give Merch" button, we want "Give Merch Without Swadge" and "Give Merch Including Swadge" buttons.

3) After the "Give Merch With Swadge" button has been pressed for the first time, we want to revert to the single "Give Merch" button, which is assumed to include the Swadge because those have arrived.

4) People who have their merch checked after they've already received merch but NOT received a swadge will show a message allowing you to give them just their swadge.

This change will happen automatically - as soon as a single swadge is handed out, we go back to just a single "Give Merch" button.  This is to prevent having to do a server restart when the swadges arrive.

@RobRuana is heading back to my location soon, at which point I'll demo all of this to him and then push it out after he has a chance to review the code.
  