### PR TITLE
Add extendable Guidebook export using Guidebook's "custom list" template

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -965,6 +965,29 @@ stripe.api_key = c.STRIPE_SECRET_KEY
 c.JAVASCRIPT_INCLUDES = []
 
 
+# A list of models that have properties defined for exporting for Guidebook
+c.GUIDEBOOK_MODELS = [
+    ('GuestGroup_guest', 'Guests'),
+    ('GuestGroup_band', 'Bands'),
+    ('MITSGame', 'MITS'),
+    ('IndieGame', 'MIVS'),
+    ('PanelApplication', 'Panels'),
+    ('Group_dealer', 'Marketplace'),
+]
+
+
+# A list of properties that we will check for when export for Guidebook
+# and the column headings Guidebook expects for them
+c.GUIDEBOOK_PROPERTIES = [
+    ('guidebook_name', 'Name'),
+    ('guidebook_subtitle', 'Sub-Title (i.e. Location, Table/Booth, or Title/Sponsorship Level)'),
+    ('guidebook_desc', 'Description (Optional)'),
+    ('guidebook_location', 'Location/Room'),
+    ('guidebook_image', 'Image (Optional)'),
+    ('guidebook_thumbnail', 'Thumbnail (Optional)'),
+]
+
+
 # =============================
 # hotel
 # =============================

--- a/uber/config.py
+++ b/uber/config.py
@@ -971,7 +971,7 @@ c.GUIDEBOOK_MODELS = [
     ('GuestGroup_band', 'Bands'),
     ('MITSGame', 'MITS'),
     ('IndieGame', 'MIVS'),
-    ('PanelApplication', 'Panels'),
+    ('Event_panels', 'Panels'),
     ('Group_dealer', 'Marketplace'),
 ]
 

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -50,6 +50,9 @@ year = string(default='')
 # If not set, we generate one using the event_name and year variables above.
 event_qr_id = string(default='')
 
+# Link to an external schedule, like Guidebook
+alt_schedule_url = string(default='')
+
 # =============================
 # Feature Flags
 # =============================
@@ -850,6 +853,9 @@ guest_info_deadline = string(default="2017-11-01")
 rock_island_deadline = string(default="2017-11-30")
 
 __many__ = string
+
+# Room deadline for hotel requests
+room_deadline = string(default='')
 
 
 [badge_type_prices]

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -241,10 +241,10 @@ def multifile_zipfile(func):
     func.site_mappable = True
 
     @wraps(func)
-    def zipfile_out(self, session):
+    def zipfile_out(self, session, **kwargs):
         zipfile_writer = BytesIO()
         with zipfile.ZipFile(zipfile_writer, mode='w') as zip_file:
-            func(self, zip_file, session)
+            func(self, zip_file, session, **kwargs)
 
         # must do this after creating the zip file as other decorators may have changed this
         # for example, if a .zip file is created from several .csv files, they may each set content-type.

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -270,3 +270,20 @@ class Group(MagModel, TakesPaymentMixin):
 
         physical_address = [address1, address2, city_region_zip, country]
         return '\n'.join([s for s in physical_address if s])
+
+    @property
+    def guidebook_name(self):
+        return self.name
+
+    @property
+    def guidebook_subtitle(self):
+        category_labels = [cat for cat in self.categories_labels if 'Other' not in cat] + [self.categories_text]
+        return ', '.join(category_labels[:5])
+
+    @property
+    def guidebook_desc(self):
+        return self.description
+
+    @property
+    def guidebook_location(self):
+        return ''

--- a/uber/models/guests.py
+++ b/uber/models/guests.py
@@ -170,6 +170,13 @@ class GuestGroup(MagModel):
     def guidebook_thumbnail(self):
         return self.bio.pic_filename if self.bio else ''
 
+    @property
+    def guidebook_images(self):
+        if not self.bio:
+            return ['', '']
+
+        return [self.bio.pic_filename], [self.bio]
+
 
 class GuestInfo(MagModel):
     guest_id = Column(UUID, ForeignKey('guest_group.id'), unique=True)

