### PR TITLE
Stop making non-public shifts public in at-con mode

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1073,8 +1073,6 @@ class Attendee(MagModel, TakesPaymentMixin):
         from uber.models.department import Job
 
         job_filters = [Job.is_unfilled]
-        if c.AT_THE_CON:
-            return job_filters
 
         member_dept_ids = set(d.department_id for d in self.dept_memberships)
         requested_dept_ids = set(d.department_id for d in self.dept_membership_requests).difference(member_dept_ids)


### PR DESCRIPTION
The effect of this line was that, if we were in at-con mode, attendees could suddenly sign up for any shift not restricted to a role. This has caused problems.