### PR TITLE
Fixes #3197: Updates to celery 4.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery==4.1.0
+celery==4.1.1
 python-dateutil==2.6.0
 psycopg2==2.7.3.2
 py3k-bcrypt==0.3


### PR DESCRIPTION
Celery 4.1.1 depends on kombu 4.2.0, which fixes hung connections.

See related celery issue:  https://github.com/celery/celery/issues/4296