### PR TITLE
Format dealer start date properly

### DIFF
--- a/uber/templates/static_views/dealer_reg_not_open.html
+++ b/uber/templates/static_views/dealer_reg_not_open.html
@@ -1,6 +1,6 @@
 <html><head></head><body style='text-align:center'>
     Dealers room applications for {{ c.EVENT_NAME_AND_YEAR }} ({{ c.EVENT_MONTH }} {{ c.EVENT_YEAR }}) are not yet open.
-    Please check back on {{ c.DEALER_REG_START }}.<br/>
+    Please check back on {{ c.DEALER_REG_START|datetime_local }}.<br/>
     <br/>
     To register as a non-vendor attendee for {{ c.EVENT_NAME_AND_YEAR }}, click <a href="../preregistration/">here</a>.<br/>
     <br/>


### PR DESCRIPTION
Found in https://github.com/MidwestFurryFandom/mff-rams-plugin/pull/55 -- the date in this template will print in a strange format without the jinja2 tag.