--- a/uber/models/guests.py
+++ b/uber/models/guests.py
@@ -163,10 +163,6 @@ class GuestGroup(MagModel):
         return self.bio.desc if self.bio else ''
 
     @property
-    def guidebook_location(self):
-        return ''
-
-    @property
     def guidebook_image(self):
         return self.bio.pic_filename if self.bio else ''
 

--- a/uber/models/guests.py
+++ b/uber/models/guests.py
@@ -150,6 +150,30 @@ class GuestGroup(MagModel):
             return getattr(subclass, 'status', getattr(subclass, 'id'))
         return ''
 
+    @property
+    def guidebook_name(self):
+        return self.group.name if self.group else ''
+
+    @property
+    def guidebook_subtitle(self):
+        return self.group_type_label
+
+    @property
+    def guidebook_desc(self):
+        return self.bio.desc if self.bio else ''
+
+    @property
+    def guidebook_location(self):
+        return ''
+
+    @property
+    def guidebook_image(self):
+        return self.bio.pic_filename if self.bio else ''
+
+    @property
+    def guidebook_thumbnail(self):
+        return self.bio.pic_filename if self.bio else ''
+
 
 class GuestInfo(MagModel):
     guest_id = Column(UUID, ForeignKey('guest_group.id'), unique=True)

--- a/uber/models/mits.py
+++ b/uber/models/mits.py
@@ -210,6 +210,29 @@ class MITSGame(MagModel):
                 return image.filename
         return self.team.pictures[1].filename if len(self.team.pictures) > 1 else self.team.pictures[0].filename
 
+    @property
+    def guidebook_images(self):
+        if not self.team.pictures:
+            return ['', '']
+
+        header = None
+        thumbnail = None
+        for image in self.team.pictures:
+            if image.is_header and not header:
+                header = image
+            if image.is_thumbnail and not thumbnail:
+                thumbnail = image
+
+        if not header:
+            header = self.team.pictures[0]
+        if not thumbnail:
+            thumbnail = self.team.pictures[1] if len(self.team.pictures) > 1 else self.team.pictures[0]
+
+        if header == thumbnail:
+            return [header.filename], [header]
+        else:
+            return [header.filename, thumbnail.filename], [header, thumbnail]
+
 
 class MITSPicture(MagModel):
     team_id = Column(UUID, ForeignKey('mits_team.id'))

--- a/uber/models/mits.py
+++ b/uber/models/mits.py
@@ -166,6 +166,40 @@ class MITSGame(MagModel):
     unlicensed = Column(Boolean, default=False)
     professional = Column(Boolean, default=False)
 
+    @property
+    def has_been_accepted(self):
+        return self.team.status == c.ACCEPTED
+
+    @property
+    def guidebook_name(self):
+        return self.team.name
+
+    @property
+    def guidebook_subtitle(self):
+        return self.name
+
+    @property
+    def guidebook_desc(self):
+        return self.description
+
+    @property
+    def guidebook_location(self):
+        return ''
+
+    @property
+    def guidebook_image(self):
+        for image in self.team.pictures:
+            if image.is_header:
+                return image
+        return self.team.pictures[0]
+
+    @property
+    def guidebook_thumbnail(self):
+        for image in self.team.pictures:
+            if image.is_thumbnail:
+                return image
+        return self.team.pictures[1] if len(self.team.pictures) > 1 else self.team.pictures[0]
+
 
 class MITSPicture(MagModel):
     team_id = Column(UUID, ForeignKey('mits_team.id'))

--- a/uber/models/mivs.py
+++ b/uber/models/mivs.py
@@ -423,6 +423,34 @@ class IndieGame(MagModel, ReviewMixin):
             and self.studio \
             and self.studio.group_id
 
