### PR TITLE
Adds efficient estimation for BADGES_SOLD

### DIFF
--- a/alembic/versions/651b1ea070d4_creates_index_on_attendee_badge_status_.py
+++ b/alembic/versions/651b1ea070d4_creates_index_on_attendee_badge_status_.py
@@ -1,0 +1,59 @@
+"""Creates index on attendee(badge_status, badge_type)
+
+Revision ID: 651b1ea070d4
+Revises: 05009fad3d3c
+Create Date: 2018-08-16 05:25:14.626408
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '651b1ea070d4'
+down_revision = '05009fad3d3c'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.create_index('ix_attendee_badge_status_badge_type', 'attendee', ['badge_status', 'badge_type'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_attendee_badge_status_badge_type', table_name='attendee')

--- a/test-defaults.ini
+++ b/test-defaults.ini
@@ -36,9 +36,6 @@ event_name = "CoolCon9000"
 numbered_badges = "True"
 badge_promo_codes_enabled = True
 
-# tests should turn this on to test the effects
-hardcore_optimizations_enabled = "False"
-
 shiftless_depts = "con_ops",
 
 # we want 2 preassigned types to test some of our logic, so we've

--- a/tests/uber/models/test_config.py
+++ b/tests/uber/models/test_config.py
@@ -164,10 +164,6 @@ class TestBadgePriceEstimate:
         monkeypatch.setattr(c, 'MAX_BADGE_SALES', 100)
         assert 100 == c.BADGES_LEFT_AT_CURRENT_PRICE
 
-    def test_hardcore_optimized_estimate(self, monkeypatch):
-        monkeypatch.setattr(c, 'HARDCORE_OPTIMIZATIONS_ENABLED', True)
-        assert None is c.BADGES_LEFT_AT_CURRENT_PRICE
-
     def test_almost_gone_estimate(self, monkeypatch):
         monkeypatch.setattr(uber.config.Config, 'BADGES_SOLD', 990)
         assert 10 == c.BADGES_LEFT_AT_CURRENT_PRICE
@@ -264,18 +260,6 @@ class TestDealerConfig:
         monkeypatch.setattr(c, 'DEALER_REG_DEADLINE', localized_now() + timedelta(days=1))
         monkeypatch.setattr(uber.config.Config, 'DEALER_APPS', 10)
         monkeypatch.setattr(c, 'MAX_DEALER_APPS', 0)
-        assert not c.DEALER_REG_SOFT_CLOSED
-
-    def test_dealer_reg_soft_closed_optimizations(self, monkeypatch):
-        monkeypatch.setattr(c, 'DEALER_REG_DEADLINE', localized_now() - timedelta(days=1))
-        monkeypatch.setattr(c, 'HARDCORE_OPTIMIZATIONS_ENABLED', True)
-        assert c.DEALER_REG_SOFT_CLOSED
-
-    def test_dealer_reg_not_soft_closed_optimizations(self, monkeypatch):
-        monkeypatch.setattr(c, 'DEALER_REG_DEADLINE', localized_now() + timedelta(days=1))
-        monkeypatch.setattr(uber.config.Config, 'DEALER_APPS', 10)
-        monkeypatch.setattr(c, 'MAX_DEALER_APPS', 1)
-        monkeypatch.setattr(c, 'HARDCORE_OPTIMIZATIONS_ENABLED', True)
         assert not c.DEALER_REG_SOFT_CLOSED
 
     def test_dealer_reg_soft_closed_over_max(self, monkeypatch):

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -12,15 +12,17 @@ dev_box = boolean(default=True)
 # in the following directories, stopping once one is found
 template_dirs = string_list(default=list('%(module_root)s/templates'))
 
-# Turn on some extremely aggressive optimizations that disable certain expensive elements of page rendering.
-# Use this only if you ABSOLUTELY NEED TO and understand what it does, and only use it temporarily under heavy load,
-# such as when opening preregistration on the first day and you have the entire internet trying to buy a badge.
-# This may cause parts of ubersystem (like badge pricing text, supporter counts, etc) to stop updating, so you
-# need to carefully keep an eye out for older data.  Use this if you have no other options. You have been warned -Dom
+# Turn on BADGES_SOLD estimation instead of using an exact count.
+# Under the hood, this causes BADGES_SOLD to query the "pg_class" table
+# for the number of rows in the Attendee table. The number of staff badges
+# in the system is then subtracted from the attendee estimate for the final
+# estimate of BADGES_SOLD.
 #
-# IMPORTANT NOTE 2: THIS DISABLES BADGE PRICING HIKES FROM UPDATING BASED ON BADGE COUNTS. YOU NEED TO KEEP AN EYE
-# ON YOUR BADGE PRICES AS IT WILL NOT INCREASE CORRECTLY WHEN BADGE THRESHOLDS ARE REACHED.
-hardcore_optimizations_enabled = boolean(default=False)
+# This estimate will probably be wrong, but it should be good enough for
+# the first couple of days after prereg launch.
+#
+# NOTE: This will only work on postgresql.
+badges_sold_estimate_enabled = boolean(default=False)
 
 # This turns on our automated emails.  See the description in the [secret]
 # section below for an explanation of how this works.

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -624,14 +624,6 @@ def single_day_prices():
 
 @JinjaEnv.jinja_export
 def price_notice(label, takedown, amount_extra=0, discount=0):
-    if c.HARDCORE_OPTIMIZATIONS_ENABLED:
-        # CPU optimizaiton: the calculations done in this function are somewhat expensive and even with caching,
-        # still do some expensive DB queries.  if hardcore optimizations mode is enabled, we display a
-        # simpler message.  This is intended to be enabled during the heaviest loads at the beginning of an event
-        # in order to reduce server load so the system stays up.  After the rush, it should be safe to turn this
-        # back off
-        return ''
-
     if not takedown:
         takedown = c.ESCHATON
 

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -407,7 +407,10 @@ class Attendee(MagModel, TakesPaymentMixin):
     checkouts = relationship('TabletopCheckout', backref='attendee')
     entrants = relationship('TabletopEntrant', backref='attendee')
 
-    _attendee_table_args = [Index('ix_attendee_paid_group_id', paid, group_id)]
+    _attendee_table_args = [
+        Index('ix_attendee_paid_group_id', paid, group_id),
+        Index('ix_attendee_badge_status_badge_type', badge_status, badge_type),
+    ]
     if not c.SQLALCHEMY_URL.startswith('sqlite'):
         _attendee_table_args.append(UniqueConstraint('badge_num', deferrable=True, initially='DEFERRED'))
 


### PR DESCRIPTION
The `BADGES_SOLD` estimate is hidden behind a `badges_sold_estimate_enabled` feature flag. This pull request also removes `HARDCORE_OPTIMIZATIONS_ENABLED` in favor of the new estimate.

I am going to merge this now, because I need to deploy it on the load testing system. However, @kitsuta and @EliAndrewC, I would love a pull request review!

Please hit me up with any questions or concerns, and I'll be happy to revise or revert things 😄 