### PR TITLE
Support multiple primary contacts for MIVS

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -722,7 +722,6 @@ if c.MIVS_ENABLED:
         ident='2018_email_blast')
 
     MIVSGuestEmailFixture(
-        IndieGame,
         'MIVS {EVENT_YEAR}: Indie Handbook and MIVS Training',
         'mivs/accepted/2019_HandbookTrainingUpdate.txt',
         lambda mg: True,

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -111,6 +111,15 @@ class MagModel:
         self._invoke_adjustment_callbacks('predelete_adjustment')
 
     @property
+    def email_to_address(self):
+        """
+        The email address that our automated emails use when emailing this model.
+        In some rare cases, a model should have a column named `email` but not always use that in
+        automated emails -- override this instead.
+        """
+        return self.email
+
+    @property
     def addons(self):
         """
         This exists only to be overridden by other events; it should return a

--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -226,7 +226,7 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
             send_func = send_email.delay if delay else send_email
             send_func(
                 self.sender,
-                model_instance.email,
+                model_instance.email_to_address,
                 self.render_template(self.subject, data),
                 self.render_template(self.body, data),
                 self.format,
@@ -237,13 +237,13 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
                 automated_email=self.to_dict('id'))
             return True
         except Exception:
-            log.error('Error sending {!r} email to {}', self.subject, model_instance.email, exc_info=True)
+            log.error('Error sending {!r} email to {}', self.subject, model_instance.email_to_address, exc_info=True)
             if raise_errors:
                 raise
         return False
 
     def would_send_if_approved(self, model_instance):
-        return model_instance and getattr(model_instance, 'email', False) and self.filter(model_instance)
+        return model_instance and getattr(model_instance, 'email_to_address', False) and self.filter(model_instance)
 
 
 class Email(MagModel, BaseEmailMixin):
@@ -262,7 +262,7 @@ class Email(MagModel, BaseEmailMixin):
     @property
     def fk_email(self):
         if self.fk:
-            return self.fk.leader.email if (self.model == 'Group') else self.fk.email
+            return self.fk.leader.email_to_address if (self.model == 'Group') else self.fk.email_to_address
         return self.to
 
     @property

--- a/uber/site_sections/mivs_admin.py
+++ b/uber/site_sections/mivs_admin.py
@@ -45,7 +45,7 @@ class Root:
     @csv_file
     def everything(self, out, session):
         out.writerow([
-            'Game', 'Studio', 'Studio URL', 'Primary Contact Name', 'Primary Contact Email',
+            'Game', 'Studio', 'Studio URL', 'Primary Contact Names', 'Primary Contact Emails',
             'Game Website', 'Twitter', 'Facebook', 'Other Social Media',
             'Genres', 'Brief Description', 'Long Description', 'How to Play',
             'Link to Video for Judging', 'Link to Promo Video', 'Link to Game', 'Game Link Password',
@@ -59,8 +59,8 @@ class Root:
                 game.title,
                 game.studio.name,
                 '{}/mivs_applications/continue_app?id={}'.format(c.PATH, game.studio.id),
-                game.studio.primary_contact.full_name,
-                game.studio.primary_contact.email,
+                game.studio.primary_contact_first_names,
+                game.studio.email,
                 game.link_to_webpage,
                 game.twitter,
                 game.facebook,
@@ -110,7 +110,7 @@ class Root:
     def discussion_group_emails(self, out, session):
         emails = []
         for studio in session.query(IndieStudio).join(IndieStudio.group).join(Group.guest):
-            emails.append(studio.group.guest.email)
+            emails.extend(studio.group.guest.email)
             if studio.discussion_emails:
                 emails.extend(studio.discussion_emails_list)
 

--- a/uber/templates/emails/mivs/2017_email_blast.txt
+++ b/uber/templates/emails/mivs/2017_email_blast.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 Since opening round 2, we've encountered two technical problems
 

--- a/uber/templates/emails/mivs/2018_december_updates.txt
+++ b/uber/templates/emails/mivs/2018_december_updates.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 We have some December updates for you from MIVS!
 

--- a/uber/templates/emails/mivs/2018_email_blast.txt
+++ b/uber/templates/emails/mivs/2018_email_blast.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 We wanted to give you some upcoming info for this year's MIVS:
 

--- a/uber/templates/emails/mivs/2018_feedback.txt
+++ b/uber/templates/emails/mivs/2018_feedback.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 We hope you enjoyed attending MAGFest 2018! One thing you can do to make MIVS Better for next year is give us feedback by filling out this google form:
 

--- a/uber/templates/emails/mivs/2018_hotel_info.txt
+++ b/uber/templates/emails/mivs/2018_hotel_info.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 We're looking forward to seeing you and your games at MAGFest 2018. We wanted to send you information about two items that require your timely attention.
 

--- a/uber/templates/emails/mivs/2019_november_updates.txt
+++ b/uber/templates/emails/mivs/2019_november_updates.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 We're looking forward to seeing your game, {{ game.title }} at the MAGFest Indie Game Showcase in just a couple weeks.
 

--- a/uber/templates/emails/mivs/Round2_Open.txt
+++ b/uber/templates/emails/mivs/Round2_Open.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 Round 2 Submissions for MAGFest Indie Videogame Showcase are now open and you may submit your game {{ game.title }}. 
 

--- a/uber/templates/emails/mivs/accepted/2019_HandbookTrainingUpdate.txt
+++ b/uber/templates/emails/mivs/accepted/2019_HandbookTrainingUpdate.txt
@@ -1,6 +1,6 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ guest.group.studio.primary_contact_first_names }},
 
-Many of you noticed there was an e-mail sent out with a lot of broken links in it. Firstly, we apologize for the error. There's a lot going on with the new system and some stuff got lost.
+Many of you noticed there was an e-mail sent out that, in some email clients, had a lot of broken links in it. Firstly, we apologize for the error. There's a lot going on with the new system and some stuff got lost.
 
 There are two new checklist items for you to complete:
 

--- a/uber/templates/emails/mivs/accepted/2019_Hotel.txt
+++ b/uber/templates/emails/mivs/accepted/2019_Hotel.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 We're here with important information about Hotels.
 

--- a/uber/templates/emails/mivs/december_updates.txt
+++ b/uber/templates/emails/mivs/december_updates.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 We have information for you on the following:
 

--- a/uber/templates/emails/mivs/game_accept_reminder.txt
+++ b/uber/templates/emails/mivs/game_accept_reminder.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 Congratulations again for your game submission ({{ game.title }}) being accepted into the {{ c.ESCHATON.year }} MAGFest Indie Videogame Showcase (MIVS).
 

--- a/uber/templates/emails/mivs/game_accepted.txt
+++ b/uber/templates/emails/mivs/game_accepted.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 Congratulations!  Your game submission ({{ game.title }}) for the {{ c.ESCHATON.year }} MAGFest Indie Videogame Showcase (MIVS) is one of the games that have been accepted into the showcase.
 

--- a/uber/templates/emails/mivs/game_accepted_from_waitlist.txt
+++ b/uber/templates/emails/mivs/game_accepted_from_waitlist.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 Congratulations!  Your game submission ({{ game.title }}) for the {{ c.ESCHATON.year }} MAGFest Indie Videogame Showcase (MIVS) is one of the games that have been accepted into the showcase.
 

--- a/uber/templates/emails/mivs/game_declined.txt
+++ b/uber/templates/emails/mivs/game_declined.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 Thank you for your game submission ({{ game.title }}) to the MAGFest Indie Videogame Showcase (MIVS).
 

--- a/uber/templates/emails/mivs/game_preflight.txt
+++ b/uber/templates/emails/mivs/game_preflight.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 Are you ready for Super MAGFest 2017?
 

--- a/uber/templates/emails/mivs/game_submitted.txt
+++ b/uber/templates/emails/mivs/game_submitted.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 This is a confirmation that you have submitted your game {{ game.title }} to our panel of judges for Round Two of judging.
 

--- a/uber/templates/emails/mivs/game_video_submitted.txt
+++ b/uber/templates/emails/mivs/game_video_submitted.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 Your game ({{ game.title }}) has been submitted for review into the MAGFest Indie Videogame Showcase (MIVS).
 

--- a/uber/templates/emails/mivs/game_waitlisted.txt
+++ b/uber/templates/emails/mivs/game_waitlisted.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 Thank you for your game submission ({{ game.title }}) to the MAGFest Indie Videogame Showcase (MIVS).
 

--- a/uber/templates/emails/mivs/mivs_checklist_open.txt
+++ b/uber/templates/emails/mivs/mivs_checklist_open.txt
@@ -1,4 +1,4 @@
-Ahoy {{ guest.group.studio.primary_contact.first_name }},
+Ahoy {{ guest.group.studio.primary_contact_first_names }},
 
 We've put together a new webpage that contains a checklist of items for you to complete that will help you better prepare for MAGFest. As we get closer to MAGFest, new checklist items may show up. You will be receiving emails from us about checklist items that need to be completed and reminders for ones that still need your attention. You can get to your checklist using this link: {{ c.URL_BASE }}/guests/index?id={{ guest.id }}
 

--- a/uber/templates/emails/mivs/mivs_checklist_reminder.txt
+++ b/uber/templates/emails/mivs/mivs_checklist_reminder.txt
@@ -1,4 +1,4 @@
-Ahoy {{ guest.group.studio.primary_contact.first_name }},
+Ahoy {{ guest.group.studio.primary_contact_first_names }},
 
 {% set two_days, one_day, overdue = guest.group.studio.checklist_items_due_soon_grouped %}
 {% if two_days %}

--- a/uber/templates/emails/mivs/reviews_summary.html
+++ b/uber/templates/emails/mivs/reviews_summary.html
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 <br/><br/>We are happy to provide the feedback our judges left your game submission ({{ game.title }}) to the {{ c.ESCHATON.year }} MAGFest Indie Videogame Showcase
 (MIVS). In the past, it's been difficult to get this information from the judges to you, the developer, but we understand how helpful this can be to those of you still in development, and it's always nice to know what someone thinks of your work!

--- a/uber/templates/emails/mivs/round_two_closing.txt
+++ b/uber/templates/emails/mivs/round_two_closing.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 Thanks again for submitting your game ({{ game.title }}) to the MAGFest Indie Videogame Showcase. In the few coming weeks, our judges are hard at work wrapping up their reviews and staff will be tallying up scores. You can expect to hear whether or not your game has made it into the showcase by {{ c.MIVS_ROUND_TWO_COMPLETE|datetime_local }}.
 

--- a/uber/templates/emails/mivs/round_two_final_reminder.txt
+++ b/uber/templates/emails/mivs/round_two_final_reminder.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 Thanks again for wanting to submit your game ({{ game.title }}) to the MAGFest Indie Videogame Showcase! (MIVS)
 

--- a/uber/templates/emails/mivs/round_two_open.txt
+++ b/uber/templates/emails/mivs/round_two_open.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 Round 2 Submissions for MAGFest Indie Videogame Showcase are now open and you may submit your game {{ game.title }}. 
 

--- a/uber/templates/emails/mivs/round_two_reminder.txt
+++ b/uber/templates/emails/mivs/round_two_reminder.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 Thanks again for wanting to submit your game ({{ game.title }}) to the MAGFest Indie Videogame Showcase! (MIVS)
 

--- a/uber/templates/emails/mivs/studio_registered.txt
+++ b/uber/templates/emails/mivs/studio_registered.txt
@@ -1,4 +1,4 @@
-{{ studio.primary_contact.first_name }},
+{{ studio.primary_contact_first_names }},
 
 Thanks for registering your studio ({{ studio.name }}) with the MAGFest Indie Videogame Showcase (MIVS).
 

--- a/uber/templates/emails/mivs/video_accepted.txt
+++ b/uber/templates/emails/mivs/video_accepted.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 Congratulations!  Your game ({{ game.title }}) has made it past Round 1 judging for the MAGFest Indie Videogame Showcase (MIVS).
 

--- a/uber/templates/emails/mivs/video_broken.txt
+++ b/uber/templates/emails/mivs/video_broken.txt
@@ -1,4 +1,4 @@
-{{ game.studio.primary_contact.first_name }},
+{{ game.studio.primary_contact_first_names }},
 
 One of the judges for the MAGFest Indie Videogame Showcase (MIVS) has tried to review your video for Round 1, but could not watch it due to a broken link! Please check your link and correct the problem within 24 hours. Bad video links that are not fixed in time will be declined.
 

--- a/uber/templates/emails/mivs/video_declined.txt
+++ b/uber/templates/emails/mivs/video_declined.txt
@@ -1,4 +1,4 @@
-Hi {{ game.studio.primary_contact.first_name }},
+Hi {{ game.studio.primary_contact_first_names }},
 
 We're sorry but your Round 1 game entry {{ game.title }} in the MAGFest Indie Videogame Showcase (MIVS) was not accepted into Round 2.
 

--- a/uber/templates/emails/mivs/videoless_studio.txt
+++ b/uber/templates/emails/mivs/videoless_studio.txt
@@ -1,4 +1,4 @@
-Hi {{ studio.primary_contact.first_name }},
+Hi {{ studio.primary_contact_first_names }},
 
 According to our records, you've registered your studio ({{ studio.name }}) for the {{ c.EVENT_YEAR }} MAGFest Indie Video Game Showcase (MIVS) but have not yet submitted a video.
 

--- a/uber/templates/guests/mivs_discussion.html
+++ b/uber/templates/guests/mivs_discussion.html
@@ -9,9 +9,9 @@
   <form class="form form-horizontal" method="post" action="mivs_discussion">
   <input type="hidden" name="guest_id" value="{{ guest.id }}"/>
     <div class="form-group">
-      <label class="col-sm-3 control-label">Primary Contact Email</label>
+      <label class="col-sm-3 control-label">Primary Contact Emails</label>
       <div class="col-sm-6 form-control-static">
-        {{ guest.group.studio.primary_contact.email }}
+        {{ guest.email|join(', ') }}
       </div>
     </div>
     <div class="form-group">

--- a/uber/templates/mivs_admin/index.html
+++ b/uber/templates/mivs_admin/index.html
@@ -67,7 +67,7 @@
             {% endif %}
         </td>
         <td><a href="../mivs_applications/continue_app?id={{ game.studio.id }}" target="_blank">{{ game.studio.name }}</a></td>
-        <td>{{ game.studio.primary_contact.full_name }}</td>
+        <td>{{ game.studio.primary_contacts[0].full_name }}</td>
         <td><a href="assign_judges?game_id={{ game.id }}">{{ game.reviews|length }}</a></td>
         <td>
             {% if game.video_reviews %}

--- a/uber/templates/mivs_admin/studios.html
+++ b/uber/templates/mivs_admin/studios.html
@@ -26,16 +26,16 @@
       <a href="../mivs_applications/continue_app?id={{ studio.id }}" target="_blank">{{ studio.name }}</a>
     </td>
     <td>
-      {%- if studio.primary_contact.matching_attendee -%}
-        <a href="../registration/form?id={{ studio.primary_contact.matching_attendee.id }}">{{ studio.primary_contact.full_name }}</a>
+      {%- if studio.primary_contacts[0].matching_attendee -%}
+        <a href="../registration/form?id={{ studio.primary_contacts[0].matching_attendee.id }}">{{ studio.primary_contacts[0].full_name }}</a>
       {%- else -%}
-        {{ studio.primary_contact.full_name }}
+        {{ studio.primary_contacts[0].full_name }}
       {%- endif %}
       <br>
-      <a href="mailto:{{ studio.primary_contact.email }}">{{ studio.primary_contact.email }}</a>
-      {% if studio.primary_contact.cellphone -%}
+      <a href="mailto:{{ studio.primary_contacts[0].email }}">{{ studio.primary_contacts[0].email }}</a>
+      {% if studio.primary_contacts[0].cellphone_num -%}
         <br>
-        {{ studio.primary_contact.cellphone }}
+        {{ studio.primary_contacts[0].cellphone_num }}
       {%- endif %}
     </td>
     <td>

--- a/uber/templates/mivs_judging/studio.html
+++ b/uber/templates/mivs_judging/studio.html
@@ -68,7 +68,7 @@
                 <tr>
                     <td>{{ dev.full_name }}</td>
                     <td><a href="mailto:{{ dev.email }}">{{ dev.email }}</a></td>
-                    <td>{{ dev.cellphone }}</td>
+                    <td>{{ dev.cellphone_num }}</td>
                     <td>
                         {% if dev.primary_contact %}
                             <b>Primary Contact</b>


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-390. In order to do this we're adding a new `email_to_address` property that can be overridden for our automated emails while leaving an existing `email` column intact. Additionally, this fixes the error introduced by https://github.com/magfest/ubersystem/pull/3401, a different bug in the email template added in https://github.com/magfest/ubersystem/pull/3398, and a bug we hadn't discovered yet related to MIVS groups created while the checklist columns exist.