### PR TITLE
Update API Version and fix config.info call

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -22,7 +22,7 @@ from uber.server import register_jsonrpc
 from uber.utils import check_csrf, normalize_newlines
 
 
-__version__ = '0.1'
+__version__ = '1.0'
 
 
 def docstring_format(*args, **kwargs):
@@ -488,7 +488,7 @@ class ConfigLookup:
     fields = [
         'EVENT_NAME',
         'ORGANIZATION_NAME',
-        'YEAR',
+        'EVENT_YEAR',
         'EPOCH',
         'ESCHATON',
         'EVENT_VENUE',
@@ -502,6 +502,10 @@ class ConfigLookup:
         Returns a list of all available configuration settings.
         """
         output = {field: getattr(c, field) for field in self.fields}
+        
+        # This is to allow backward compatibility with pre 1.0 code
+        output['YEAR'] = c.EVENT_YEAR
+        
         output['API_VERSION'] = __version__
         return output
 

--- a/uber/api.py
+++ b/uber/api.py
@@ -502,10 +502,10 @@ class ConfigLookup:
         Returns a list of all available configuration settings.
         """
         output = {field: getattr(c, field) for field in self.fields}
-        
+
         # This is to allow backward compatibility with pre 1.0 code
         output['YEAR'] = c.EVENT_YEAR
-        
+
         output['API_VERSION'] = __version__
         return output
 


### PR DESCRIPTION
This change updated the API Version to 1.0, since we made a breaking change to the API Authentication and code written for the 0.1 version is universally broken.

This change also updated the variable YEAR to EVENT_YEAR, tracking an earlier change to the config object.  It both returns the new variable as EVENT_YEAR and returns the legacy variable as YEAR for compatibility with APIs that rewrite their auth code.