### PR TITLE
Add ability to import departments without shifts

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -664,7 +664,7 @@ class DepartmentLookup:
                 'is_shiftless': True,
                 'is_setup_approval_exempt': True,
                 'is_teardown_approval_exempt': True,
-                'max_consecutive_hours': 0,
+                'max_consecutive_hours': True,
                 'jobs': {
                     'id': True,
                     'type': True,

--- a/uber/site_sections/staffing_admin.py
+++ b/uber/site_sections/staffing_admin.py
@@ -41,6 +41,74 @@ def _format_import_params(target_server, api_token):
     return (target_url, target_host, remote_api_token.strip())
 
 
+def _create_copy_department(from_department):
+    to_department = Department()
+    for field in ['name', 'description', 'solicits_volunteers', 'is_shiftless',
+                  'is_setup_approval_exempt', 'is_teardown_approval_exempt', 'max_consecutive_hours']:
+        if field in from_department:
+            setattr(to_department, field, from_department[field])
+    return to_department
+
+
+def _copy_department_roles(to_department, from_department):
+    to_dept_roles_by_id = to_department.dept_roles_by_id
+    to_dept_roles_by_name = to_department.dept_roles_by_name
+    dept_role_map = {}
+    for from_dept_role in from_department['dept_roles']:
+        to_dept_role = to_dept_roles_by_id.get(from_dept_role['id'], [None])[0]
+        if not to_dept_role:
+            to_dept_role = to_dept_roles_by_name.get(from_dept_role['name'], [None])[0]
+        if not to_dept_role:
+            to_dept_role = DeptRole(
+                name=from_dept_role['name'],
+                description=from_dept_role['description'],
+                department_id=to_department.id)
+            to_department.dept_roles.append(to_dept_role)
+        dept_role_map[from_dept_role['id']] = to_dept_role
+
+    return dept_role_map
+
+
+def _copy_department_shifts(service, to_department, from_department, dept_role_map):
+    from_config = service.config.info()
+    FROM_EPOCH = c.EVENT_TIMEZONE.localize(datetime.strptime(from_config['EPOCH'], '%Y-%m-%d %H:%M:%S.%f'))
+    EPOCH_DELTA = c.EPOCH - FROM_EPOCH
+
+    for from_job in from_department['jobs']:
+        to_job = Job(
+            name=from_job['name'],
+            description=from_job['description'],
+            duration=from_job['duration'],
+            type=from_job['type'],
+            extra15=from_job['extra15'],
+            slots=from_job['slots'],
+            start_time=UTC.localize(dateparser.parse(from_job['start_time'])) + EPOCH_DELTA,
+            visibility=from_job['visibility'],
+            weight=from_job['weight'],
+            department_id=to_department.id)
+        for from_required_role in from_job['required_roles']:
+            to_job.required_roles.append(dept_role_map[from_required_role['id']])
+        to_department.jobs.append(to_job)
+
+
+def _get_service(target_server, api_token):
+    target_url, target_host, remote_api_token = _format_import_params(target_server, api_token)
+    uri = '{}/jsonrpc/'.format(target_url)
+
+    message = ''
+    service = None
+    if target_server or api_token:
+        if not remote_api_token:
+            message = 'No API token given and could not find a token for: {}'.format(target_host)
+        elif not target_url:
+            message = 'Unrecognized hostname: {}'.format(target_server)
+
+        if not message:
+            service = ServerProxy(uri=uri, extra_headers={'X-Auth-Token': remote_api_token})
+
+    return service, message, uri
+
+
 @all_renderable()
 class Root:
     @site_mappable
@@ -54,19 +122,7 @@ class Root:
             message='',
             **kwargs):
 
-        target_url, target_host, remote_api_token = _format_import_params(target_server, api_token)
-        uri = '{}/jsonrpc/'.format(target_url)
-
-        message = ''
-        service = None
-        if target_server or api_token:
-            if not remote_api_token:
-                message = 'No API token given and could not find a token for: {}'.format(target_host)
-            elif not target_url:
-                message = 'Unrecognized hostname: {}'.format(target_server)
-
-            if not message:
-                service = ServerProxy(uri=uri, extra_headers={'X-Auth-Token': remote_api_token})
+        service, message, uri = _get_service(target_server, api_token)
 
         department = {}
         from_departments = []
