### PR TITLE
Make base_badge_price actually store correct price

### DIFF
--- a/tests/uber/models/test_attendee.py
+++ b/tests/uber/models/test_attendee.py
@@ -78,6 +78,10 @@ class TestCosts:
         assert 10 == Attendee(overridden_price=10).total_cost
         assert 15 == Attendee(overridden_price=10, amount_extra=5).total_cost
 
+    def test_age_discount_doesnt_stack(self, monkeypatch):
+        monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 5})
+        assert 10 == Attendee(badge_type=c.ONE_DAY_BADGE).badge_cost
+
 
 class TestHalfPriceAgeDiscountCosts:
     @pytest.fixture(autouse=True)

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -578,12 +578,22 @@ class Attendee(MagModel, TakesPaymentMixin):
         return self.calculate_badge_cost(use_promo_code=False)
 
     def calculate_badge_cost(self, use_promo_code=True):
+        registered = self.registered_local if self.registered else None
+        base_badge_price = self.base_badge_price or c.get_attendee_price(registered)
+
         if self.paid == c.NEED_NOT_PAY:
             return 0
         elif self.overridden_price is not None:
             return self.overridden_price
+        elif self.is_dealer:
+            return c.DEALER_BADGE_PRICE
+        elif self.badge_type == c.ATTENDEE_BADGE and self.age_discount != 0:
+            return max(0, base_badge_price + self.age_discount)
+        elif self.badge_type == c.ATTENDEE_BADGE and self.group \
+                and self.paid == c.PAID_BY_GROUP:
+            return base_badge_price - c.GROUP_DISCOUNT
         elif self.base_badge_price:
-            cost = self.base_badge_price
+            cost = base_badge_price
         else:
             cost = self.new_badge_cost
 
@@ -597,18 +607,12 @@ class Attendee(MagModel, TakesPaymentMixin):
         # What this badge would cost if it were new, i.e., not taking into
         # account special overrides
         registered = self.registered_local if self.registered else None
-        if self.is_dealer:
-            return c.DEALER_BADGE_PRICE
-        elif self.badge_type == c.ONE_DAY_BADGE:
+        if self.badge_type == c.ONE_DAY_BADGE:
             return c.get_oneday_price(registered)
         elif self.is_presold_oneday:
             return c.get_presold_oneday_price(self.badge_type)
         elif self.badge_type in c.BADGE_TYPE_PRICES:
             return int(c.BADGE_TYPE_PRICES[self.badge_type])
-        elif self.age_discount != 0:
-            return max(0, c.get_attendee_price(registered) + self.age_discount)
-        elif self.group and self.paid == c.PAID_BY_GROUP:
-            return c.get_attendee_price(registered) - c.GROUP_DISCOUNT
         else:
             return c.get_attendee_price(registered)
 

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -68,7 +68,6 @@ def _decline_and_convert_dealer_group(session, group, delete_when_able=False):
         else:
             if _is_dealer_convertible(attendee):
                 attendee.badge_status = c.NEW_STATUS
-                attendee.overridden_price = attendee.new_badge_cost
 
                 try:
                     send_email.delay(


### PR DESCRIPTION
Fixes MAGDEV-254.

One of the entire points of base_badge_price was to allow us to store what the badge WOULD have cost if it were a regular attendee badge... a purpose we completely undermined by putting discounted and overridden prices in the calculation we used for base_badge_price. Most noticeably, this led us to charging dealers whose apps had been rejected only the dealer price, not the attendee price at the time they applied. We've instead moved ALL discounts and overrides to calculate_badge_cost, so they get applied to any price except the "base" price.

Thank goodness for unit tests.