### PR TITLE
added public_id to returned fields in API AttendeeLookup class

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -266,6 +266,7 @@ class AttendeeLookup:
         'staffing': True,
         'is_dept_head': True,
         'ribbon_labels': True,
+        'public_id': True,
     }
 
     fields_full = dict(fields, **{


### PR DESCRIPTION
took 1 minute to get it to clone the repo, then another 30 to re-clone it twice while discovering how to fork it so I can actually upload and do a pull request.  Please let me know if I need to change how I do this for general process or convenience or whatever.