@@ -74,44 +130,21 @@ class Root:
             from_departments = [(id, name) for id, name in sorted(service.dept.list().items(), key=lambda d: d[1])]
             if cherrypy.request.method == 'POST':
                 from_department = service.dept.jobs(department_id=from_department_id)
-                to_department = session.query(Department).get(to_department_id)
-                from_config = service.config.info()
-                FROM_EPOCH = c.EVENT_TIMEZONE.localize(datetime.strptime(from_config['EPOCH'], '%Y-%m-%d %H:%M:%S.%f'))
-                EPOCH_DELTA = c.EPOCH - FROM_EPOCH
+                if to_department_id == "None":
+                    to_department = _create_copy_department(from_department)
+                    session.add(to_department)
+                else:
+                    to_department = session.query(Department).get(to_department_id)
 
-                to_dept_roles_by_id = to_department.dept_roles_by_id
-                to_dept_roles_by_name = to_department.dept_roles_by_name
-                dept_role_map = {}
-                for from_dept_role in from_department['dept_roles']:
-                    to_dept_role = to_dept_roles_by_id.get(from_dept_role['id'], [None])[0]
-                    if not to_dept_role:
-                        to_dept_role = to_dept_roles_by_name.get(from_dept_role['name'], [None])[0]
-                    if not to_dept_role:
-                        to_dept_role = DeptRole(
-                            name=from_dept_role['name'],
-                            description=from_dept_role['description'],
-                            department_id=to_department.id)
-                        to_department.dept_roles.append(to_dept_role)
-                    dept_role_map[from_dept_role['id']] = to_dept_role
+                dept_role_map = _copy_department_roles(to_department, from_department)
 
-                for from_job in from_department['jobs']:
-                    to_job = Job(
-                        name=from_job['name'],
-                        description=from_job['description'],
-                        duration=from_job['duration'],
-                        type=from_job['type'],
-                        extra15=from_job['extra15'],
-                        slots=from_job['slots'],
-                        start_time=UTC.localize(dateparser.parse(from_job['start_time'])) + EPOCH_DELTA,
-                        visibility=from_job['visibility'],
-                        weight=from_job['weight'],
-                        department_id=to_department.id)
-                    for from_required_role in from_job['required_roles']:
-                        to_job.required_roles.append(dept_role_map[from_required_role['id']])
-                    to_department.jobs.append(to_job)
+                shifts_text = ' shifts' if 'skip_shifts' in kwargs else ''
+                if shifts_text:
+                    _copy_department_shifts(service, to_department, from_department, dept_role_map)
 
-                message = '{} shifts successfully imported from {}'.format(to_department.name, uri)
-                raise HTTPRedirect('import_shifts?target_server={}&api_token={}&message={}', target_server, api_token, message)
+                message = '{}{}successfully imported from {}'.format(to_department.name, shifts_text, uri)
+                raise HTTPRedirect('import_shifts?target_server={}&api_token={}&message={}',
+                                   target_server, api_token, message)
 
         return {
             'target_server': target_server,
@@ -145,3 +178,32 @@ class Root:
                 'error': str(ex),
                 'target_url': uri,
             }
+
+    def bulk_dept_import(
+            self,
+            session,
+            target_server='',
+            api_token='',
+            message='',
+            **kwargs):
+
+        service, message, uri = _get_service(target_server, api_token)
+
+        if not message and service and cherrypy.request.method == 'POST':
+            from_departments = [(id, name) for id, name in sorted(service.dept.list().items(), key=lambda d: d[1])]
+            for id, name in from_departments:
+                from_department = service.dept.jobs(department_id=id)
+                to_department = session.query(Department).filter_by(name=from_department['name']).first()
+                if not to_department:
+                    to_department = _create_copy_department(from_department)
+                    session.add(to_department)
+
+                dept_role_map = _copy_department_roles(to_department, from_department)
+
+                shifts_text = ' and shifts' if 'skip_shifts' in kwargs else ''
+                if shifts_text:
+                    _copy_department_shifts(service, to_department, from_department, dept_role_map)
+
+                message = 'Bulk import of departments{} done!'.format(shifts_text)
+                raise HTTPRedirect('import_shifts?target_server={}&api_token={}&message={}',
+                                   target_server, api_token, message)

