### PR TITLE
Normalizes API error format and uses HTTP status codes where appropriate

### DIFF
--- a/tests/uber/test_barcode.py
+++ b/tests/uber/test_barcode.py
@@ -45,15 +45,15 @@ def test_fail_wrong_event_id(cfg, monkeypatch):
     with pytest.raises(ValueError) as ex:
         barcode = generate_barcode_from_badge_num(badge_num=1, event_id=1)
         get_badge_num_from_barcode(barcode_num=barcode, event_id=2)
-    assert "doesn't match our event ID" in str(ex.value)
+    assert 'unrecognized event id' in str(ex.value)
 
 
 def test_dontfail_wrong_event_id(cfg):
     badge_num = 78946
     barcode = generate_barcode_from_badge_num(badge_num=badge_num)
-    decrytped = get_badge_num_from_barcode(barcode_num=barcode, event_id=2, verify_event_id_matches=False)
-    assert decrytped['badge_num'] == badge_num
-    assert decrytped['event_id'] == c.BARCODE_EVENT_ID
+    decrypted = get_badge_num_from_barcode(barcode_num=barcode, event_id=2, verify_event_id_matches=False)
+    assert decrypted['badge_num'] == badge_num
+    assert decrypted['event_id'] == c.BARCODE_EVENT_ID
 
 
 def test_valid_barcode_character_validations(cfg):

--- a/uber/barcode/__init__.py
+++ b/uber/barcode/__init__.py
@@ -123,9 +123,7 @@ def get_badge_num_from_barcode(barcode_num, salt=None, key=None, event_id=None, 
     result['badge_num'] = struct.unpack('>I', badge_bytes)[0] - salt
 
     if verify_event_id_matches and result['event_id'] != event_id:
-        raise ValueError(
-            "error: event_id of decrypted barcode doesn't match our event ID."
-            "expected: " + str(event_id) + " got: " + str(result['event_id']))
+        raise ValueError('unrecognized event id: {}'.format(result['event_id']))
 
     return result
 
@@ -157,7 +155,7 @@ def verify_barcode_is_valid_code128_charset(str):
 
 def assert_is_valid_rams_barcode(barcode):
     if not verify_is_valid_rams_barcode(barcode):
-        raise ValueError("barcode validation error: invalid format for RAMS barcode: '{}'".format(barcode))
+        raise ValueError("barcode validation error: invalid format for barcode: {}".format(barcode))
 
 
 def _barcode_raw_encrypt(value, key):
@@ -230,7 +228,7 @@ def _barcode_raw_decrypt(value, key):
         uber.barcode.skip32.skip32(key, decrytped, _encrypt)
     except Exception as e:
         raise ValueError(
-            "Failed to decrypt barcode. check secret_key, event_id, and whether this barcode is from this event") from e
+            "Failed to decrypt barcode: check secret_key, event_id, and whether this barcode is from this event") from e
 
     if len(decrytped) != 4:
         raise ValueError("Invalid barcode decryption: output result was not exactly 4 bytes")

--- a/uber/server.py
+++ b/uber/server.py
@@ -1,13 +1,17 @@
 import json
 import mimetypes
 import os
+import traceback
 from pprint import pformat
 
 import cherrypy
 import jinja2
+from cherrypy import HTTPError
 from pockets.autolog import log
-from sideboard.jsonrpc import _make_jsonrpc_handler
+from sideboard.jsonrpc import json_handler, ERR_INVALID_RPC, ERR_MISSING_FUNC, ERR_INVALID_PARAMS, \
+    ERR_FUNC_EXCEPTION, ERR_INVALID_JSON
 from sideboard.server import jsonrpc_reset
+from sideboard.websockets import trigger_delayed_notifications
 
 from uber.config import c, Config
 from uber.decorators import all_renderable, render
@@ -195,6 +199,70 @@ cherrypy.tree.mount(Root(), c.CHERRYPY_MOUNT_PATH, c.APPCONF)
 static_overrides(os.path.join(c.MODULE_ROOT, 'static'))
 
 