+    @property
+    def has_been_accepted(self):
+        return self.status == c.ACCEPTED
+
+    @property
+    def guidebook_name(self):
+        return self.studio.name
+
+    @property
+    def guidebook_subtitle(self):
+        return self.title
+
+    @property
+    def guidebook_desc(self):
+        return self.description
+
+    @property
+    def guidebook_location(self):
+        return ''
+
+    @property
+    def guidebook_image(self):
+        return self.best_screenshot_download_filenames()[0]
+
+    @property
+    def guidebook_thumbnail(self):
+        return self.best_screenshot_download_filenames()[1]
+
 
 class IndieGameImage(MagModel):
     game_id = Column(UUID, ForeignKey('indie_game.id'))

--- a/uber/models/mivs.py
+++ b/uber/models/mivs.py
@@ -10,6 +10,7 @@ from sideboard.lib import on_startup
 from sqlalchemy import func
 from sqlalchemy.schema import ForeignKey, UniqueConstraint
 from sqlalchemy.types import Boolean, Integer
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from uber.config import c
 from uber.decorators import presave_adjustment
@@ -423,7 +424,7 @@ class IndieGame(MagModel, ReviewMixin):
             and self.studio \
             and self.studio.group_id
 
-    @property
+    @hybrid_property
     def has_been_accepted(self):
         return self.status == c.ACCEPTED
 
@@ -449,7 +450,8 @@ class IndieGame(MagModel, ReviewMixin):
 
     @property
     def guidebook_thumbnail(self):
-        return self.best_screenshot_download_filenames()[1]
+        return self.best_screenshot_download_filenames()[1] \
+            if len(self.best_screenshot_download_filenames()) > 1 else self.best_screenshot_download_filenames()[0]
 
 
 class IndieGameImage(MagModel):

--- a/uber/models/mivs.py
+++ b/uber/models/mivs.py
@@ -453,6 +453,16 @@ class IndieGame(MagModel, ReviewMixin):
         return self.best_screenshot_download_filenames()[1] \
             if len(self.best_screenshot_download_filenames()) > 1 else self.best_screenshot_download_filenames()[0]
 
+    @property
+    def guidebook_images(self):
+        image_filenames = [self.best_screenshot_download_filenames()[0]]
+        images = [self.best_screenshot_downloads()[0]]
+        if self.guidebook_image != self.guidebook_thumbnail:
+            image_filenames.append(self.guidebook_thumbnail)
+            images.append(self.best_screenshot_downloads()[1])
+
+        return image_filenames, images
+
 
 class IndieGameImage(MagModel):
     game_id = Column(UUID, ForeignKey('indie_game.id'))

--- a/uber/models/panels.py
+++ b/uber/models/panels.py
@@ -48,6 +48,33 @@ class Event(MagModel):
     def end_time(self):
         return self.start_time + timedelta(minutes=self.minutes)
 
+    @property
+    def guidebook_name(self):
+        return self.name
+
+    @property
+    def guidebook_subtitle(self):
+        # Note: not everything on this list is actually exported
+        if self.location in c.PANEL_ROOMS:
+            return 'Panel'
+        if self.location in c.MUSIC_ROOMS:
+            return 'Music'
+        if self.location in c.TABLETOP_LOCATIONS:
+            return 'Tabletop Event'
+        if "Autograph" in self.location_label:
+            return 'Autograph Session'
+
+    @property
+    def guidebook_desc(self):
+        panelists_creds = '<br/><br/>' + '<br/><br/>'.join(
+            a.other_credentials for a in self.applications[0].applicants if a.other_credentials
+        ) if self.applications else ''
+        return self.description + panelists_creds
+
+    @property
+    def guidebook_location(self):
+        return self.event.location_label
+
 
 class AssignedPanelist(MagModel):
     attendee_id = Column(UUID, ForeignKey('attendee.id', ondelete='cascade'))
@@ -118,23 +145,6 @@ class PanelApplication(MagModel):
     @hybrid_property
     def has_been_accepted(self):
         return self.status == c.ACCEPTED
