### PR TITLE
Add 'check if applied' function for MITS

### DIFF
--- a/uber/site_sections/mits_applications.py
+++ b/uber/site_sections/mits_applications.py
@@ -1,5 +1,5 @@
 import shutil
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import cherrypy
 from cherrypy.lib.static import serve_file
@@ -7,9 +7,11 @@ from pockets import listify
 from pytz import UTC
 
 from uber.config import c
-from uber.decorators import all_renderable, csrf_protected
+from uber.decorators import all_renderable, csrf_protected, render
 from uber.errors import HTTPRedirect
-from uber.utils import check
+from uber.models import Email, MITSTeam
+from uber.tasks.email import send_email
+from uber.utils import check, localized_now
 
 
 @all_renderable()
@@ -38,6 +40,49 @@ class Root:
         doc = session.mits_document(id)
         cherrypy.response.headers['Content-Disposition'] = 'attachment; filename="{}"'.format(doc.filename)
         return serve_file(doc.filepath, name=doc.filename)
+
+    def check_if_applied(self, session, message='', **params):
+        if cherrypy.request.method == 'POST':
+            subject = c.EVENT_NAME_AND_YEAR + ' MITS Team Confirmation'
+
+            if 'email' not in params:
+                message = "Please enter an email address."
+
+            if not message:
+                last_email = (session.query(Email)
+                              .filter(Email.to.ilike(params['email']))
+                              .filter_by(subject=subject)
+                              .order_by(Email.when.desc()).first())
+                if not last_email or last_email.when < (
+                            localized_now() - timedelta(days=7)):
+                    can_send_email = True
+                else:
+                    can_send_email = False
+
+                mits_teams = session.query(MITSTeam).all()
+
+                match_counter = 0
+                for team in mits_teams:
+                    if params['email'] in team.email:
+                        match_counter += 1
+
+                        if can_send_email:
+                            send_email.delay(
+                                c.MITS_EMAIL,
+                                params['email'],
+                                subject,
+                                render('emails/mits/mits_check.txt',
+                                       {'team': team}, encoding=None),
+                                cc=team.email,
+                                model=team.to_dict('id'))
+
+                if match_counter:
+                    message = 'We found {} team{}.{}'\
+                        .format(match_counter, 's' if match_counter > 1 else '',
+                                ' Please check your email for a link to your application.'
+                                if can_send_email else ' Please check your spam or junk folder.')
+
+        return {'message': message}
 
     def team(self, session, message='', **params):
         params.pop('id', None)

--- a/uber/templates/emails/mits/mits_check.txt
+++ b/uber/templates/emails/mits/mits_check.txt
@@ -1,0 +1,7 @@
+Thank you for double-checking your MITS application for {{ c.EVENT_NAME_AND_YEAR }}.
+
+Your MITS application is currently {{ team.status_label }}. You can view{% if team.can_save %} and save{% endif %} your application here: {{ c.URL_BASE }}/mits_applications/continue_app?id={{ team.id }}
+
+If you have any questions about your application, please contact us at {{ c.MITS_EMAIL|email_only }}. Thank you!
+
+{{ c.MITS_EMAIL_SIGNATURE }}

--- a/uber/templates/mits_applications/check_if_applied.html
+++ b/uber/templates/mits_applications/check_if_applied.html
@@ -1,0 +1,29 @@
+{% extends "mits_base.html" %}
+{% block body %}
+
+  <h2>Check MITS Application</h2>
+  If you believe you've already filled out the MITS application, please enter the email address of anyone in the studio set to <em>receive emails</em>.
+  By default, this is the person who originally filled out the application.
+
+  <br/><br/>If you have applied for MITS, you will receive a confirmation email (usually within 5 minutes). If you do not receive this email, and it is not in your Spam or Junk folder, please contact us at {{ c.MITS_EMAIL|email_to_link }}.
+
+  <br/><br/>
+
+  <form method="post" action="check_if_applied" class="form-horizontal" role="form">
+    <div class="form-group">
+      <label class="col-sm-3 control-label">Email Address</label>
+      <div class="col-sm-6">
+        <input class="form-control focus" type="text" name="email" />
+      </div>
+      <p class="help-block col-sm-9 col-sm-offset-3">
+        Please note that in order to avoid accidentally spamming people, we can only send a confirmation email once per week.
+      </p>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-6 col-sm-offset-3">
+        <button type="submit" class="btn btn-primary">Check Application</button>
+      </div>
+    </div>
+  </form>
+
+{% endblock %}

--- a/uber/templates/mits_applications/team.html
+++ b/uber/templates/mits_applications/team.html
@@ -17,6 +17,7 @@
 {% else %}
     {% if team.is_new %}
         <h2>MAGFest Indie Tabletop Showcase Application</h2>
+        Have you already filled this out? If so, click <a href="../mits_applications/check_if_applied">here</a>. <br/><br/>
     {% else %}
         <h2>Edit Your Team Information</h2>
     {% endif %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-308. Unlike the similar "check if preregistered" function, it's not a big privacy concern if we tell attendees that a studio has or has not applied, since they aren't necessarily going to MAGFest just because they applied. That's my theory, anyway.