### PR TITLE
Add fields from registration/stats to secure with API

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -588,6 +588,9 @@ class ConfigLookup:
         'URL_BASE',
         'URL_ROOT',
         'PATH',
+        'BADGE_PRICE',
+        'BADGES_SOLD',
+        'REMAINING_BADGES',
     ]
 
     def info(self):


### PR DESCRIPTION
The fields `BADGE_PRICE`, `BADGES_SOLD`, and `REMAINING_BADGES` are currently openly exposed on `/uber/registration/stats`. This was historically for MAGBot, as well as part of [MAGFest's Website](http://super.magfest.org).

Once MAGBot and the MAGFest website no longer rely on `/uber/registration/stats` it should be removed. 