### PR TITLE
Compare new group badges' cost to the correct base price

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -668,8 +668,9 @@ class Root:
     def pay_for_extra_members(self, session, payment_id, stripeToken):
         charge = Charge.get(payment_id)
         [group] = charge.groups
-        badges_to_add = charge.dollar_amount // c.GROUP_PRICE
-        if charge.dollar_amount % c.GROUP_PRICE:
+        group_badge_price = c.DEALER_BADGE_PRICE if group.tables else c.GROUP_PRICE
+        badges_to_add = charge.dollar_amount // group_badge_price
+        if charge.dollar_amount % group_badge_price:
             message = 'Our preregistration price has gone up since you tried to add the badges; please try again'
         else:
             message = charge.charge_cc(session, stripeToken)


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-500. This bug has been in the code base for, quite possibly, the entire time we've had groups. We've just always happened to have a dealer badge price that could modulo into the attendee group price correctly.