-
-    @property
-    def guidebook_name(self):
-        return self.name
-
-    @property
-    def guidebook_subtitle(self):
-        return 'Panel'
-
-    @property
-    def guidebook_desc(self):
-        panelists_creds = '<br/><br/>'.join(a.other_credentials for a in self.applicants if a.other_credentials)
-        return self.description + '<br/><br/>' + panelists_creds
-
-    @property
-    def guidebook_location(self):
-        return self.event.location_label if self.event else ''
 
 
 class PanelApplicant(SocialMediaMixin, MagModel):

--- a/uber/models/panels.py
+++ b/uber/models/panels.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from residue import CoerceUTF8 as UnicodeText, UTCDateTime, UUID
 from sqlalchemy.schema import ForeignKey
 from sqlalchemy.types import Boolean, Integer
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from uber.config import c
 from uber.models import MagModel
@@ -113,6 +114,10 @@ class PanelApplication(MagModel):
     @property
     def unmatched_applicants(self):
         return [a for a in self.applicants if not a.attendee_id]
+
+    @hybrid_property
+    def has_been_accepted(self):
+        return self.status == c.ACCEPTED
 
     @property
     def guidebook_name(self):

--- a/uber/models/panels.py
+++ b/uber/models/panels.py
@@ -114,6 +114,23 @@ class PanelApplication(MagModel):
     def unmatched_applicants(self):
         return [a for a in self.applicants if not a.attendee_id]
 
+    @property
+    def guidebook_name(self):
+        return self.name
+
+    @property
+    def guidebook_subtitle(self):
+        return 'Panel'
+
+    @property
+    def guidebook_desc(self):
+        panelists_creds = '<br/><br/>'.join(a.other_credentials for a in self.applicants if a.other_credentials)
+        return self.description + '<br/><br/>' + panelists_creds
+
+    @property
+    def guidebook_location(self):
+        return self.event.location_label if self.event else ''
+
 
 class PanelApplicant(SocialMediaMixin, MagModel):
     app_id = Column(UUID, ForeignKey('panel_application.id', ondelete='cascade'))

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -14,9 +14,9 @@ from sqlalchemy.orm import joinedload, subqueryload
 from uber.config import c
 from uber.decorators import all_renderable, csv_file, multifile_zipfile, render, site_mappable, xlsx_file
 from uber.errors import HTTPRedirect
-from uber.models import Attendee, Department, FoodRestrictions, Group, GuestGroup, Session
+from uber.models import Attendee, Department, FoodRestrictions, Group, Session
 from uber.reports import PersonalizedBadgeReport, PrintedBadgeReport
-from uber.utils import filename_safe
+from uber.utils import filename_safe, localized_now
 
 
 def generate_staff_badges(start_badge, end_badge, out, session):
@@ -702,23 +702,25 @@ class Root:
     def export_guidebook(self, out, session, selected_model=''):
         from uber.decorators import _set_response_filename
 
-        if 'Group' in selected_model:
-            model = selected_model.split('_')[0]
-            model_list = session.query(Session.resolve_model(model))
+        model = selected_model.split('_')[0] if '_' in selected_model else selected_model
+        model_query = session.query(Session.resolve_model(model))
 
-            if '_band' in selected_model:
-                model_list = model_list.filter_by(group_type=c.BAND).all()
-            elif '_guest' in selected_model:
-                model_list = model_list.filter_by(group_type=c.GUEST).all()
-            elif '_dealer' in selected_model:
-                model_list = model_list.filter_by(is_dealer=True).all()
+        if '_band' in selected_model:
+            model_list = model_query.filter_by(group_type=c.BAND).all()
+        elif '_guest' in selected_model:
+            model_list = model_query.filter_by(group_type=c.GUEST).all()
+        elif '_dealer' in selected_model:
+            model_list = model_query.filter_by(is_dealer=True).all()
+        elif 'Game' in selected_model or 'Panel' in selected_model:
+            model_list = model_query.filter_by(has_been_accepted=True).all()
         else:
-            model_list = session.query(Session.resolve_model(selected_model)).all()
+            model_list = model_query.all()
 
