### PR TITLE
Retool how Staff and Event shirts interact to allow more flexibility

### DIFF
--- a/alembic/versions/8f8419ebcf27_replace_second_shirt_column_with_more_.py
+++ b/alembic/versions/8f8419ebcf27_replace_second_shirt_column_with_more_.py
@@ -1,0 +1,61 @@
+"""Replace second_shirt column with more flexible num_event_shirts column
+
+Revision ID: 8f8419ebcf27
+Revises: e0c620d341cb
+Create Date: 2019-07-19 16:31:05.311139
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '8f8419ebcf27'
+down_revision = 'e0c620d341cb'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('num_event_shirts', sa.Integer(), server_default='0', nullable=False))
+    op.drop_column('attendee', 'second_shirt')
+
+
+def downgrade():
+    op.add_column('attendee', sa.Column('second_shirt', sa.INTEGER(), server_default=sa.text('194196342'), autoincrement=False, nullable=False))
+    op.drop_column('attendee', 'num_event_shirts')

--- a/tests/uber/models/test_merch.py
+++ b/tests/uber/models/test_merch.py
@@ -22,7 +22,7 @@ def donation_tier_fixture(monkeypatch):
     monkeypatch.setattr(c, 'SUPPORTER_LEVEL', supporter_level)
 
     monkeypatch.setattr(c, 'SHIRTS_PER_STAFFER', 3)
-    monkeypatch.setattr(c, 'STAFF_ELIGIBLE_FOR_SWAG_SHIRT', False)
+    monkeypatch.setattr(c, 'STAFF_EVENT_SHIRT_OPTS', '[]')
 
 
 class TestMerchAttrs:
@@ -38,7 +38,7 @@ class TestMerchAttrs:
         assert not Attendee(ribbon=c.VOLUNTEER_RIBBON, badge_type=c.STAFF_BADGE).volunteer_event_shirt_eligible
 
     def test_staff_event_shirt_eligible(self, monkeypatch):
-        monkeypatch.setattr(c, 'STAFF_ELIGIBLE_FOR_SWAG_SHIRT', True)
+        monkeypatch.setattr(c, 'STAFF_EVENT_SHIRT_OPTS', 1)
         assert Attendee(badge_type=c.STAFF_BADGE).volunteer_event_shirt_eligible
         assert Attendee(badge_type=c.STAFF_BADGE, ribbon=c.VOLUNTEER_RIBBON).volunteer_event_shirt_eligible
 
@@ -56,17 +56,6 @@ class TestMerchAttrs:
             monkeypatch.setattr(Attendee, 'volunteer_event_shirt_eligible', eligible)
             assert expected == Attendee(nonshift_hours=worked_hours).volunteer_event_shirt_earned
 
-    def test_replacement_staff_shirts(self, monkeypatch):
-        for staff_shirt, second_shirt, expected in [
-                (False, c.TWO_STAFF_SHIRTS,      0),
-                (False, c.UNKNOWN,               0),
-                (False, c.STAFF_AND_EVENT_SHIRT, 0),
-                (True, c.TWO_STAFF_SHIRTS,       0),
-                (True, c.UNKNOWN,                1),
-                (True, c.STAFF_AND_EVENT_SHIRT,  1)]:
-            monkeypatch.setattr(Attendee, 'gets_staff_shirt', staff_shirt)
-            assert expected == Attendee(second_shirt=second_shirt).replacement_staff_shirts
-
     def test_num_event_shirts_owed(self, monkeypatch):
         for paid, volunteer, replacement, owed in [
                 (False, False, 0, 0),
@@ -79,21 +68,18 @@ class TestMerchAttrs:
                 (True, True, 1, 3)]:
             monkeypatch.setattr(Attendee, 'paid_for_a_shirt', paid)
             monkeypatch.setattr(Attendee, 'volunteer_event_shirt_eligible', volunteer)
-            monkeypatch.setattr(Attendee, 'replacement_staff_shirts', replacement)
+            monkeypatch.setattr(Attendee, 'num_event_shirts', replacement)
             assert owed == Attendee().num_event_shirts_owed
 
     def test_num_staff_shirts_owed(self, monkeypatch):
-        for gets_shirt, replacement_shirts, expected in [
+        for gets_shirt, replacement, expected in [
                 (False, 0, 0),
                 (False, 1, 0),
                 (True, 0, 3),
                 (True, 1, 2),
-
-                # replacement_staff_shirts as currently programmed will only ever be 0 or 1 but
-                # we're testing with a higher value just to ensure this will work if that changes
                 (True, 2, 1)]:
             monkeypatch.setattr(Attendee, 'gets_staff_shirt', gets_shirt)
-            monkeypatch.setattr(Attendee, 'replacement_staff_shirts', replacement_shirts)
+            monkeypatch.setattr(Attendee, 'num_event_shirts', replacement)
             assert expected == Attendee().num_staff_shirts_owed
 
     def test_gets_staff_shirt(self):

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -315,15 +315,10 @@ collect_extra_donation = boolean(default=False)
 # their swag except a shirt, so we can contact them later.
 out_of_shirts = boolean(default=False)
 
-# This is the number of staff uniform shirts (i.e. the shirt that says "{EVENT_NAME} staff") that EACH staffer gets.
-# set this to zero if your event doesn't have staff uniform shirts.
-shirts_per_staffer = integer(default=0)
-
-# If false, staff badges will NOT earn a free swag shirt.  This shirt has nothing to do with staffing,
-# and is the same type of shirt that supporters get and are sold at the merch booth.
-# Some events will choose to give staff a staff-specific shirt and not give away a free swag shirt to staff
-# note: volunteers (not staff badges) always get a free swag shirt
-staff_eligible_for_swag_shirt = boolean(default=True)
+# This is the number of shirts that each staffer gets.
+# You can populate [[staff_event_shirt]] to allow staff to choose to
+# replace 1 or more of their staff shirts with event shirts
+shirts_per_staffer = integer(default=1)
 
 # Some events giv their staffers their special merch (such as swag shirts)
 # at a separate location from the normal merch booth.  If this setting is true,
@@ -1035,6 +1030,7 @@ __many__ = integer
 # These sections need to exist but can stay empty for events which are not using
 # the features they represent.
 [[shirt]]
+[[staff_event_shirt]]
 [[donation_tier]]
 [[store_price]]
 [[fee_price]]

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -214,7 +214,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     # attendee shirt size for both swag and staff shirts
     shirt = Column(Choice(c.SHIRT_OPTS), default=c.NO_SHIRT)
-    second_shirt = Column(Choice(c.SECOND_SHIRT_OPTS), default=c.UNKNOWN)
+    num_event_shirts = Column(Choice(c.STAFF_EVENT_SHIRT_OPTS), default=0)
     can_spam = Column(Boolean, default=False)
     regdesk_info = Column(UnicodeText, admin_only=True)
     extra_merch = Column(UnicodeText, admin_only=True)
@@ -917,40 +917,28 @@ class Attendee(MagModel, TakesPaymentMixin):
         return self.amount_extra >= c.SHIRT_LEVEL
 
     @property
+    def num_free_event_shirts(self):
+        """
+        Volunteers get one free event shirt by default; otherwise, we use whatever the attendee
+        has selected for their comped shirts while completing the volunteer checklist.
+        Returns: Integer representing the number of free event shirts this attendee should get.
+
+        """
+        return 1 if c.VOLUNTEER_RIBBON in self.ribbon_ints else self.num_event_shirts
+
+    @property
     def volunteer_event_shirt_eligible(self):
-        """
-        Returns a truthy value if this attendee either automatically gets a
-        complementary event shirt for being staff OR if they've eligible for a
-        complementary event shirt if they end up working enough volunteer hours
-        """
-        # Some events want to exclude staff badges from getting event shirts
-        # (typically because they are getting staff uniform shirts instead).
-        if self.badge_type == c.STAFF_BADGE:
-            return c.STAFF_ELIGIBLE_FOR_SWAG_SHIRT
-        else:
-            return c.VOLUNTEER_RIBBON in self.ribbon_ints
+        return c.VOLUNTEER_RIBBON in self.ribbon_ints
 
     @property
     def volunteer_event_shirt_earned(self):
-        return self.volunteer_event_shirt_eligible and (not self.takes_shifts or self.worked_hours >= c.HOURS_FOR_SHIRT)
-
-    @property
-    def replacement_staff_shirts(self):
-        """
-        Staffers can choose whether or not they want to swap out one of their
-        staff shirts for an event shirt.  By default and if the staffer opts
-        into this, we deduct 1 staff shirt from the staff shirt count and add 1
-        to the event shirt count.
-        """
-        is_replaced = self.second_shirt in [c.UNKNOWN, c.STAFF_AND_EVENT_SHIRT]
-        return 1 if c.SHIRTS_PER_STAFFER > 1 and self.gets_staff_shirt and is_replaced else 0
+        return c.volunteer_event_shirt_eligible and (not self.takes_shifts or self.worked_hours >= c.HOURS_FOR_SHIRT)
 
     @property
     def num_event_shirts_owed(self):
         return sum([
             int(self.paid_for_a_shirt),
-            int(self.volunteer_event_shirt_eligible),
-            self.replacement_staff_shirts
+            self.num_free_event_shirts
         ])
 
     @property
@@ -959,7 +947,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def num_staff_shirts_owed(self):
-        return 0 if not self.gets_staff_shirt else (c.SHIRTS_PER_STAFFER - self.replacement_staff_shirts)
+        return 0 if not self.gets_staff_shirt else (c.SHIRTS_PER_STAFFER - self.num_free_event_shirts)
 
     @property
     def gets_any_kind_of_shirt(self):
@@ -1030,7 +1018,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         elif self.num_event_shirts_owed > 1:
             merch.append('a 2nd tshirt')
 
-        if self.volunteer_event_shirt_eligible and not self.volunteer_event_shirt_earned:
+        if self.volunteer_shirt_eligible and not self.volunteer_event_shirt_earned:
             merch[-1] += (
                 ' (this volunteer must work at least {} hours or they will be reported for picking up their shirt)'
                     .format(c.HOURS_FOR_SHIRT))

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -919,12 +919,12 @@ class Attendee(MagModel, TakesPaymentMixin):
     @property
     def num_free_event_shirts(self):
         """
