### PR TITLE
Fixes the convert_to_absolute_url() function to accept absolute urls and root relative urls

### DIFF
--- a/tests/uber/test_utils.py
+++ b/tests/uber/test_utils.py
@@ -13,11 +13,21 @@ from uber.utils import add_opt, convert_to_absolute_url, Charge, get_age_from_bi
 
 @pytest.fixture
 def base_url(monkeypatch):
+    monkeypatch.setattr(c, 'PATH', '/uber')
+    monkeypatch.setattr(c, 'URL_ROOT', 'https://server.com')
     monkeypatch.setattr(c, 'URL_BASE', 'https://server.com/uber')
 
 
 def test_absolute_urls(base_url):
     assert convert_to_absolute_url('../somepage.html') == 'https://server.com/uber/somepage.html'
+
+
+def test_absolute_urls_relative_root(base_url):
+    assert convert_to_absolute_url('/uber/somepage.html') == 'https://server.com/uber/somepage.html'
+
+
+def test_absolute_urls_already_absolute(base_url):
+    assert convert_to_absolute_url('https://server.com/uber/somepage.html') == 'https://server.com/uber/somepage.html'
 
 
 def test_absolute_urls_empty(base_url):
@@ -34,6 +44,9 @@ def test_absolute_url_error(base_url):
 
     with pytest.raises(ValueError):
         convert_to_absolute_url('////')
+
+    with pytest.raises(ValueError):
+        convert_to_absolute_url('https://server.com/somepage.html')
 
 
 @pytest.mark.parametrize('test_input,expected', [

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -124,7 +124,8 @@ def normalize_newlines(text):
 def convert_to_absolute_url(relative_uber_page_url):
     """
     In ubersystem, we always use relative url's of the form
-    "../{some_site_section}/{somepage}". We use relative URLs so that no
+    "../{some_site_section}/{somepage}" or
+    "/{c.PATH}/{some_site_section}/{somepage}". We use relative URLs so that no
     matter what proxy server we are behind on the web, it always works.
 
     We normally avoid using absolute URLs at all costs, but sometimes
@@ -140,10 +141,16 @@ def convert_to_absolute_url(relative_uber_page_url):
     if not relative_uber_page_url:
         return ''
 
-    if relative_uber_page_url[:3] != '../':
-        raise ValueError("relative url MUST start with '../'")
+    if relative_uber_page_url.startswith('../'):
+        return urljoin(c.URL_BASE + '/', relative_uber_page_url[3:])
 
-    return urljoin(c.URL_BASE + "/", relative_uber_page_url[3:])
+    if relative_uber_page_url.startswith(c.PATH):
+        return urljoin(c.URL_ROOT, relative_uber_page_url)
+
+    if relative_uber_page_url.startswith(c.URL_BASE):
+        return relative_uber_page_url
+
+    raise ValueError("relative url MUST start with '../' or '{}'".format(c.PATH))
 
 
 def make_url(s):


### PR DESCRIPTION
This is kind of an emergency patch, so I am going to merge it now.