### PR TITLE
Fix bug when no rock island groups are configured

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -1092,8 +1092,7 @@ c.ACCESS.update(c.GUEST_ACCESS_LEVELS)
 c.ACCESS_OPTS.extend(c.GUEST_ACCESS_LEVEL_OPTS)
 c.ACCESS_VARS.extend(c.GUEST_ACCESS_LEVEL_VARS)
 
-if c.ROCK_ISLAND_GROUPS != ['']:
-    c.ROCK_ISLAND_GROUPS = [getattr(c, group_type.upper()) for group_type in c.ROCK_ISLAND_GROUPS]
+c.ROCK_ISLAND_GROUPS = [getattr(c, group.upper()) for group in c.ROCK_ISLAND_GROUPS if group or group.strip()]
 
 # A list of checklist items for display on the guest group admin page
 c.GUEST_CHECKLIST_ITEMS = [

--- a/uber/config.py
+++ b/uber/config.py
@@ -1092,7 +1092,8 @@ c.ACCESS.update(c.GUEST_ACCESS_LEVELS)
 c.ACCESS_OPTS.extend(c.GUEST_ACCESS_LEVEL_OPTS)
 c.ACCESS_VARS.extend(c.GUEST_ACCESS_LEVEL_VARS)
 
-c.ROCK_ISLAND_GROUPS = [getattr(c, group_type.upper()) for group_type in c.ROCK_ISLAND_GROUPS]
+if c.ROCK_ISLAND_GROUPS != ['']:
+    c.ROCK_ISLAND_GROUPS = [getattr(c, group_type.upper()) for group_type in c.ROCK_ISLAND_GROUPS]
 
 # A list of checklist items for display on the guest group admin page
 c.GUEST_CHECKLIST_ITEMS = [


### PR DESCRIPTION
The server would attempt to redefine c.ROCK_ISLAND_GROUPS even if the list was empty, resulting in a 500 error. Checking for truthiness wasn't sufficient, presumably since the list technically has an item in it.