--- a/uber/templates/staffing_admin/import_shifts.html
+++ b/uber/templates/staffing_admin/import_shifts.html
@@ -16,7 +16,7 @@
 <script type="text/javascript">
   $(function() {
     var $shiftsForm = $("form[action='import_shifts']"),
-        $departmentsBlock = $('#departments_block'),
+        $departmentsBlock = $('.departments_block'),
         $targetUrl = $('#target_url'),
         $fromDepartment = $('#from_department_id');
 
@@ -86,12 +86,13 @@
   </div>
   <input class="btn btn-primary" type="submit" id="lookup_departments" value="Lookup Departments" />
 
-  <div id="departments_block" {% if not from_departments %}style="display: none;"{% endif %}>
+  <div class="departments_block" {% if not from_departments %}style="display: none;"{% endif %}>
     <div class="form-group">
       <div class="col-sm-6">
         <h4>To Department</h4>
         <select id="to_department_id" name="to_department_id" required="required">
           <option value="">Select a department...</option>
+          <option value="None">Create a new department</option>
           {% for value, label in to_departments %}
             <option value="{{ value }}">{{ label }}</option>
           {% endfor %}
@@ -109,8 +110,18 @@
         <p id="target_url" class="help-block">{{ target_url }}</p>
       </div>
     </div>
-    <input class="btn btn-primary" type="submit" value="Import Shifts" />
+    <label><input type="checkbox" name="skip_shifts" /> Only import department roles</label><br/>
+    <input class="btn btn-primary" type="submit" value="Import Department Roles and Shifts" />
   </div>
 </form>
+
+  <div class="departments_block" {% if not from_departments %}style="display: none;"{% endif %}>
+  <form name="bulk_dept_import" action="bulk_dept_import" method="post" class="form">
+  <input type="hidden" name="target_server" value="{{ target_server }}" />
+  <input type="hidden" name="api_token" value="{{ api_token }}" />
+  <label><input type="checkbox" name="skip_shifts" /> Only import department roles</label><br/>
+  <input class="btn btn-info" type="submit" value="Import ALL Departments from {{ target_server }}" />
+  </form>
+  </div>
 
 {% endblock %}

--- a/uber/templates/staffing_admin/import_shifts.html
+++ b/uber/templates/staffing_admin/import_shifts.html
@@ -119,8 +119,8 @@
   <form name="bulk_dept_import" action="bulk_dept_import" method="post" class="form">
   <input type="hidden" name="target_server" value="{{ target_server }}" />
   <input type="hidden" name="api_token" value="{{ api_token }}" />
-  <label><input type="checkbox" name="skip_shifts" /> Only import department roles</label><br/>
-  <input class="btn btn-info" type="submit" value="Import ALL Departments from {{ target_server }}" />
+    <p class="help-text">NOTE: Importing all departments takes a long time. Please be patient.</p>
+  <input class="btn btn-info" type="submit" value="Import ALL Departments and Roles from {{ target_server }}" />
   </form>
   </div>
 


### PR DESCRIPTION
This is key in executing https://jira.magfest.net/browse/MAGDEV-545 -- before, you could only import departments with their roles if you ALSO imported all their shifts, which obviously would be undesirable in a lot of cases. This also adds a bulk import feature to make it easier on us. The bulk import will either transfer roles to departments with the same name, or create a new department if one doesn't exist (it will not import shifts, as doing so causes a 504 timeout). You can also now choose to create a new department when importing individual departments.

What we'll want to do for Super 2020 is to remove all the 'default' departments (in fact, I'll be filing another PR soon to remove the config that populates those departments, as they just cause confusion) and use the bulk import without shifts to grab all our departments from Super 2019.