### PR TITLE
Use the max_dealers property if it is set

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -324,6 +324,7 @@ separate_staff_merch = boolean(default=True)
 # interface allows you to give a dealer a higher number than this.
 max_tables = integer(default=4)
 # The max number of badges which a dealer may apply for.
+# If this is set to 0, dealers may have badges equal to the number of tables they buy + 1.
 max_dealers = integer(default=20)
 
 # The number of dealer apps we will accept before auto-waitlisting further

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -233,6 +233,8 @@ class Group(MagModel, TakesPaymentMixin):
 
     @property
     def min_badges_addable(self):
+        if self.is_dealer and not self.dealer_badges_remaining:
+            return 0
         if self.can_add:
             return 1
         elif self.is_dealer:

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -210,7 +210,7 @@ class Group(MagModel, TakesPaymentMixin):
 
     @property
     def dealer_max_badges(self):
-        return math.ceil(self.tables) + 1
+        return c.MAX_DEALERS or math.ceil(self.tables) + 1
 
     @property
     def dealer_badges_remaining(self):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -668,8 +668,8 @@ class Root:
     def pay_for_extra_members(self, session, payment_id, stripeToken):
         charge = Charge.get(payment_id)
         [group] = charge.groups
-        badges_to_add = charge.dollar_amount // c.GROUP_PRICE
-        if charge.dollar_amount % c.GROUP_PRICE:
+        badges_to_add = charge.dollar_amount // c.DEALER_BADGE_PRICE
+        if charge.dollar_amount % c.DEALER_BADGE_PRICE:
             message = 'Our preregistration price has gone up since you tried to add the badges; please try again'
         else:
             message = charge.charge_cc(session, stripeToken)

--- a/uber/templates/groupform.html
+++ b/uber/templates/groupform.html
@@ -1,4 +1,26 @@
 {% set attendee_or_group = attendee if attendee else group %}
+
+{% if not c.MAX_DEALERS %}
+  <script type="text/javascript">
+  updateBadgeMax = function() {
+      var new_badge_max = Math.ceil(parseFloat($("select[name=tables]").val())) + 1;
+      var curr_badge_max = parseInt($('select[name=badges] option:last').val());
+      if (curr_badge_max > new_badge_max) {
+          $("select[name=badges] option").slice(new_badge_max, curr_badge_max).remove();
+      } else {
+          for (i = curr_badge_max+1; i < new_badge_max+1; i++) {
+              $("select[name=badges]").append('<option value="'+i+'">'+i+'</option>');
+          }
+      }
+  };
+  $(function() {
+      $("select[name=tables]").on('change', updateBadgeMax);
+      updateBadgeMax();
+  });
+
+  </script>
+{% endif %}
+
 {% if not attendee_or_group.is_dealer %}
     <div class="form-group" id="badge-types">
         <label class="col-sm-3 control-label">Badge Level</label>

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -122,7 +122,11 @@
 {% endfor %}
 </table>
 
-<br/>
+<br/>{% if group.is_dealer and group.min_badges_addable %}
+    You may purchase up to <strong>{{ group.dealer_badges_remaining }}</strong> additional badges.<br/><br/>
+  {% elif group.is_dealer %}
+    Please contact us at <strong>{{ c.MARKETPLACE_EMAIL|email_only|email_to_link }}</strong> if you wish to purchase additional badges.
+  {% endif %}
 
 {% if c.PRE_CON and group.min_badges_addable %}
     <div id="add" style="display:none">


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-491. We now use max_dealers as the actual maximum number of badges, unless it is not set, in which case we default to letting them have the number of tables they order plus 1. The dealer application page handles both cases.

This also improves the UI around dealers self-purchasing badges. If a dealer was maxed out on badges, the form would still offer to let them purchase badges, but would not let them select a number.

Now, if a dealer is either at their maximum badge count or does not have `can_add` set, they see:
![image](https://user-images.githubusercontent.com/7198215/58429850-2ca43a00-8075-11e9-9848-c7386285c132.png)

If `can_add` is set and they have badges remaining that they can purchase, they see:
![image](https://user-images.githubusercontent.com/7198215/58429871-42196400-8075-11e9-9dcb-a0da2acc5ffb.png)