### PR TITLE
Add Volunteer Hours Overview page with dynamic filtering and export

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -859,7 +859,7 @@ if c.MIVS_ENABLED:
         'mivs/accepted/2019_Hotel.txt',
         lambda game: game.confirmed,
         ident='2019_mivs_accepted_hotel')
-    
+
     MIVSEmailFixture(
         IndieGame,
         'MIVS {EVENT_YEAR}: Important Events and MIVS Training Reminder',

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -248,6 +248,13 @@ class Root:
             } for dept in departments]
         }
 
+    def volunteer_hours_overview(self, session, message=''):
+        attendees = session.staffers()
+        return {
+            'volunteers': attendees,
+            'message': message,
+        }
+
     @csv_file
     def dept_head_contact_info(self, out, session):
         out.writerow(["Full Name", "Email", "Phone", "Department(s)"])

--- a/uber/templates/guest_admin/index.html
+++ b/uber/templates/guest_admin/index.html
@@ -20,7 +20,7 @@
   <div id="show-opts" class="btn-group" style="margin-bottom: 10px" data-toggle="buttons"></div>
 
   <div class="table-responsive">
-    <table id="group-table" class="datatable table table-striped" data-page-length="-1">
+    <table id="group-table" class="datatable table table-striped" data-info="false" data-page-length="-1">
       <thead>
       <tr>
         <th>Group</th>

--- a/uber/templates/summary/volunteer_hours_overview.html
+++ b/uber/templates/summary/volunteer_hours_overview.html
@@ -1,0 +1,122 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Staffing Overview{% endblock %}
+{% block content %}
+  <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.2/js/dataTables.buttons.min.js"></script>
+  <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.2/js/buttons.html5.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.2/css/buttons.dataTables.min.css">
+  <script type="text/javascript">
+      $.fn.dataTable.ext.search.push(
+          function( settings, data, dataIndex ) {
+              var min_hours = parseFloat( $('#min_hours').val());
+              var max_hours = parseFloat( $('#max_hours').val());
+              var hours = parseFloat( data[3] ) || 0;
+
+              var min_worked = parseFloat( $('#min_worked').val());
+              var max_worked = parseFloat( $('#max_worked').val());
+              var worked = parseFloat( data[3] ) || 0;
+
+              var show_hotel = ($('#show_all').is(':visible'));
+              var hotel_requested = (data[6] == "yes");
+
+              if ( ( isNaN( min_hours ) && isNaN( max_hours ) ) ||
+                  ( isNaN( min_hours ) && hours <= max_hours ) ||
+                  ( min_hours <= hours   && isNaN( max_hours ) ) ||
+                  ( min_hours <= hours   && hours <= max_hours ) )
+              {
+                  if ( ( isNaN( min_worked ) && isNaN( max_worked ) ) ||
+                      ( isNaN( min_worked ) && worked <= max_worked ) ||
+                      ( min_worked <= worked   && isNaN( max_worked ) ) ||
+                      ( min_worked <= worked   && worked <= max_worked ) )
+                  {
+                      if ( !show_hotel || hotel_requested )
+                      {
+                          return true;
+                      }
+                      return false;
+                  }
+                  return false;
+              }
+              return false;
+          }
+      );
+
+      $().ready(function() {
+          $('#show_all').hide();
+          var dtable = $('#volunteer_hours').DataTable({
+              dom: 'Bfrtip',
+              buttons: [
+                  {
+                      extend: 'excelHtml5',
+                      exportOptions: {
+                          columns: ':visible'
+                      }
+                  },
+              ]
+          });
+
+          // Hide hotel space requests
+          dtable.column(6).visible(false);
+
+          $('#show_hotel a').click(function() {
+              $('#show_all').show();
+              $('#show_hotel').hide();
+          });
+          $('#show_all a').click(function() {
+              $('#show_hotel').show();
+              $('#show_all').hide();
+          });
+
+          $('#min_hours, #max_hours, #min_worked, #max_worked').keyup( function() {
+              dtable.draw();
+          } );
+          $('#show_all a, #show_hotel a').click( function() {
+              dtable.draw();
+          } );
+      });
+  </script>
+
+  <div class="panel panel-body"><h2> Volunteer Hours Overview </h2>
+    <p class="text-center"><span id="show_all" class="show_or_hide_hotel"><a href="#">View all volunteers instead of only those who have requested hotel space</a>.</span>
+      <span id="show_hotel"><a href="#">View only volunteers who have requested hotel space</a>.</span></p>
+
+    <div class="pull-left"><h4>Filter by Weighted Hours</h4>
+      <p class="form-inline">Min: <input type="text" class="form-control" id="min_hours" name="min_hours">
+        Max: <input type="text" class="form-control" id="min_hours" name="min_hours"></p></div>
+
+    <div class="pull-right"><h4>Filter by Hours Worked</h4>
+      <p class="form-inline">Min: <input type="text" class="form-control" id="min_worked" name="min_worked">
+        Max: <input type="text" class="form-control" id="min_worked" name="min_worked"></p></div></div>
+  <div class="table-responsive">
+    <table id="volunteer_hours"
+           class="table table-hover"
+           data-page-length="-1"
+           data-info="false"
+           data-auto-width="true">
+      <thead>
+      <tr>
+        <th>Last Name</th>
+        <th>First Name</th>
+        <th>Legal Name</th>
+        <th>Weighted Hours</th>
+        <th>Hours Worked</th>
+        <th>Supporter Package</th>
+        <th>Requested Hotel Space</th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for volunteer in volunteers %}
+        <tr>
+          <td>{{ volunteer.last_name }}</td>
+          <td>{{ volunteer.first_name }}</td>
+          <td>{{ volunteer.legal_name }}</td>
+          <td>{{ volunteer.weighted_hours }}</td>
+          <td>{{ volunteer.worked_hours }}</td>
+          <td>{{ (volunteer.amount_extra >= c.SUPPORTER_LEVEL)|yesno }}</td>
+          <td>{{ 'no' if volunteer.hotel_requests is none else 'yes' }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-404, and addresses several other related requests for data, by allowing admins to view all volunteers based on a few filters. We then use the DataTables Button extension to export only the filtered data.

Also fixes https://github.com/magfest/ubersystem/issues/3372, albeit in a bit of a lazy way.
