### PR TITLE
emergency fix for the MITS waiver

### DIFF
--- a/uber/site_sections/mits_applications.py
+++ b/uber/site_sections/mits_applications.py
@@ -325,8 +325,8 @@ class Root:
         }
 
     def waiver(self, session, message='', **params):
-        if 'id' in params and params['id']:
-            team = session.mits_team(params['id'])
+        if params.get('id'):
+            session.log_in_as_mits_team(params['id'], redirect_to='waiver')
         else:
             team = session.logged_in_mits_team()
 
@@ -336,7 +336,7 @@ class Root:
 
             else:
                 for applicant in team.applicants:
-                    if applicant.attendee.full_name == params['waiver_signature']:
+                    if getattr(applicant.attendee, 'full_name', applicant.full_name) == params['waiver_signature']:
                         team.waiver_signature = params['waiver_signature']
                         team.waiver_signed = localized_now()
                         break


### PR DESCRIPTION
I found that the issue was that we were checking for the logged-in team but then not actually logging them in!  So the waiver form would pull up, but then when you tried to submit the waiver it would fail.  We weren't testing it far enough to the point of submitting.

I'm going to merge this in and deploy right away because Janus just sent out a bunch of emails telling people to retry.