### PR TITLE
Update pytz to not conflict with residue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ python-dateutil==2.6.0
 psycopg2==2.7.3.2
 py3k-bcrypt==0.3
 stripe==1.11.0
-pytz==2014.4
+pytz==2017.2
 alembic==0.9.1
 treepoem==1.0.1
 email_validator==1.0.2


### PR DESCRIPTION
Residue requires at least 2017.2 but we were pinning to an older version. It doesn't seem to affect anything right now, but better to update it.