### PR TITLE
Account for admin accounts that have never had an access group

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -71,7 +71,8 @@ def has_email_address(account):
 
 @validation.AdminAccount
 def admin_has_required_access(account):
-    if (account.is_new or account.orig_value_of('access_group_id') != account.access_group_id) \
+    if (account.is_new or (account.orig_value_of('access_group_id')
+                           and account.orig_value_of('access_group_id') != account.access_group_id)) \
             and getattr(account.access_group, 'required_access_groups', None):
         with Session() as session:
             admin_account = session.current_admin_account()

--- a/uber/models/admin.py
+++ b/uber/models/admin.py
@@ -98,11 +98,12 @@ class AdminAccount(MagModel):
 
     @presave_adjustment
     def _disable_api_access(self):
-        old_access_group = self.session.access_group(self.orig_value_of('access_group_id'))
-        if self.access_group != old_access_group:
-            invalid_api = self.access_group.invalid_api_accesses()
-            if invalid_api:
-                self.remove_disabled_api_keys(invalid_api)
+        if self.orig_value_of('access_group_id'):
+            old_access_group = self.session.access_group(self.orig_value_of('access_group_id'))
+            if self.access_group != old_access_group:
+                invalid_api = self.access_group.invalid_api_accesses()
+                if invalid_api:
+                    self.remove_disabled_api_keys(invalid_api)
 
     def remove_disabled_api_keys(self, invalid_api):
         revoked_time = datetime.utcnow()


### PR DESCRIPTION
Attempting to fix a bug on Super 2020 production caused by the rare case of an admin account existing but not having had an access group prior to their access group being updated.