### PR TITLE
Make Badge Status read-only during the event

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -132,6 +132,7 @@ class Root:
             'check_in':   check_in,
             'return_to':  return_to,
             'omit_badge': omit_badge,
+            'admin_can_change_status': session.admin_attendee().is_dept_head_of(c.REGDESK),
             'group_opts': [(g.id, g.name) for g in session.query(Group).order_by(Group.name).all()],
             'unassigned': {group_id: unassigned
                            for group_id, unassigned in session.query(Attendee.group_id, func.count('*'))

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -160,9 +160,12 @@
     <div class="form-group">
         <label for="badge_status" class="col-sm-3 control-label">Status</label>
         <div class="col-sm-6">
-            <select name="badge_status">
+          <select name="badge_status"{% if c.AT_THE_CON and not admin_can_change_status %} disabled="true"{% endif %}>
             {{ options(c.BADGE_STATUS_OPTS,attendee.badge_status) }}
             </select>
+          {% if c.AT_THE_CON and not admin_can_change_status %}
+            <input type="hidden" name="badge_status" value="{{ attendee.badge_status }}"/>
+            Altering the badge status is disabled during the event. The system will update it automatically.{% endif %}
         </div>
     </div>
 


### PR DESCRIPTION
Volunteers are using the badge status dropdown to bypass important system checks, so we're making it readonly for anyone who is not a department head of Registration.