### PR TITLE
Add Emails By Kickin level report

### DIFF
--- a/uber/site_sections/emails.py
+++ b/uber/site_sections/emails.py
@@ -146,3 +146,28 @@ class Root:
         for a in attendees:
             if set(interests).intersection(a.interests_ints):
                 out.writerow([a.full_name, a.email, a.zip_code])
+
+    def emails_by_kickin(self, message=''):
+        return {
+            'message': message
+        }
+
+    @csv_file
+    def emails_by_kickin_csv(self, out, session, **params):
+        """
+        Generate a list of attendee emails by what kick-in level they've donated at
+        """
+        if 'amount_extra' not in params:
+            raise HTTPRedirect('emails_by_kickin?message={}', 'You must select a kick-in level')
+
+        amount_extra = params['amount_extra']
+
+        status_filter = Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS])
+        email_filter = [Attendee.can_spam == True] if 'only_can_spam' in params else []
+
+        attendees = session.query(Attendee).filter(status_filter, *email_filter).all()
+        out.writerow(["fullname", "email", "zipcode"])
+
+        for a in attendees:
+            if amount_extra == a.amount_extra:
+                out.writerow([a.full_name, a.email, a.zip_code])

--- a/uber/templates/emails/emails_by_kickin.html
+++ b/uber/templates/emails/emails_by_kickin.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% block title %}Email addresses by interest{% endblock %}
+{% block title %}Email addresses by kick-in{% endblock %}
 {% block content %}
 
-  <h1>Emails by Interest</h1>
+  <h1>Emails by Kick-in Level</h1>
 
   Use this page to generate a CSV file of emails of people who donated at a certain kick-in level at
   {{ c.EVENT_NAME }}.<br/><br/>

--- a/uber/templates/emails/emails_by_kickin.html
+++ b/uber/templates/emails/emails_by_kickin.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Email addresses by interest{% endblock %}
+{% block content %}
+
+  <h1>Emails by Interest</h1>
+
+  Use this page to generate a CSV file of emails of people who donated at a certain kick-in level at
+  {{ c.EVENT_NAME }}.<br/><br/>
+
+  <form action="emails_by_kickin_csv">
+    Generate list of emails from attendees with one of the following kick-in levels or more:<br/>
+    <select name="amount_extra">
+      {{ options(c.DONATION_TIER_OPTS) }}
+    </select><br/>
+    <label><input type="checkbox" name="only_can_spam" value="1"/>
+      I want to use these emails for marketing campaigns.</label>
+    <br/><input name="submit" type="submit"/><br/>
+  </form>
+
+{% endblock %}


### PR DESCRIPTION
Our swadges team needs to get the emails of everyone who's kicked in at least at the Supporter level. This report lets you choose the kick-in level you get the emails of, plus has an optional option to only pull emails from attendees who agreed to receive marketing emails.