### PR TITLE
Stop resetting ANY boolean values on the admin reg form

### DIFF
--- a/alembic/versions/4c9ae1c0db43_set_guestgroup_event_id_to_null_when_.py
+++ b/alembic/versions/4c9ae1c0db43_set_guestgroup_event_id_to_null_when_.py
@@ -1,7 +1,7 @@
 """Set GuestGroup event ID to null when their Event is deleted
 
 Revision ID: 4c9ae1c0db43
-Revises: 73b22ccbe472
+Revises: 61734fcb2e72
 Create Date: 2019-04-29 16:27:19.146652
 
 """

--- a/alembic/versions/6c5cf22429e2_add_mivs_judge_status_and_game_.py
+++ b/alembic/versions/6c5cf22429e2_add_mivs_judge_status_and_game_.py
@@ -1,7 +1,7 @@
 """Add MIVS Judge status and game submission tracker
 
 Revision ID: 6c5cf22429e2
-Revises: 73b22ccbe472
+Revises: 5c14f5a350dd
 Create Date: 2018-09-21 22:25:24.475167
 
 """

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -88,15 +88,6 @@
             });
         </script>
         {% endif %}
-      <script type="text/javascript">
-      $(function() {
-          $('.form-control-static').each(function(index) {
-            if($( this ).text().trim() == '') {
-                $(this).parents('.form-group').hide();
-            }
-          })
-      });
-      </script>
     {% endblock %}
 
     <meta charset="utf-8">
@@ -495,6 +486,15 @@
             <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
         <![endif]-->
         {% include "baseextra.html" %}
+      <script type="text/javascript">
+          $(function() {
+              $('.form-control-static').each(function(index) {
+                  if($( this ).text().trim() == '') {
+                      $(this).parents('.form-group').hide();
+                  }
+              })
+          });
+      </script>
     {% endblock %}
     {% block additional_scripts %}
         {% block page_scripts %} {% endblock %}

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1085,7 +1085,8 @@
 {% endset %}
 
 
