### PR TITLE
Stop resetting boolean values on confirmation page

### DIFF
--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1597,7 +1597,7 @@ $(function(){
   <label class="col-sm-3 control-label">Agreed to Volunteer Agreement</label>
   <div class="col-sm-9">
     <div class="form-control-static">
-      {% if c.VOLUNTEER_AGREEMENT_ENABLED %}{{ attendee.agreed_to_volunteer_agreement|yesno("Yes,No") }}{% endif %}
+      {% if c.VOLUNTEER_AGREEMENT_ENABLED and admin_area %}{{ attendee.agreed_to_volunteer_agreement|yesno("Yes,No") }}{% endif %}
       <input type="hidden" name="agreed_to_volunteer_agreement" value="{{ attendee.agreed_to_volunteer_agreement|yesno("1,0") }}" />
     </div>
   </div>
@@ -1623,7 +1623,7 @@ $(function(){
   <label class="col-sm-3 control-label">Attraction Sign-Ups</label>
   <div class="col-sm-9">
     <div class="form-control-static">
-      {% if c.ATTRACTIONS_ENABLED %}{{ attendee.attractions_opt_out|yesno("Disabled,Enabled") }}{% endif %}
+      {% if c.ATTRACTIONS_ENABLED and admin_area %}{{ attendee.attractions_opt_out|yesno("Disabled,Enabled") }}{% endif %}
       <input type="hidden" name="attractions_opt_out" value="{{ attendee.attractions_opt_out|yesno("1,0") }}" />
     </div>
   </div>

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -64,6 +64,7 @@
       {{ attendee_fields.extra_donation }}
       {{ attendee_fields.staffing }}
       {{ attendee_fields.job_interests }}
+      {{ attendee_fields.agreed_to_volunteer_agreement }}
       {{ attendee_fields.age }}
       {{ attendee_fields.email }}
       {{ attendee_fields.address }}
@@ -75,6 +76,8 @@
       {{ attendee_fields.comments }}
       {{ attendee_fields.can_spam }}
       {{ attendee_fields.requested_accessibility_services }}
+      {{ attendee_fields.requested_hotel_info }}
+      {{ attendee_fields.attractions_opt_out }}
       {% if attendee.placeholder %}{{ attendee_fields.pii_consent_checkbox }}{% endif %}
 
       {# Deprecated form included for backwards compatibility with old plugins #}


### PR DESCRIPTION
Same as https://github.com/magfest/ubersystem/pull/3474, but for the non-restricted booleans that would be reset on someone's confirmation page.