### PR TITLE
Fixes c.ROCK_ISLAND default settings

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -560,7 +560,7 @@ band_email = string(default="MAGFest Music Department <music@magfest.org>")
 band_email_signature = string(default="- MAGFest Music Department")
 
 require_dedicated_guest_table_presence = boolean(default=True)
-rock_island_groups = string_list(default=list('band'))
+rock_island_groups = string_list(default=list(''))
 
 allowed_w9_extensions = string_list(default=list("pdf", "png", "gif", "jpg", "jpeg", "doc", "docx"))
 allowed_bio_pic_extensions = string_list(default=list("png", "gif", "jpg", "jpeg"))
@@ -1310,6 +1310,7 @@ bands = string(default="Guest Group Management")
 [[guest_merch]]
 no_merch = string(default="Not selling merch")
 own_table = string(default="Dedicated table")
+rock_island = string(default="")
 
 [[guest_charity]]
 not_donating = string(default="Nothing to donate at this time")

--- a/uber/templates/guest_checklist/band_merch_deadline.html
+++ b/uber/templates/guest_checklist/band_merch_deadline.html
@@ -1,6 +1,6 @@
 {% extends "guest_checklist/merch_deadline.html" %}
 
-{%- set HAS_ROCK_ISLAND = c.ROCK_ISLAND and guest.group_type in c.ROCK_ISLAND_GROUPS -%}
+{%- set HAS_ROCK_ISLAND = c.ROCK_ISLAND in c.GUEST_MERCHS and guest.group_type in c.ROCK_ISLAND_GROUPS -%}
 
 {% block deadline_text %}
   {% if guest.merch_status %}

--- a/uber/templates/guest_checklist/guest_merch_deadline.html
+++ b/uber/templates/guest_checklist/guest_merch_deadline.html
@@ -1,6 +1,6 @@
 {% extends "guest_checklist/merch_deadline.html" %}
 
-{%- set HAS_ROCK_ISLAND = c.ROCK_ISLAND and guest.group_type in c.ROCK_ISLAND_GROUPS -%}
+{%- set HAS_ROCK_ISLAND = c.ROCK_ISLAND in c.GUEST_MERCHS and guest.group_type in c.ROCK_ISLAND_GROUPS -%}
 
 {% block form_extra %}
   {{ super() }}

--- a/uber/templates/guest_checklist/merch_deadline.html
+++ b/uber/templates/guest_checklist/merch_deadline.html
@@ -1,4 +1,4 @@
-{%- set HAS_ROCK_ISLAND = c.ROCK_ISLAND and guest.group_type in c.ROCK_ISLAND_GROUPS -%}
+{%- set HAS_ROCK_ISLAND = c.ROCK_ISLAND in c.GUEST_MERCHS and guest.group_type in c.ROCK_ISLAND_GROUPS -%}
 
 {% if snippet %}
   <tr>


### PR DESCRIPTION
Fixes the following error we're seeing on servers that don't have rock island enabled:

```
   Traceback (most recent call last):
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 631, in respond
       self._do_respond(path_info)
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 690, in _do_respond
       response.body = self.handler()
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/lib/encoding.py", line 221, in __call__
       self.body = self.oldhandler(*args, **kwargs)
     File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/_cpdispatch.py", line 60, in __call__
       return self.callable(*self.args, **self.kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 400, in with_timing
       return func(*args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 416, in with_session
       retval = func(*args, session=session, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 524, in with_restrictions
       return func(*args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/decorators.py", line 463, in with_rendering
       result = func(*args, **kwargs)
     File "/usr/local/uber/plugins/uber/uber/site_sections/guests.py", line 156, in merch
       message = check(guest_merch)
     File "/usr/local/uber/plugins/uber/uber/utils.py", line 400, in check
       message = validator(model)
     File "/usr/local/uber/plugins/uber/uber/model_checks.py", line 962, in is_merch_checklist_complete
       elif guest_merch.selling_merch == c.ROCK_ISLAND:
     File "/usr/local/uber/plugins/uber/uber/config.py", line 695, in __getattr__
       raise AttributeError('no such attribute {}'.format(name))
   AttributeError: no such attribute ROCK_ISLAND
```