### PR TITLE
fix year config line 

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -837,8 +837,8 @@ c.TEARDOWN_TIME_OPTS = [
 c.CON_TOTAL_LENGTH = int((c.TEARDOWN_TIME_OPTS[-1][0] - c.SETUP_TIME_OPTS[0][0]).seconds / 3600)
 c.ALL_TIME_OPTS = [(dt, dt.strftime('%I %p %a %d %b')) for dt in ((c.EPOCH - timedelta(days=c.SETUP_SHIFT_DAYS) + timedelta(hours=i)) for i in range(c.CON_TOTAL_LENGTH))]
 
-c.EVENT_NAME_AND_YEAR = c.EVENT_NAME + (' {}'.format(c.YEAR) if c.YEAR else '')
 c.EVENT_YEAR = c.EPOCH.strftime('%Y')
+c.EVENT_NAME_AND_YEAR = c.EVENT_NAME + (' {}'.format(c.EVENT_YEAR) if c.EVENT_YEAR else '')
 c.EVENT_MONTH = c.EPOCH.strftime('%B')
 c.EVENT_START_DAY = int(c.EPOCH.strftime('%d')) % 100
 c.EVENT_END_DAY = int(c.ESCHATON.strftime('%d')) % 100

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -18,7 +18,7 @@ def check_post_con(klass):
                     <h2 style='color:red'>Hope you had a great {event}!</h2>
                     Preregistration for {event} {year} will open in a few months.
                 </body></html>
-                """.format(event=c.EVENT_NAME, year=(1 + int(c.YEAR)) if c.YEAR else '')
+                """.format(event=c.EVENT_NAME, year=(1 + int(c.EVENT_YEAR)) if c.EVENT_YEAR else '')
             else:
                 return func(self, *args, **kwargs)
         return wrapped

--- a/uber/templates/emails/mivs/videoless_studio.txt
+++ b/uber/templates/emails/mivs/videoless_studio.txt
@@ -8,6 +8,6 @@ Failure to submit a video URL even 1 second after the deadline results in a lame
 
 Fear not! If your game is not ready for a video capture we will again have at least 2 Quick Play areas where you can showcase your game for a window of time with other indies.  Details about the Quick Play tables will be released about a month before MAGFest.
 
-Either way, we hope to see you at MAGFest {{ c.YEAR }} and wish you luck, and no bugs, in all your game development efforts!
+Either way, we hope to see you at MAGFest {{ c.EVENT_YEAR }} and wish you luck, and no bugs, in all your game development efforts!
 
 {{ c.MIVS_EMAIL_SIGNATURE }}


### PR DESCRIPTION
- use c.EVENT_YEAR for everything instead of c.YEAR
- calc c.EVENT_YEAR in the right order in order to use it

- [ ] TEST THIS FIRST ON STAGING (I DIDN'T TEST)
- [ ] see if we should remove all references to $year in the YAML files and the nginx.pp file in ubersystem-puppet module (I think it's safe)

semi-high priority because confirmation emails should contain the year, but, I don't think we should interrupt the launch for this.