### PR TITLE
Only allow access to group leader's badge from group page

### DIFF
--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -81,7 +81,9 @@
         <td><ul style="margin: 5px 0; padding-right: 0"><li></li></ul></td>
         {% if attendee.first_name %}
             <td style="padding-right: 10px">
-                <a href="confirm?id={{ attendee.id }}">{{ attendee.full_name }}</a>
+                {% if attendee.is_group_leader %}
+                  <a href="confirm?id={{ attendee.id }}">{{ attendee.full_name }}</a>
+                {% else %}{{ attendee.full_name }}{% endif %}
             </td>
             <td style="padding-right: 10px">
                 {{ attendee.email|email_to_link }}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-231. We still keep the link to the group leader's badge because I'm pretty sure that's they only way they can get to it -- in any case, we generally assume the group leader is the one on this page.