### PR TITLE
Account for timezones when adjusting promo code expiration dates

### DIFF
--- a/uber/models/promo_code.py
+++ b/uber/models/promo_code.py
@@ -334,6 +334,8 @@ class PromoCode(MagModel):
                 dt = dateparser.parse(dt)
             else:
                 dt = c.ESCHATON
+        if dt.tzinfo:
+            dt = dt.astimezone(c.EVENT_TIMEZONE)
         return c.EVENT_TIMEZONE.localize(dt.replace(hour=23, minute=59, second=59, tzinfo=None))
 
     @property


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-453. We were naively replacing the expiration datetime's time, which works for initially setting the expiration date, but when we saved an 11:59pm PDT datetime to the database it was saving as a 6:59am time the next day in UTC... which we were then naively replacing, thus effectively moving the expiration date forward every time we saved the PromoCode. Now we first convert it back to the local timezone if necessary.