### PR TITLE
Add volunteer agreement item to volunteer checklist

### DIFF
--- a/alembic/versions/9d90d3d538c6_add_volunteer_waiver_agreement.py
+++ b/alembic/versions/9d90d3d538c6_add_volunteer_waiver_agreement.py
@@ -1,0 +1,59 @@
+"""Add volunteer waiver agreement
+
+Revision ID: 9d90d3d538c6
+Revises: e4d09d36083d
+Create Date: 2018-08-05 11:10:27.007024
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '9d90d3d538c6'
+down_revision = 'e4d09d36083d'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('agreed_to_volunteer_agreement', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('attendee', 'agreed_to_volunteer_agreement')

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -427,6 +427,13 @@ StopsEmailFixture(
     when=days_before(1, c.FINAL_EMAIL_DEADLINE),
     ident='volunteer_shift_schedule')
 
+StopsEmailFixture(
+    'Reminder: Please agree to terms of {EVENT_NAME} ({EVENT_DATE}) volunteer agreement',
+    'signups/volunteer_agreement.txt',
+    lambda a: c.SHIFTS_CREATED and c.VOLUNTEER_AGREEMENT_ENABLED and not a.agreed_to_volunteer_agreement,
+    when=days_before(45, c.FINAL_EMAIL_DEADLINE),
+    ident='volunteer_agreement')
+
 
 # For events with customized badges, these emails remind people to let us know what we want on their badges.  We have
 # one email for our volunteers who haven't bothered to confirm they're coming yet (bleh) and one for everyone else.

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -384,6 +384,7 @@ AutomatedEmailFixture(
 
 # Volunteer emails; none of these will be sent unless SHIFTS_CREATED is set.
 
+
 StopsEmailFixture(
     'Please complete your {EVENT_NAME} Staff/Volunteer Checklist',
     'shifts/created.txt',
@@ -427,12 +428,13 @@ StopsEmailFixture(
     when=days_before(1, c.FINAL_EMAIL_DEADLINE),
     ident='volunteer_shift_schedule')
 
-StopsEmailFixture(
-    'Reminder: Please agree to terms of {EVENT_NAME} ({EVENT_DATE}) volunteer agreement',
-    'signups/volunteer_agreement.txt',
-    lambda a: c.SHIFTS_CREATED and c.VOLUNTEER_AGREEMENT_ENABLED and not a.agreed_to_volunteer_agreement,
-    when=days_before(45, c.FINAL_EMAIL_DEADLINE),
-    ident='volunteer_agreement')
+if c.VOLUNTEER_AGREEMENT_ENABLED:
+    StopsEmailFixture(
+        'Reminder: Please agree to terms of {EVENT_NAME} ({EVENT_DATE}) volunteer agreement',
+        'signups/volunteer_agreement.txt',
+        lambda a: c.SHIFTS_CREATED and c.VOLUNTEER_AGREEMENT_ENABLED and not a.agreed_to_volunteer_agreement,
+        when=days_before(45, c.FINAL_EMAIL_DEADLINE),
+        ident='volunteer_agreement')
 
 
 # For events with customized badges, these emails remind people to let us know what we want on their badges.  We have

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -384,7 +384,6 @@ AutomatedEmailFixture(
 
 # Volunteer emails; none of these will be sent unless SHIFTS_CREATED is set.
 
-
 StopsEmailFixture(
     'Please complete your {EVENT_NAME} Staff/Volunteer Checklist',
     'shifts/created.txt',

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1431,8 +1431,8 @@ email_post_con = boolean(default=False)
 1 = string(default="signups/placeholder_item.html")
 2 = string(default="signups/shirt_item.html")
 3 = string(default="signups/food_item.html")
-4 = string(default="signups/shifts_item.html")
 6 = string(default="signups/volunteer_agreement_item.html")
+99 = string(default="signups/shifts_item.html")
 __many__ = string(default="")
 
 

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -337,6 +337,14 @@ group_update_grace_period = integer(default=24)
 # many other registrations (Staff, Dealers, Guests, etc) are in the system.
 max_badge_sales = integer(default=20000)
 
+# Some events require an explicit legal agreement for volunteers as part of
+# the volunteer checklist. For evernts where this is true, set this to true
+# and make sure signups/volunteer_agreement_item.html is included in the
+# [volunteer_checklist] section of the INI.
+#
+# By default this is turned off.
+volunteer_agreement_enabled = boolean(default=False)
+
 # Attendees kicking in extra can enter their own new "affiliate" or select
 # from a list of all affiliates which have already been entered.  This is
 # the list of the top affiliates from last year which we use to prepopulate
@@ -1424,6 +1432,7 @@ email_post_con = boolean(default=False)
 2 = string(default="signups/shirt_item.html")
 3 = string(default="signups/food_item.html")
 4 = string(default="signups/shifts_item.html")
+6 = string(default="signups/volunteer_agreement_item.html")
 __many__ = string(default="")
 
 

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -89,6 +89,11 @@ def full_datetime_local(dt):
 
 
 @JinjaEnv.jinja_export
+def now():
+    return datetime.utcnow()
+
+
+@JinjaEnv.jinja_export
 def event_dates():
     if c.EPOCH.date() == c.ESCHATON.date():
         return c.EPOCH.strftime('%B %-d')

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -342,6 +342,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         viewonly=True)
 
     staffing = Column(Boolean, default=False)
+    agreed_to_volunteer_agreement = Column(Boolean, default=False)
     nonshift_hours = Column(Integer, default=0, admin_only=True)
     past_years = Column(UnicodeText, admin_only=True)
     can_work_setup = Column(Boolean, default=False, admin_only=True)

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -1,4 +1,5 @@
 import cherrypy
+from datetime import timedelta
 
 from uber.config import c
 from uber.custom_tags import safe_string
@@ -58,6 +59,23 @@ class Root:
             'message': message,
             'attendee': attendee,
             'opts': [('', 'Enter your shirt size')] + c.SHIRT_OPTS[1:]
+        }
+
+    @check_shutdown
+    def volunteer_agreement(self, session, message='', agreed_to_terms=None, csrf_token=None):
+        attendee = session.logged_in_volunteer()
+        if csrf_token is not None:
+            check_csrf(csrf_token)
+            if agreed_to_terms:
+                attendee.agreed_to_volunteer_agreement = True
+                raise HTTPRedirect('index?message={}', 'Agreement received')
+
+            message = "You must agree to the terms of the agreement"
+
+        return {
+            'message': message,
+            'attendee': attendee,
+            'agreement_end_date': c.ESCHATON.date() + timedelta(days=31),
         }
 
     @check_shutdown

--- a/uber/templates/emails/signups/volunteer_agreement.txt
+++ b/uber/templates/emails/signups/volunteer_agreement.txt
@@ -1,0 +1,9 @@
+{{ attendee.first_name }},
+
+Thanks again for signing up to volunteer at {{ c.EVENT_NAME }}!
+
+Before volunteering, we need you to agree to the terms of the volunteer agreement, which you can find here:
+{{ c.URL_BASE }}/signups/login?first_name={{ attendee.first_name|urlencode }}&last_name={{ attendee.last_name|urlencode }}&email={{ attendee.email|urlencode }}&zip_code={{ attendee.zip_code|urlencode }}
+
+Thanks!
+{{ c.STOPS_EMAIL_SIGNATURE }}

--- a/uber/templates/signups/volunteer_agreement.html
+++ b/uber/templates/signups/volunteer_agreement.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Volunteer Agreement{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+
+<h1>Volunteer Agreement</h1>
+
+<p>
+This Volunteer Agreement (the "Agreement") is entered into by and between MAGFest, Inc. (the "Company"),
+and {{ attendee.full_name }} ("Volunteer"), and is effective as of {{ now()|datetime("%m/%d, %Y") }} (the "Effective Date").
+</p>
+
+<p>
+In consideration of the mutual promises contained herein and other good and sufficient consideration, the receipt and
+adequacy of which is hereby acknowledged, the parties hereby agree as follows:
+</p>
+
+<p><b>Services.</b>
+Volunteer agrees that he/she will provide the following services, ("Services"), to the Company:<br/>
+(a) attend the Company's event ("{{ c.EVENT_NAME }}") Volunteer training;<br/>
+(b) assist the Company in hosting {{ c.EVENT_NAME }} and assist {{ c.EVENT_NAME }} patrons;<br/>
+(c) preparation and cleaning of the {{ c.EVENT_NAME }} venue; and<br/>
+(d) any other tasks requested by the Company.<br/>
+<br/>
+Volunteer agrees that he/she would like to provide the Services without compensation
+and wishes to contribute his/her time.  All costs and expenses incurred by Volunteer
+in providing the Services shall be the responsibility of Volunteer,
+unless approved in writing in advance by the Company. </p>
+
+<p>
+<b>Swag.</b>
+Volunteer shall receive the following Swag. determined by the amount of Services provided by the Volunteer::<br/>
+(a) for providing six (6) hours of Services, the Company shall give the Volunteer a {{ c.EVENT_NAME }} t-shirt;<br/>
+(b) for providing eighteen (18) hours of Services, the Company shall give the Volunteer a complementary staff badge
+for the following year's {{ c.EVENT_NAME }}, allowing the Volunteer to be eligible for a staff hotel room;<br/>
+(c) for providing twenty-four (24) hours of Services, the Company shall reimburse the amount, if any, Volunteer
+paid for Volunteer's {{ c.EVENT_NAME }} badge; and<br/>
+(d) for providing twenty-four (24) hours of Services at this {{ c.EVENT_NAME }} and providing Services at one of the Company's
+previous events, the Company shall allow the Volunteer space in one of the Company's staff hotel rooms for this {{ c.EVENT_NAME }}.<br/>
+
+Other than the aforesaid amounts Volunteer acknowledges and agrees he/she is not entitled to any compensation of any
+type from {{ c.EVENT_NAME }}.</p>
+
+<p>
+<b>Term.</b>
+Volunteer's Services will commence on the Effective Date and will remain in effect until {{ agreement_end_date|datetime("%m/%d/%Y") }} unless
+earlier terminated by the Company, for any reason or no reason, effective immediately upon written notice to Volunteer.
+</p>
+<p>
+<b>Acknowledgement.</b>
+Volunteer acknowledges and agrees that:<br/>
+(a) the Services will be performed faithfully and to the best of his/her ability;<br/>
+(b) the Services will be performed in compliance with all applicable laws and regulations;<br/>
+(c) neither the Services nor the Work Product will infringe the rights of any third party or violate any law; and<br/>
+(d) Volunteer has full power and authority to enter into this Agreement and to provide the Services in accordance with this Agreement.
+The Company acknowledges and agrees that it has full power and authority to enter into this Agreement.
+</p>
+<p>
+<b>Miscellaneous.</b>
+This Agreement and all performance under this Agreement shall be governed by the laws of the State of California,
+without regard to conflict of law principles. In any dispute relating to this Agreement,
+the parties hereto admit venue and submit themselves to the exclusive jurisdiction of the state or federal courts
+located in Los Angeles County, California. Volunteer's remedy, if any, for any breach of this Agreement shall be
+solely in damages, and Volunteer shall not be entitled to equitable relief by way of injunction or otherwise.
+In the event any provision of this Agreement is determined to be invalid, prohibited or unenforceable by a court or
+other body of competent jurisdiction, this Agreement shall be construed as if such provision has been more narrowly
+drawn so as not to be invalid, prohibited or unenforceable. No waiver of any provision of this Agreement will be
+effective unless it is in writing and signed by both parties, and no such waiver will result in the waiver of any
+other provision of this Agreement. Failure of either party at any time to enforce any of the provisions of this Agreement
+will not be construed as a waiver of such provisions or in any way affect the validity of this Agreement or parts thereof.
+In performing the Services, Volunteer will act and represent itself as an independent volunteer and not as an employee
+or agent of the Company. Volunteer has no authority to obligate the Company by contract or otherwise.
+Volunteer may not assign any rights or obligations under this Agreement without the advance written consent of the Company,
+which may be withheld in its sole discretion. The Company may assign its rights or obligations under this Agreement in its
+sole discretion. This Agreement is the parties' final, exclusive and complete understanding and agreement, and supersedes
+all prior and contemporaneous understandings and agreements relating to the subject matter of this Agreement.
+This Agreement may be amended only by a writing signed by both parties. This Agreement may be executed in counterparts
+which, when taken together, will constitute one Agreement.
+</p>
+
+{% if not attendee.agreed_to_volunteer_agreement %}
+    <form method="post" action="volunteer_agreement">
+        {{ csrf_token() }}
+        I agree to the terms of the volunteer agreement: <input type="checkbox" name="agreed_to_terms" /><br/>
+        <input type="submit" value="Save" />
+    </form>
+{% else %}
+    <p>You have accepted the terms of this agreement already.</p>
+{% endif %}
+
+{% endblock %}

--- a/uber/templates/signups/volunteer_agreement.html
+++ b/uber/templates/signups/volunteer_agreement.html
@@ -81,8 +81,11 @@ which, when taken together, will constitute one Agreement.
 {% if not attendee.agreed_to_volunteer_agreement %}
     <form method="post" action="volunteer_agreement">
         {{ csrf_token() }}
-        I agree to the terms of the volunteer agreement: <input type="checkbox" name="agreed_to_terms" /><br/>
-        <input type="submit" value="Save" />
+        <label for="agreed_to_terms">
+          I agree to the terms of the volunteer agreement: <input type="checkbox" id="agreed_to_terms" name="agreed_to_terms" />
+        </label>
+        <br><br>
+        <input class="btn btn-primary" type="submit" value="Save" />
     </form>
 {% else %}
     <p>You have accepted the terms of this agreement already.</p>

--- a/uber/templates/signups/volunteer_agreement_item.html
+++ b/uber/templates/signups/volunteer_agreement_item.html
@@ -1,0 +1,13 @@
+{% import 'macros.html' as macros %}
+
+{% if c.VOLUNTEER_AGREEMENT_ENABLED %}
+    <li>
+        {{ macros.checklist_image(attendee.agreed_to_volunteer_agreement) }}
+        {% if not attendee.agreed_to_volunteer_agreement %}
+            Please read and agree
+        {% else %}
+            You have agreed
+        {% endif %}
+        to the terms of the <a href="volunteer_agreement">Volunteer Agreement</a>
+    </li>
+{% endif %}


### PR DESCRIPTION
Also adds a reminder email reminder to STOPs workflow

Backstory: Magwest is in California which has more legal regulations than you can shake a stick at.   So, our Cali lawyers were pretty adamant about us having an explicit agreement that volunteers agreed to spelling out some legalese.

Last year, this was something we had volunteers sign physically on a piece of paper, but the legal crew was OK with this being a part of the volunteer checklist.

---

Tech notes:
All of this is controlled by a new config option, c.VOLUNTEER_AGREEMENT_ENABLED.  By default, this feature is disabled except by events that explicitly turn it on (i.e. MAGwest).

Though the waiver text is currently MAGWest-specific, I felt it was a better idea to include it here instead of in the magwest plugin because other events might find this feature useful / required in the future.   If other events start to use it, we should make this text less california-specific and have magwest plugin override just the text of the agreement.

There's also an email reminder that goes out 45 days before the event.

I test all of this pretty decently with all the options on or off, email generation, and checking on the agreement status, so hopefully this is good to go.

After this, please merge accompanying PR's for puppet stuff:
https://github.com/magfest/ubersystem-puppet/pull/218
https://github.com/magfest/production-config/pull/449