### PR TITLE
fixes #3412

### DIFF
--- a/alembic/versions/72f97bdad2fa_add_mits_panel_application_table.py
+++ b/alembic/versions/72f97bdad2fa_add_mits_panel_application_table.py
@@ -9,7 +9,7 @@ Create Date: 2018-10-04 23:14:03.153533
 
 # revision identifiers, used by Alembic.
 revision = '72f97bdad2fa'
-down_revision = '9d90d3d538c6'
+down_revision = 'b574c0577253'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/b574c0577253_add_separate_mits_showcase_scheduling_.py
+++ b/alembic/versions/b574c0577253_add_separate_mits_showcase_scheduling_.py
@@ -9,7 +9,7 @@ Create Date: 2018-09-26 19:29:40.149653
 
 # revision identifiers, used by Alembic.
 revision = 'b574c0577253'
-down_revision = '6c5cf22429e2'
+down_revision = '735063d71b57'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
See my comment at https://github.com/magfest/ubersystem/issues/3412#issuecomment-450712780 for a full explanation of this bug.

This fix is to adjust the ``down_revision`` values so that they cause the migrations to be executed in the proper order.