### PR TITLE
Replace MITS schedule availability step with showcase availability

### DIFF
--- a/alembic/versions/b574c0577253_add_separate_mits_showcase_scheduling_.py
+++ b/alembic/versions/b574c0577253_add_separate_mits_showcase_scheduling_.py
@@ -1,0 +1,61 @@
+"""Add separate MITS showcase scheduling column.
+
+Revision ID: b574c0577253
+Revises: 6c5cf22429e2
+Create Date: 2018-09-26 19:29:40.149653
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'b574c0577253'
+down_revision = '6c5cf22429e2'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('mits_times', sa.Column('showcase_availability', sa.Unicode(), server_default='', nullable=False))
+    op.drop_column('mits_times', 'multiple_tables')
+
+
+def downgrade():
+    op.drop_column('mits_times', 'showcase_availability')
+    op.add_column('mits_times', sa.Column('multiple_tables', sa.Unicode(), server_default='', nullable=False))

--- a/uber/config.py
+++ b/uber/config.py
@@ -1047,7 +1047,7 @@ for num in range(c.ESCHATON.year - c.MIVS_START_YEAR):
 
 # The number of steps to the MITS application process.  Since changing this requires a code change
 # anyway (in order to add another step), this is hard-coded here rather than being a config option.
-c.MITS_APPLICATION_STEPS = 6
+c.MITS_APPLICATION_STEPS = 5
 
 # The options for the recommended minimum age for games, as filled out by the teams.
 c.MITS_AGE_OPTS = [(i, i) for i in range(4, 20, 2)]

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1290,6 +1290,13 @@ sunday_early = string(default="Sunday 4am - 8am")
 sunday_morning = string(default="Sunday 8am - noon")
 sunday_afternoon = string(default="Sunday noon - 4pm")
 
+[[mits_showcase_schedule]]
+friday_afternoon = string(default="Friday 1 - 3pm")
+friday_evening = string(default="Friday 3pm - 7pm")
+friday_night = string(default="Friday 7pm - 11pm")
+saturday_afternoon = string(default="Saturday 1pm - 3pm")
+saturday_evening = string(default="Saturday 3pm - 7pm")
+saturday_night = string(default="Saturday 7pm - 11pm")
 
 [[communication_pref]]
 email = string(default="Email")

--- a/uber/models/mits.py
+++ b/uber/models/mits.py
@@ -91,19 +91,21 @@ class MITSTeam(MagModel):
         return any(a.declined_hotel_space or a.requested_room_nights for a in self.applicants)
 
     @property
+    def wants_showcase(self):
+        return self.schedule.showcase_availability
+
+    @property
     def steps_completed(self):
         if not self.games:
             return 1
         elif not self.pictures:
             return 2
-        elif not self.schedule:
-            return 3
         elif not self.completed_hotel_form:
-            return 4
+            return 3
         elif not self.submitted:
-            return 5
+            return 4
         else:
-            return 6
+            return 5
 
     @property
     def completion_percentage(self):
@@ -178,8 +180,8 @@ class MITSDocument(MagModel):
 
 class MITSTimes(MagModel):
     team_id = Column(ForeignKey('mits_team.id'))
+    showcase_availability = Column(MultiChoice(c.MITS_SHOWCASE_SCHEDULE_OPTS))
     availability = Column(MultiChoice(c.MITS_SCHEDULE_OPTS))
-    multiple_tables = Column(MultiChoice(c.MITS_SCHEDULE_OPTS))
 
 
 @on_startup

--- a/uber/site_sections/mits_admin.py
+++ b/uber/site_sections/mits_admin.py
@@ -128,16 +128,15 @@ class Root:
                     ])
 
     @csv_file
-    def schedule_requests(self, out, session):
-        out.writerow([''] + [desc for val, desc in c.MITS_SCHEDULE_OPTS])
+    def showcase_requests(self, out, session):
+        out.writerow(['Team Name'] + [desc for val, desc in c.MITS_SHOWCASE_SCHEDULE_OPTS])
         for team in session.mits_teams().filter_by(status=c.ACCEPTED):
-            available = getattr(team.schedule, 'availability_ints', [])
-            multiple = getattr(team.schedule, 'multiple_tables_ints', [])
-            out.writerow([team.name] + [
-                'multiple' if val in multiple else
-                '1 table' if val in available else ''
-                for val, desc in c.MITS_SCHEDULE_OPTS
-            ])
+            if team.wants_showcase:
+                available = getattr(team.schedule, 'showcase_availability_ints', [])
+                out.writerow([team.name] + [
+                    'available' if val in available else ''
+                    for val, desc in c.MITS_SHOWCASE_SCHEDULE_OPTS
+                ])
 
     @csv_file
     def panel_requests(self, out, session):

--- a/uber/site_sections/mits_applications.py
+++ b/uber/site_sections/mits_applications.py
@@ -171,7 +171,7 @@ class Root:
         raise HTTPRedirect('index?message={}', 'Game deleted')
 
     def schedule(self, session, message='', **params):
-        times = session.mits_times(params, applicant=True)
+        times = session.mits_times(params, applicant=True, checkgroups=['showcase_availability'])
         if cherrypy.request.method == 'POST':
             message = check(times)
             if not message:
@@ -181,9 +181,9 @@ class Root:
         return {
             'times': times,
             'message': message,
-            'grid': [
-                (val, desc, val in times.availability_ints, val in times.multiple_tables_ints)
-                for val, desc in c.MITS_SCHEDULE_OPTS
+            'list': [
+                (val, desc, val in times.showcase_availability_ints)
+                for val, desc in c.MITS_SHOWCASE_SCHEDULE_OPTS
             ]
         }
 

--- a/uber/templates/mits_applications/index.html
+++ b/uber/templates/mits_applications/index.html
@@ -133,14 +133,17 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
 
 
 {% if team.steps_completed >= 3 %}
-    <h3>Request Timeslots</h3>
+    <h3>MITS Showcase</h3>
 
-    <p>Tell us specifically when during the event you're available to present.</p>
+    <p>MITS has added a new showcase available to a subset of accepted presenters.
+      This is completely optional, and it's more competitive than just being accepted by MITS!</p>
 
-    <p><a href="schedule?id={{ team.schedule.id if team.schedule else 'None' }}">Manage Requested Schedule Times</a></p>
+    <p>You currently <strong>have{% if not team.wants_showcase %} not{% endif %}</strong> applied for the showcase.</p>
+
+    <p><a href="schedule?id={{ team.schedule.id if team.schedule else 'None' }}">Update Showcase Availability</a></p>
 {% endif %}
 
-{% if team.steps_completed >= 4 %}
+{% if team.steps_completed >= 3 %}
     <h3>Manage Hotel Room Requests</h3>
 
     <p>We have a limited number of rooms set aside for people who need hotel space and haven't secured it for themselves.</p>
@@ -150,7 +153,7 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
     <p><a href="hotel_requests">Enter your hotel request information</a></p>
 {% endif %}
 
-{% if team.steps_completed == 5 %}
+{% if team.steps_completed == 4 %}
     <h3>Submit Your Application</h3>
     <p>
         Now that you've filled out all of your information above, the only remaining step is to formally submit this

--- a/uber/templates/mits_applications/schedule.html
+++ b/uber/templates/mits_applications/schedule.html
@@ -1,45 +1,41 @@
 {% extends "mits_base.html" %}
 {% block body %}
 
-<h2>When Can You Present?</h2>
+<h2>MITS Showcase</h2>
 
 <p>
-    For each timeslot listed below, please indicate whether or not you can present during that time, and whether you
-    will be bringing enough volunteers to run enough games to need multiple tables.
+    MITS has added a new showcase available to a subset of accepted presenters.
+    This is completely optional, and it's more competitive than just being accepted by MITS!
 </p>
 <p>
-    We cannot guarantee that you'll be given every timeslot you request or that you will get multiple tables in each
-    timeslot you request, but we will do our best based on the available space during each timeslot.
+    This is a time for promotion and selling, so if accepted then you should prepare for larger foot
+    traffic and have all your staff ready to explain your games, demo your games, talk about your games, etc.
 </p>
 <p>
-    As a reminder, {{ c.EVENT_NAME }} runs from {{ c.EPOCH|datetime("%A, %B %-d") }} through {{ c.ESCHATON|datetime("%A, %B %-d") }}.
+    The showcase is for more polished games which have either already been published or are ready for publication.
 </p>
+
+<p><strong>To apply for the showcase, simply select your availability from the times below.</strong></p>
 
 <form method="post" action="schedule" class="form-horizontal" role="form">
     {{ csrf_token() }}
     <input type="hidden" name="id" value="{{ times.db_id }}" />
 
     <table>
-    {% for val, desc, avail_checked, multi_checked in grid %}
+    {% for val, desc, avail_checked in list %}
         <tr>
             <td>{{ desc }}</td>
             <td>
                 <label class='checkbox-label'>
-                    <input type="checkbox" name="availability" value="{{ val }}" {% if avail_checked %}checked{% endif %} />
-                    Can present
-                </label>
-            </td>
-            <td>
-                <label class='checkbox-label'>
-                    <input type="checkbox" name="multiple_tables" value="{{ val }}" {% if multi_checked %}checked{% endif %} />
-                    Can use multiple tables
+                    <input type="checkbox" name="showcase_availability" value="{{ val }}" {% if avail_checked %}checked{% endif %} />
+                    Available
                 </label>
             </td>
         </tr>
     {% endfor %}
     <tr>
         <td></td>
-        <td><input type="submit" value="Upload Requested Schedule" /></td>
+        <td><button type="submit" class="btn btn-primary">Update Availability</button></td>
         <td></td>
     </tr>
     </table>


### PR DESCRIPTION
Converts the 'schedule' step, which used to ask for MITS teams' overall availability, to a 'showcase availability' form that lets them apply for the MITS Showcase. Fixes https://jira.magfest.net/browse/MAGDEV-313. Fixes https://jira.magfest.net/browse/MAGDEV-315.