### PR TITLE
Remove "taking an unassigned group badge" from at-door payment methods

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -173,7 +173,6 @@ stripe_error = "Stripe Error Override"
 cash   = "Pay with cash"
 stripe = "Pay with credit card now (faster, can use prereg line)"
 manual = "Pay with credit card at the registration desk"
-group  = "Taking an unassigned Group badge (group leader must be present)"
 
 [[event_location]]
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -698,9 +698,6 @@ class Root:
                     attendee.paid = c.NEED_NOT_PAY
                 elif attendee.payment_method == c.STRIPE:
                     raise HTTPRedirect('pay?id={}', attendee.id)
-                elif attendee.payment_method == c.GROUP:
-                    message = 'Please proceed to the preregistration line to pick up your badge.'
-                    attendee.paid = c.PAID_BY_GROUP
                 elif attendee.payment_method == c.CASH:
                     message = message.format('cash', '${}'.format(attendee.total_cost))
                 elif attendee.payment_method == c.MANUAL:


### PR DESCRIPTION
This was confusing attendees more than it was helping. I thought I'd already done this when reg decided to stop using it, but apparently not!