### PR TITLE
Add config flag for marking merch pickup at check-in

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -103,6 +103,10 @@ wristbands_enabled = boolean(default=False)
 # If this is False, we won't display the "Want to Kick in Extra" stuff.
 donations_enabled = boolean(default=True)
 
+# If this is True, the check-in form will have a checkbox for
+# marking the attendee as having received their merch
+merch_at_checkin = boolean(default=False)
+
 # True to show relevant features in the UI and enable relevant automated
 # emails/notifications. False to UI hide features and disable notifications.
 # NOTE: Even if these are set to False, the features will still _exist_ in the

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -430,7 +430,8 @@ class Root:
     @check_for_encrypted_badge_num
     @ajax
     def check_in(self, session, message='', group_id='', **params):
-        attendee = session.attendee(params, allow_invalid=True)
+        bools = ['got_merch'] if c.MERCH_AT_CHECKIN else []
+        attendee = session.attendee(params, allow_invalid=True, bools=bools)
         group = attendee.group or (session.group(group_id) if group_id else None)
 
         pre_badge = attendee.badge_num

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -98,7 +98,7 @@
             <td>{{ attendee.regdesk_info }}</td>
         </tr>
     {% endif %}
-    {% if attendee.amount_extra >= c.SHIRT_LEVEL and c.MERCH_AT_CHECKIN %}
+    {% if attendee.amount_extra and c.MERCH_AT_CHECKIN %}
       <tr>
         <td><strong>Picked Up Merch?</strong></td>
         <td><label style="font-weight:normal;"><input type="checkbox" name="got_merch" value="1" /> Yes, this attendee has received their merch</label></td>

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -98,6 +98,12 @@
             <td>{{ attendee.regdesk_info }}</td>
         </tr>
     {% endif %}
+    {% if attendee.amount_extra >= c.SHIRT_LEVEL and c.MERCH_AT_CHECKIN %}
+      <tr>
+        <td><strong>Picked Up Merch?</strong></td>
+        <td><label style="font-weight:normal;"><input type="checkbox" name="got_merch" value="1" /> Yes, this attendee has received their merch</label></td>
+      </tr>
+    {% endif %}
     {% endblock checkin_fields %}
 </table>
 </form>


### PR DESCRIPTION
This is mainly to fix https://jira.magfest.net/browse/MAGDEV-170 -- page handlers cannot be overridden in plugins, and we can't mark booleans without the page handler being aware of them -- but I made it a feature flag because many events under a certain size dole out merch at check-in.