### PR TITLE
Stop deleting GuestGroups when an associated Event is deleted

### DIFF
--- a/alembic/versions/4c9ae1c0db43_set_guestgroup_event_id_to_null_when_.py
+++ b/alembic/versions/4c9ae1c0db43_set_guestgroup_event_id_to_null_when_.py
@@ -1,0 +1,61 @@
+"""Set GuestGroup event ID to null when their Event is deleted
+
+Revision ID: 4c9ae1c0db43
+Revises: 73b22ccbe472
+Create Date: 2019-04-29 16:27:19.146652
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '4c9ae1c0db43'
+down_revision = '73b22ccbe472'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.drop_constraint('fk_guest_group_event_id_event', 'guest_group', type_='foreignkey')
+    op.create_foreign_key(op.f('fk_guest_group_event_id_event'), 'guest_group', 'event', ['event_id'], ['id'], ondelete='SET NULL')
+
+
+def downgrade():
+    op.drop_constraint(op.f('fk_guest_group_event_id_event'), 'guest_group', type_='foreignkey')
+    op.create_foreign_key('fk_guest_group_event_id_event', 'guest_group', 'event', ['event_id'], ['id'])

--- a/uber/models/guests.py
+++ b/uber/models/guests.py
@@ -26,7 +26,7 @@ __all__ = [
 
 class GuestGroup(MagModel):
     group_id = Column(UUID, ForeignKey('group.id'))
-    event_id = Column(UUID, ForeignKey('event.id'), nullable=True)
+    event_id = Column(UUID, ForeignKey('event.id', ondelete='SET NULL'), nullable=True)
     group_type = Column(Choice(c.GROUP_TYPE_OPTS), default=c.BAND)
     num_hotel_rooms = Column(Integer, default=1, admin_only=True)
     payment = Column(Integer, default=0, admin_only=True)

--- a/uber/models/panels.py
+++ b/uber/models/panels.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from residue import CoerceUTF8 as UnicodeText, UTCDateTime, UUID
+from sqlalchemy.orm import backref
 from sqlalchemy.schema import ForeignKey
 from sqlalchemy.types import Boolean, Integer
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -25,7 +26,8 @@ class Event(MagModel):
     applications = relationship('PanelApplication', backref='event')
     panel_feedback = relationship('EventFeedback', backref='event')
     tournaments = relationship('TabletopTournament', backref='event', uselist=False)
-    guest = relationship('GuestGroup', backref='event')
+    guest = relationship('GuestGroup', backref=backref('event', cascade="save-update,merge"),
+                         cascade='save-update,merge')
 
     @property
     def half_hours(self):


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-451 -- confusingly, we actually override SQLAlchemy's default behavior for cascading, so by default our object relationships cascade deletes. Yikes (TM)