### PR TITLE
Allow MITS teams without games to add a game

### DIFF
--- a/uber/templates/mits_applications/index.html
+++ b/uber/templates/mits_applications/index.html
@@ -94,8 +94,8 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
             </form>
         </td>
     </tr>
-  <tr><td></td><td colspan="3"><a class="btn btn-success" href="game?id=None">Add a Game</a></td></tr>
 {% endfor %}
+<tr><td></td><td colspan="3"><a class="btn btn-success" href="game?id=None">Add a Game</a></td></tr>
 </table>
 
 


### PR DESCRIPTION
A template mistake would have prevented any MITS team from actually adding any games. This fixes that so testing can commence.