-        if 'Game' in selected_model:
-            model_list = [model for model in model_list if getattr(model, 'has_been_accepted', None)]
+        _set_response_filename('{}_guidebook_{}.csv'.format(
+            filename_safe(dict(c.GUIDEBOOK_MODELS)[selected_model]).lower(),
+            localized_now().strftime('%Y%m%d'),
 
-        _set_response_filename('{}_guidebook.csv'.format(filename_safe(selected_model)))
+        ))
 
         out.writerow([val for key, val in c.GUIDEBOOK_PROPERTIES])
 

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -698,7 +698,7 @@ class Root:
             'tables': c.GUIDEBOOK_MODELS,
         }
 
-    @csv_file
+    @xlsx_file
     def export_guidebook(self, out, session, selected_model=''):
         from uber.decorators import _set_response_filename
 
@@ -716,7 +716,7 @@ class Root:
         else:
             model_list = model_query.all()
 
-        _set_response_filename('{}_guidebook_{}.csv'.format(
+        _set_response_filename('{}_guidebook_{}.xlsx'.format(
             filename_safe(dict(c.GUIDEBOOK_MODELS)[selected_model]).lower(),
             localized_now().strftime('%Y%m%d'),
 
@@ -727,5 +727,5 @@ class Root:
         for model in model_list:
             row = []
             for key, val in c.GUIDEBOOK_PROPERTIES:
-                row.append(getattr(model, key, ''))
+                row.append(getattr(model, key, '').replace('\n', '<br/>'))
             out.writerow(row)

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -12,7 +12,8 @@ from sqlalchemy.sql.expression import extract, literal
 from sqlalchemy.orm import joinedload, subqueryload
 
 from uber.config import c
-from uber.decorators import all_renderable, csv_file, multifile_zipfile, render, site_mappable, xlsx_file
+from uber.decorators import all_renderable, csv_file, multifile_zipfile, render, site_mappable, xlsx_file, \
+    _set_response_filename
 from uber.errors import HTTPRedirect
 from uber.models import Attendee, Department, FoodRestrictions, Group, Session
 from uber.reports import PersonalizedBadgeReport, PrintedBadgeReport
@@ -68,6 +69,22 @@ def volunteer_checklists(session):
         'checklist_items': checklist_items,
         'attendees': attendees,
     }
+
+
+def _get_guidebook_models(session, selected_model=''):
+    model = selected_model.split('_')[0] if '_' in selected_model else selected_model
+    model_query = session.query(Session.resolve_model(model))
+
+    if '_band' in selected_model:
+        return model_query.filter_by(group_type=c.BAND)
+    elif '_guest' in selected_model:
+        return model_query.filter_by(group_type=c.GUEST)
+    elif '_dealer' in selected_model:
+        return model_query.filter_by(is_dealer=True)
+    elif 'Game' in selected_model or 'Panel' in selected_model:
+        return model_query.filter_by(has_been_accepted=True)
+    else:
+        return model_query
 
 
 @all_renderable(c.STATS)
@@ -699,22 +716,8 @@ class Root:
         }
 
     @xlsx_file
-    def export_guidebook(self, out, session, selected_model=''):
-        from uber.decorators import _set_response_filename
-
-        model = selected_model.split('_')[0] if '_' in selected_model else selected_model
-        model_query = session.query(Session.resolve_model(model))
-
-        if '_band' in selected_model:
-            model_list = model_query.filter_by(group_type=c.BAND).all()
-        elif '_guest' in selected_model:
-            model_list = model_query.filter_by(group_type=c.GUEST).all()
-        elif '_dealer' in selected_model:
-            model_list = model_query.filter_by(is_dealer=True).all()
-        elif 'Game' in selected_model or 'Panel' in selected_model:
-            model_list = model_query.filter_by(has_been_accepted=True).all()
-        else:
-            model_list = model_query.all()
+    def export_guidebook_xlsx(self, out, session, selected_model=''):
+        model_list = _get_guidebook_models(session, selected_model).all()
 
         _set_response_filename('{}_guidebook_{}.xlsx'.format(
             filename_safe(dict(c.GUIDEBOOK_MODELS)[selected_model]).lower(),
@@ -729,3 +732,14 @@ class Root:
             for key, val in c.GUIDEBOOK_PROPERTIES:
                 row.append(getattr(model, key, '').replace('\n', '<br/>'))
             out.writerow(row)
+
+    @multifile_zipfile
+    def export_guidebook_zip(self, zip_file, session, selected_model=''):
+        model_list = _get_guidebook_models(session, selected_model).all()
+
+        for model in model_list:
+            filenames, files = getattr(model, 'guidebook_images', ['', ''])
+
+            for filename, file in zip(filenames, files):
+                if filename:
+                    zip_file.write(getattr(file, 'filepath', file.pic_fpath), filename)

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -15,7 +15,7 @@ from uber.config import c
 from uber.decorators import all_renderable, csv_file, multifile_zipfile, render, site_mappable, xlsx_file, \
     _set_response_filename
 from uber.errors import HTTPRedirect
-from uber.models import Attendee, Department, FoodRestrictions, Group, Session
+from uber.models import Attendee, Department, Event, FoodRestrictions, Group, Session
 from uber.reports import PersonalizedBadgeReport, PrintedBadgeReport
 from uber.utils import filename_safe, localized_now
 
@@ -81,7 +81,9 @@ def _get_guidebook_models(session, selected_model=''):
         return model_query.filter_by(group_type=c.GUEST)
     elif '_dealer' in selected_model:
         return model_query.filter_by(is_dealer=True)
-    elif 'Game' in selected_model or 'Panel' in selected_model:
+    elif '_panels' in selected_model:
+        return model_query.filter(Event.location.in_(c.PANEL_ROOMS))
+    elif 'Game' in selected_model:
         return model_query.filter_by(has_been_accepted=True)
     else:
         return model_query

--- a/uber/templates/export/index.html
+++ b/uber/templates/export/index.html
@@ -11,7 +11,7 @@ they will freeze up the system. THIS PAGE IS FOR EXPERTS ONLY.</strong>
 
 <form action="export_model" method="post" enctype="multipart/form-data">
     <select name="selected_model">
-        {{ options(tables, default='attendee') }}
+        {{ options(tables, default='Attendee') }}
     </select><br />
     <input type="submit" value="Download" />
 </form>

--- a/uber/templates/summary/guidebook_exports.html
+++ b/uber/templates/summary/guidebook_exports.html
@@ -6,11 +6,12 @@
 
 <br/>
 
-<form action="export_guidebook" method="post" enctype="multipart/form-data">
-    <select name="selected_model">
+<form method="post" enctype="multipart/form-data" class="form form-inline">
+    <select name="selected_model" class="form-control">
         {{ options(tables) }}
-    </select><br />
-    <input type="submit" value="Download" />
+    </select>
+  <button type="submit" class="btn btn-primary" onClick="form.action='export_guidebook_xlsx';">Download Data Xlsx</button>
+  <button type="submit" class="btn btn-success" onClick="form.action='export_guidebook_zip';">Download Images Zip</button>
 </form>
 
 

--- a/uber/templates/summary/guidebook_exports.html
+++ b/uber/templates/summary/guidebook_exports.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Guidebook Export{% endblock %}
+{% block content %}
+
+<h2> Guidebook Table Export </h2>
+
+<br/>
+
+<form action="export_guidebook" method="post" enctype="multipart/form-data">
+    <select name="selected_model">
+        {{ options(tables) }}
+    </select><br />
+    <input type="submit" value="Download" />
+</form>
+
+
+{% endblock %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-309. Many of our exports have to be hardcoded just because our models don't necessarily mirror how we want to display information in Guidebook, so this is about the most flexible/easily extendable way we can do this now. In the future, if we want to add a new model, we simply have to add it to the list in config.py, define the appropriate properties on that model, and in some cases update the export page handler to select the right models for us.