### PR TITLE
Fixes prereg total cost calculation if attendee removes themselves from group

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -157,6 +157,8 @@ class Root:
                 # was edited and switched from a group badge back to a single badge.
                 group.attendees = []
                 attendee.group_id = None
+                if attendee.paid == c.PAID_BY_GROUP:
+                    attendee.paid = c.NOT_PAID
             params.setdefault('badges', group.badges)
         else:
             attendee = session.attendee(params, ignore_csrf=True, restricted=True)


### PR DESCRIPTION
Steps to reproduce:
1. Fill out prereg form for a **single attendee**
2. From overview page, click "Edit"
3. Change reg to **group**, click update
4. From overview page, click "Edit"
3. Change reg back to **single attendee**, click update
5. On overview page, not the **Total Cost** is incorrect 
<img width="851" alt="screen shot 2018-08-27 at 3 36 07 pm" src="https://user-images.githubusercontent.com/2592431/44682732-36c7d800-aa12-11e8-80a4-e5eeb90435aa.png">
