### PR TITLE
Fixes swag list confusion

### DIFF
--- a/uber/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/uber/templates/emails/reg_workflow/attendee_confirmation.html
@@ -38,7 +38,7 @@ Badges are not mailed out before the event, so your badge will be available for 
 {% if attendee.amount_extra %}
     <br/> <br/>
     Your additional contribution of ${{ attendee.amount_extra }} provides you with these bonus items, which may be picked up at our merch booth:
-    <ul>
+    <ul style="margin-bottom: 0">
     {% for swag in attendee.donation_swag|list %}
         <li>{{ swag }}</li>
     {% endfor %}
@@ -48,7 +48,7 @@ Badges are not mailed out before the event, so your badge will be available for 
 {% if attendee.addons %}
     <br/> <br/>
     Additionally, you will receive the following addons:
-    <ul>
+    <ul style="margin-bottom: 0">
     {% for addon in attendee.addons|list %}
         <li>{{ addon }}</li>
     {% endfor %}

--- a/uber/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/uber/templates/emails/reg_workflow/attendee_confirmation.html
@@ -39,8 +39,18 @@ Badges are not mailed out before the event, so your badge will be available for 
     <br/> <br/>
     Your additional contribution of ${{ attendee.amount_extra }} provides you with these bonus items, which may be picked up at our merch booth:
     <ul>
-    {% for swag in attendee.donation_swag|list + attendee.addons|list %}
+    {% for swag in attendee.donation_swag|list %}
         <li>{{ swag }}</li>
+    {% endfor %}
+    </ul>
+{% endif %}
+
+{% if attendee.addons %}
+    <br/> <br/>
+    Additionally, you will receive the following addons:
+    <ul>
+    {% for addon in attendee.addons|list %}
+        <li>{{ addon }}</li>
     {% endfor %}
     </ul>
 {% endif %}

--- a/uber/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/uber/templates/emails/reg_workflow/attendee_confirmation.html
@@ -47,7 +47,7 @@ Badges are not mailed out before the event, so your badge will be available for 
 
 {% if attendee.addons %}
     <br/> <br/>
-    Additionally, you will receive the following addons:
+    Additionally, you will receive the following add-ons:
     <ul style="margin-bottom: 0">
     {% for addon in attendee.addons|list %}
         <li>{{ addon }}</li>


### PR DESCRIPTION
As reported by a MAGStock attendee, the confirmation email is confusing, because it includes addons (like food) in the list with donation swag. It looks like food is received as part of the kickin level rather than being an additional cost.

![image](https://user-images.githubusercontent.com/2592431/37975695-e0ebdac6-31ad-11e8-8c59-4648e2fa7928.png)
