### PR TITLE
Allow staffers to abandon their badge

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -759,7 +759,9 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def can_abandon_badge(self):
-        return not self.amount_paid and not self.paid == c.NEED_NOT_PAY and not self.is_group_leader
+        return not self.amount_paid and (
+            not self.paid == c.NEED_NOT_PAY or self.badge_type == c.STAFF_BADGE
+        ) and not self.is_group_leader and not self.checked_in
 
     @property
     def can_self_service_refund_badge(self):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -728,9 +728,11 @@ class Root:
 
             session.delete_from_group(attendee, attendee.group)
             raise HTTPRedirect('not_found?id={}&message={}', attendee.id, success_message)
-        # otherwise, we will mark attendee as invalid
+        # otherwise, we will mark attendee as invalid and remove them from shifts if necessary
         else:
             attendee.badge_status = new_status
+            for shift in attendee.shifts:
+                session.delete(shift)
             raise HTTPRedirect('{}?id={}&message={}', page_redirect, attendee.id, success_message)
 
     def badge_updated(self, session, id, message=''):

--- a/uber/templates/preregistration/badge_refund.html
+++ b/uber/templates/preregistration/badge_refund.html
@@ -13,6 +13,8 @@ We cannot automatically refund your badge at the moment due to technical difficu
 As a leader of a group, you cannot abandon your badge.
     {% elif attendee.paid == c.NEED_NOT_PAY %}
 You cannot abandon a comped badge.
+    {% elif attendee.checked_in %}
+This badge has already been picked up.s
     {% endif %}
 Please {% if attendee.is_transferable and not c.SELF_SERVICE_REFUNDS_OPEN %}transfer your badge instead or
 {% endif %}contact us at {{ c.REGDESK_EMAIL|email_only }}{% if c.SELF_SERVICE_REFUNDS_OPEN %} to make sure your refund gets processed.{% endif %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-352. Also deletes any shifts assigned to a staffer when they abandon their badge. Also also adds a check to prevent abandoning a badge that's been picked up.