### PR TITLE
Adds database session caching

### DIFF
--- a/tests/uber/conftest.py
+++ b/tests/uber/conftest.py
@@ -57,10 +57,10 @@ def csrf_token(monkeypatch):
 
 @pytest.fixture()
 def admin_attendee():
-    with Session() as session:
+    with Session(no_cache=True) as session:
         session.insert_test_admin_account()
 
-    with Session() as session:
+    with Session(no_cache=True) as session:
         attendee = session.query(Attendee).filter(
             Attendee.email == 'magfest@example.com').one()
         cherrypy.session['account_id'] = attendee.admin_account.id
@@ -87,7 +87,7 @@ def init_db(request):
     patch_session(Session, request)
     initialize_db(modify_tables=True)
     register_session_listeners()
-    with Session() as session:
+    with Session(no_cache=True) as session:
         session.add(Attendee(
             placeholder=True,
             first_name='Regular',

--- a/tests/uber/site_sections/test_guest_admin.py
+++ b/tests/uber/site_sections/test_guest_admin.py
@@ -5,7 +5,7 @@ import pytest
 
 from uber.config import c
 from uber.errors import HTTPRedirect
-from uber.models import Attendee, Group, Session
+from uber.models import Group, Session
 from uber.site_sections import guest_admin
 
 

--- a/tests/uber/site_sections/test_guest_admin.py
+++ b/tests/uber/site_sections/test_guest_admin.py
@@ -32,20 +32,6 @@ def csrf_token(monkeypatch):
     yield token
 
 
-@pytest.fixture()
-def admin_attendee():
-    with Session() as session:
-        session.insert_test_admin_account()
-
-    with Session() as session:
-        attendee = session.query(Attendee).filter(
-            Attendee.email == 'magfest@example.com').one()
-        cherrypy.session['account_id'] = attendee.admin_account.id
-        yield attendee
-        cherrypy.session['account_id'] = None
-        session.delete(attendee)
-
-
 class TestAddGuestGroup(object):
 
     def _add_group_response(self, **params):

--- a/tests/uber/test_schedule.py
+++ b/tests/uber/test_schedule.py
@@ -1,11 +1,10 @@
 from datetime import datetime, timedelta
 
-import cherrypy
 import pytest
 import pytz
 
 from uber.config import c
-from uber.models import Attendee, Event, Session
+from uber.models import Event, Session
 from uber.site_sections import schedule
 
 

--- a/tests/uber/test_schedule.py
+++ b/tests/uber/test_schedule.py
@@ -14,20 +14,6 @@ UTC20DAYSLATER = UTCNOW + timedelta(days=20)
 
 
 @pytest.fixture()
-def admin_attendee():
-    with Session() as session:
-        session.insert_test_admin_account()
-
-    with Session() as session:
-        attendee = session.query(Attendee).filter(
-            Attendee.email == 'magfest@example.com').one()
-        cherrypy.session['account_id'] = attendee.admin_account.id
-        yield attendee
-        cherrypy.session['account_id'] = None
-        session.delete(attendee)
-
-
-@pytest.fixture()
 def create_events():
     with Session() as session:
         for index, (loc, desc) in enumerate(c.EVENT_LOCATION_OPTS):

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -397,9 +397,7 @@ class MagModel:
                             value = int(value[:-2])
 
                     elif isinstance(column.type, (MultiChoice)):
-                        if not value:
-                            value = ''
-                        elif isinstance(value, list):
+                        if isinstance(value, list):
                             value = ','.join(map(lambda x: str(x).strip(), value))
                         else:
                             value = str(value).strip()

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -15,7 +15,7 @@ from dateutil import parser as dateparser
 from pockets import cached_classproperty, classproperty, listify
 from pockets.autolog import log
 from residue import check_constraint_naming_convention, declarative_base, JSON, SessionManager, UTCDateTime, UUID
-from sideboard.lib import on_startup, stopped
+from sideboard.lib import on_startup, stopped, threadlocal
 from sqlalchemy import and_, func, or_, not_
 from sqlalchemy.event import listen
 from sqlalchemy.exc import IntegrityError
@@ -376,47 +376,54 @@ class MagModel:
         checkgroups = self.regform_checkgroups if restricted else checkgroups
         for column in self.__table__.columns:
             if (not restricted or column.name in self.unrestricted) and column.name in params and column.name != 'id':
-                if column.type is JSON or isinstance(column.type, JSON):
-                    value = params[column.name]
-                elif isinstance(params[column.name], list):
+                if isinstance(params[column.name], list):
                     value = ','.join(map(str, params[column.name]))
-                elif isinstance(params[column.name], bool):
-                    value = params[column.name]
-                elif params[column.name] is None:
-                    value = None
                 else:
-                    value = str(params[column.name]).strip()
+                    value = params[column.name]
 
                 try:
                     if value is None:
                         pass  # Totally fine for value to be None
-                    elif isinstance(column.type, Float):
-                        if value == '':
-                            value = None
-                        else:
-                            value = float(value)
-                    elif isinstance(column.type, Numeric):
-                        if value == '':
-                            value = None
-                        elif value.endswith('.0'):
-                            value = int(value[:-2])
-                    elif isinstance(column.type, (Choice, Integer)):
-                        if value == '':
-                            value = None
-                        else:
-                            value = int(float(value))
-                    elif isinstance(column.type, UTCDateTime):
-                        try:
-                            value = datetime.strptime(value, c.TIMESTAMP_FORMAT)
-                        except ValueError:
-                            value = dateparser.parse(value)
-                        value = c.EVENT_TIMEZONE.localize(value)
-                    elif isinstance(column.type, Date):
-                        try:
-                            value = datetime.strptime(value, c.DATE_FORMAT)
-                        except ValueError:
-                            value = dateparser.parse(value)
-                        value = value.date()
+
+                    elif isinstance(value, six.string_types):
+                        if isinstance(column.type, Float):
+                            value = value.strip()
+                            if value == '':
+                                value = None
+                            else:
+                                value = float(value)
+
+                        elif isinstance(column.type, Numeric):
+                            value = value.strip()
+                            if value == '':
+                                value = None
+                            elif value.endswith('.0'):
+                                value = int(value[:-2])
+
+                        elif isinstance(column.type, (Choice, Integer)):
+                            value = value.strip()
+                            if value == '':
+                                value = None
+                            else:
+                                value = int(float(value))
+
+                        elif isinstance(column.type, UTCDateTime):
+                            value = value.strip()
+                            try:
+                                value = datetime.strptime(value, c.TIMESTAMP_FORMAT)
+                            except ValueError:
+                                value = dateparser.parse(value)
+                            if not value.tzinfo:
+                                value = c.EVENT_TIMEZONE.localize(value)
+
+                        elif isinstance(column.type, Date):
+                            value = value.strip()
+                            try:
+                                value = datetime.strptime(value, c.DATE_FORMAT)
+                            except ValueError:
+                                value = dateparser.parse(value)
+                            value = value.date()
+
                 except Exception as error:
                     log.debug(
                         'Ignoring error coercing value for column {}.{}: {}', self.__tablename__, column.name, error)
@@ -505,6 +512,9 @@ from uber.models.tracking import Tracking  # noqa: E402
 
 
 class Session(SessionManager):
+
+    _SESSION_KEY = 'uber.models.Session.session'
+
     # This looks strange, but `sqlalchemy.create_engine` will throw an error
     # if it's passed arguments that aren't supported by the given DB engine.
     # For example, SQLite doesn't support either `pool_size` or `max_overflow`,
@@ -556,6 +566,52 @@ class Session(SessionManager):
             if drop:
                 from uber.migration import stamp
                 stamp('heads' if modify_tables else None)
+
+
+    def __init__(self, force_new_session=False, use_nested_transaction=False):
+        if not force_new_session and threadlocal.get(self._SESSION_KEY):
+            self.session = threadlocal.get(self._SESSION_KEY)
+            self.is_new_session = False
+        else:
+            self.session = self.session_factory()
+            self.is_new_session = True
+
+            import types
+            for name, val in self.SessionMixin.__dict__.items():
+                if not name.startswith('__'):
+                    assert not hasattr(self.session, name) and hasattr(val, '__call__')
+                    setattr(self.session, name, types.MethodType(val, self.session))
+
+        self.use_nested_transaction = use_nested_transaction
+        self.transaction = None
+        if not threadlocal.get(self._SESSION_KEY):
+            threadlocal.set(self._SESSION_KEY, self.session)
+
+    def __enter__(self):
+        if not self.is_new_session and self.use_nested_transaction:
+            self.session.begin_nested()
+        return self.session
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            if self.is_new_session or self.use_nested_transaction:
+                if exc_type is None:
+                    self.session.commit()
+                else:
+                    self.session.rollback()
+        finally:
+            if self.is_new_session:
+                self._close_session()
+
+    def __del__(self):
+        if self.is_new_session and self.session.transaction._connections:
+            log.error('SessionManager went out of scope without underlying connection being closed; did you forget to use it as a context manager?')
+            self._close_session()
+
+    def _close_session(self):
+        if self.session is threadlocal.get(self._SESSION_KEY):
+            threadlocal.set(self._SESSION_KEY, None)
+        self.session.close()
 
     class QuerySubclass(Query):
         @property

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -386,29 +386,26 @@ class MagModel:
                         pass  # Totally fine for value to be None
 
                     elif isinstance(value, six.string_types):
+                        value = value.strip()
                         if isinstance(column.type, Float):
-                            value = value.strip()
                             if value == '':
                                 value = None
                             else:
                                 value = float(value)
 
                         elif isinstance(column.type, Numeric):
-                            value = value.strip()
                             if value == '':
                                 value = None
                             elif value.endswith('.0'):
                                 value = int(value[:-2])
 
                         elif isinstance(column.type, (Choice, Integer)):
-                            value = value.strip()
                             if value == '':
                                 value = None
                             else:
                                 value = int(float(value))
 
                         elif isinstance(column.type, UTCDateTime):
-                            value = value.strip()
                             try:
                                 value = datetime.strptime(value, c.TIMESTAMP_FORMAT)
                             except ValueError:
@@ -417,7 +414,6 @@ class MagModel:
                                 value = c.EVENT_TIMEZONE.localize(value)
 
                         elif isinstance(column.type, Date):
-                            value = value.strip()
                             try:
                                 value = datetime.strptime(value, c.DATE_FORMAT)
                             except ValueError:


### PR DESCRIPTION
This should radically improve performance under heavy load.

**Note**: the page load times below are representative instances of the typical page load times for the given request. I repeated the requests many times, and chose examples that were near the median value of the sample set.

# Loading Attendee Registration Details

### Without Caching
* 12 new sessions
* Page loads in ~0.2 secs

```
NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f2508224828>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f252864ceb8>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f252864ceb8>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f252864c358>
        NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f25280afba8>
            NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082c7cf8>
            CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082c7cf8>
        CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f25280afba8>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f252864c358>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082b3be0>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082b3be0>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082c7358>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082c7358>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082b3518>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082b3518>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f2528094be0>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f2528094be0>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f25280bf8d0>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f25280bf8d0>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082b30f0>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f25082b30f0>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f2528037d68>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f2528037d68>
CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f2508224828>
2018-08-13 03:35:22,953 [DEBUG] uber.decorators: uber.site_sections.registration.form loaded in 0.212305 seconds
2018-08-13 03:35:22,954 [INFO] cherrypy.access.139798003845384: 10.0.2.2 - - [13/Aug/2018:03:35:22] "GET /reggie/registration/form?id=aec400a8-283e-4afe-a330-f0d8c162417f HTTP/1.1" 200 72596 "https://localhost:4443/registration/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
```

### With Caching
* 1 new session
* Page loads in ~0.1 sec

```
NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d220d4b38>
2018-08-13 03:36:34,818 [DEBUG] uber.decorators: uber.site_sections.registration.form loaded in 0.094528 seconds
2018-08-13 03:36:34,820 [INFO] cherrypy.access.139834081298584: 10.0.2.2 - - [13/Aug/2018:03:36:34] "GET /reggie/registration/form?id=aec400a8-283e-4afe-a330-f0d8c162417f HTTP/1.1" 200 72596 "https://localhost:4443/registration/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
```


# Loading Preregistration Page

### Without Caching

* 3 new sessions
* Page loads in ~ 0.35 secs

```
NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f452803d7f0>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f4518167ef0>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f4518167ef0>
    NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f44f44cc588>
    CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f44f44cc588>
CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f452803d7f0>
2018-08-13 03:41:16,165 [DEBUG] uber.decorators: uber.site_sections.preregistration.form loaded in 0.364221 seconds
2018-08-13 03:41:16,166 [INFO] cherrypy.access.139935184459928: 10.0.2.2 - - [13/Aug/2018:03:41:16] "GET /reggie/preregistration/form HTTP/1.1" 200 66955 "https://localhost:4443/common/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
```

### With Caching

* 1 new sessions
* Page loads in ~0.2 secs

```
NEW SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d21cbd208>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d21cbd208>
    CACHED SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d21cbd208>
CLOSING SESSION: <sqlalchemy.orm.session.Session object at 0x7f2d21cbd208>
2018-08-13 03:39:53,949 [DEBUG] uber.decorators: uber.site_sections.preregistration.form loaded in 0.199263 seconds
2018-08-13 03:39:53,951 [INFO] cherrypy.access.139834081298584: 10.0.2.2 - - [13/Aug/2018:03:39:53] "GET /reggie/preregistration/form HTTP/1.1" 200 66955 "https://localhost:4443/common/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
```