### PR TITLE
Stop always requiring second_shirt for staff

### DIFF
--- a/tests/uber/models/test_merch.py
+++ b/tests/uber/models/test_merch.py
@@ -109,6 +109,17 @@ class TestMerchAttrs:
             monkeypatch.setattr(Attendee, 'gets_staff_shirt', staff)
             monkeypatch.setattr(Attendee, 'num_event_shirts_owed', swag)
             assert expected == Attendee().gets_any_kind_of_shirt
+            
+    def test_shirt_info_marked_event_shirtless(self, monkeypatch):
+        monkeypatch.setattr(c, 'SHIRTS_PER_STAFFER', 0)
+        for marked, gets_shirt, expected in [
+                (False, False, False),
+                (False, True,  False),
+                (True,  False, True),
+                (True,  True,  True)]:
+            monkeypatch.setattr(Attendee, 'shirt_size_marked', marked)
+            monkeypatch.setattr(Attendee, 'gets_staff_shirt', gets_shirt)
+            assert expected == Attendee(second_shirt=c.UNKNOWN).shirt_info_marked
 
     def test_shirt_info_marked_before_deadline(self, monkeypatch):
         monkeypatch.setattr(c, 'AFTER_SHIRT_DEADLINE', False)

--- a/tests/uber/models/test_merch.py
+++ b/tests/uber/models/test_merch.py
@@ -109,7 +109,7 @@ class TestMerchAttrs:
             monkeypatch.setattr(Attendee, 'gets_staff_shirt', staff)
             monkeypatch.setattr(Attendee, 'num_event_shirts_owed', swag)
             assert expected == Attendee().gets_any_kind_of_shirt
-            
+
     def test_shirt_info_marked_event_shirtless(self, monkeypatch):
         monkeypatch.setattr(c, 'SHIRTS_PER_STAFFER', 0)
         for marked, gets_shirt, expected in [

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -756,7 +756,11 @@ class Attendee(MagModel, TakesPaymentMixin):
     @property
     def shirt_info_marked(self):
         return self.shirt_size_marked and (
-            not self.gets_staff_shirt or self.second_shirt != c.UNKNOWN or c.AFTER_SHIRT_DEADLINE)
+            not self.gets_staff_shirt
+            or not c.SHIRTS_PER_STAFFER > 1
+            or self.second_shirt != c.UNKNOWN
+            or c.AFTER_SHIRT_DEADLINE
+        )
 
     @property
     def is_group_leader(self):

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -50,7 +50,7 @@ class Root:
                 message = 'You must select a shirt size'
             else:
                 attendee.shirt = int(shirt)
-                if attendee.gets_staff_shirt and c.BEFORE_SHIRT_DEADLINE:
+                if attendee.gets_staff_shirt and c.SHIRTS_PER_STAFFER > 1 and c.BEFORE_SHIRT_DEADLINE:
                     attendee.second_shirt = int(second_shirt)
                 raise HTTPRedirect('index?message={}', 'Shirt info uploaded')
 


### PR DESCRIPTION
If one's shirt size was marked, shirt_info_marked was only truthy if either the person in question wasn't staff or if their second_shirt was set -- this meant that for events without 2 shirts, staffers would never be able to move past the 'shirt' step. This fixes that by checking the event's config, much like the shirt template does.

This should fix #3170.