### PR TITLE
Stop removing everyone's FoodRestriction setting if it is vegan

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1661,8 +1661,6 @@ class FoodRestrictions(MagModel):
             restriction = getattr(c, name.upper())
             if restriction not in c.FOOD_RESTRICTIONS:
                 return MagModel.__getattr__(self, name)
-            elif restriction == c.VEGAN and c.VEGAN in self.standard_ints:
-                return False
             elif restriction == c.PORK and c.VEGAN in self.standard_ints:
                 return True
             else:

--- a/uber/templates/summary/food_restrictions.html
+++ b/uber/templates/summary/food_restrictions.html
@@ -14,8 +14,7 @@
     <li>{{ count }}: {{ label }}</li>
 {% endfor %}
 </ul>
-<b>Note:</b> <i>People who checked both "vegetarian" and "vegan" on their form are only counted as vegans for the purposes of these numbers and do not add to the "vegetarians" number listed here.</i> <br/>
-<b>Note:</b> <i>People who checked either "vegetarian" or "vegan" on their form are automatically counted as "no pork" for the purposes of these numbers regardless of whether they checked it.</i>
+<b>Note:</b> <i>People who checked "vegan" on their form are automatically counted as "no pork" for the purposes of these numbers regardless of whether they checked it.</i>
 
 <h3> Sandwich Preferences </h3>
 <ul>


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-358.

We used to collect vegetarian and vegan information from attendees separately. In cases where an attendee checked both boxes, we would forcibly remove the "Vegetarian" option from reports, much like we add the "No Pork" option to anyone who is vegetarian or vegan.

At some point in the past, we changed it so c.VEGAN was the only option (now called "Vegetarian/Vegan"), but during the refactor we must have changed all instances of `c.VEGETARIAN` to `c.VEGAN`, leading to this completely pointless line that removes the "Vegan" option from... anyone who has checked the "Vegan" option.