-{% set hotel_request %}
+{% set requested_hotel_info %}
+{% set read_only = requested_hotel_info_ro or page_ro %}
 {% if c.HOTELS_ENABLED and c.PREREG_REQUEST_HOTEL_INFO_DURATION > 0 and (admin_area or (not is_prereg_attendee and not is_after_request_hotel)) %}
   {#-
     In both the admin area and non-preregistration forms, we will display a
@@ -1151,14 +1152,20 @@
 {% endset %}
 
 
-{% set accessibility_interest %}
-{% set read_only = accessibility_interest_ro or page_ro %}
+{% set requested_accessibility_services %}
+{% set read_only = requested_accessibility_services_ro or page_ro %}
 {% if c.ACCESSIBILITY_SERVICES_ENABLED %}
   <div class="form-group">
-    <label for="email_option" class="col-sm-3 control-label optional-field">Accessibility Services</label>
-    <div class="checkbox col-sm-9">
-      {{ macros.checkbox(attendee, 'requested_accessibility_services', label='I would like to be contacted by the ' ~ c.EVENT_NAME ~ ' Accessibility Services department prior to the event.', is_readonly=read_only) }}
-    </div>
+    <label for="requested_accessibility_services_option" class="col-sm-3 control-label optional-field">Accessibility Services</label>
+    {% if c.HAS_ACCESSIBILITY_ACCESS %}
+      <div class="checkbox col-sm-9">
+        {{ macros.checkbox(attendee, 'requested_accessibility_services', label='I would like to be contacted by the ' ~ c.EVENT_NAME ~ ' Accessibility Services department prior to the event.', is_readonly=read_only) }}
+      </div>
+    {% else %}
+      <div class="form-control-static">
+        <input type="hidden" name="requested_accessibility_services" value="{{ attendee.requested_accessibility_services|yesno("1,0") }}" />
+      </div>
+    {% endif %}
   </div>
 {% endif %}
 {% endset %}
@@ -1524,6 +1531,7 @@ $(function(){
     {{ macros.checkbox(attendee, 'got_merch', label='Yes', is_readonly=read_only) }}
   </div>
 </div>
+
 {% endset %}
 
 
@@ -1582,3 +1590,43 @@ $(function(){
 {% endcall %}
 </div>
 {% endset %}
+
+{% set agreed_to_volunteer_agreement %}
+{# Always read-only #}
+<div class="form-group staffing staffing-checked">
+  <label class="col-sm-3 control-label">Agreed to Volunteer Agreement</label>
+  <div class="col-sm-9">
+    <div class="form-control-static">
+      {% if c.VOLUNTEER_AGREEMENT_ENABLED %}{{ attendee.agreed_to_volunteer_agreement|yesno("Yes,No") }}{% endif %}
+      <input type="hidden" name="agreed_to_volunteer_agreement" value="{{ attendee.agreed_to_volunteer_agreement|yesno("1,0") }}" />
+    </div>
+  </div>
+</div>
+{% endset %}
+
+{% set hotel_eligible %}
+{# Always read-only #}
+<div class="form-group staffing staffing-checked">
+  <label class="col-sm-3 control-label">Hotel Eligible</label>
+  <div class="col-sm-9">
+    <div class="form-control-static">
+      {% if c.HAS_STAFF_ROOMS_ACCESS %}{{ attendee.agreed_to_volunteer_agreement|yesno("Yes,No") }}{% endif %}
+      <input type="hidden" name="hotel_eligible" value="{{ attendee.hotel_eligible|yesno("1,0") }}" />
+    </div>
+  </div>
+</div>
+{% endset %}
+
+{% set attractions_opt_out %}
+{# Always read-only #}
+<div class="form-group">
+  <label class="col-sm-3 control-label">Attraction Sign-Ups</label>
+  <div class="col-sm-9">
+    <div class="form-control-static">
+      {% if c.ATTRACTIONS_ENABLED %}{{ attendee.attractions_opt_out|yesno("Disabled,Enabled") }}{% endif %}
+      <input type="hidden" name="attractions_opt_out" value="{{ attendee.attractions_opt_out|yesno("1,0") }}" />
+    </div>
+  </div>
+</div>
+{% endset %}
+

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1157,7 +1157,7 @@
 {% if c.ACCESSIBILITY_SERVICES_ENABLED %}
   <div class="form-group">
     <label for="requested_accessibility_services_option" class="col-sm-3 control-label optional-field">Accessibility Services</label>
-    {% if c.HAS_ACCESSIBILITY_ACCESS %}
+    {% if c.HAS_ACCESSIBILITY_ACCESS or not admin_area %}
       <div class="checkbox col-sm-9">
         {{ macros.checkbox(attendee, 'requested_accessibility_services', label='I would like to be contacted by the ' ~ c.EVENT_NAME ~ ' Accessibility Services department prior to the event.', is_readonly=read_only) }}
       </div>

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -74,7 +74,7 @@
       {{ attendee_fields.found_how }}
       {{ attendee_fields.comments }}
       {{ attendee_fields.can_spam }}
-      {{ attendee_fields.accessibility_interest }}
+      {{ attendee_fields.requested_accessibility_services }}
       {% if attendee.placeholder %}{{ attendee_fields.pii_consent_checkbox }}{% endif %}
 
       {# Deprecated form included for backwards compatibility with old plugins #}

--- a/uber/templates/preregistration/register_group_member.html
+++ b/uber/templates/preregistration/register_group_member.html
@@ -33,7 +33,7 @@
       {{ attendee_fields.comments }}
       {{ attendee_fields.can_spam }}
       {{ attendee_fields.promo_code }}
-      {{ attendee_fields.accessibility_interest }}
+      {{ attendee_fields.requested_accessibility_services }}
       {{ attendee_fields.pii_consent_checkbox }}
       {# Deprecated form included for backwards compatibility with old plugins #}
       {% include "regform.html" %}

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -56,6 +56,7 @@
 {{ attendee_fields.found_how }}
 {{ attendee_fields.comments }}
 {{ attendee_fields.can_spam }}
+{{ attendee_fields.attractions_opt_out }}
 
 {% block post_regform %}{% endblock %}
 
@@ -63,6 +64,8 @@
 {{ attendee_fields.job_interests }}
 {{ attendee_fields.assigned_depts }}
 {{ attendee_fields.setup_teardown }}
+{{ attendee_fields.hotel_eligible }}
+{{ attendee_fields.agreed_to_volunteer_agreement }}
 
 {{ attendee_fields.got_merch }}
 
@@ -74,6 +77,8 @@
 {{ attendee_fields.merch }}
 {{ attendee_fields.staff_merch }}
 {{ attendee_fields.regdesk_info }}
+{{ attendee_fields.requested_hotel_info }}
+{{ attendee_fields.requested_accessibility_services }}
 {{ attendee_fields.for_review }}
 {{ attendee_fields.admin_notes }}
 {# Deprecated form included for backwards compatibility with old plugins #}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-534. Also (hopefully) fixes any other 'reset' bug for this form, except for `got_swadge` (which is supposedly not meant to be permanent so I'm not adding new code) and any columns that come from event plugins (we'll need to fix those in their respective plugins).

To explain what's going on: checkboxes always pass either a string, or no value at all -- we tell our page handler to process them by telling it which fields are boolean, so it can interpret a value as "Yes" and a lack of value as "No." However, we were telling it to check every boolean column that an Attendee object could have, and many of those values were not actually represented on our admin form. Now they are.