### PR TITLE
Fixes bug where an unpaid prereg is switched from a group badge to a single badge or vice-versa

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -368,8 +368,8 @@ def credit_card(func):
         except Exception:
             error_text = \
                 'Got an error while calling charge' \
-                '(self, payment_id={!r}, stripeToken={!r}, ignored={}):\n{}\n' \
-                '\n IMPORTANT: This could have resulted in an attendee paying and not being' \
+                '(self, payment_id={!r}, stripeToken={!r}, ignored={}):\n{}\n\n' \
+                'IMPORTANT: This could have resulted in an attendee paying and not being ' \
                 'marked as paid in the database. Definitely double check this.'\
                 .format(payment_id, stripeToken, ignored, traceback.format_exc())
 


### PR DESCRIPTION
Steps to reproduce bug:
1. Fill out prereg form for a single attendee badge
2. From the overview page, click "Edit" to change the badge details
3. Change the badge from a single attendee to a group badge and click "Update"
4. **NOTE**: On the overview page, both the original single attendee badge and the new group badge will both be listed
5. Pay for the badges
6. The following error will be raised:
```
Traceback (most recent call last):
 File "/srv/reggie/plugins/uber/uber/decorators.py", line 356, in charge
   return func(self, session=session, payment_id=payment_id, stripeToken=stripeToken)
 File "/srv/reggie/plugins/uber/uber/site_sections/preregistration.py", line 385, in prereg_payment
   session.commit()  # paranoia: really make sure we lock in marking taking payments in the database
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 943, in commit
   self.transaction.commit()
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 467, in commit
   self._prepare_impl()
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 447, in _prepare_impl
   self.session.flush()
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 2254, in flush
   self._flush(objects)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 2380, in _flush
   transaction.rollback(_capture_exception=True)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/util/langhelpers.py", line 66, in __exit__
   compat.reraise(exc_type, exc_value, exc_tb)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 249, in reraise
   raise value
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 2344, in _flush
   flush_context.execute()
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/unitofwork.py", line 391, in execute
   rec.execute(self)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/unitofwork.py", line 556, in execute
   uow
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/persistence.py", line 181, in save_obj
   mapper, table, insert)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/orm/persistence.py", line 830, in _emit_insert_statements
   execute(statement, multiparams)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 948, in execute
   return meth(self, multiparams, params)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/sql/elements.py", line 269, in _execute_on_connection
   return connection._execute_clauseelement(self, multiparams, params)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1060, in _execute_clauseelement
   compiled_sql, distilled_params
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1200, in _execute_context
   context)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1413, in _handle_dbapi_exception
   exc_info
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 265, in raise_from_cause
   reraise(type(exception), exception, tb=exc_tb, cause=cause)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 248, in reraise
   raise value.with_traceback(tb)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1170, in _execute_context
   context)
 File "/srv/reggie/env/lib/python3.6/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 683, in do_executemany
   cursor.executemany(statement, parameters)
sqlalchemy.exc.IntegrityError: (psycopg2.IntegrityError) duplicate key value violates unique constraint "pk_attendee"
DETAIL:  Key (id)=(XXXX-XXXX-XXXX-XXXX) already exists.
```

