### PR TITLE
Make all MITS application steps clearly opt-outable

### DIFF
--- a/uber/models/mits.py
+++ b/uber/models/mits.py
@@ -17,8 +17,8 @@ __all__ = ['MITSTeam', 'MITSApplicant', 'MITSGame', 'MITSPicture', 'MITSDocument
 
 class MITSTeam(MagModel):
     name = Column(UnicodeText)
-    panel_interest = Column(Boolean, nullable=True)
-    showcase_interest = Column(Boolean, nullable=True)
+    panel_interest = Column(Boolean, nullable=True, admin_only=True)
+    showcase_interest = Column(Boolean, nullable=True, admin_only=True)
     want_to_sell = Column(Boolean, default=False)
     address = Column(UnicodeText)
     submitted = Column(UTCDateTime, nullable=True)
@@ -83,11 +83,11 @@ class MITSTeam(MagModel):
 
     @property
     def completed_panel_request(self):
-        return not self.panel_interest or self.schedule.availability
+        return self.panel_interest is not None
 
     @property
     def completed_showcase_request(self):
-        return not self.showcase_interest or self.schedule.showcase_availability
+        return self.showcase_interest is not None
 
     @property
     def completed_hotel_form(self):
@@ -100,6 +100,10 @@ class MITSTeam(MagModel):
         remaining hotel info.
         """
         return any(a.declined_hotel_space or a.requested_room_nights for a in self.applicants)
+
+    @property
+    def no_hotel_space(self):
+        return all(a.declined_hotel_space for a in self.applicants)
 
     @property
     def steps_completed(self):

--- a/uber/site_sections/mits_applications.py
+++ b/uber/site_sections/mits_applications.py
@@ -111,6 +111,9 @@ class Root:
                 team.showcase_interest = False
             if 'no_panel' in params:
                 team.panel_interest = False
+            if 'no_hotel_space' in params:
+                for applicant in team.applicants:
+                    applicant.declined_hotel_space = True
             message = check(team)
             if not message and team.is_new:
                 applicant.team = team

--- a/uber/templates/mits_admin/index.html
+++ b/uber/templates/mits_admin/index.html
@@ -20,7 +20,7 @@
 {% for team in teams %}
     <tr>
         <td><a href="team?id={{ team.id }}">{{ team.name }}</a></td>
-        <td>{{ team.primary_contacts[0].full_name }}</td>
+        <td>{{ team.primary_contacts[0].full_name if team.primary_contacts }}</td>
         <td>{{ team.applied_local|datetime("%Y-%m-%d") }}</td>
         <td>{{ team.completion_percentage }}%</td>
         <td>

--- a/uber/templates/mits_applications/index.html
+++ b/uber/templates/mits_applications/index.html
@@ -156,9 +156,9 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
       <form method="post" action="team" class="form-inline">
       <div class="btn-group">
     {% endif %}
-    <a href="panel?id={{ team.panel_app.db_id if team.panel_app else 'None' }}&schedule_id={{ team.schedule.id if team.schedule else 'None' }}"
-      {% if not team.panel_interest %} class="btn btn-success">Apply for a Panel
-      {% else %} class="btn btn-default">Update Panel Application{% endif %}
+    <a href="panel?id={{ team.panel_app.db_id if team.panel_app else 'None' }}&schedule_id={{ team.schedule.id if team.schedule else 'None' }}" class="btn
+      {% if team.panel_interest %}btn-default">Update Panel Application
+      {% else %}btn-success">Apply for a Panel{% endif %}
     </a>
 
     {% if team.panel_interest != False %}
@@ -186,9 +186,9 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
       <div class="btn-group">
     {% endif %}
 
-    <a href="schedule?id={{ team.schedule.id if team.schedule else 'None' }}"
-      {% if not team.showcase_interest %} class="btn btn-success">Apply for the Showcase
-      {% else %} class="btn btn-default">Update Showcase Availability{% endif %}
+    <a href="schedule?id={{ team.schedule.id if team.schedule else 'None' }}" class="btn
+      {% if team.showcase_interest %}btn-default">Update Showcase Availability
+      {% else %}btn-success">Apply for the Showcase{% endif %}
     </a>
 
     {% if team.showcase_interest != False %}
@@ -213,9 +213,26 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
     <p>Please let us know whether or not you would like to request room space.</p>
 
     <table><tr><td></td><td>
-      <a href="hotel_requests" class="btn
+    {% if not team.no_hotel_space %}
+      <form method="post" action="team" class="form-inline">
+      <div class="btn-group">
+    {% endif %}
+
+    <a href="hotel_requests" class="btn
       {% if team.completed_hotel_form %}btn-default">Update Hotel Request Information
-      {% else %}btn-success">Enter Hotel Request Information{% endif %}</a>
+      {% else %}btn-success">Enter Hotel Request Information{% endif %}
+    </a>
+
+    {% if not team.no_hotel_space %}
+      <input type="hidden" name="id" value="{{ team.id }}" />
+      <input type="hidden" name="no_hotel_space" value="1" />
+      {{ csrf_token() }}
+      <button type="submit" class="btn btn-warning">
+        {% if team.completed_hotel_form and not team.no_hotel_space %}Nevermind, {% endif %}No One Needs Hotel Space
+      </button>
+      </div>
+      </form>
+    {% endif %}
     </td></tr></table>
 {% endif %}
 


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-341. Also fixes a bug I ran into where the MITS admin index page would break if a studio didn't have any primary contacts. Also also fixes the panel and showcase columns, which were getting automatically set to False when they should start out as None.