### PR TITLE
Adds cherrypy mount path config setting to distinguish the cherrypy mount point from the URL path

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -141,9 +141,14 @@ check_out_time = string(default='12pm/Noon')
 # This often will be different based on the length of the event.
 hotel_req_hours = integer(default='30')
 
+# The path used to mount the app in cherrypy's mount tree. This may be
+# different from the "path" setting if the server is running behind a
+# reverse proxy with rewrite rules that change the URL path.
+cherrypy_mount_path = string(default="/uber")
+
 # These are used for web server configuration and for linking back to our
-# pages in emails; these definitely needs to be overridden in production.
-path = string(default="/uber")
+# pages in emails; these definitely need to be overridden in production.
+path = string(default="%(cherrypy_mount_path)s")
 hostname = string(default="localhost")
 url_root = string(default="http://localhost:8282")
 url_base = string(default="%(url_root)s%(path)s")

--- a/uber/server.py
+++ b/uber/server.py
@@ -187,7 +187,7 @@ def error_page_404(status, message, traceback, version):
 
 c.APPCONF['/']['error_page.404'] = error_page_404
 
-cherrypy.tree.mount(Root(), c.PATH, c.APPCONF)
+cherrypy.tree.mount(Root(), c.CHERRYPY_MOUNT_PATH, c.APPCONF)
 static_overrides(os.path.join(c.MODULE_ROOT, 'static'))
 
 
@@ -201,4 +201,4 @@ def register_jsonrpc(service, name=None):
 
 
 jsonrpc_handler = _make_jsonrpc_handler(jsonrpc_services, precall=jsonrpc_reset)
-cherrypy.tree.mount(jsonrpc_handler, os.path.join(c.PATH, 'jsonrpc'), c.APPCONF)
+cherrypy.tree.mount(jsonrpc_handler, os.path.join(c.CHERRYPY_MOUNT_PATH, 'jsonrpc'), c.APPCONF)

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -247,7 +247,7 @@ class Root:
 
     @unrestricted
     def sitemap(self):
-        site_sections = cherrypy.tree.apps[c.PATH].root
+        site_sections = cherrypy.tree.apps[c.CHERRYPY_MOUNT_PATH].root
         modules = {name: getattr(site_sections, name) for name in dir(site_sections) if not name.startswith('_')}
         pages = defaultdict(list)
         access_set = AdminAccount.access_set()

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -621,7 +621,7 @@ def static_overrides(dirname):
     are the theme image files, but theoretically a plugin can override anything
     it wants by calling this method and passing its static directory.
     """
-    appconf = cherrypy.tree.apps[c.PATH].config
+    appconf = cherrypy.tree.apps[c.CHERRYPY_MOUNT_PATH].config
     basedir = os.path.abspath(dirname).rstrip('/')
     for dpath, dirs, files in os.walk(basedir):
         relpath = dpath[len(basedir):]


### PR DESCRIPTION
This will allow us to set `c.PATH = ""` and clean up the URLs returned to users for the new deployment. It shouldn't affect any of our legacy deployments.