-        Volunteers get one free event shirt by default; otherwise, we use whatever the attendee
-        has selected for their comped shirts while completing the volunteer checklist.
+        If someone is staff-shirt-eligible, we use the number of event shirts they have selected (if any)
+        Volunteers also get a free event shirt.
         Returns: Integer representing the number of free event shirts this attendee should get.
 
         """
-        return 1 if c.VOLUNTEER_RIBBON in self.ribbon_ints else self.num_event_shirts
+        return self.num_event_shirts if self.gets_staff_shirt else c.VOLUNTEER_RIBBON in self.ribbon_ints
 
     @property
     def volunteer_event_shirt_eligible(self):

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -43,7 +43,7 @@ class Root:
         }
 
     @check_shutdown
-    def shirt_size(self, session, message='', shirt=None, second_shirt=None, csrf_token=None):
+    def shirt_size(self, session, message='', shirt=None, num_event_shirts=None, csrf_token=None):
         attendee = session.logged_in_volunteer()
         if shirt is not None:
             check_csrf(csrf_token)
@@ -51,8 +51,8 @@ class Root:
                 message = 'You must select a shirt size'
             else:
                 attendee.shirt = int(shirt)
-                if attendee.gets_staff_shirt and c.SHIRTS_PER_STAFFER > 1 and c.BEFORE_SHIRT_DEADLINE:
-                    attendee.second_shirt = int(second_shirt)
+                if c.STAFF_EVENT_SHIRT_OPTS and c.BEFORE_SHIRT_DEADLINE:
+                    attendee.num_event_shirts = int(num_event_shirts)
                 raise HTTPRedirect('index?message={}', 'Shirt info uploaded')
 
         return {

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -490,8 +490,7 @@ class Root:
             shirt_label = attendee.shirt_label or 'size unknown'
             counts['all_staff_shirts'][label(shirt_label)][status(attendee.got_merch)] += attendee.num_staff_shirts_owed
             counts['all_event_shirts'][label(shirt_label)][status(attendee.got_merch)] += attendee.num_event_shirts_owed
-            if attendee.volunteer_event_shirt_eligible or attendee.replacement_staff_shirts:
-                counts['free_event_shirts'][label(shirt_label)][status(attendee.got_merch)] += 1
+            counts['free_event_shirts'][label(shirt_label)][status(attendee.got_merch)] += attendee.num_free_event_shirts
             if attendee.paid_for_a_shirt:
                 counts['paid_event_shirts'][label(shirt_label)][status(attendee.got_merch)] += 1
                 sales_by_week[(min(datetime.now(UTC), c.ESCHATON) - attendee.registered).days // 7] += 1

--- a/uber/templates/emails/shifts/schedule.html
+++ b/uber/templates/emails/shifts/schedule.html
@@ -11,7 +11,7 @@
     Thanks again for Volunteering at {{ c.EVENT_NAME }}!
 {% endif %}
 
-{% if attendee.badge_type == c.STAFF_BADGE and (c.SHIRTS_PER_STAFFER > 0 or c.STAFF_ELIGIBLE_FOR_SWAG_SHIRT) %}
+{% if attendee.badge_type == c.STAFF_BADGE and c.SHIRTS_PER_STAFFER > 0 %}
     <br><br>
     Please remember to also pick up your
     {% if c.SHIRTS_PER_STAFFER > 1 %}
@@ -37,10 +37,11 @@
         everyone else.
     {% endif %}
 
-    {% if c.SHIRTS_PER_STAFFER > 0 and c.STAFF_ELIGIBLE_FOR_SWAG_SHIRT %}
+    {% if c.SHIRTS_PER_STAFFER > 0 and c.STAFF_EVENT_SHIRT_OPTS %}
         <br><br>
-        You also qualify for a {{ c.EVENT_NAME }} swag shirt. This is the same
-        shirt that attendees can buy and is provided as a perk for staffing.
+        You may choose to receive a {{ c.EVENT_NAME }} swag shirt instead of
+        {% if c.SHIRTS_PER_STAFFER > 1 %}one of {% end %}your staff shirt{{ c.SHIRTS_PER_STAFFER|pluralize }}.
+        This is the same shirt that attendees can buy and is provided as a perk for staffing.
     {% endif %}
 {% endif %}
 

--- a/uber/templates/signups/shirt_size.html
+++ b/uber/templates/signups/shirt_size.html
@@ -8,9 +8,9 @@
 
 <h2> Tell Us Your Shirt Size </h2>
 
-<p>One of the perks of volunteering is a tshirt for anyone who takes at least 6 weighted hours worth of shifts.</p>
+<p>One of the perks of volunteering is a tshirt for anyone who takes at least {{ c.HOURS_FOR_SHIRT }} weighted hours worth of shifts.</p>
 
-{% if attendee.gets_staff_shirt and c.SHIRTS_PER_STAFFER > 1 %}
+{% if c.gets_staff_shirt and c.STAFF_EVENT_SHIRT_OPTS %}
     <h3>Staff Shirt Policy</h3>
     <p>
         Event staff are given a themed staff t-shirt that serves as a uniform for the event, and is theirs to keep forever.
@@ -43,8 +43,8 @@
         {% if c.AFTER_SHIRT_DEADLINE %}
             <b>Because we are past the deadline, your choice has been locked in.</b>
         {% endif %}
-        <br/> <input type="radio" name="second_shirt" value="{{ c.TWO_STAFF_SHIRTS }}" {% if attendee.second_shirt == c.TWO_STAFF_SHIRTS %}checked{% endif %} {% if c.AFTER_SHIRT_DEADLINE %}disabled{% endif %} /> I'd like {{ c.SHIRTS_PER_STAFFER }} staff shirts, to help keep them fresh through the event.
-        <br/> <input type="radio" name="second_shirt" value="{{ c.STAFF_AND_EVENT_SHIRT }}" {% if attendee.second_shirt != c.TWO_STAFF_SHIRTS %}checked{% endif %} {% if c.AFTER_SHIRT_DEADLINE %}disabled{% endif %} /> I'd like {{ c.SHIRTS_PER_STAFFER - 1 }} staff shirt{{ (c.SHIRTS_PER_STAFFER - 1)|pluralize }}, and 1 standard event-themed swag shirt. <i>I can keep a staff shirt fresh through the event.</i>
+        <br/> <input type="radio" name="num_event_shirts" value="0" {% if attendee.num_event_shirts == 0 %}checked{% endif %} {% if c.AFTER_SHIRT_DEADLINE %}disabled{% endif %} /> I'd like {{ c.SHIRTS_PER_STAFFER }} staff shirts, to help keep them fresh through the event.
+        <br/> <input type="radio" name="num_event_shirts" value="1" {% if attendee.num_event_shirts == 1 %}checked{% endif %} {% if c.AFTER_SHIRT_DEADLINE %}disabled{% endif %} /> I'd like {{ c.SHIRTS_PER_STAFFER - 1 }} staff shirt{{ (c.SHIRTS_PER_STAFFER - 1)|pluralize }}, and 1 standard event-themed swag shirt. <i>I can keep a staff shirt fresh through the event.</i>
     </p>
 {% endif %}
 <p>


### PR DESCRIPTION
The way we handled staff and event shirts was not flexible enough for MAGWest's purposes. I've replaced our `second_shirt` column with `num_event_shirts`, which allows events to add configuration for any number of shirts along with c.SHIRTS_PER_STAFFER. For example, an event can now have three shirts per staffer and let them replace either one or two (or none) of them, using just config. Or, in MAGWest's case, an event can have just 1 shirt per staffer but still allow them to select between that shirt and an event shirt.

We do still assume that staffers (and not volunteers) are the only ones who get this selection, but this can be overridden using two properties (which you'll see shortly with MAGWest). The template for selecting shirt type/size is also still using Super MAGFest text, which we may want to move later or just override for other events that want to use this event-shirt-replacing selection.