### PR TITLE
fixed dev environment

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -74,7 +74,7 @@ ApiToken.required = [('name', 'Name'), ('description', 'Intended Usage'), ('acce
 def admin_has_required_api_access(api_token):
     admin_account_id = cherrypy.session['account_id']
     if api_token.is_new and admin_account_id != api_token.admin_account_id:
-            return 'You may not create an API token for another user'
+        return 'You may not create an API token for another user'
 
     with Session() as session:
         admin_account = session.current_admin_account()

--- a/uber/models/tracking.py
+++ b/uber/models/tracking.py
@@ -5,8 +5,10 @@ from threading import current_thread
 from urllib.parse import parse_qsl
 
 import cherrypy
-from pockets.autolog import log
 from pytz import UTC
+from sqlalchemy.ext import associationproxy
+
+from pockets.autolog import log
 from residue import CoerceUTF8 as UnicodeText, UTCDateTime, UUID
 from sideboard.lib import serializer
 
@@ -16,8 +18,9 @@ from uber.models.admin import AdminAccount
 from uber.models.email import Email
 from uber.models.types import Choice, DefaultColumn as Column, MultiChoice
 
-
 __all__ = ['PageViewTracking', 'Tracking']
+
+serializer.register(associationproxy._AssociationList, list)
 
 
 class PageViewTracking(MagModel):


### PR DESCRIPTION
This is a quick-and-dirty fix, and in the long run we'll probably need something better.

We pin some of our dependencies to an exact version, and others we merely specify a minimum version.  SQLAlchemy is one of the ones that we DON'T pin to an exact version - perhaps we should.  Because it looks like there was recently a small change to their class hierarchy.  Their API didn't change, but anyone relying on certain ``isinstance`` behaviors (as we are) would have been bitten.

In particular, our ``Model.to_dict()`` methods include all of our columns by default but exclude ``AssociationProxy`` objects:
https://github.com/magfest/sideboard/blob/master/sideboard/lib/sa/_crud.py#L1279

It looks like SQLAlchemy has recently changed how association proxies work such that association lists are no longer a subclass of ``AssociationProxy``.

Ideally we'd update that Sideboard ``to_dict`` method to check explicitly for the association list type.  However, that type appears to treated as an implementation detail, i.e. it begins with an underscore.  So while we could do this in that Sideboard file:

```python
from sqlalchemy.ext.associationproxy import _AssociationList

...
isinstance(..., (..., _AssociationList))
```

that would be somewhat fragile because SQLAlchemy isn't offering any guarantees on ``_AssociationList`` sticking around, hence the leading underscore.

In the medium run we can probably implement a solution and then pin the version of SQLAlchemy.  In the short run, this PR fixes things by converting ``_AssociationList`` fields to lists before they're serialized to JSON, since that was the error preventing a ``vagrant up`` from working properly.

If we decide to pin our SQLAlchemy version, then we should probably just update https://github.com/magfest/sideboard/blob/master/requirements.txt#L4 to pin to the current version (1.3.0) or perhaps pin to something earlier like the last known good version that we've currently got deployed.