### PR TITLE
Add iCal file export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ geopy==1.11.0
 twilio==6.10.0
 cherrys==0.4
 redis==2.10.6
+ics==0.4

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -24,6 +24,7 @@ class Root:
         else:
             raise HTTPRedirect("internal")
 
+    @cached
     def internal(self, session, message=''):
         if c.HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
             return "The {} schedule is being developed and will be made public " \

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -1,4 +1,5 @@
 import json
+import ics
 from collections import defaultdict
 from datetime import datetime, time, timedelta
 from time import mktime
@@ -23,7 +24,6 @@ class Root:
         else:
             raise HTTPRedirect("internal")
 
-    @cached
     def internal(self, session, message=''):
         if c.HIDE_SCHEDULE and not AdminAccount.access_set() and not cherrypy.session.get('staffer_id'):
             return "The {} schedule is being developed and will be made public " \
@@ -104,6 +104,33 @@ class Root:
         return render('schedule/schedule.tsv', {
             'schedule': sorted(schedule.items(), key=lambda tup: c.ORDERED_EVENT_LOCS.index(tup[1][0]['location']))
         })
+
+    def ical(self, session, **params):
+        icalendar = ics.Calendar()
+
+        if 'locations' not in params or not params['locations']:
+            locations = [id for id, name in c.EVENT_LOCATION_OPTS]
+            calname="all_locations"
+        else:
+            locations = json.loads(params['locations'])
+            calname="_".join([name for id, name in c.EVENT_LOCATION_OPTS if str(id) in locations]).lower().replace(' ', '_')
+
+        for location in locations:
+            for event in session.query(Event).filter_by(location=int(location)).order_by('start_time').all():
+                icalendar.events.add(ics.Event(
+                    name=event.name,
+                    begin=event.start_time,
+                    end=(event.start_time + timedelta(minutes=event.minutes)),
+                    description=normalize_newlines(event.description),
+                    created=event.created.when,
+                    location=event.location_label))
+
+        cherrypy.response.headers['Content-Type'] = 'text/calendar;' \
+                                                    'charset=utf-8'
+        cherrypy.response.headers['Content-Disposition'] = 'attachment;' \
+                                     'filename="{}.ics"'.format(calname)
+
+        return icalendar
 
     @csv_file
     def csv(self, out, session):

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -137,6 +137,9 @@ class Root:
 
         return icalendar
 
