### PR TITLE
final fix to db migration order

### DIFF
--- a/alembic/versions/6c5cf22429e2_add_mivs_judge_status_and_game_.py
+++ b/alembic/versions/6c5cf22429e2_add_mivs_judge_status_and_game_.py
@@ -9,7 +9,7 @@ Create Date: 2018-09-21 22:25:24.475167
 
 # revision identifiers, used by Alembic.
 revision = '6c5cf22429e2'
-down_revision = '73b22ccbe472'
+down_revision = '5c14f5a350dd'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
This is what's causing our migrations to give an error when we deploy via magbot.  I've tested this fix locally on Vagrant as well as onsite, so I'm gonna merge this in and deploy.