### PR TITLE
Fix Group address form on admin pages

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -254,7 +254,7 @@ class MarketplaceEmailFixture(AutomatedEmailFixture):
 if c.DEALER_REG_START:
 
     MarketplaceEmailFixture(
-        'Your {EVENT_NAME} Dealer registration has been approved',
+        'Your {EVENT_NAME} {} has been approved'.format(c.DEALER_REG_TERM),
         'dealers/approved.html',
         lambda g: g.status == c.APPROVED,
         # query=Group.status == c.APPROVED,
@@ -262,7 +262,7 @@ if c.DEALER_REG_START:
         ident='dealer_reg_approved')
 
     MarketplaceEmailFixture(
-        'Reminder to pay for your {EVENT_NAME} Dealer registration',
+        'Reminder to pay for your {EVENT_NAME} {}'.format(c.DEALER_REG_TERM),
         'dealers/payment_reminder.txt',
         lambda g: g.status == c.APPROVED and days_after(30, g.approved)() and g.is_unpaid,
         # query=and_(
@@ -273,7 +273,7 @@ if c.DEALER_REG_START:
         ident='dealer_reg_payment_reminder')
 
     MarketplaceEmailFixture(
-        'Your {EVENT_NAME} ({EVENT_DATE}) Dealer registration is due in one week',
+        'Your {EVENT_NAME} ({EVENT_DATE}) {} is due in one week'.format(c.DEALER_REG_TERM),
         'dealers/payment_reminder.txt',
         lambda g: g.status == c.APPROVED and g.is_unpaid,
         # query=and_(Group.status == c.APPROVED, Group.is_unpaid == True),
@@ -282,7 +282,7 @@ if c.DEALER_REG_START:
         ident='dealer_reg_payment_reminder_due_soon')
 
     MarketplaceEmailFixture(
-        'Last chance to pay for your {EVENT_NAME} ({EVENT_DATE}) Dealer registration',
+        'Last chance to pay for your {EVENT_NAME} ({EVENT_DATE}) {}'.format(c.DEALER_REG_TERM),
         'dealers/payment_reminder.txt',
         lambda g: g.status == c.APPROVED and g.is_unpaid,
         # query=and_(Group.status == c.APPROVED, Group.is_unpaid == True),
@@ -337,7 +337,7 @@ AutomatedEmailFixture(
 
 AutomatedEmailFixture(
     Attendee,
-    '{EVENT_NAME} Dealer Information Required',
+    '{EVENT_NAME} {} Information Required'.format(c.DEALER_TERM.capitalize()),
     'placeholders/dealer.txt',
     lambda a: a.placeholder and a.is_dealer and a.group.status == c.APPROVED,
     # query=and_(

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -57,6 +57,13 @@ alt_schedule_url = string(default='')
 # MAGFest's is set as the default since it's theoretically event-agnostic
 admin_guide_url = string(default='https://www.notion.so/magfest/Uber-Guide-46e447e70b724618b8de96d37a77483c')
 
+# This changes the text that references the main vendor hall
+dealer_term = string(default='dealer')
+dealer_helper_term = string(default='Dealer Assistant')
+dealer_app_term = string(default='dealer application')
+dealer_loc_term = string(default='dealers room')
+dealer_reg_term = string(default='Dealer registration')
+
 # =============================
 # Feature Flags
 # =============================

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -171,7 +171,7 @@ def group_money(group):
 @prereg_validation.Group
 def edit_only_correct_statuses(group):
     if group.status not in [c.WAITLISTED, c.UNAPPROVED]:
-        return "You cannot change your dealer application after it has been {}.".format(group.status_label)
+        return "You cannot change your {} after it has been {}.".format(c.DEALER_APP_TERM, group.status_label)
 
 
 def _invalid_phone_number(s):
@@ -242,7 +242,7 @@ def promo_code_is_useful(attendee):
         if not attendee.is_unpaid:
             return "You can't apply a promo code after you've paid or if you're in a group."
         elif attendee.is_dealer:
-            return "You can't apply a promo code to a dealer registration."
+            return "You can't apply a promo code to a {}.".format(c.DEALER_REG_TERM)
         elif attendee.age_discount != 0:
             return "You are already receiving an age based discount, you can't use a promo code on top of that."
         elif attendee.badge_type == c.ONE_DAY_BADGE or attendee.is_presold_oneday:
@@ -455,7 +455,7 @@ def attendee_money(attendee):
 @validation.Attendee
 def dealer_needs_group(attendee):
     if attendee.is_dealer and not attendee.badge_type == c.PSEUDO_DEALER_BADGE and not attendee.group_id:
-        return 'Dealers must be associated with a group'
+        return '{}s must be associated with a group'.format(c.DEALER_TERM)
 
 
 @validation.Attendee

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -213,13 +213,13 @@ class Root:
                         send_email.delay(
                             c.MARKETPLACE_EMAIL,
                             c.MARKETPLACE_EMAIL,
-                            'Dealer Application Received',
+                            '{} Received'.format(c.DEALER_APP_TERM),
                             render('emails/dealers/reg_notification.txt', {'group': group}, encoding=None),
                             model=group.to_dict('id'))
                         send_email.delay(
                             c.MARKETPLACE_EMAIL,
                             attendee.email,
-                            'Dealer Application Received',
+                            '{} Received'.format(c.DEALER_APP_TERM),
                             render('emails/dealers/application.html', {'group': group}, encoding=None),
                             'html',
                             model=group.to_dict('id'))
@@ -265,8 +265,8 @@ class Root:
                     attendee.requested_hotel_info = True
 
             if attendee.badge_type == c.PSEUDO_DEALER_BADGE and c.DEALER_REG_SOFT_CLOSED:
-                message = 'Dealer registration is closed, but you can ' \
-                    'fill out this form to add yourself to our waitlist'
+                message = '{} is closed, but you can ' \
+                    'fill out this form to add yourself to our waitlist'.format(c.DEALER_REG_TERM.capitalize())
 
         promo_code_group = None
         if attendee.promo_code:
@@ -534,7 +534,7 @@ class Root:
                     send_email.delay(
                         c.MARKETPLACE_EMAIL,
                         c.MARKETPLACE_EMAIL,
-                        'Dealer Application Changed',
+                        '{} Changed'.format(c.DEALER_APP_TERM),
                         render('emails/dealers/appchange_notification.html', {'group': group}, encoding=None),
                         'html',
                         model=group.to_dict('id'))
@@ -618,11 +618,11 @@ class Root:
                     send_email.delay(
                         c.MARKETPLACE_EMAIL,
                         c.MARKETPLACE_EMAIL,
-                        'Dealer Payment Completed',
+                        '{} Payment Completed'.format(c.DEALER_TERM.capitalize()),
                         render('emails/dealers/payment_notification.txt', {'group': group}, encoding=None),
                         model=group.to_dict('id'))
                 except Exception:
-                    log.error('unable to send dealer payment confirmation email', exc_info=True)
+                    log.error('unable to send {} payment confirmation email'.format(c.DEALER_TERM), exc_info=True)
             raise HTTPRedirect('group_members?id={}&message={}', group.id, 'Your payment has been accepted!')
 
     @csrf_protected
@@ -692,7 +692,7 @@ class Root:
                 send_email.delay(
                     c.MARKETPLACE_EMAIL,
                     c.MARKETPLACE_EMAIL,
-                    'Dealer Paid for Extra Members',
+                    '{} Paid for Extra Members'.capitalize(c.DEALER_TERM.capitalize()),
                     render('emails/dealers/payment_notification.txt', {'group': group}, encoding=None),
                     model=group.to_dict('id'))
             raise HTTPRedirect(

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -266,7 +266,7 @@ class Root:
     def dealer_table_info(self, out, session):
         out.writerow([
             'Business Name',
-            'Dealer Name',
+            'Table Name',
             'Description',
             'URL',
             'Point of Contact',

--- a/uber/templates/budget/index.html
+++ b/uber/templates/budget/index.html
@@ -32,7 +32,7 @@
       {{ table_entry('Attendee Badges', preregs.Attendee) }}
       {{ table_entry('Extra Payments (Kickins, Shirts, Food, anything else)', preregs.extra) }}
       {{ table_entry('Group Badges', preregs.group_badges) }}
-      {{ table_entry('Dealer Badges', preregs.dealer_badges) }}
+      {{ table_entry(c.DEALER_TERM + ' Badges', preregs.dealer_badges) }}
       {{ table_entry('Staff Badges', preregs.Staff) }}
       {{ table_entry('Single Day Badges', preregs.OneDay) }}
 

--- a/uber/templates/emails/dealers/appchange_notification.html
+++ b/uber/templates/emails/dealers/appchange_notification.html
@@ -7,7 +7,7 @@
 <br/><br/>Below is the new application:
 
 <ul>
-    <li><strong>Dealer Table Name</strong>: {{ group.name }}</li>
+    <li><strong>Table Name</strong>: {{ group.name }}</li>
     <li><strong>What do you sell?</strong> {{ group.wares }}</li>
     <li><strong>Description</strong>: {{ group.description }}</li>
     {% if group.special_needs %}<li><strong>Table Requests and Special Requests</strong>: {{ group.special_needs }}</li>{% endif %}

--- a/uber/templates/emails/dealers/application.html
+++ b/uber/templates/emails/dealers/application.html
@@ -2,12 +2,12 @@
 <head></head>
 <body>
 
-Your group ({{ group.name }}) has successfully submitted a Dealer application for {{ c.EVENT_NAME }}
+Your group ({{ group.name }}) has successfully submitted a {{ c.DEALER_APP_TERM }} for {{ c.EVENT_NAME }}
 this coming {{ event_dates() }}. Below is a copy of your application. You may
 <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">update it here</a> or
 <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader.id }}">view your badge here</a>.
 <ul>
-    <li><strong>Dealer Table Name</strong>: {{ group.name }}</li>
+    <li><strong>Table Name</strong>: {{ group.name }}</li>
     <li><strong>Tables</strong>: {{ group.tables }} table{{ group.tables|pluralize }} (${{ group.table_cost|round(2) }}) </li>
     <li><strong>Badges</strong>: {{ group.badges }} badge{{ group.badges|pluralize }} (${{ group.badge_cost|round(2) }}) </li>
     <li><strong>Total Price</strong> ${{ group.cost }}</li>
@@ -37,7 +37,7 @@ not approved to vend.
     {% include "preregistration/hotel_disclaimer.html" %}
 {%- endif %}
 
-<br/> <br/> <u>Dealer Rules and Information</u>
+<br/> <br/> <u>{{ c.DEALER_LOC_TERM|capitalize }} Rules and Information</u>
 {% include "static_views/dealerRules.html" %}
 
 </body>

--- a/uber/templates/emails/dealers/approved.html
+++ b/uber/templates/emails/dealers/approved.html
@@ -1,7 +1,7 @@
 <html>
 <head></head>
 <body>
-Your group ({{ group.name }}) has been approved as a {{ c.EVENT_NAME }} Dealer for this coming {{ event_dates() }}!
+Your group ({{ group.name }}) has been approved as a {{ c.EVENT_NAME }} {{ c.DEALER_TERM }} for this coming {{ event_dates() }}!
 You can pay the ${{ group.cost }} you owe using the credit card button
 <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">on this page</a>.
 Payment is expected by: {{ c.DEALER_PAYMENT_DUE|datetime_local }} or your application may be removed and your tables filled by another applicant.
@@ -21,7 +21,7 @@ This registration includes:
     <li> {{ group.badges }} badge{{ group.badges|pluralize }} (${{ group.badge_cost|round(2) }}) </li>
 </ul>
 
-<br/> <u>Dealer Rules and Information</u>
+<br/> <u>{{ c.DEALER_LOC_TERM|capitalize }} Rules and Information</u>
 {% include "static_views/dealerRules.html" %}
 
 

--- a/uber/templates/emails/dealers/badge_converted.html
+++ b/uber/templates/emails/dealers/badge_converted.html
@@ -4,12 +4,12 @@
 
 {{ attendee.first_name }},
 
-<br/><br/>Although your group ({{ group.name}}) {{ 'cancelled their dealer application' if group.status == c.CANCELLED else 'was not taken off the waitlist' }}, we think you may still want to come and enjoy all that {{ c.EVENT_NAME }} has to offer!
+<br/><br/>Although your group ({{ group.name}}) {{ 'cancelled their ' + c.DEALER_APP_TERM if group.status == c.CANCELLED else 'was not taken off the waitlist' }}, we think you may still want to come and enjoy all that {{ c.EVENT_NAME }} has to offer!
 Therefore, we have reserved a badge for you{% if c.PRICE_BUMPS and attendee.badge_cost < c.BADGE_PRICE %} at the price of registration when you first applied{% endif %}.
 Badges went to anyone in your group who had a valid email on the badge, and any unassigned badges were dropped.
 
-<br/><br/>Please note: You are choosing to accept or decline an ATTENDEE badge at the price it would have been had you bought it instead of applying to be a dealer.
-  <strong>You were not accepted as a dealer, and will not have space in the Marketplace.</strong>
+<br/><br/>Please note: You are choosing to accept or decline an ATTENDEE badge at the price it would have been had you bought it instead of applying for the {{ c.DEALER_LOC_TERM }}.
+  <strong>You were not accepted as a {{ c.DEALER_TERM }}, and will not have space in the {{ c.DEALER_LOC_TERM }}.</strong>
 
 <br/><br/>Please go ahead and confirm or decline <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">your registration</a>. We hope to see you this year!
 

--- a/uber/templates/emails/dealers/payment_notification.txt
+++ b/uber/templates/emails/dealers/payment_notification.txt
@@ -1,2 +1,2 @@
-"{{ group.name }}" has just paid ${{ group.amount_paid }} for their Dealer registration.
+"{{ group.name }}" has just paid ${{ group.amount_paid }} for their {{ c.DEALER_REG_TERM }}.
 {{ c.URL_BASE }}/groups/form?id={{ group.id }}

--- a/uber/templates/emails/dealers/payment_reminder.txt
+++ b/uber/templates/emails/dealers/payment_reminder.txt
@@ -1,6 +1,6 @@
 {{ group.leader.first_name }},
 
-Thanks again for registering as a Dealer for this year's {{ c.EVENT_NAME }}.  Our records indicate that your Dealer registration ({{ group.name }}) is still unpaid, and if we do not receive payment by {{ c.DEALER_PAYMENT_DUE|datetime_local }} then it will be deleted.
+Thanks again for registering as a {{ c.DEALER_TERM }} for this year's {{ c.EVENT_NAME }}.  Our records indicate that your Dealer registration ({{ group.name }}) is still unpaid, and if we do not receive payment by {{ c.DEALER_PAYMENT_DUE|datetime_local }} then it will be deleted.
 
 You can use the credit card button on your group's page to pay the ${{ group.amount_unpaid }} that you owe: {{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}
 

--- a/uber/templates/emails/dealers/reg_notification.txt
+++ b/uber/templates/emails/dealers/reg_notification.txt
@@ -1,2 +1,2 @@
-"{{ group.name }}" has just applied for a Dealer registration{% if c.DEALER_REG_SOFT_CLOSED %} and was automatically waitlisted{% endif %}:
+"{{ group.name }}" has just applied for a {{ c.DEALER_REG_TERM }}{% if c.DEALER_REG_SOFT_CLOSED %} and was automatically waitlisted{% endif %}:
 {{ c.URL_BASE }}/groups/form?id={{ group.id }}

--- a/uber/templates/emails/reg_workflow/group_confirmation.html
+++ b/uber/templates/emails/reg_workflow/group_confirmation.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
 
-Your {{ group.is_dealer|yesno("Dealer registration,group") }} ({{ group.name }}) has been preregistered for
+Your {{ group.is_dealer|yesno(c.DEALER_REG_TERM + ",group") }} ({{ group.name }}) has been preregistered for
 {{ c.EVENT_NAME }} this coming {{ event_dates() }} and your payment of ${{ group.amount_paid }} has been received.
 
 {% if group.unregistered_badges %}

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -7,7 +7,7 @@
 
 {% set prereg_intro %}
 {% if is_prereg_dealer %}
-  <h2 class="text-center">Dealer Application</h2>
+  <h2 class="text-center">{{ c.DEALER_APP_TERM|capitalize }}</h2>
 {% elif is_prereg_attendee %}
   {{ macros.prereg_wizard(c.PAGE_PATH, c.PREREG_REQUEST_HOTEL_INFO_OPEN) }}
 
@@ -31,9 +31,9 @@
     {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC and c.DEALER_REG_OPEN %}
       <div class="form-group row">
         <p class="col-sm-9 col-sm-offset-3">
-          <strong>Dealers:</strong>
+          <strong>{{ c.DEALER_TERM }}s:</strong>
           {% if c.BEFORE_DEALER_REG_START %}
-            Registrations for dealer memberships begin {{ c.DEALER_REG_START|datetime_local }}.
+            {{ c.DEALER_REG_TERM|capitalize }} begin {{ c.DEALER_REG_START|datetime_local }}.
           {% else %}
             Please register <a href="dealer_registration">here</a>.
           {% endif %}

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -259,18 +259,20 @@
 
 {% set address %}
 {% set read_only = group_address_ro or page_ro %}
-{% if not read_only and not admin_area %}
+{% if not read_only %}
   {% if not c.COLLECT_FULL_ADDRESS or not attendee %}
     <script type="text/javascript">
         {% include "region_opts.html" %}
     </script>
   {% endif %}
+  {% if not admin_area %}
   <div class="form-group">
     <p class="col-sm-10 col-sm-offset-1">
       Please enter your <strong>business</strong> address below. This
       should be the address you use for tax purposes.
     </p>
   </div>
+  {% endif %}
 {% endif %}
 
 {{ macros.address_form(group, name_prefix="group_", is_readonly=read_only, is_required=True) }}

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -17,11 +17,11 @@
           <a href="#" onClick="$('#setstatus').toggle(); return false;">Waitlist or Decline (with Email)</a> <br/>
           <div id="setstatus" style="display:none">
             Enter an email message to be sent along with the notification: <br/>
-            (The email subject will be "Your {{ c.EVENT_NAME }} Dealer registration has been [waitlisted | declined]")
+            (The email subject will be "Your {{ c.EVENT_NAME }} {{ c.DEALER_REG_TERM }} has been [waitlisted | declined]")
             <textarea name="email" class="form-control" rows="5" cols="50"></textarea> <br/>
             <button class="btn btn-warning" onClick="unapprove('waitlisted'); return false;">Waitlist</button>
             <button class="btn btn-danger" onClick="unapprove('declined'); return false;">Reject and Convert Badges</button>
-            <p class="help-block">(Rejected dealers are able to register at the price they would have paid when they applied.)</p>
+            <p class="help-block">(Rejected {{ c.DEALER_TERM }}s are able to register at the price they would have paid when they applied.)</p>
           </div>
         {% endif %}
       </div>
@@ -31,7 +31,7 @@
   {# Always read-only for attendees #}
   {% if group.status == c.APPROVED %}
     <div class="alert alert-success">
-    Congratulations, your dealer application has been <strong>approved</strong>!
+    Congratulations, your {{ c.DEALER_APP_TERM }} has been <strong>approved</strong>!
     {% if group.cost %}
       <br/><br/>Here is your group's cost breakdown:
       <ul>
@@ -52,11 +52,11 @@
     {% endif %}
   {% elif group.status == c.CANCELLED %}
     <div class="alert alert-info">
-    You have <strong>cancelled</strong> your dealer application. If this was a mistake, please contact us at
+    You have <strong>cancelled</strong> your {{ c.DEALER_APP_TERM }}. If this was a mistake, please contact us at
     <a href="mailto:{{ c.MARKETPLACE_EMAIL }}">{{ c.MARKETPLACE_EMAIL }}</a>.
   {% else %}
     <div class="alert alert-{{ 'danger' if group.status == c.DECLINED else 'warning' }}">
-    Your dealer application {{ 'is' if group.status == c.UNAPPROVED else 'has been' }} <strong>{{ group.status_label }}</strong>.
+    Your {{ c.DEALER_APP_TERM }} {{ 'is' if group.status == c.UNAPPROVED else 'has been' }} <strong>{{ group.status_label }}</strong>.
   {% endif %}
 </div>
 {% endif %}
@@ -67,7 +67,7 @@
 {% set read_only = group_name_ro or page_ro %}
 <div class="group_fields">
   <div class="form-group">
-    <label for="name" class="col-sm-3 control-label">{{ "Dealer Table" if attendee_or_group.is_dealer else "Group" }} Name</label>
+    <label for="name" class="col-sm-3 control-label">{{ "Table" if attendee_or_group.is_dealer else "Group" }} Name</label>
     {% call macros.read_only_if(read_only, attendee_or_group.name) %}
       <div class="col-sm-6">
         <input type="text" name="name" class="form-control" value="{{ attendee_or_group.name }}" maxlength="40" />

--- a/uber/templates/graphs/index.html
+++ b/uber/templates/graphs/index.html
@@ -16,8 +16,8 @@
 
         <h1>Badges sold per day:</h1>
         <p>
-            This graph only includes attendees that have paid in full and are not dealers.
-            It does not include comp'd badges for staff, guests, bands. It does not include dealers.
+            This graph only includes attendees that have paid in full and are not {{ c.DEALER_TERM }}s.
+            It does not include comp'd badges for staff, guests, bands. It does not include {{ c.DEALER_TERM }}s.
         </p>
 
     <div id="attendanceGraphScroller">

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -34,7 +34,7 @@
 
     $(function() {
         {% if group.is_new and not new_dealer %}
-            $.field("status").find("[value={{ c.UNAPPROVED }}]").text("n/a (not a paid Dealer)");
+            $.field("status").find("[value={{ c.UNAPPROVED }}]").text("n/a (not a paid {{ c.DEALER_TERM }})");
         {% endif %}
     });
 

--- a/uber/templates/groups/index.html
+++ b/uber/templates/groups/index.html
@@ -24,7 +24,7 @@
   </div>
   <div class="panel-footer">
     <a class="btn btn-default" href="form?id=None">Add a group</a>
-    <a class="btn btn-default" href="form?id=None&new_dealer=true">Add a dealer</a>
+    <a class="btn btn-default" href="form?id=None&new_dealer=true">Add a {{ c.DEALER_TERM }}</a>
   </div>
 </div>
 

--- a/uber/templates/groups/waitlist.html
+++ b/uber/templates/groups/waitlist.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% block title %}Waitlisted Dealers{% endblock %}
+{% block title %}Waitlisted {{ c.DEALER_TERM|capitalize }}s{% endblock %}
 {% block content %}
 
 <style type="text/css">
@@ -13,11 +13,11 @@
       event.preventDefault();
       bootbox.confirm({
         backdrop: true,
-        title: 'Decline All Waitlisted Dealers?',
-        message: '<p>Are you sure you want to decline <b>EVERY</b> waitlisted dealer?</p>' +
+        title: 'Decline All Waitlisted {{ c.DEALER_TERM|capitalize }}s?',
+        message: '<p>Are you sure you want to decline <b>EVERY</b> waitlisted {{ c.DEALER_TERM }}?</p>' +
           '<p>This will delete the groups and convert the badges to normal Attendee badges ' +
           'at the price of registration when they first applied. An email will be sent to ' +
-          'each declined dealer.</p>' +
+          'each declined {{ c.DEALER_TERM }}.</p>' +
           '<p>This <b>CANNOT</b> be undone.</p>',
         buttons: {
           confirm: { label: '<span class="glyphicon glyphicon-repeat"></span> Decline & Convert', className: 'btn-danger' },
@@ -41,7 +41,7 @@
       Decline & Convert
     </button>
   </form>
-  Waitlisted Dealers
+  Waitlisted {{ c.DEALER_TERM|capitalize }}s
 </h2>
 <div class="clearfix"></div>
 <table class="table table-striped datatable">

--- a/uber/templates/preregistration/add_group_members.html
+++ b/uber/templates/preregistration/add_group_members.html
@@ -7,7 +7,7 @@
   <div class="panel-body">
     <h2> Add Members to {{ group.name }} </h2>
 
-    You've indicated you'd like to add {{ count }} {{ group.is_dealer|yesno("Dealer Assistants,group members") }}, at a cost of ${{ charge.dollar_amount }}.
+    You've indicated you'd like to add {{ count }} {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}, at a cost of ${{ charge.dollar_amount }}.
 
     <table style="width: auto; margin: 15px auto 0;">
       <tr>

--- a/uber/templates/preregistration/dealer_confirmation.html
+++ b/uber/templates/preregistration/dealer_confirmation.html
@@ -1,13 +1,13 @@
 {% extends "./preregistration/preregbase.html" %}
-{% block title %}Dealer Application Received{% endblock %}
+{% block title %}{{ c.DEALER_APP_TERM|capitalize }} Received{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
 {% include 'prereg_masthead.html' %}
 <div class="panel panel-default">
   <div class="panel-body">
-    <h2>{% if group.status == c.WAITLISTED %}You've been added to our waitlist!{% else %}Thanks for applying as a Dealer!{% endif %}</h2>
+    <h2>{% if group.status == c.WAITLISTED %}You've been added to our waitlist!{% else %}Thanks for applying as a {{ c.DEALER_TERM }}!{% endif %}</h2>
 
-    We've received your application for {{ group.name }} to purchase a Dealer registration for {{ c.EVENT_NAME }}.
+    We've received your application for {{ group.name }} to purchase a {{ c.DEALER_REG_TERM }} for {{ c.EVENT_NAME }}.
 
     <br/><br/>
     {% if group.status == c.WAITLISTED %}
@@ -18,20 +18,20 @@
     {% endif %}
 
     <h3>What Happens Next</h3>
-    After approval, you will be emailed a link to manage your dealer registration. From this link, you will be able to:
+    After approval, you will be emailed a link to manage your {{ c.DEALER_REG_TERM }}. From this link, you will be able to:
     <ul>
-        <li>Pay for your dealer registration, which includes the cost of tables and badges.</li>
-        <li>Register your Dealer Assistants.</li>
-        <li>After your badge and table payment is received, you may add and pay for additional Dealer Assistants.</li>
+        <li>Pay for your {{ c.DEALER_REG_TERM }}, which includes the cost of tables and badges.</li>
+        <li>Register your {{ c.DEALER_HELPER_TERM }}s.</li>
+        <li>After your badge and table payment is received, you may add and pay for additional {{ c.DEALER_HELPER_TERM }}s.</li>
     </ul>
 
-    Your Dealership Payment includes your table cost and all badges in your group.  After payment, you'll be sent a link
-    by email to follow if you wish to later upgrade your badge. Your Dealer Assistants will be able to upgrade their own
+    Your {{ c.DEALER_REG_TERM }} payment includes your table cost and all badges in your group.  After payment, you'll be sent a link
+    by email to follow if you wish to later upgrade your badge. Your {{ c.DEALER_HELPER_TERM }}s will be able to upgrade their own
     badges and pay for those upgrades on their own.
 
     <br/><br/>Later, you will receive another email with more specific information about this year's event.
 
-    <br/><br/>In the event we cannot accommodate your Dealership, you will receive an email. If your application
+    <br/><br/>In the event we cannot accommodate your {{ c.DEALER_REG_TERM }}, you will receive an email. If your application
     is not approved, you will be able to purchase badges for yourself and the number of assistants on the application
     at the pre-registration price of ${{ c.BADGE_PRICE }} when the waitlist is exhausted. You will receive an email
     when these badges are available for purchase.

--- a/uber/templates/preregistration/disclaimers.html
+++ b/uber/templates/preregistration/disclaimers.html
@@ -22,7 +22,7 @@
     badges so any surprises aren't ruined.
   </li>
   <li>
-    Attendees (including dealers) must abide by our
+    Attendees (including {{ c.DEALER_TERM }}s) must abide by our
     <a href="http://super.magfest.org/codeofconduct">code of conduct</a>.
   </li>
   {% if c.CONSENT_FORM_URL %}

--- a/uber/templates/preregistration/duplicate.html
+++ b/uber/templates/preregistration/duplicate.html
@@ -32,7 +32,7 @@
 
     {% if attendee.group and attendee.group.is_dealer and attendee.group.status != c.APPROVED %}
         <br/> <br/>
-        It looks like your dealership application has not been approved yet. If your application
+        It looks like your {{ c.DEALER_REG_TERM }} application has not been approved yet. If your application
         is not approved, you will be able to purchase badges for yourself and the number of assistants on the application
         at the pre-registration price of ${{ attendee.badge_cost }} when the waitlist is exhausted. You will receive an email
         when these badges are available for purchase.

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -75,7 +75,7 @@
         {{ group_fields.address }}
         {% if not page_ro %}
         <button type="submit" class="btn btn-primary" value="Update Application">Update Application</button>
-        <button type="submit" class="btn btn-danger" value="Cancel Dealer Application" form="cancel_dealer">Cancel Application</button>
+        <button type="submit" class="btn btn-danger" value="Cancel {{ c.DEALER_APP_TERM|capitalize }}" form="cancel_dealer">Cancel Application</button>
         {% endif %}
       </form>
         <form method="post" id="cancel_dealer" action="../groups/cancel_dealer" class="form-horizontal" role="form">
@@ -94,12 +94,12 @@
 
 <div style="margin:15px">
     {% if group.unregistered_badges and group.tables %}
-        Some of your Dealer Assistant badges are not yet assigned to a specific person. Using the links below, please assign these badges before the close of preregistration; any badges unclaimed at that time will be
+        Some of your {{ c.DEALER_HELPER_TERM }} badges are not yet assigned to a specific person. Using the links below, please assign these badges before the close of preregistration; any badges unclaimed at that time will be
         invalid. You may also distribute each of the registration links below to the individual members of your group,
         which will allow them to fill in their own information as well as purchase any upgrades on their own.
         <br/> <br/>
     {% endif %}
-    If a {{ group.is_dealer|yesno("planned Dealer Assistant,group member") }} cannot attend, you may use the "This person
+    If a {{ group.is_dealer|yesno("planned " + c.DEALER_HELPER_TERM + ",group member") }} cannot attend, you may use the "This person
     isn't coming" button next to their entry on the list below to unset their badge, which may then be assigned to
     someone else. Upgraded badges may only be transferred directly between two people; please contact us at
     <a href="{{ c.CONTACT_URL }}">{{ c.CONTACT_URL }}</a> if you wish to transfer badges.
@@ -167,7 +167,7 @@
         <input type="hidden" name="id" value="{{ group.id }}" />
         <p>
           {%- set min_badges = group.min_badges_addable -%}
-          {%- set members = group.is_dealer|yesno("Dealer Assistants,group members") -%}
+          {%- set members = group.is_dealer|yesno(c.DEALER_HELPER_TERM + ",group members") -%}
           Enter the number of {{ members }} to add.
           {% if min_badges > 1 -%}
             {%- set hours_remaining = group.hours_remaining_in_grace_period -%}
@@ -188,7 +188,7 @@
             {{ int_options(min_badges, 10) }}
           {%- endif -%}
         </select>
-        <input class="btn btn-primary" type="submit" value="{{ group.is_dealer|yesno("Add Dealer Assistants,Add Group Members") }}">
+        <input class="btn btn-primary" type="submit" value="{{ group.is_dealer|yesno("Add " + c.DEALER_HELPER_TERM + ",Add Group Members") }}">
       </form>
     </div>
 
@@ -196,12 +196,12 @@
         {% if group.amount_unpaid %}
             $(function(){
                 $('<div class="disabled" title="Group must be paid for before new members can be added">' +
-                    '<button disabled class="btn btn-primary">Click here to add more {{ group.is_dealer|yesno("Dealer Assistants,group members") }}</button>' +
+                    '<button disabled class="btn btn-primary">Click here to add more {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}</button>' +
                   '</div>').insertAfter($("#add"));
             });
         {% else %}
             $(function(){
-                $('<button class="btn btn-primary">Click here to add more {{ group.is_dealer|yesno("Dealer Assistants,group members") }}</button>').click(function(e){
+                $('<button class="btn btn-primary">Click here to add more {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}</button>').click(function(e){
                         $(e.target).hide();
                         $("#add").show();
                     }).insertAfter($("#add"));

--- a/uber/templates/registration/duplicate.html
+++ b/uber/templates/registration/duplicate.html
@@ -31,7 +31,7 @@
     editing the attendee's name if at all possible, as badges with duplicate names may be picked up by the wrong
     person.
     {% if attendee.paid == c.PAID_BY_GROUP and attendee.group.status == c.WAITLISTED %}
-        Please keep in mind that dealers have an option to buy their badge once the Marketplace fills up, so you
+        Please keep in mind that {{ c.DEALER_TERM }}s have an option to buy their badge once the {{ c.DEALER_LOC_TERM }} fills up, so you
         normally do not need to create an additional badge for them.
     {% endif %}
     If you are at all not sure what to do, contact your Registration department at {{ c.REGDESK_EMAIL }}.

--- a/uber/templates/static_views/attendees.html
+++ b/uber/templates/static_views/attendees.html
@@ -14,7 +14,7 @@ all of the things listed below, most of which are open 24-hours per day:
     <li> LAN room </li>
     <li> tabletop room </li>
     <li> jam space </li>
-    <li> dealers room </li>
+    <li> {{ c.DEALER_LOC_TERM }} </li>
     <li> video room </li>
     <li> arcade cabinets, all on free-play </li>
     <li> all of our nightly concerts </li>

--- a/uber/templates/static_views/dealerRules.html
+++ b/uber/templates/static_views/dealerRules.html
@@ -2,14 +2,14 @@
     <li> Be kind to your neighbors and respectful of space. </li>
     <li> No taking tables, even unused ones. You get the number of tables that you paid for. Also, you may not use the hotel carts as an addition to your table. </li>
     <li> Your displays and products cannot block the aisles or walkways. </li>
-    <li> You can set up and leave anytime - there are no set dealer hours. We run 24 hours, but it is up to if you want to be open that long. </li>
+    <li> You can set up and leave anytime - there are no set {{ c.DEALER_TERM }} hours. We run 24 hours, but it is up to if you want to be open that long. </li>
     <li> No refunds are provided at anytime should you decide to leave {{ c.EVENT_NAME }} and stop selling before the event is over. We reserved your space on a per-event basis, not a per-day basis, so even partial refunds are not possible. </li>
-    <li> No selling out of a hotel room (this is against state law), away from the dealer area, or away from your table; i.e. no peddling. </li>
-    <li> Only people with dealer ribbons or guest badges are allowed behind the table - no regular attendee badges. </li>
+    <li> No selling out of a hotel room (this is against state law), away from the {{ c.DEALER_TERM }}, or away from your table; i.e. no peddling. </li>
+    <li> Only people with {{ c.DEALER_TERM }} ribbons or guest badges are allowed behind the table - no regular attendee badges. </li>
     <li> Electricity is free but not provided. You will need your own power strips, extension cords, and tape. However, we will help tape down the power cords. </li>
-    <li> There is no security provided for tables in the dealers room. Have a lockdown plan for when you leave or take your stuff with you. {{ c.EVENT_NAME }} is not responsible for lost or stolen property. There is minimal storage available on a first-come first-serve basis. A staffer will be required to access storage. Also, if you need a table watcher for a few minutes (e.g. for a bathroom break or run to the car), then we can get one for you. </li>
+    <li> There is no security provided for tables in the {{ c.DEALER_LOC_NAME }}. Have a lockdown plan for when you leave or take your stuff with you. {{ c.EVENT_NAME }} is not responsible for lost or stolen property. There is minimal storage available on a first-come first-serve basis. A staffer will be required to access storage. Also, if you need a table watcher for a few minutes (e.g. for a bathroom break or run to the car), then we can get one for you. </li>
     <li> If you catch a shoplifter, then notify us and we will handle it. </li>
-    <li> Do not leave trash in your dealer area once you pack up to leave. There will be a fine if {{ c.EVENT_NAME }} has to pick up the trash once you leave -- there are several trash bins provided for you to use. </li>
-    <li> If you would like to donate any prizes to our treasure chests (which are chests we place randomly throughout the festival for attendees to get prizes from) or tournaments, then we will mention that the item came from your table for some advertising. If you want to do this, then you can give the item to dealers room staff, who will make sure it gets to the right people. </li>
+    <li> Do not leave trash in your {{ c.DEALER_TERM }} area once you pack up to leave. There will be a fine if {{ c.EVENT_NAME }} has to pick up the trash once you leave -- there are several trash bins provided for you to use. </li>
+    <li> If you would like to donate any prizes to our treasure chests (which are chests we place randomly throughout the festival for attendees to get prizes from) or tournaments, then we will mention that the item came from your table for some advertising. If you want to do this, then you can give the item to {{ c.DEALER_LOC_NAME }} staff, who will make sure it gets to the right people. </li>
     <li> These rules are subject to change before {{ c.EVENT_NAME }}, but you will receive the most up to date rules at the start of the festival, which you will sign at that time. </li>
 </ul>

--- a/uber/templates/static_views/dealer_reg_closed.html
+++ b/uber/templates/static_views/dealer_reg_closed.html
@@ -1,16 +1,16 @@
 <html><head></head><body style='text-align:center'>
-    Dealers room applications for {{ c.EVENT_NAME_AND_YEAR }} ({{ c.EVENT_MONTH }} {{ c.EVENT_YEAR }}) are now closed.<br/>
+    {{ c.DEALER_APP_TERM }}s for {{ c.EVENT_NAME_AND_YEAR }} ({{ c.EVENT_MONTH }} {{ c.EVENT_YEAR }}) are now closed.<br/>
     {% if c.AFTER_DEALER_REG_DEADLINE %}
       <br/>
-      The deadline for dealer registration was {{ c.DEALER_REG_DEADLINE|datetime_local }}.
+      The deadline for {{ c.DEALER_REG_TERM }} was {{ c.DEALER_REG_DEADLINE|datetime_local }}.
       <br/>
     {% elif c.AFTER_DEALER_REG_SHUTDOWN %}
       <br/>
-      Dealer registration was shut down {{ c.DEALER_REG_SHUTDOWN|datetime_local }}.
+      {{ c.DEALER_REG_TERM|capitalize }} was shut down {{ c.DEALER_REG_SHUTDOWN|datetime_local }}.
       <br/>
     {% elif c.DEALER_APPS >= c.MAX_DEALER_APPS and c.MAX_DEALER_APPS > 0 %}
       <br/>
-      We have already received the maximum number of dealer applications ({{ c.MAX_DEALER_APPS }}) we are accepting this year.
+      We have already received the maximum number of {{ c.DEALER_APP_TERM }}s ({{ c.MAX_DEALER_APPS }}) we are accepting this year.
       <br/>
     {% endif %}
     <br/>

--- a/uber/templates/static_views/dealer_reg_not_open.html
+++ b/uber/templates/static_views/dealer_reg_not_open.html
@@ -1,5 +1,5 @@
 <html><head></head><body style='text-align:center'>
-    Dealers room applications for {{ c.EVENT_NAME_AND_YEAR }} ({{ c.EVENT_MONTH }} {{ c.EVENT_YEAR }}) are not yet open.
+    {{ c.DEALER_APP_TERM }}s for {{ c.EVENT_NAME_AND_YEAR }} ({{ c.EVENT_MONTH }} {{ c.EVENT_YEAR }}) are not yet open.
     Please check back on {{ c.DEALER_REG_START|datetime_local }}.<br/>
     <br/>
     To register as a non-vendor attendee for {{ c.EVENT_NAME_AND_YEAR }}, click <a href="../preregistration/">here</a>.<br/>

--- a/uber/templates/static_views/dealers.html
+++ b/uber/templates/static_views/dealers.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title> {{ c.EVENT_NAME }} - Dealer Arrangements </title>
+    <title> {{ c.EVENT_NAME }} - {{ c.DEALER_TERM|capitalize }} Arrangements </title>
     <link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />
     <style type="text/css">
         li { padding-top:10px }
@@ -16,7 +16,7 @@
 </head>
 <body>
 
-<h3 class="center">Dealers</h3>
+<h3 class="center">{{ c.DEALER_TERM|capitalize }}s</h3>
 
 <div id="rules" />
 

--- a/uber/templates/static_views/prereg_not_yet_open.html
+++ b/uber/templates/static_views/prereg_not_yet_open.html
@@ -12,9 +12,9 @@
   </p>
   {%- if c.DEALER_REG_START and c.DEALER_REG_PUBLIC and c.DEALER_REG_OPEN -%}
   <p>
-    <strong>Dealers:</strong>
+    <strong>{{ c.DEALER_TERM|capitalize }}s:</strong>
     {% if c.BEFORE_DEALER_REG_START %}
-        Registrations for dealer memberships begin {{ c.DEALER_REG_START|datetime_local }}.
+        {{ c.DEALER_REG_TERM|capitalize }} begin {{ c.DEALER_REG_START|datetime_local }}.
     {% else %}
         Please register <a href="../preregistration/dealer_registration">here</a>.
     {% endif %}


### PR DESCRIPTION
We were not including region_opts on the admin pages for groups, which resulted in a broken form for anyone in the US or Canada. This fixes that.