+def _make_jsonrpc_handler(services, debug=c.DEV_BOX, precall=lambda body: None):
+
+    @cherrypy.expose
+    @cherrypy.tools.force_json_in()
+    @cherrypy.tools.json_out(handler=json_handler)
+    def _jsonrpc_handler(self=None):
+        id = None
+
+        def error(status, code, message):
+            response = {'jsonrpc': '2.0', 'id': id, 'error': {'code': code, 'message': message}}
+            log.debug('Returning error message: {!r}', response)
+            cherrypy.response.status = status
+            return response
+
+        def success(result):
+            response = {'jsonrpc': '2.0', 'id': id, 'result': result}
+            log.debug('Returning success message: {!r}', response)
+            cherrypy.response.status = 200
+            return response
+
+        request_body = cherrypy.request.json
+        if not isinstance(request_body, dict):
+            return error(400, ERR_INVALID_JSON, 'Invalid json input {!r}'.format(cherrypy.request.body))
+
+        log.debug('jsonrpc request body: {!r}', request_body)
+
+        id, params = request_body.get('id'), request_body.get('params', [])
+        if 'method' not in request_body:
+            return error(400, ERR_INVALID_RPC, '"method" field required for jsonrpc request')
+
+        method = request_body['method']
+        if method.count('.') != 1:
+            return error(404, ERR_MISSING_FUNC, 'Invalid method ' + method)
+
+        module, function = method.split('.')
+        if module not in services:
+            return error(404, ERR_MISSING_FUNC, 'No module ' + module)
+
+        service = services[module]
+        if not hasattr(service, function):
+            return error(404, ERR_MISSING_FUNC, 'No function ' + method)
+
+        if not isinstance(params, (list, dict)):
+            return error(400, ERR_INVALID_PARAMS, 'Invalid parameter list: {!r}'.format(params))
+
+        args, kwargs = (params, {}) if isinstance(params, list) else ([], params)
+
+        precall(request_body)
+        try:
+            return success(getattr(service, function)(*args, **kwargs))
+        except HTTPError as http_error:
+            return error(http_error.code, ERR_FUNC_EXCEPTION, http_error._message)
+        except Exception as e:
+            log.error('Unexpected error', exc_info=True)
+            message = 'Unexpected error: {}'.format(e)
+            if debug:
+                message += '\n' + traceback.format_exc()
+            return error(500, ERR_FUNC_EXCEPTION, message)
+        finally:
+            trigger_delayed_notifications()
+
+    return _jsonrpc_handler
+
+
 jsonrpc_services = {}
 
 
@@ -204,5 +272,5 @@ def register_jsonrpc(service, name=None):
     jsonrpc_services[name] = service
 
 
-jsonrpc_handler = _make_jsonrpc_handler(jsonrpc_services, precall=jsonrpc_reset)
-cherrypy.tree.mount(jsonrpc_handler, os.path.join(c.CHERRYPY_MOUNT_PATH, 'jsonrpc'), c.APPCONF)
+jsonrpc_app = _make_jsonrpc_handler(jsonrpc_services, precall=jsonrpc_reset)
+cherrypy.tree.mount(jsonrpc_app, os.path.join(c.CHERRYPY_MOUNT_PATH, 'jsonrpc'), c.APPCONF)

--- a/uber/templates/api/reference.html
+++ b/uber/templates/api/reference.html
@@ -176,7 +176,8 @@
               }
             },
             error: function (xhr, textStatus, errorThrown) {
-              handleError('Error ' + xhr.status + ': ' + xhr.statusText);
+              print('Error ' + xhr.status + ': ' + xhr.statusText);
+              handleError(xhr.responseJSON || xhr.responseText);
             },
             beforeSend: function(xhr, settings) {
               print(this.type + ' ' + this.url);
@@ -205,9 +206,10 @@
   <div class="row">
     <div class="col-sm-6 prose-column">
       <p>
-        The API is based around JSON RPC. API calls should be made using HTTP
-        POST requests. The request body should be a JSON formatted string
-        including the following properties:
+        The API is based on JSON-RPC, and conforms to the
+        <a href="https://www.jsonrpc.org/specification">JSON-RPC spec</a>.
+        API calls should be made using HTTP POST requests. The request body
+        should be a JSON formatted string including the following properties:
       </p>
       <dl>
         <div>
@@ -253,6 +255,19 @@
       "id": "{{ admin_account.attendee.id }}"
     }
   ]
+}
+</pre>
+      </div>
+      <div class="example">
+        <label>Example Error Body</label>
+        <pre>
+{
+  "id": null,
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32603,
+    "message": "Unexpected error"
+  }
 }
 </pre>
       </div>
@@ -302,6 +317,21 @@
         <label>Using Curl</label>
         <pre class="code">curl -v -k -d '{"method": "config.info"}' -H "X-Auth-Token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" -w "\n" {{ c.URL_BASE }}/jsonrpc/</pre>
       </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-6 prose-column">
+      <h3>Note on 404 Not Found</h3>
+      <p>
+        Methods that are expected to return a single specific object, like
+        <code>attendee.lookup</code>, will raise a <em>404 Not Found</em>
+        if the object is not found.
+      </p>
+      <p>
+        Methods that are expected to return many objects, like
+        <code>attendee.search</code>, will return <em>200 OK</em>
+        with an empty array if no matching objects are found.
+      </p>
     </div>
   </div>
   {%-


### PR DESCRIPTION
This pull request changes the API so it uses HTTP status codes where appropriate (404 Not Found, 403 Forbidden, 500 Server Error).

Furthermore, this pull request normalizes the format of returned errors. Previously, some methods would return 200 OK with an embedded error message in the result object:
### Before
```
200 OK
{
  "id": null,
  "jsonrpc": "2.0",
  "result": [
    {
      "error": "No attendee found with Badge #217"
    }
  ]
}
```

### After
```
404 Not Found
{
  "id": null,
  "jsonrpc": "2.0",
  "error": {
    "code": -32603,
    "message": "No attendee found with Badge #217"
  }
}
```