### PR TITLE
Better email preview rendering.

### DIFF
--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -37,9 +37,14 @@ class BaseEmailMixin(object):
     _repr_attr_names = ['subject']
 
     @property
+    def body_with_body_tag_stripped(self):
+        body = re.split(r'<\s*body[^>]*>', self.body)[-1]
+        return re.split(r'<\s*\/\s*body\s*>', body)[0]
+
+    @property
     def body_as_html(self):
         if self.is_html:
-            return re.split('<body[^>]*>', self.body)[-1].split('</body>')[0]
+            return self.body_with_body_tag_stripped
         else:
             return normalize_newlines(self.body).replace('\n', '<br>')
 

--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -447,18 +447,14 @@
 {%- endmacro %}
 
 {% macro preview_email(email) %}
-  {% if email.format == 'text' %}
-    {# Text formatted Email or AutomatedEmail #}
-    <div class="well email-preview" style='font-family: Menlo, Monaco, Consolas, "Courier New", monospace; font-size: 13px'>
-      {{ email.body_as_html|safe }}
-    </div>
+  {%- set body_html = email.body_as_html if email.format == 'text' else email.body_with_body_tag_stripped -%}
+  {% if email.to is defined %}
+    {# Rendered email to a specific model instance #}
+    <div class="well email-preview">{{ body_html|safe }}</div>
   {% else %}
-    {% if email.to is defined %}
-      {# HTML formatted Email to a specific model instance #}
-      <div class="well email-preview">{{ email.body_as_html|safe }}</div>
-    {% else %}
-      {# HTML formatted AutomatedEmail template #}
-      <pre class="well email-preview" style="white-space: pre-wrap">{{ email.body }}</pre>
-    {% endif %}
+    {# Unrendered email template #}
+    <div class="well email-preview" style='font-family: Menlo, Monaco, Consolas, "Courier New", monospace; font-size: 13px'>
+      {{ body_html|safe }}
+    </div>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Only uses fixed-width font when looking at an unrendered template. Always shows whitespace how the recepient will see it.