### PR TITLE
Makes attendance graph responsive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ node_modules/
 .eggs/
 .coverage
 uploaded_files/*
+uber/static/analytics/extra-attendance-data.json
+

--- a/uber/static/analytics/analytics.css
+++ b/uber/static/analytics/analytics.css
@@ -1,5 +1,12 @@
-#attendanceGraph {
-    /* I don't know how to CSS canvas, it's weird. -Dom
-       width: 100%;
-       height: 50%;*/
+#attendanceGraphScroller {
+    height: auto;
+    width: 100%;
+    overflow: auto;
+}
+
+#attendanceGraphContainer {
+    height: auto;
+    width: 100%;
+    max-width: 1024px;
+    min-width: 480px;
 }

--- a/uber/static/analytics/attendance.js
+++ b/uber/static/analytics/attendance.js
@@ -152,6 +152,7 @@ function draw_attendance_chart(raw_data)
     pointDot: false,
     pointHitDetectionRadius: 1,
     scaleShowLabels: true,
+    responsive: true,
     multiTooltipTemplate: "<%= datasetLabel %>: <%= value %>",
     showXLabels: 20
   };

--- a/uber/templates/graphs/index.html
+++ b/uber/templates/graphs/index.html
@@ -20,7 +20,11 @@
             It does not include comp'd badges for staff, guests, bands. It does not include dealers.<br/>
         </p>
 
-        {# Yea.... I don't know how to fix the w/h here.  someone with better css/html5 do it.#}
+    <div id="attendanceGraphScroller">
+      <div id="attendanceGraphContainer">
+        {# Width and height are only used to set the aspect ratio. The graph maintains its own size. #}
         <canvas id="attendanceGraph" width="1000" height="800"></canvas>
+      </div>
+    </div>
 
 {% endblock %}


### PR DESCRIPTION
Allows the attendance graph to resize between 480px - 1024px. Wraps graph in scrolling element.

# Smaller Screen
![screen shot 2018-09-01 at 8 04 47 pm](https://user-images.githubusercontent.com/2592431/44950898-7e8b9c80-ae22-11e8-8d40-d2de4234da5e.png)



# Larger Screen
![screen shot 2018-09-01 at 8 05 39 pm](https://user-images.githubusercontent.com/2592431/44950899-84817d80-ae22-11e8-8d2d-477d30dccd56.png)
