### PR TITLE
Support for retina merch tier icons on the prereg page

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -263,7 +263,11 @@
                                   <h4>{{ tier.name }}</h4>
                                   {% if tier.price %}
                                     <span>
-                                      <img src="{{ tier.icon }}" alt=""> + ${{ tier.price }}
+                                      <img
+                                          class="tier-icon tier-icon-{{ tier.icon|basename|replace('_', '-')|replace('.png', '') }}"
+                                          src="{{ tier.icon }}"
+                                          alt="">
+                                      + ${{ tier.price }}
                                     </span>
                                   {% endif %}
                                 </div>


### PR DESCRIPTION
This adds a different CSS class to each merch tier icon, so we can easily target them to add retina icons.