### PR TITLE
Pins cherrypy to v17.3.0 – v18.* has breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cherrypy==17.3.0
 celery==4.1.1
 python-dateutil==2.6.0
 psycopg2==2.7.3.2


### PR DESCRIPTION
Looks like cherrypy moved around some of it's internals. Here's the error we're receiving on new deployments:
```
Traceback (most recent call last):
  File "/root/.pythonstartup.py", line 24, in <module>
    import sideboard
  File "/home/vagrant/reggie-formula/reggie_install/sideboard/__init__.py", line 9, in <module>
    import sideboard.server
  File "/home/vagrant/reggie-formula/reggie_install/sideboard/server.py", line 11, in <module>
    from sideboard.jsonrpc import _make_jsonrpc_handler
  File "/home/vagrant/reggie-formula/reggie_install/sideboard/jsonrpc.py", line 6, in <module>
    from cherrypy.lib.jsontools import json_decode
ImportError: cannot import name 'json_decode'
```

For breaking changes, see here and possibly elsewhere: https://github.com/cherrypy/cherrypy/commit/5f8d4358cfc7580bdb22e471dd1e4b03cc3887c5#diff-7e898fcd50f5e7b56b4486a6060f483f