### PR TITLE
update c.REMAINING_BADGES to report the actual number we use

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -606,7 +606,7 @@ class Config(_Overridable):
     @property
     @dynamic
     def REMAINING_BADGES(self):
-        return max(0, self.MAX_BADGE_SALES - self.BADGES_SOLD)
+        return max(0, self.ATTENDEE_BADGES_SOLD - self.MAX_BADGE_SALES)
 
     @request_cached_property
     @dynamic

--- a/uber/config.py
+++ b/uber/config.py
@@ -606,7 +606,7 @@ class Config(_Overridable):
     @property
     @dynamic
     def REMAINING_BADGES(self):
-        return max(0, self.ATTENDEE_BADGES_SOLD - self.MAX_BADGE_SALES)
+        return max(0, self.MAX_BADGE_SALES - self.ATTENDEE_BADGES_SOLD)
 
     @request_cached_property
     @dynamic

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -84,7 +84,7 @@ def check_if_can_reg(func):
                 return render('static_views/dealer_reg_closed.html')
             else:
                 return render('static_views/dealer_reg_not_open.html')
-        elif c.ATTENDEE_BADGES_SOLD >= c.MAX_BADGE_SALES:
+        elif c.REMAINING_BADGES <= 0:
             # ===============================================================
             # TODO: MAKE THIS COMPARE THE SPECIFIC BADGE TYPE AGAINST OUR
             # STOCKS OF THAT TYPE. LUMPING ALL THE BADGE TYPES TOGETHER


### PR DESCRIPTION
- in it's current form, c.REMAINING_BADGES is just kind of incorrect and misleading
- currently, this is out of sync with the page that says "sold out"
- in the code, it looks like there's nothing that uses this number for calculations so I think this is safe to change
- change this number to be used in calculations
- could not test due to laptop weirdness

This is slightly optional, but, would help us provide more visibility into situations (like we're in now) where the badge cap is super-close to being hit

fixes https://github.com/magfest/ubersystem/issues/3155