### PR TITLE
Add dropdown for payment_method in attendee form

### DIFF
--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -52,6 +52,7 @@
     var showOrHideAmounts = function (focus) {
         var paid = $.val('paid'), extra = $.val('amount_extra');
         setVisible('#amount_paid', paid !== {{ c.NEED_NOT_PAY }} && paid !== {{ c.PAID_BY_GROUP }} || extra > 0);
+        setVisible('#payment_method', paid !== {{ c.NEED_NOT_PAY }} && paid !== {{ c.PAID_BY_GROUP }} || extra > 0);
         setVisible('#amount_refunded', paid === {{ c.REFUNDED }});
         setAmountPaid(focus);
     };
@@ -349,6 +350,11 @@
     <div class="col-sm-6">
         <select name="paid" onChange="showOrHideAmounts(true)">
             {{ options(c.PAYMENT_OPTS,attendee.paid) }}
+        </select>
+        &nbsp;&nbsp;&nbsp;
+        <select id="payment_method" name="payment_method">
+            <option value="">Payment Method</option>
+            {{ options(c.NEW_REG_PAYMENT_METHOD_OPTS,attendee.payment_method) }}
         </select>
         &nbsp;&nbsp;&nbsp;
         <span id="amount_paid">


### PR DESCRIPTION
Partially fixes https://github.com/magfest/ubersystem/issues/3136 - specifically, it allows payment methods to be displayed/edited in the full attendee view. Previously, these were only able to be set on the "Recent At-the-Door Registrations" page.

Use case: Someone registered last month, didn't pay, and showed up at-event needing to pay. Their account is no longer in the "recent registrations" page, so the staffer pulls up their main info page, and enters in their payment. With this new form, they can also set the payment type.

Not done here, but on my todo: Add a "last 4 digits of CC" field to model/attendee, so that Stripe refunds can be more easily done. (That field will also be exposed here, as well as on the "recent regs" page)

![image](https://user-images.githubusercontent.com/953151/40445635-8af850b2-5e81-11e8-93b1-ae3b93bc59dd.png)

![screenshot](https://user-images.githubusercontent.com/953151/40445714-c517b80a-5e81-11e8-869c-b2ac6188af28.png)

![image](https://user-images.githubusercontent.com/953151/40445737-d38c8a28-5e81-11e8-96f7-7634c51e0e08.png)

(Changing back to "Payment Method" removes the payment_method)