### PR TITLE
Add new MIVS scoring categories

### DIFF
--- a/alembic/versions/bf427bc2a7f2_add_new_mivs_game_scoring_columns.py
+++ b/alembic/versions/bf427bc2a7f2_add_new_mivs_game_scoring_columns.py
@@ -1,0 +1,65 @@
+"""Add new MIVS game scoring columns
+
+Revision ID: bf427bc2a7f2
+Revises: 9d90d3d538c6
+Create Date: 2018-10-05 17:04:48.477995
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'bf427bc2a7f2'
+down_revision = '9d90d3d538c6'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('indie_game_review', sa.Column('design_score', sa.Integer(), server_default='0', nullable=False))
+    op.add_column('indie_game_review', sa.Column('enjoyment_score', sa.Integer(), server_default='0', nullable=False))
+    op.add_column('indie_game_review', sa.Column('readiness_score', sa.Integer(), server_default='0', nullable=False))
+    op.drop_column('indie_game_review', 'game_score')
+
+
+def downgrade():
+    op.add_column('indie_game_review', sa.Column('game_score', sa.INTEGER(), server_default=sa.text('0'), autoincrement=False, nullable=False))
+    op.drop_column('indie_game_review', 'readiness_score')
+    op.drop_column('indie_game_review', 'enjoyment_score')
+    op.drop_column('indie_game_review', 'design_score')

--- a/uber/models/mivs.py
+++ b/uber/models/mivs.py
@@ -388,10 +388,12 @@ class IndieGameReview(MagModel):
         Choice(c.MIVS_GAME_REVIEW_STATUS_OPTS), default=c.PENDING)
     game_content_bad = Column(Boolean, default=False)
     video_score = Column(Choice(c.MIVS_VIDEO_REVIEW_OPTS), default=c.PENDING)
+    video_review = Column(UnicodeText)
 
     # 0 = not reviewed, 1-10 score (10 is best)
-    game_score = Column(Integer, default=0)
-    video_review = Column(UnicodeText)
+    readiness_score = Column(Integer, default=0)
+    design_score = Column(Integer, default=0)
+    enjoyment_score = Column(Integer, default=0)
     game_review = Column(UnicodeText)
     developer_response = Column(UnicodeText)
     staff_notes = Column(UnicodeText)
@@ -405,8 +407,12 @@ class IndieGameReview(MagModel):
     def no_score_if_broken(self):
         if self.has_video_issues:
             self.video_score = c.PENDING
-        if self.has_game_issues:
-            self.game_score = 0
+
+    @property
+    def game_score(self):
+        if self.has_game_issues or not (self.readiness_score and self.design_score and self.enjoyment_score):
+            return 0
+        return sum([self.readiness_score, self.design_score, self.enjoyment_score]) / float(3)
 
     @property
     def has_video_issues(self):

--- a/uber/site_sections/mivs_judging.py
+++ b/uber/site_sections/mivs_judging.py
@@ -68,9 +68,9 @@ class Root:
                 message = 'You must select a Game Status to tell us ' \
                     'whether or not you were able to download and run the game'
             elif review.game_status == c.PLAYABLE and not review.game_score:
-                message = 'You must indicate whether or not you believe the game should be accepted'
+                message = "You must indicate the game's readiness, design, and enjoyment"
             elif review.game_status != c.PLAYABLE and review.game_score:
-                message = 'If the game is not playable, please leave the score field blank'
+                message = 'If the game is not playable, please leave the score fields blank'
             else:
                 if review.game_status in c.MIVS_PROBLEM_STATUSES\
                         and review.game_status != review.orig_value_of('game_status'):

--- a/uber/templates/mivs_admin/game_results.html
+++ b/uber/templates/mivs_admin/game_results.html
@@ -47,7 +47,10 @@
         <th>Judge</th>
         <th>Game Status</th>
         <th>Inappropriate Content?</th>
-        <th>Score</th>
+        <th>Show Readiness</th>
+        <th>Overall Design</th>
+        <th>Overall Enjoyment</th>
+        <th>Overall Score</th>
         <th>Notes</th>
         <th>Send to Developer?</th>
     </tr>
@@ -58,6 +61,9 @@
         <td>{{ review.judge.full_name }}</td>
         <td>{{ review.game_status_label }}</td>
         <td>{{ review.game_content_bad|yesno }}</td>
+        <td>{% if review.readiness_score %}{{ review.readiness_score }}{% endif %}</td>
+        <td>{% if review.design_score %}{{ review.design_score }}{% endif %}</td>
+        <td>{% if review.enjoyment_score %}{{ review.enjoyment_score }}{% endif %}</td>
         <td>{% if review.game_score %}{{ review.game_score }}{% endif %}</td>
         <td>{{ review.game_review|linebreaksbr }}</td>
     <td><input type="checkbox" name="review_id" value="{{ review.id }}"

--- a/uber/templates/mivs_admin/game_results.html
+++ b/uber/templates/mivs_admin/game_results.html
@@ -64,7 +64,7 @@
         <td>{% if review.readiness_score %}{{ review.readiness_score }}{% endif %}</td>
         <td>{% if review.design_score %}{{ review.design_score }}{% endif %}</td>
         <td>{% if review.enjoyment_score %}{{ review.enjoyment_score }}{% endif %}</td>
-        <td>{% if review.game_score %}{{ review.game_score }}{% endif %}</td>
+        <td>{% if review.game_score %}{{ review.game_score|round(1) }}{% endif %}</td>
         <td>{{ review.game_review|linebreaksbr }}</td>
     <td><input type="checkbox" name="review_id" value="{{ review.id }}"
                {% if review.send_to_studio %} checked {% endif %}/></td>

--- a/uber/templates/mivs_admin/index.html
+++ b/uber/templates/mivs_admin/index.html
@@ -79,7 +79,7 @@
                 0
             {% endif %}
         </td>
-        <td>{{ game.average_score }}</td>
+        <td>{{ game.average_score|round(1) }}</td>
     </tr>
 {% endfor %}
 </tbody>

--- a/uber/templates/mivs_judging/game_review.html
+++ b/uber/templates/mivs_judging/game_review.html
@@ -107,22 +107,46 @@ for reviewing the game:
         </div>
     </div>
 
-    <div class="form-group">
-        <label class="col-sm-3 control-label">Score</label>
-        <div class="col-sm-6">
-            <select name="game_score" class="form-control">
-                <option value="0">Rate this Game</option>
-                {{ int_options(1, 10, review.game_score) }}
-            </select>
-            <p class="help-block">
-                Please score the game on a scale of 1-10 where 1 is the lowest score and 10 is the highest score.
-                If you were not able to play due to some problem, you should leave this unscored
-            </p>
-        </div>
-        <div class="checkbox col-sm-6 col-sm-offset-3">
-            {{ macros.checkbox(review, 'game_content_bad', label="This game contains inappropriate content.") }}
-        </div>
+  <div class="text-center">
+    <h3>Scoring</h3>
+    <span class="popup">{{ macros.popup_link("../static_views/mivs_scoring.html", 'Scoring Explanation') }}</span>
+  </div>
+  <div class="form-group">
+    <label class="col-sm-3 control-label">Show Readiness</label>
+    <div class="col-sm-6">
+      <select name="readiness_score" class="form-control">
+        <option value="0">Unscored</option>
+        {{ int_options(1, 10, review.readiness_score) }}
+      </select>
     </div>
+  </div>
+  <div class="form-group">
+    <label class="col-sm-3 control-label">Overall Design</label>
+    <div class="col-sm-6">
+      <select name="design_score" class="form-control">
+        <option value="0">Unscored</option>
+        {{ int_options(1, 10, review.design_score) }}
+      </select>
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-sm-3 control-label">Overall Enjoyment</label>
+    <div class="col-sm-6">
+      <select name="enjoyment_score" class="form-control">
+        <option value="0">Unscored</option>
+        {{ int_options(1, 10, review.enjoyment_score) }}
+      </select>
+      <p class="help-block">
+      See 'Scoring Explanation' for breakdown of each category. If game was unplayable due to a problem, leave each category unscored.
+    </p>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="checkbox col-sm-6 col-sm-offset-3">
+      {{ macros.checkbox(review, 'game_content_bad', label="This game contains inappropriate content.") }}
+    </div>
+  </div>
 
     <div class="form-group">
         <label class="col-sm-3 control-label optional-field">Notes</label>

--- a/uber/templates/mivs_judging/index.html
+++ b/uber/templates/mivs_judging/index.html
@@ -88,6 +88,7 @@ and {{ judge.game_reviews|length }} have had the actual game reviewed.
         {% if c.AFTER_MIVS_ROUND_TWO_START %}
             <th>Game Review Status</th>
             <th>Your Score</th>
+            <th>Score Breakdown</th>
         {% else %}
             <th>Video Review Status</th>
         {% endif %}
@@ -101,7 +102,15 @@ and {{ judge.game_reviews|length }} have had the actual game reviewed.
             <td><a href="studio?id={{ review.game.studio.id }}">{{ review.game.studio.name }}</a></td>
             {% if c.AFTER_MIVS_ROUND_TWO_START %}
                 <td><a href="game_review?id={{ review.id }}">{{ review.game_status_label }}</a></td>
-                <td>{{ review.game_score|default("not reviewed yet") }}</td>
+                {% if not review.game_score %}<td>N/A</td>
+                <td>N/A</td>
+                {% else %}<td>{{ review.game_score|round(1) }}</td>
+                <td>
+                  <em>Show Readiness</em>: {{ review.readiness_score }} <br/>
+                  <em>Overall Design</em>: {{ review.design_score }} <br/>
+                  <em>Overall Enjoyment</em>: {{ review.enjoyment_score }}
+                </td>
+                {% endif %}
             {% else %}
                 <td><a href="video_review?id={{ review.id }}">{{ review.video_status_label }}</a></td>
             {% endif %}

--- a/uber/templates/static_views/mivs_scoring.html
+++ b/uber/templates/static_views/mivs_scoring.html
@@ -1,0 +1,68 @@
+<html>
+<head>
+    <title> MIVS Scoring Explanation </title>
+</head>
+<body>
+
+The games will receive a score in each of the following categories:
+
+<br/><br/>
+<strong><u>“Show Readiness”</u></strong>
+<br/>This category focuses on how ready the game appears to be when shown to the public. This means the degree of visual and audible asset completion as well any programming bugs.
+
+<br/><br/>
+<strong>Sample Score Descriptions</strong>
+<br/>Scores of 1-3
+<ul>
+  <li>Placeholder/missing visual and/or sound assets that are damaging to gameplay</li>
+  <li>Major/Game-breaking bugs</li>
+</ul>
+
+<br/>Scores 4-6
+<ul>
+  <li>Could use some serious polish on visual or audible elements</li>
+  <li>Minor bugs (non-game breaking)</li>
+</ul>
+
+<br/>Scores 7-10
+<ul>
+  <li>Game is visually and audibly good/excellent</li>
+  <li>Free of noticeable bugs</li>
+</ul>
+
+<br/><br/>
+<strong><u>“Overall Design”</u></strong>
+<br/>No two games are alike; some have a strong narrative or visuals while others may be more focused on mechanics or puzzle design. This category is for how well the judge feels that the game addresses its own central concept. Examples:
+<ul>
+  <li>If it is a puzzle game, are the puzzles good?</li>
+  <li>If it is a narrative-driven game, is the story compelling?</li>
+</ul>
+
+<strong>Sample Score Descriptions</strong>
+<br/>Scores of 1-3
+<ul>
+  <li>Game is a very poor/weak example of its category</li>
+</ul>
+
+<br/>Scores 4-6
+<ul>
+  <li>Game could use improvement in central structure around being a better example of its genre, however the core concept is there</li>
+</ul>
+
+<br/>Scores 7-10
+<ul>
+  <li>Game is a good, excellent, or very interesting example of its respective genre or structure</li>
+</ul>
+
+<br/><br/>
+<strong><u>“Overall Enjoyment”</u></strong>
+<br/>Games can be enjoyed for any number of reasons such as:
+<ul>
+  <li>Challenging your reflexes and skill</li>
+  <li>Making you think</li>
+  <li>Taking you on a journey</li>
+  <li>Making you laugh</li>
+</ul>
+So this category is wide open. In terms of what the game sought out to do, how enjoyable was it? There is no point breakdown here, just score it 1-10! Include additional information in the “Notes” section about what you thought about the game.
+</body>
+</html>


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-295.

The new judging page has a Scoring section:
![image](https://user-images.githubusercontent.com/7198215/46566765-2a923d00-c925-11e8-8910-fc9215fc92f4.png)

The scoring explanation is a static_views page, so formatting is limited. It pops up in a new window, so in fullscreen Chrome it ends up looking like this:
![image](https://user-images.githubusercontent.com/7198215/46566770-4269c100-c925-11e8-9060-d1c5d947dcd5.png)

The scoring breakdown is shown to judges on their games page alongside the averaged score:
![image](https://user-images.githubusercontent.com/7198215/46566785-983e6900-c925-11e8-9242-af857cd033eb.png)

Finally, the three scores are also on the game results page:
![image](https://user-images.githubusercontent.com/7198215/46566810-f8cda600-c925-11e8-806c-163c64df87f0.png)