### PR TITLE
Stop showing Badge Printed Name during At-Door Checkin

### DIFF
--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -213,7 +213,7 @@
         {% block tableheadings %}
         <th align="left">Registered</th>
         <th align="left">Name</th>
-        <th align="left">Badge Name</th>
+        {% if c.ATTENDEE_BADGE in c.PREASSIGNED_BADGE_TYPES %}<th align="left">Badge Name</th>{% endif %}
         <th>Badge Type</th>
         <th>Age</th>
         <th>Cost</th>
@@ -236,9 +236,11 @@
                 <div style="color:red">There is a problem with this registration. Please contact your department head.</div>
             {% endif %}
         </td>
+        {% if c.ATTENDEE_BADGE in c.PREASSIGNED_BADGE_TYPES %}
         <td>
             <input type="text" class="form-control" form="new_checkin_{{ attendee.id }}" name="badge_printed_name" value="{{ attendee.badge_printed_name }}" />
         </td>
+        {% endif %}
         <td>
             {{ attendee.badge_type_label }}
             {% if attendee.ribbon %}


### PR DESCRIPTION
No MAGFest event needs or can use this, so we now hide it using a close approximation of events that would want it (those that personalize badges onsite)