### PR TITLE
Mention shirt and supporter deadlines only when appropriate

### DIFF
--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -296,8 +296,8 @@
 
                 <p class="help-block col-sm-offset-3 col-sm-9">
                     Each level includes all lower levels. <br/>
-                    Supporter level and higher {% if c.BEFORE_SUPPORTER_DEADLINE %}are{% else %}were{% endif %} only available until {{ c.SUPPORTER_DEADLINE|datetime_local }}.<br/>
-                    Shirt level up to Supporter level {% if c.BEFORE_SHIRT_DEADLINE %}are{% else %}were{% endif %} only available until {{ c.SHIRT_DEADLINE|datetime_local }}.
+                    {% if c.SUPPORTER_DEADLINE != c.SHIRT_DEADLINE %}Supporter level and higher {% if c.BEFORE_SUPPORTER_DEADLINE %}are{% else %}were{% endif %} only available until {{ c.SUPPORTER_DEADLINE|datetime_local }}.<br/>{% endif %}
+                    {% if c.SHIRT_DEADLINE %} {% if c.SUPPORTER_DEADLINE != c.SHIRT_DEADLINE %}Shirt level up to Supporter level{% else %}Shirt level and higher{% endif %} {% if c.BEFORE_SHIRT_DEADLINE %}are{% else %}were{% endif %} only available until {{ c.SHIRT_DEADLINE|datetime_local }}.{% endif %}
                 </p>
             </div>
         {% endif %}


### PR DESCRIPTION
The prereg form was telling people both the shirt and supporter deadlines, even if they were the same. This re-implements https://github.com/magfest/magstock/commit/28913c1855dcf66e462fe1593117a7e779068acd by adding some conditionals to the text we print. Note that you can set the shirt deadline to be blank if you want only the supporter deadline to be printed.