### PR TITLE
Use new primary_contact_first_names property

### DIFF
--- a/uber/templates/emails/mivs/accepted/2019_DecemberUpdate.txt
+++ b/uber/templates/emails/mivs/accepted/2019_DecemberUpdate.txt
@@ -1,4 +1,4 @@
-Ahoy {{ game.studio.primary_contact.first_name }},
+Ahoy {{ game.studio.primary_contact_first_names }},
 
 MAGFest is only a few days away!  We had some important reminders as well as some events at MAGFest we wanted you to know about.
 


### PR DESCRIPTION
The `primary_contact` property no longer exists, so we need to use the new property for emails `primary_contact_first_names`.