### PR TITLE
Add prereg line message to at-door registration

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -171,7 +171,7 @@ stripe_error = "Stripe Error Override"
 
 [[door_payment_method]]
 cash   = "Pay with cash"
-stripe = "Pay with credit card now (faster)"
+stripe = "Pay with credit card now (faster, can use prereg line)"
 manual = "Pay with credit card at the registration desk"
 group  = "Taking an unassigned Group badge (group leader must be present)"
 

--- a/test-defaults.ini
+++ b/test-defaults.ini
@@ -215,7 +215,7 @@ stripe_error = "Stripe Error Override"
 
 [[door_payment_method]]
 cash   = "Pay with cash"
-stripe = "Pay with credit card now (faster)"
+stripe = "Pay with credit card now (faster, can use prereg line)"
 manual = "Pay with credit card at the registration desk"
 group  = "Taking an unassigned Group badge (group leader must be present)"
 


### PR DESCRIPTION
**WARNING**: I'm not sure if this is overridden in production's config (as I think I don't have access to prod's config? I don't know how deployment works, hah). When merging this, please check to make sure it isn't.

Background: the at-door payment line is sometimes 15-30 minutes long, and pre-reg is usually instant or a couple minutes. I get really sad whenever someone waits 30 minutes to use the at-door table, when they could have just immediately picked up their badge in the prereg line.

![screenshot](https://user-images.githubusercontent.com/953151/50566243-41f68180-0cec-11e9-95e7-9c437ec8814a.png)