### PR TITLE
Allow MITS teams to cancel their applications

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1252,6 +1252,7 @@ pending = string(default="Pending")
 waitlisted = string(default="Waitlisted")
 declined = string(default="Declined")
 accepted = string(default="Accepted")
+cancelled = string(default="Cancelled")
 
 [[mits_phase]]
 development = string(default="Development")

--- a/uber/site_sections/mits_applications.py
+++ b/uber/site_sections/mits_applications.py
@@ -30,6 +30,23 @@ class Root:
     def login_explanation(self, message=''):
         return {'message': message}
 
+    def cancel(self, session, id):
+        team = session.mits_team(id)
+
+        if team.status != c.ACCEPTED:
+            team.status = c.CANCELLED
+            raise HTTPRedirect('index?message={}', 'You have successfully cancelled your application.')
+        else:
+            raise HTTPRedirect(
+                'Your application has already been accepted. Please contact us at {}.".format(c.MITS_EMAIL)')
+
+    @csrf_protected
+    def uncancel(self, session, id):
+        team = session.mits_team(id)
+        team.status = c.PENDING
+
+        raise HTTPRedirect('index?message={}', 'Application re-enabled.')
+
     def view_picture(self, session, id):
         picture = session.mits_picture(id)
         return serve_file(picture.filepath, name=picture.filename, content_type=picture.content_type)

--- a/uber/templates/mits_applications/index.html
+++ b/uber/templates/mits_applications/index.html
@@ -7,6 +7,18 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
 <a href="team">{{ team.name }}</a>.  If you are not a member of {{ team.name }} then please
 <a href="logout">log out</a>.
 
+{% if team.status == c.CANCELLED %}
+  {% if c.HAS_MITS_ADMIN_ACCESS %}
+    <br/><br/>This application has been cancelled by its team "{{ team.name }}."
+    <form method="post" action="uncancel" class="form-horizontal">
+    <input type="hidden" name="id" value="{{ team.id }}" />
+    {{ csrf_token() }}
+    <button type="submit" class="btn btn-success">Re-enable This Application</button>
+    </form>
+  {% else %}
+    <br/><br/>You have chosen to cancel your MITS application. If this was a mistake or if you have any questions, please contact us at {{ c.MITS_EMAIL|email_to_link }}.
+  {% endif %}
+{% else %}
 {% if team.steps_completed < c.MITS_APPLICATION_STEPS %}
     <h3 style="color:red">You have completed {{ team.completion_percentage }}% of your application!</h3>
     You <b>must</b> complete the remaining steps below by {{ c.MITS_SUBMISSION_DEADLINE|datetime_local }} to be considered for the showcase.
@@ -163,5 +175,33 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
         </form>
     </p>
 {% endif %}
+{% endif %}
+{% if team.status not in [c.ACCEPTED, c.CANCELLED] %}
+  <form method="post" action="cancel" class="form-horizontal">
+  <input type="hidden" name="id" value="{{ team.id }}" />
+
+  <button type="submit" id="cancel_app" class="btn btn-danger">Cancel My MITS Application</button>
+  </form>
+{% endif %}
+
+  <script type="text/javascript">
+      $('#cancel_app').on('click', function(event) {
+          event.preventDefault();
+          var formToSubmit = $(this).closest('form');
+
+          bootbox.confirm({
+              backdrop: true,
+              message: '<p>Are you sure you want to cancel your MITS application?</p>',
+              buttons: {
+                  confirm: { label: 'Yes, Cancel My Application', className: 'btn-danger' },
+                  cancel: { label: 'Nevermind', className: 'btn-default' }
+              },
+              callback: function (result) {
+          if (result) {
+              formToSubmit.submit();
+          }
+      }});
+      });
+  </script>
 
 {% endblock %}


### PR DESCRIPTION
If they have not been accepted into MITS, teams can cancel their own applications. A MITS admin can now also 'un'cancel a cancelled application. Fixes https://jira.magfest.net/browse/MAGDEV-307.