### PR TITLE
Always let volunteers see public shifts if they want to

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1084,15 +1084,16 @@ class Attendee(MagModel, TakesPaymentMixin):
         no_max = max_depts < 1
 
         requested_filter = None
-        if requested_dept_ids and (len(member_dept_ids) < max_depts or no_max):
-            depts_where_working = set(j.department_id for j in self.jobs)
-            if len(depts_where_working) >= max_depts and not no_max:
-                requested_dept_ids = depts_where_working.difference(member_dept_ids)
-
+        if requested_dept_ids:
             requested_any_dept = None in requested_dept_ids
+
             if requested_any_dept:
                 requested_filter = Job.visibility > Job._ONLY_MEMBERS
             elif requested_dept_ids:
+                depts_where_working = set(j.department_id for j in self.jobs)
+                if len(depts_where_working) >= max_depts and not no_max:
+                    requested_dept_ids = depts_where_working.difference(member_dept_ids)
+
                 requested_filter = and_(Job.visibility > Job._ONLY_MEMBERS, Job.department_id.in_(requested_dept_ids))
 
         if member_filter is not None and requested_filter is not None:


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-350. It seems we were intentionally removing public shifts from volunteers who were assigned to more departments than the maximum, but this was unintuitive. We still change some behavior based on the max departments, but we only do so if the volunteer hasn't requested 'Anywhere' in their department requests.