### PR TITLE
Sets better volunteer checklist defaults

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1431,8 +1431,7 @@ email_post_con = boolean(default=False)
 1 = string(default="signups/placeholder_item.html")
 2 = string(default="signups/shirt_item.html")
 3 = string(default="signups/food_item.html")
-6 = string(default="signups/volunteer_agreement_item.html")
-99 = string(default="signups/shifts_item.html")
+99 = string(default="signups/shifts_item.html")  # We always want shift signups to come last
 __many__ = string(default="")
 
 


### PR DESCRIPTION
I realized our default settings were not optimal because we had to override them everywhere.

See https://github.com/magfest/production-config/pull/450