### PR TITLE
Add defaults to event_location in development-defaults.ini

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -35,7 +35,7 @@ expected_response = "December 2016"
 alt_schedule_url = ""
 
 tabletop_twilio_number = "+15713646627"
-tabletop_locations = "tabletop_tournaments", "tabletop_tournaments_2", "tabletop_indie"
+tabletop_locations = ,
 
 
 [dates]

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -495,10 +495,10 @@ hide_schedule = boolean(default=True)
 
 # These are the areas from which we'll show events to associated with panel
 # applications on the schedule.
-panel_rooms = string_list(default=list("panels_1", "panels_2", "panels_3", "panels_4"))
+panel_rooms = string_list(default=list())
 
 # These are the areas which we'll use to filter "Show only music rooms"
-music_rooms = string_list(default=list("concerts", "chiptunes", "pose_lounge", "lobby_bar", "jamspace", "jam_clinic"))
+music_rooms = string_list(default=list())
 
 # Signature at the end of every panel-related email.  This replaces the now-
 # deprecated "peglegs_email_signature" from the main repo.
@@ -525,7 +525,7 @@ app_limit = integer(default=3)
 # tabletop
 # =============================
 
-tabletop_locations = string_list(default=list("tabletop_tournaments"))
+tabletop_locations = string_list(default=list())
 
 # Twilio-provided phone number used to send/receive SMS messages.
 tabletop_twilio_number = string(default="")


### PR DESCRIPTION
Without these, a default initialization (during `./env/bin/sep reset_uber_db`) produces:

```
config: panels_room config problem: Ignoring 'PANELS_1' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'PANELS_2' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'PANELS_3' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'PANELS_4' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'CONCERTS' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'CHIPTUNES' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'POSE_LOUNGE' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'LOBBY_BAR' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'JAMSPACE' because it was not also found in [[event_location]] section.
config: panels_room config problem: Ignoring 'JAM_CLINIC' because it was not also found in [[event_location]] section.
config: tabletop_locations config problem: Ignoring 'TABLETOP_TOURNAMENTS' because it was not also found in [[event_location]] section.
config: tabletop_locations config problem: Ignoring 'TABLETOP_TOURNAMENTS_2' because it was not also found in [[event_location]] section.
config: tabletop_locations config problem: Ignoring 'TABLETOP_INDIE' because it was not also found in [[event_location]] section.
```