### PR TITLE
Make flake8 happy again

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ environment at the `installdeps` step. Each subsequent run should start quickly.
 directory as the `tox.ini` file -- this should always be the root folder of
 the plugin. E.g.:
     ```
-    cd sideboard/plugins/my_plugin
+    cd reggie-formula/reggie_install/plugins/my_plugin
     ```
 
 3. Run your tests! To run all tests and flake8 validation from the command line:

--- a/uber/api.py
+++ b/uber/api.py
@@ -99,7 +99,7 @@ def auth_by_token(required_access):
 def auth_by_session(required_access):
     try:
         check_csrf()
-    except CSRFException as ex:
+    except CSRFException:
         return (403, 'Your CSRF token is invalid. Please go back and try again.')
     admin_account_id = cherrypy.session.get('account_id', None)
     if not admin_account_id:

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -278,7 +278,7 @@ def sortBy(xs, attrName):
 
 @JinjaEnv.jinja_filter
 def idize(s):
-    return re.sub('\W+', '_', str(s)).strip('_')
+    return re.sub(r'\W+', '_', str(s)).strip('_')
 
 
 @JinjaEnv.jinja_filter

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -732,7 +732,7 @@ class Session(SessionManager):
                 if isinstance(attendee.birthdate, six.string_types):
                     try:
                         birthdate = dateparser.parse(attendee.birthdate).date()
-                    except Exception as ex:
+                    except Exception:
                         log.debug('Error parsing attendee birthdate: {}'.format(attendee.birthdate))
                     else:
                         or_clauses.append(WatchList.birthdate == birthdate)
@@ -834,7 +834,7 @@ class Session(SessionManager):
             # PromoCode.id to the filter clause
             try:
                 promo_code_id = uuid.UUID(normalized_code).hex
-            except Exception as ex:
+            except Exception:
                 pass
             else:
                 clause = clause.or_(PromoCode.id == promo_code_id)
@@ -1281,7 +1281,7 @@ class Session(SessionManager):
         def logged_in_studio(self):
             try:
                 return self.indie_studio(cherrypy.session['studio_id'])
-            except Exception as ex:
+            except Exception:
                 raise HTTPRedirect('../mivs_applications/studio')
 
         def logged_in_judge(self):
@@ -1306,7 +1306,7 @@ class Session(SessionManager):
             self.delete(screenshot)
             try:
                 os.remove(screenshot.filepath)
-            except Exception as ex:
+            except Exception:
                 pass
             self.commit()
 
@@ -1332,7 +1332,7 @@ class Session(SessionManager):
                     team = self.mits_team(team.duplicate_of)
                     assert team.id not in duplicate_teams, 'circular reference in duplicate_of: {}'.format(
                         duplicate_teams)
-            except Exception as ex:
+            except Exception:
                 log.error('attempt to log into invalid team {}', team_id, exc_info=True)
                 raise HTTPRedirect('../mits_applications/login_explanation')
             else:
@@ -1343,7 +1343,7 @@ class Session(SessionManager):
             try:
                 team = self.mits_team(cherrypy.session['mits_team_id'])
                 assert not team.deleted or team.duplicate_of
-            except Exception as ex:
+            except Exception:
                 raise HTTPRedirect('../mits_applications/login_explanation')
             else:
                 if team.duplicate_of:
@@ -1369,7 +1369,7 @@ class Session(SessionManager):
         def delete_mits_file(self, model):
             try:
                 os.remove(model.filepath)
-            except Exception as ex:
+            except Exception:
                 log.error('Unexpected error deleting MITS file {}', model.filepath)
 
             # Regardless of whether removing the file from the
@@ -1455,7 +1455,7 @@ def initialize_db(modify_tables=False):
             Session.initialize_db(modify_tables=modify_tables, initialize=True)
         except KeyboardInterrupt:
             log.critical('DB initialize: Someone hit Ctrl+C while we were starting up')
-        except Exception as ex:
+        except Exception:
             num_tries_remaining -= 1
             if num_tries_remaining == 0:
                 log.error("DB initialize: couldn't connect to DB, we're giving up")

--- a/uber/models/admin.py
+++ b/uber/models/admin.py
@@ -41,7 +41,7 @@ class AdminAccount(MagModel):
             from uber.models import Session
             with Session() as session:
                 return session.admin_attendee().full_name
-        except Exception as ex:
+        except Exception:
             return None
 
     @staticmethod
@@ -50,7 +50,7 @@ class AdminAccount(MagModel):
             from uber.models import Session
             with Session() as session:
                 return session.admin_attendee().email
-        except Exception as ex:
+        except Exception:
             return None
 
     @staticmethod
@@ -60,7 +60,7 @@ class AdminAccount(MagModel):
             with Session() as session:
                 id = id or cherrypy.session['account_id']
                 return set(session.admin_account(id).access_ints)
-        except Exception as ex:
+        except Exception:
             return set()
 
     def _allowed_opts(self, opts, required_access):

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -477,7 +477,7 @@ class Attendee(MagModel, TakesPaymentMixin):
                     c.EVENT_NAME + ' WatchList Notification',
                     render('emails/reg_workflow/attendee_watchlist.txt', {'attendee': self}, encoding=None),
                     model='n/a')
-            except Exception as ex:
+            except Exception:
                 log.error('unable to send banned email about {}', self, exc_info=True)
 
         elif self.badge_status == c.NEW_STATUS and not self.placeholder and self.first_name and (
@@ -1479,7 +1479,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     def hotel_nights(self):
         try:
             return self.hotel_requests.nights
-        except Exception as ex:
+        except Exception:
             return []
 
     @property

--- a/uber/models/tracking.py
+++ b/uber/models/tracking.py
@@ -116,13 +116,13 @@ class Tracking(MagModel):
                 """
                 try:
                     old_val_repr = cls.repr(column, old_val)
-                except Exception as e:
+                except Exception:
                     log.error('Tracking repr({}) failed on old value'.format(attr), exc_info=True)
                     old_val_repr = '<ERROR>'
 
                 try:
                     new_val_repr = cls.repr(column, new_val)
-                except Exception as e:
+                except Exception:
                     log.error('Tracking repr({}) failed on new value'.format(attr), exc_info=True)
                     new_val_repr = '<ERROR>'
 

--- a/uber/models/types.py
+++ b/uber/models/types.py
@@ -186,7 +186,7 @@ class Choice(TypeDecorator):
         if value is not None:
             try:
                 assert self.allow_unspecified or int(value) in self.choices
-            except Exception as ex:
+            except Exception:
                 raise ValueError('{!r} not a valid option out of {}'.format(
                     value, self.choices))
             else:

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -174,7 +174,7 @@ class Root:
                 elif not attendee.dept_memberships and not c.AT_THE_CON:
                     message = 'You have not been assigned to any departments; ' \
                         'an admin must assign you to a department before you can log in'
-            except Exception as ex:
+            except Exception:
                 message = 'No attendee matches that name and email address and zip code'
 
             if not message:


### PR DESCRIPTION
Flake8 tests were failing thanks to our pattern of using `except Exception as ex:` whether or not we did anything with the error `ex`. Now we just use `except Exception:` instead.

I also updated the example path in the test README, since the new infrastructure changed the path to the plugins.