+    if not c.HIDE_SCHEDULE:
+        ical.restricted = False
+
     @csv_file
     def csv(self, out, session):
         out.writerow(['Session Title', 'Date', 'Time Start', 'Time End', 'Room/Location',

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -111,12 +111,16 @@ class Root:
 
         if 'locations' not in params or not params['locations']:
             locations = [id for id, name in c.EVENT_LOCATION_OPTS]
-            calname = "all_locations"
+            calname = "full"
         else:
             locations = json.loads(params['locations'])
-            calname = "_".join([name for id, name in c.EVENT_LOCATION_OPTS
-                                if str(id) in locations])\
-                .lower().replace(' ', '_')
+            if len(locations) > 3:
+                calname = "partial"
+            else:
+                calname = "_".join([name for id, name in c.EVENT_LOCATION_OPTS 
+                                    if str(id) in locations])
+                
+        calname = '{}_{}_schedule'.format(c.EVENT_NAME, calname).lower().replace(' ', '_')
 
         for location in locations:
             for event in session.query(Event)\

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -117,9 +117,9 @@ class Root:
             if len(locations) > 3:
                 calname = "partial"
             else:
-                calname = "_".join([name for id, name in c.EVENT_LOCATION_OPTS 
+                calname = "_".join([name for id, name in c.EVENT_LOCATION_OPTS
                                     if str(id) in locations])
-                
+
         calname = '{}_{}_schedule'.format(c.EVENT_NAME, calname).lower().replace(' ', '_')
 
         for location in locations:

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -111,13 +111,17 @@ class Root:
 
         if 'locations' not in params or not params['locations']:
             locations = [id for id, name in c.EVENT_LOCATION_OPTS]
-            calname="all_locations"
+            calname = "all_locations"
         else:
             locations = json.loads(params['locations'])
-            calname="_".join([name for id, name in c.EVENT_LOCATION_OPTS if str(id) in locations]).lower().replace(' ', '_')
+            calname = "_".join([name for id, name in c.EVENT_LOCATION_OPTS
+                                if str(id) in locations])\
+                .lower().replace(' ', '_')
 
         for location in locations:
-            for event in session.query(Event).filter_by(location=int(location)).order_by('start_time').all():
+            for event in session.query(Event)\
+                    .filter_by(location=int(location))\
+                    .order_by('start_time').all():
                 icalendar.events.add(ics.Event(
                     name=event.name,
                     begin=event.start_time,
@@ -126,10 +130,10 @@ class Root:
                     created=event.created.when,
                     location=event.location_label))
 
-        cherrypy.response.headers['Content-Type'] = 'text/calendar;' \
-                                                    'charset=utf-8'
-        cherrypy.response.headers['Content-Disposition'] = 'attachment;' \
-                                     'filename="{}.ics"'.format(calname)
+        cherrypy.response.headers['Content-Type'] = \
+            'text/calendar; charset=utf-8'
+        cherrypy.response.headers['Content-Disposition'] = \
+            'attachment; filename="{}.ics"'.format(calname)
 
         return icalendar
 

--- a/uber/templates/schedule_common.html
+++ b/uber/templates/schedule_common.html
@@ -241,6 +241,7 @@ label.radio-label {
 
 
 <script>
+  filtered_locs = [];
   $(function() {
     var $scheduleTable = $('.schedule-table'),
         $scheduleRooms = $('.schedule-rooms'),
@@ -264,6 +265,8 @@ label.radio-label {
       var text = $(this).val().toLowerCase(),
           textLength = text.length,
           rooms = roomTrie;
+      filtered_locs = [];
+      $('#filtered_locations').val('');
 
       if (textLength <= 0) {
         $scheduleRooms.find('td, th').css('display', '');
@@ -282,11 +285,13 @@ label.radio-label {
         $scheduleRooms.find('td, th').hide();
         $.each(rooms['__rooms__'], function(location, index) {
           $scheduleRooms.find('td.room_' + location + ', th.room_' + location).css('display', '');
+          filtered_locs.push(location);
         });
       } else {
         $scheduleRooms.find('td, th').hide();
       }
       $scheduleRooms.scrollLeft(0);
+      $('#filtered_locations').val(JSON.stringify(filtered_locs))
     });
 
     var delay = (function(){
@@ -324,7 +329,12 @@ label.radio-label {
     <label class="radio-label"><input type="radio" name="toggle" class="toggle" id="show_other"> Other</label>
   </div>
   <div id="room_filter">
+    <form method="post" action="ical" class="form-horizontal" role="form">
     <label for="room_filter_text">Filter</label>
     <input type="text" name="filter" class="filter" id="room_filter_text" autofocus="autofocus" placeholder="Room Name">
+
+      <input type="hidden" id="filtered_locations" name="locations" />
+    <button class="btn btn-primary form-inline">Export to iCal</button>
+      </form>
   </div>
 </div>

--- a/uber/templates/schedule_common.html
+++ b/uber/templates/schedule_common.html
@@ -242,6 +242,17 @@ label.radio-label {
 
 <script>
   filtered_locs = [];
+  var updateiCalFilter = function() {
+      filtered_locs = [];
+      $('#filtered_locations').val('');
+
+      $("th:visible[class*='room_']").each(function() {
+          var location = this.className.split('room_')[1].split(' ', 1)[0];
+          filtered_locs.push(location);
+      });
+      $('#filtered_locations').val(JSON.stringify(filtered_locs))
+  };
+
   $(function() {
     var $scheduleTable = $('.schedule-table'),
         $scheduleRooms = $('.schedule-rooms'),
@@ -258,6 +269,7 @@ label.radio-label {
       if (isToggledOn) {
         $scheduleRooms.scrollLeft(0);
       }
+      updateiCalFilter();
     });
 
     var roomTrie = {{ c.ROOM_TRIE|jsonize }};
@@ -265,11 +277,10 @@ label.radio-label {
       var text = $(this).val().toLowerCase(),
           textLength = text.length,
           rooms = roomTrie;
-      filtered_locs = [];
-      $('#filtered_locations').val('');
 
       if (textLength <= 0) {
         $scheduleRooms.find('td, th').css('display', '');
+        updateiCalFilter();
         return;
       }
 
@@ -285,13 +296,12 @@ label.radio-label {
         $scheduleRooms.find('td, th').hide();
         $.each(rooms['__rooms__'], function(location, index) {
           $scheduleRooms.find('td.room_' + location + ', th.room_' + location).css('display', '');
-          filtered_locs.push(location);
         });
       } else {
         $scheduleRooms.find('td, th').hide();
       }
       $scheduleRooms.scrollLeft(0);
-      $('#filtered_locations').val(JSON.stringify(filtered_locs))
+      updateiCalFilter();
     });
 
     var delay = (function(){


### PR DESCRIPTION
Allows admins to export the current version of the schedule into an iCal file, suitable for/tested with Google Calendar and iCloud Calendar. Admins may filter the schedule by location before exporting to get just a few locations in the file.