### PR TITLE
Add a pre-event checklist for MIVS Studios

### DIFF
--- a/alembic/versions/da22d6a6407c_add_fields_for_mivs_checklist.py
+++ b/alembic/versions/da22d6a6407c_add_fields_for_mivs_checklist.py
@@ -1,0 +1,75 @@
+"""Add fields for MIVS checklist
+
+Revision ID: da22d6a6407c
+Revises: 5ae9cea2cd6d
+Create Date: 2018-11-20 17:36:05.248730
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'da22d6a6407c'
+down_revision = '5ae9cea2cd6d'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('indie_studio', sa.Column('accepted_core_hours', sa.Boolean(), server_default='False', nullable=False))
+    op.add_column('indie_studio', sa.Column('completed_discussion', sa.Boolean(), server_default='False', nullable=False))
+    op.add_column('indie_studio', sa.Column('discussion_emails', sa.Unicode(), server_default='', nullable=False))
+    op.add_column('indie_studio', sa.Column('email_for_hotel', sa.Unicode(), server_default='', nullable=False))
+    op.add_column('indie_studio', sa.Column('name_for_hotel', sa.Unicode(), server_default='', nullable=False))
+    op.add_column('indie_studio', sa.Column('needs_hotel_space', sa.Boolean(), nullable=True))
+    op.add_column('indie_studio', sa.Column('read_handbook', sa.Boolean(), server_default='False', nullable=False))
+    op.add_column('indie_studio', sa.Column('selling_at_event', sa.Boolean(), nullable=True))
+    op.add_column('indie_studio', sa.Column('training_password', sa.Unicode(), server_default='', nullable=False))
+
+
+def downgrade():
+    op.drop_column('indie_studio', 'training_password')
+    op.drop_column('indie_studio', 'selling_at_event')
+    op.drop_column('indie_studio', 'read_handbook')
+    op.drop_column('indie_studio', 'needs_hotel_space')
+    op.drop_column('indie_studio', 'name_for_hotel')
+    op.drop_column('indie_studio', 'email_for_hotel')
+    op.drop_column('indie_studio', 'discussion_emails')
+    op.drop_column('indie_studio', 'completed_discussion')
+    op.drop_column('indie_studio', 'accepted_core_hours')

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -568,6 +568,19 @@ class MIVSEmailFixture(AutomatedEmailFixture):
         AutomatedEmailFixture.__init__(self, *args, sender=c.MIVS_EMAIL, **kwargs)
 
 
+class MIVSGuestEmailFixture(AutomatedEmailFixture):
+    def __init__(self, subject, template, filter, ident, **kwargs):
+        AutomatedEmailFixture.__init__(
+            self,
+            GuestGroup,
+            subject,
+            template,
+            lambda mg: mg.group_type == c.MIVS and mg.group.studio and filter(mg),
+            ident,
+            sender=c.MIVS_EMAIL,
+            **kwargs)
+
+
 if c.MIVS_ENABLED:
 
     MIVSEmailFixture(
@@ -837,6 +850,56 @@ if c.MIVS_ENABLED:
         'mivs/accepted/2019_hotel.txt',
         lambda game: game.confirmed,
         ident='2019_mivs_accepted_hotel')
+
+    MIVSGuestEmailFixture(
+        '{EVENT_NAME} MIVS Checklist',
+        'mivs/mivs_checklist_open.txt',
+        lambda mg: True,
+        ident='mivs_checklist_open'
+    )
+
+    for key, val in c.MIVS_CHECKLIST.items():
+        if val['start']:
+            MIVSGuestEmailFixture(
+                'New MIVS Checklist Item Available: {}'.format(val['name']),
+                'mivs/mivs_checklist_new_item.txt',
+                lambda mg: val['start'] > mg.created.when,
+                when=after(val['start']),
+                ident='mivs_checklist_new_item_{}'.format(key),
+            )
+
+    deadline_groups = set([val['deadline'] for key, val in c.MIVS_CHECKLIST.items()])
+
+    for deadline in deadline_groups:
+        MIVSGuestEmailFixture(
+            'An item on your {EVENT_NAME} MIVS Checklist is due soon',
+            'mivs/mivs_checklist_reminder.txt',
+            lambda mg: any(getattr(mg.group.studio, key + "_status", None) is None
+                           for key, val in c.MIVS_CHECKLIST.items() if val['deadline'] == deadline),
+            when=days_before(2, deadline),
+            needs_approval=False,
+            ident='mivs_checklist_due_2_days_from_{}'.format(deadline.strftime('%m_%d')),
+        )
+
+        MIVSGuestEmailFixture(
+            'An item on your {EVENT_NAME} MIVS Checklist is due tomorrow',
+            'mivs/mivs_checklist_reminder.txt',
+            lambda mg: any(getattr(mg.group.studio, key + "_status", None) is None
+                           for key, val in c.MIVS_CHECKLIST.items() if val['deadline'] == deadline),
+            when=days_before(1, deadline),
+            needs_approval=False,
+            ident='mivs_checklist_due_1_day_from_{}'.format(deadline.strftime('%m_%d')),
+        )
+
+        MIVSGuestEmailFixture(
+            'An item on your {EVENT_NAME} MIVS Checklist is overdue',
+            'mivs/mivs_checklist_reminder.txt',
+            lambda mg: any(getattr(mg.group.studio, key + "_status", None) is None
+                           for key, val in c.MIVS_CHECKLIST.items() if val['deadline'] == deadline),
+            when=days_after(1, deadline),
+            needs_approval=False,
+            ident='mivs_checklist_overdue_{}'.format(deadline.strftime('%m_%d')),
+        )
 
 
 # =============================

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -877,7 +877,6 @@ if c.MIVS_ENABLED:
             lambda mg: any(getattr(mg.group.studio, key + "_status", None) is None
                            for key, val in c.MIVS_CHECKLIST.items() if val['deadline'] == deadline),
             when=days_before(2, deadline),
-            needs_approval=False,
             ident='mivs_checklist_due_2_days_from_{}'.format(deadline.strftime('%m_%d')),
         )
 
@@ -887,7 +886,6 @@ if c.MIVS_ENABLED:
             lambda mg: any(getattr(mg.group.studio, key + "_status", None) is None
                            for key, val in c.MIVS_CHECKLIST.items() if val['deadline'] == deadline),
             when=days_before(1, deadline),
-            needs_approval=False,
             ident='mivs_checklist_due_1_day_from_{}'.format(deadline.strftime('%m_%d')),
         )
 
@@ -897,7 +895,6 @@ if c.MIVS_ENABLED:
             lambda mg: any(getattr(mg.group.studio, key + "_status", None) is None
                            for key, val in c.MIVS_CHECKLIST.items() if val['deadline'] == deadline),
             when=days_after(1, deadline),
-            needs_approval=False,
             ident='mivs_checklist_overdue_{}'.format(deadline.strftime('%m_%d')),
         )
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -846,6 +846,12 @@ c.DISCOUNTABLE_BADGE_TYPES = [getattr(c, badge_type.upper()) for badge_type in c
 c.PREASSIGNED_BADGE_TYPES = [getattr(c, badge_type.upper()) for badge_type in c.PREASSIGNED_BADGE_TYPES]
 c.TRANSFERABLE_BADGE_TYPES = [getattr(c, badge_type.upper()) for badge_type in c.TRANSFERABLE_BADGE_TYPES]
 
+c.MIVS_CHECKLIST = _config['mivs_checklist']
+for key, val in c.MIVS_CHECKLIST.items():
+    val['deadline'] = c.EVENT_TIMEZONE.localize(datetime.strptime(val['deadline'] + ' 23:59', '%Y-%m-%d %H:%M'))
+    if val['start']:
+        val['start'] = c.EVENT_TIMEZONE.localize(datetime.strptime(val['start'] + ' 23:59', '%Y-%m-%d %H:%M'))
+
 c.DEPT_HEAD_CHECKLIST = _config['dept_head_checklist']
 
 c.CON_LENGTH = int((c.ESCHATON - c.EPOCH).total_seconds() // 3600)

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -473,6 +473,9 @@ mivs_submission_grace_period = integer(default=10)
 # Their custom confirmation deadline is calculated using this config option.
 mivs_confirm_deadline = integer(default=14)
 
+# We use a password in MIVS training material to confirm the studio actually did the training
+mivs_training_password = string(default="mivs")
+
 
 # =============================
 # mits
@@ -1368,6 +1371,7 @@ awesome = string(default=":D (awesome)")
 # These are used to generate and check for specific deadlines and templates
 band = string(default="Band")
 guest = string(default="Guest")
+mivs = string(default="MIVS")
 
 [[guest_access_level]]
 bands = string(default="Guest Group Management")
@@ -1455,6 +1459,16 @@ xl = string(default="XL")
 
 [[__many__]]
 __many__ = string
+
+
+[mivs_checklist]
+[[__many__]]
+start = string(default="")
+deadline = string
+description = string
+name = string(default="")
+editable = boolean(default=False)
+email_post_con = boolean(default=False)
 
 
 [dept_checklist]

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -94,6 +94,11 @@ def now():
 
 
 @JinjaEnv.jinja_export
+def now_localized():
+    return localized_now()
+
+
+@JinjaEnv.jinja_export
 def event_dates():
     if c.EPOCH.date() == c.ESCHATON.date():
         return c.EPOCH.strftime('%B %-d')

--- a/uber/menu.py
+++ b/uber/menu.py
@@ -106,6 +106,7 @@ c.MENU = MenuItem(name='Root', submenu=[
         MenuItem(name='Groups', href='../groups/'),
         MenuItem(name='Bands', href='../guest_admin/?filter=only-bands', access=c.BANDS),
         MenuItem(name='Guests', href='../guest_admin/?filter=only-guests', access=c.BANDS),
+        MenuItem(name='MIVS', href='../guest_admin/?filter=only-mivss', access=c.MIVS),
         MenuItem(name='Watchlist', href='../registration/watchlist_entries', access=c.WATCHLIST),
     ]),
 

--- a/uber/site_sections/guest_admin.py
+++ b/uber/site_sections/guest_admin.py
@@ -9,7 +9,7 @@ from uber.models import Event, Group, GuestGroup, GuestMerch
 from uber.utils import check, convert_to_absolute_url
 
 
-@all_renderable(c.BANDS)
+@all_renderable(c.BANDS, c.INDIE_ADMIN)
 class Root:
 
     def _required_message(self, params, fields):

--- a/uber/site_sections/guests.py
+++ b/uber/site_sections/guests.py
@@ -378,9 +378,9 @@ class Root:
                 if not params['selling_at_event']:
                     message = "Please select if you want to sell items at MAGFest or not."
                 elif params['selling_at_event'] == '1':
-                    if not 'confirm_checkbox1' in params:
+                    if 'confirm_checkbox1' not in params:
                         message = "You must confirm that you will bring a signed copy of the selling waiver to MAGFest."
-                    elif not 'confirm_checkbox2' in params:
+                    elif 'confirm_checkbox2' not in params:
                         message = "You must confirm that you have filled out the Google form provided."
 
                 if not message:

--- a/uber/site_sections/guests.py
+++ b/uber/site_sections/guests.py
@@ -309,6 +309,93 @@ class Root:
             'message': message
         }
 
+    def mivs_core_hours(self, session, guest_id, message='', **params):
+        guest = session.guest_group(guest_id)
+        if cherrypy.request.method == 'POST':
+            if guest.group.studio:
+                guest.group.studio.accepted_core_hours = True
+                session.add(guest)
+                raise HTTPRedirect('index?id={}&message={}', guest.id, 'You have accepted the MIVS core hours.')
+            else:
+                message = "Something is wrong with your group -- please contact us at {}.".format(c.MIVS_EMAIL)
+        return {
+            'guest': guest,
+            'message': message,
+        }
+
+    def mivs_discussion(self, session, guest_id, message='', **params):
+        guest = session.guest_group(guest_id)
+        if cherrypy.request.method == 'POST':
+            if guest.group.studio:
+                guest.group.studio.completed_discussion = True
+                guest.group.studio.discussion_emails = ','.join(params['discussion_emails'])
+                session.add(guest)
+                raise HTTPRedirect('index?id={}&message={}', guest.id, 'Discussion email addresses updated.')
+            else:
+                message = "Something is wrong with your group -- please contact us at {}.".format(c.MIVS_EMAIL)
+        return {
+            'guest': guest,
+            'message': message,
+        }
+
+    def mivs_hotel_space(self, session, guest_id, message='', **params):
+        guest = session.guest_group(guest_id)
+        if cherrypy.request.method == 'POST':
+            if guest.group.studio:
+                if not params['needs_hotel_space']:
+                    message = "Please select if you need hotel space or not."
+                elif 'confirm_checkbox' not in params:
+                    message = "You must confirm that you have {}".format(
+                        "filled out the hotel form." if params['needs_hotel_space'] == '1'
+                        else "taken care of your own accommodations for MAGFest."
+                    )
+                elif params['needs_hotel_space'] == '1':
+                    guest.group.studio.name_for_hotel = params['name_for_hotel']
+                    guest.group.studio.email_for_hotel = params['email_for_hotel']
+                    if not guest.group.studio.name_for_hotel:
+                        message = "Please provide the first and last name you are using in your hotel booking."
+                    elif not guest.group.studio.email_for_hotel:
+                        message = "Please provide the email address you are using in your hotel booking."
+
+                if not message:
+                    guest.group.studio.needs_hotel_space = True if params['needs_hotel_space'] == '1' else False
+                    session.add(guest)
+                    raise HTTPRedirect('index?id={}&message={}',
+                                       guest.id,
+                                       'Hotel needs updated.')
+            else:
+                message = "Something is wrong with your group -- please contact us at {}.".format(c.MIVS_EMAIL)
+        return {
+            'guest': guest,
+            'message': message,
+            'confirm_checkbox': True if 'confirm_checkbox' in params else False,
+        }
+
+    def mivs_selling_at_event(self, session, guest_id, message='', **params):
+        guest = session.guest_group(guest_id)
+        if cherrypy.request.method == 'POST':
+            if guest.group.studio:
+                if not params['selling_at_event']:
+                    message = "Please select if you want to sell items at MAGFest or not."
+                elif params['selling_at_event'] == '1':
+                    if not 'confirm_checkbox1' in params:
+                        message = "You must confirm that you will bring a signed copy of the selling waiver to MAGFest."
+                    elif not 'confirm_checkbox2' in params:
+                        message = "You must confirm that you have filled out the Google form provided."
+
+                if not message:
+                    guest.group.studio.selling_at_event = True if params['selling_at_event'] == '1' else False
+                    session.add(guest)
+                    raise HTTPRedirect('index?id={}&message={}',
+                                       guest.id,
+                                       'Selling preferences updated.')
+            else:
+                message = "Something is wrong with your group -- please contact us at {}.".format(c.MIVS_EMAIL)
+        return {
+            'guest': guest,
+            'message': message,
+        }
+
     def view_inventory_file(self, session, id, item_id, name):
         guest_merch = session.guest_merch(id)
         if guest_merch:

--- a/uber/site_sections/mivs_applications.py
+++ b/uber/site_sections/mivs_applications.py
@@ -7,7 +7,7 @@ from cherrypy.lib.static import serve_file
 from uber.config import c
 from uber.decorators import all_renderable, csrf_protected
 from uber.errors import HTTPRedirect
-from uber.models import Attendee, Group, IndieDeveloper, IndieStudio
+from uber.models import Attendee, Group, GuestGroup, IndieDeveloper, IndieStudio
 from uber.utils import check, check_csrf
 
 
@@ -258,6 +258,8 @@ class Root:
                 for i in range(badges_remaining):
                     group.attendees.append(Attendee(badge_type=c.ATTENDEE_BADGE, paid=c.NEED_NOT_PAY))
                 group.cost = group.default_cost
+                group.guest = GuestGroup()
+                group.guest.group_type = c.MIVS
                 raise HTTPRedirect('index?message={}', 'Your studio has been registered')
 
         return {

--- a/uber/templates/emails/mivs/mivs_checklist_new_item.txt
+++ b/uber/templates/emails/mivs/mivs_checklist_new_item.txt
@@ -1,0 +1,1 @@
+This space intentionally left blank.

--- a/uber/templates/emails/mivs/mivs_checklist_open.txt
+++ b/uber/templates/emails/mivs/mivs_checklist_open.txt
@@ -1,6 +1,6 @@
 Ahoy {{ guest.group.studio.primary_contact.first_name }},
 
-We've put together a new webpage that contains a checklist of items for you to complete that will help you better prepare for MAGFest. As we get closer to MAGFest, new checklist items may show up. You will be receiving emails from us about checklist items that need to be completed and reminders for ones that still need your attention.
+We've put together a new webpage that contains a checklist of items for you to complete that will help you better prepare for MAGFest. As we get closer to MAGFest, new checklist items may show up. You will be receiving emails from us about checklist items that need to be completed and reminders for ones that still need your attention. You can get to your checklist using this link: {{ c.URL_BASE }}/guests/index?id={{ guest.id }}
 
 We hope that this will help you manage the logistics so you can put on a great show for the MAGFest Attendees.
 

--- a/uber/templates/emails/mivs/mivs_checklist_open.txt
+++ b/uber/templates/emails/mivs/mivs_checklist_open.txt
@@ -1,0 +1,10 @@
+Ahoy {{ guest.group.studio.primary_contact.first_name }},
+
+We've put together a new webpage that contains a checklist of items for you to complete that will help you better prepare for MAGFest. As we get closer to MAGFest, new checklist items may show up. You will be receiving emails from us about checklist items that need to be completed and reminders for ones that still need your attention.
+
+We hope that this will help you manage the logistics so you can put on a great show for the MAGFest Attendees.
+
+If you have any questions, please email mivs@magfest.org
+
+Forever Your Fan,
+-The MIVS Team

--- a/uber/templates/emails/mivs/mivs_checklist_reminder.txt
+++ b/uber/templates/emails/mivs/mivs_checklist_reminder.txt
@@ -1,0 +1,1 @@
+This space intentionally left blank.

--- a/uber/templates/guest_admin/mivs_info.html
+++ b/uber/templates/guest_admin/mivs_info.html
@@ -1,0 +1,18 @@
+<h2>MIVS Checklist Info for <a href="../guests/index?id={{ guest.id }}">{{ guest.group.name }}</a></h2>
+
+<form class="form-horizontal" role="form" method="post" action="group_info">
+  {{ csrf_token() }}
+  <input type="hidden" name="id" value="{{ guest.id }}" />
+
+    <h3>Checklist Status</h3>
+      <table class="table">
+        {% for key, val in c.MIVS_CHECKLIST.items() %}
+          <tr>
+          <td><strong>{{ val['name'] }}</strong></td><td>{{ guest.group.studio[key + "_status"] if guest.group.studio[key + "_status"] is not none else "Not Completed" }}
+          {% if guest.group.studio %}
+            <td>{{ humanize_timedelta(guest.group.studio.past_checklist_deadline(key), granularity='hours', past_suffix=' until deadline', suffix=' past deadline') }}</td>
+          {% endif %}
+          </tr>
+        {% endfor %}
+      </table>
+</form>

--- a/uber/templates/guests/index.html
+++ b/uber/templates/guests/index.html
@@ -1,6 +1,6 @@
 {% extends "guestbase.html" %}
 {% block body %}
-{% set snippet=True %}
+  {% set snippet=True %}
   <style type="text/css">
     td img {
       width: 20px;
@@ -11,21 +11,43 @@
   </style>
 
   <h2>{% if guest.group_type == c.GUEST %}Guests & Events Checklist for {{ guest.group.name }}
-  {% else %}{{ guest.group_type_label }} Checklist for {{ guest.group.name }}{% endif %}</h2>
+    {% else %}{{ guest.group_type_label }} Checklist for {{ guest.group.name }}{% endif %}</h2>
 
   {% if guest.group_type == c.GUEST %}This checklist will help make sure {{ c.EVENT_NAME }} has all the group, panel, activity, and
-  support information we need from you before the event.
+    support information we need from you before the event.
   {% else %}Here is a list of things which {{ c.EVENT_NAME }} needs from you before the event.{% endif %}
   <br/><br/>
 
   <table style="width:auto">
-    {% for item in sorted_checklist -%}
+    {% if guest.group_type == c.MIVS %}
+      {% for key, val in c.MIVS_CHECKLIST.items() %}
+        <h3>{{ val['name'] }}</h3>
+        <p>{{ val['description'] }}</p>
+        <p>
+          {% if not val['start'] or now_localized() >= val['start'] %}
+            <strong>Deadline</strong>: {{ guest.group.studio.checklist_deadline(key)|datetime_local if guest.group.studio }}</p>
+            <p>
+            {% if not guest.group.studio[key + "_status"] %}
+              <a href="mivs_{{ key }}?guest_id={{ guest.id }}">Complete this checklist step</a>.
+            {% elif val['editable'] and now_localized() <= guest.group.studio.checklist_deadline(key) %}
+              You've <strong>already completed</strong> this step but you can still <a href="mivs_{{ key }}?guest_id={{ guest.id }}">edit your response</a> until the deadline.
+            {% else %}
+              You've <strong>already completed</strong> this step.
+            {% endif %}
+          {% else %}
+            This step is not available yet. We will email you when it becomes available, so keep an eye on your inbox.
+          {% endif %}
+          </p>
+      {% endfor %}
+    {% else %}
+      {% for item in sorted_checklist -%}
         {# Try to include the checklist template with a prefix matching the group's type, e.g. band_info_deadline.html #}
         {%- include [
           item['deadline_template'][0] ~ guest.group_type_label|lower ~ '_' ~ item['deadline_template'][1],
           item['deadline_template'][0] ~ item['deadline_template'][1]
         ] -%}
-    {%- endfor %}
+      {%- endfor %}
+    {% endif %}
     {% include "guests/guestextra.html" %}
   </table>
 

--- a/uber/templates/guests/mivs_core_hours.html
+++ b/uber/templates/guests/mivs_core_hours.html
@@ -1,0 +1,21 @@
+{% extends "guestbase.html" %}
+
+{% block body %}
+
+  <h3>Accept Core Hours</h3>
+  Core Hours are:
+  <ul>
+    <li>Thursday : 1pm - 7pm</li>
+    <li>Friday : 12pm - 7pm</li>
+    <li>Saturday : 12pm - 7pm</li>
+    <li>Sunday: 12pm - 2pm</li>
+  </ul>
+
+  <p>In exchange for your space and two free badges, MIVS expects your studio to have your booth area up-and-running during core hours. You also must have at least one representative from your studio present, in your booth, during core hours. Exceptions are made for booths manned with just one person, such as short bathroom breaks or super-quick food runs, but we request you alert a volunteer before leaving the EXPO hall and in general we recommend against having only one representative for your studio manning your booth, because it can be quite a burden. We take core hours seriously, because it's YOU the attendees paid to see; not empty booths.</p>
+
+  <form class="form form-horizontal" method="post" action="mivs_core_hours">
+    <input type="hidden" name="guest_id" value="{{ guest.id }}"/>
+    <strong>I accept. I will have someone at my booth during core hours.</strong>
+    <br/><button type="submit" class="btn btn-primary">Accept Core Hours</button>
+  </form>
+{% endblock body %}

--- a/uber/templates/guests/mivs_discussion.html
+++ b/uber/templates/guests/mivs_discussion.html
@@ -1,0 +1,32 @@
+{% extends "guestbase.html" %}
+
+{% block body %}
+  <h3>MIVS Discussion Group</h3>
+  <p>In the future, you will be invited to join a google discussion group. This will have MIVS Staff, as well as other Indies that are part of MIVS this year on it. This group is here to help facilitate discussion with your peers, and for MIVS staff to more easily send information to you.</p>
+
+  <p>The primary contact for your game will be added to the group. You may enter emails for any team members associated with your game who you think should also be added to the group.</p>
+
+  <form class="form form-horizontal" method="post" action="mivs_discussion">
+  <input type="hidden" name="guest_id" value="{{ guest.id }}"/>
+    <div class="form-group">
+      <label class="col-sm-3 control-label">Primary Contact Email</label>
+      <div class="col-sm-6 form-control-static">
+        {{ guest.group.studio.primary_contact.email }}
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="col-sm-3 control-label optional-field">Additional Emails</label>
+      <div class="col-sm-6">
+        <input type="text" name="discussion_emails" class="form-control" placeholder="email1@example.com" value="{{ guest.group.studio.discussion_emails_list[0] }}" />
+        <br/><input type="text" name="discussion_emails" class="form-control" placeholder="email2@example.com" value="{{ guest.group.studio.discussion_emails_list[1] }}" />
+        <br/><input type="text" name="discussion_emails" class="form-control" placeholder="email3@example.com" value="{{ guest.group.studio.discussion_emails_list[2] }}" />
+        <br/><input type="text" name="discussion_emails" class="form-control" placeholder="email4@example.com" value="{{ guest.group.studio.discussion_emails_list[3] }}" />
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-6 col-sm-offset-3">
+        <button type="submit" class="btn btn-primary">Confirm Emails for Discussion Group</button>
+      </div>
+    </div>
+  </form>
+{% endblock body %}

--- a/uber/templates/guests/mivs_hotel_space.html
+++ b/uber/templates/guests/mivs_hotel_space.html
@@ -1,0 +1,66 @@
+{% extends "guestbase.html" %}
+
+{% block body %}
+  <h3>Hotel Signups</h3>
+  <p>We're happy to allow you to purchase 1 hotel room for the Gaylord and this service is made available to you for being part of MIVS. We don't have any extra rooms other than the 1 provided for you. This room is for your use and you are not allowed to transfer your reservation to someone else unless authorized by MAGFest. Dropping out of MIVS may cause your room to be canceled.</p>
+
+  <p>Please email any hotel questions about to {{ 'hotel@magfest.org'|email_to_link }}.</p>
+
+  <form class="form form-horizontal" method="post" action="mivs_hotel_space">
+    <input type="hidden" name="guest_id" value="{{ guest.id }}"/>
+    <div class="form-group">
+      <label for="needs_hotel_space" class="col-sm-3 control-label optional-field">Need Hotel Space?</label>
+      <div class="col-sm-6">
+        <select name="needs_hotel_space" id="needs_hotel_space" class="form-control">
+          <option value="">Please select an option</option>
+          <option value="1"{% if guest.group.studio.needs_hotel_space %} selected{% endif %}>Yes</option>
+          <option value="0"{% if guest.group.studio.needs_hotel_space == False %} selected{% endif %}>No</option>
+        </select>
+      </div>
+    </div>
+    <div id="hotel_link">
+      <div class="form-group">
+        <div class="col-sm-9 col-sm-offset-3">
+          We will need the First & Last Name, and Email address of the person who will be registering for the hotel room. Please make sure this is the same information that you use in with the hotel link below.
+        </div>
+      </div>
+      {{ macros.form_group(guest.group.studio, 'name_for_hotel', placeholder="First Last") }}
+      {{ macros.form_group(guest.group.studio, 'email_for_hotel', placeholder="email@example.com") }}
+      <div class="form-group">
+        <div class="col-sm-9 col-sm-offset-3">
+          Please <strong><a href="https://registration.experientevent.com/Showmfs191/flow/mivs" target="_hotel">fill out the hotel form here</a></strong>.
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-9 col-sm-offset-3">
+        <label for="confirm_checkbox">
+          <input type="checkbox" name="confirm_checkbox" id="confirm_checkbox" value="1"{% if confirm_checkbox %} checked{% endif %}>
+          <span id="confirm_text"></span>
+        </label>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-6 col-sm-offset-3">
+        <button type="submit" class="btn btn-primary">Confirm Hotel Needs</button>
+      </div>
+    </div>
+  </form>
+
+  <script type="text/javascript">
+      var showOrHideConfirm = function() {
+          if ($('#needs_hotel_space').val() == '1') {
+              $('#confirm_text').text('I have filled out the given link, and taken care of my hotel accommodations for MAGFest.')
+          } else {
+              $('#confirm_text').text('I have taken care of my own hotel accommodations for MAGFest.')
+          }
+
+          setVisible($.field('confirm_checkbox').parents('.form-group'), $('#needs_hotel_space').val());
+          setVisible($('#hotel_link'), $('#needs_hotel_space').val() == '1');
+      };
+      $().ready(function() {
+          showOrHideConfirm();
+          $('#needs_hotel_space').change(showOrHideConfirm);
+      });
+  </script>
+{% endblock body %}

--- a/uber/templates/guests/mivs_selling_at_event.html
+++ b/uber/templates/guests/mivs_selling_at_event.html
@@ -1,0 +1,60 @@
+{% extends "guestbase.html" %}
+
+{% block body %}
+  <h3>Selling at MAGFest</h3>
+  <p>We are allowing Indies to sell items in MIVS. If you wish to do so, the highlights to remember are:</p>
+  <ul>
+  <li>You can only sell things that are directly related to your game or studio</li>
+  <li>You must own the license to any intellectual property that you are selling</li>
+  <li>You are responsible for paying taxes to the Maryland Comptroller</li>
+  <li>You will need to sign a waiver form and bring it with you to MAGFest, and signup using a google form.</li>
+  <li>The Selling Policy is at the discretion of MIVS</li>
+  </ul>
+
+  <p>You can find more information as well as the Waiver form you will need to
+    <a href="https://docs.google.com/document/d/1syCLRqOPmgeTKsbEgko8_9utpOgi7ap7CYEaLArNjmQ/edit?usp=sharing" target="_waiver">sign here</a>.</p>
+
+  <form class="form form-horizontal" method="post" action="mivs_selling_at_event">
+    <input type="hidden" name="guest_id" value="{{ guest.id }}"/>
+    <div class="form-group">
+      <label for="selling_at_event" class="col-sm-3 control-label optional-field">Want to sell at MAGFest?</label>
+      <div class="col-sm-6">
+        <select name="selling_at_event" id="selling_at_event" class="form-control">
+          <option value="">Please select an option</option>
+          <option value="1"{% if guest.group.studio.selling_at_event %} selected{% endif %}>Yes</option>
+          <option value="0"{% if guest.group.studio.selling_at_event == False %} selected{% endif %}>No</option>
+        </select>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-9 col-sm-offset-3">
+        <p id="selling_link">
+          Along with bringing a signed copy of the Waiver form, you will also need to fill out <a href="https://goo.gl/forms/fQPxo5uMUdohZU893" target="_gform">this google form</a>.
+        <label for="confirm_checkbox1">
+          <input type="checkbox" name="confirm_checkbox1" id="confirm_checkbox1" value="1"{% if guest.group.studio.selling_at_event %} checked{% endif %}>
+          I will bring a signed copy of the MIVS Waiver Form with me to MAGFest.
+        </label>
+        <label for="confirm_checkbox2">
+          <input type="checkbox" name="confirm_checkbox2" id="confirm_checkbox2" value="1"{% if guest.group.studio.selling_at_event %} checked{% endif %}>
+          I have filled out the "Maryland Tax Info Collection" google form.
+        </label>
+        </p>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-6 col-sm-offset-3">
+        <button type="submit" class="btn btn-primary">Confirm Selling Preferences</button>
+      </div>
+    </div>
+  </form>
+
+  <script type="text/javascript">
+      var showOrHideConfirm = function() {
+          setVisible($('#selling_link'), $('#selling_at_event').val() == '1');
+      };
+      $().ready(function() {
+          showOrHideConfirm();
+          $('#selling_at_event').change(showOrHideConfirm);
+      });
+  </script>
+{% endblock body %}


### PR DESCRIPTION
Based off the Guest Groups checklists, this is a fully-custom checklist for MIVS Studios to fill out. Fixes https://jira.magfest.net/browse/MAGDEV-298. Requires a [mivs_checklist] section in our config to match the code.

Two of the steps described in https://jira.magfest.net/browse/MAGDEV-298 are not in this, as the MIVS team isn't ready to set them up yet -- those will be in another PR.

We also need the email templates for the three types of emails added here: mivs_checklist_open.txt, mivs_checklist_new_item.txt, and mivs_checklist_reminder.txt. They can be changed to HTML if desired. That should be done in this PR.

This is also dependent on https://jira.magfest.net/browse/MAGDEV-330, so I can actually test the emails coded.