### PR TITLE
Force swag icons to be 50px wide regardless of source image size

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -266,6 +266,7 @@
                                       <img
                                           class="tier-icon tier-icon-{{ tier.icon|basename|replace('_', '-')|replace('.png', '') }}"
                                           src="{{ tier.icon }}"
+                                          width="50px"
                                           alt="">
                                       + ${{ tier.price }}
                                     </span>


### PR DESCRIPTION
This just means it's easier to keep things standard on the reg form.