### PR TITLE
Add "Badge counts by type" to Summary

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -149,12 +149,13 @@ class Config(_Overridable):
 
     def get_badge_count_by_type(self, badge_type):
         """
-        Returns the count of all "Complete" badges of the given type; unlike the
-        BADGES_SOLD property, this counts all paid values.  Thus we have counts
-        for badge types that aren't typically sold, e.g. Staff badges.
+        Returns the count of all badges of the given type that we've promised to attendees.
+
         """
         with sa.Session() as session:
-            return session.query(sa.Attendee).filter_by(badge_type=badge_type, badge_status=c.COMPLETED_STATUS).count()
+            return session.query(sa.Attendee).filter(sa.Attendee.badge_type == badge_type,
+                                                     sa.Attendee.badge_status.in_([c.COMPLETED_STATUS, c.NEW_STATUS])) \
+                .count()
 
     def get_printed_badge_deadline_by_type(self, badge_type):
         """

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -40,6 +40,7 @@ class Root:
         for var in c.BADGE_VARS:
             badge_type = getattr(c, var)
             counts['stocks'][c.BADGES[badge_type]] = stocks.get(var.lower(), 'no limit set')
+            counts['counts'][c.BADGES[badge_type]] = c.get_badge_count_by_type(badge_type)
 
         for a in session.query(Attendee).options(joinedload(Attendee.group)):
             counts['paid'][a.paid_label] += 1

--- a/uber/templates/summary/index.html
+++ b/uber/templates/summary/index.html
@@ -18,11 +18,22 @@
 {% endfor %}
 
 <h4>Badge Types</h4>
+  The total number of badges in the system, by type.
+  <br/>
 <ul>
     {% for desc, count in counts.badges.items() %}
         <li><i>{{ desc }}:</i> {{ count }}</li>
     {% endfor %}
 </ul>
+
+  <h4>Badge Counts by Type</h4>
+  Badges that count against badge stocks -- these represent the physical badges we have promised attendees so far.
+  <br/>
+  <ul>
+    {% for desc, count in counts.counts.items() %}
+      <li><i>{{ desc }}:</i> {{ count }}</li>
+    {% endfor %}
+  </ul>
 
 <h4>Badge Stocks</h4>
 <ul>


### PR DESCRIPTION
Per registration's request, the summary page now lists all badges in the system we've promised to attendees. It does this by counting all badges of a type as long as it is New or Complete status.