### PR TITLE
Fix bug where bulk import wasn't working under certain circumstances

### DIFF
--- a/uber/site_sections/staffing_admin.py
+++ b/uber/site_sections/staffing_admin.py
@@ -206,7 +206,7 @@ class Root:
                     to_department = _create_copy_department(from_department)
                     session.add(to_department)
 
-                roles = _copy_department_roles(to_department, from_department)
+                _copy_department_roles(to_department, from_department)
 
             message = 'Successfully imported all departments and roles from {}'.format(uri)
             raise HTTPRedirect('import_shifts?target_server={}&api_token={}&message={}',

--- a/uber/templates/staffing_admin/import_shifts.html
+++ b/uber/templates/staffing_admin/import_shifts.html
@@ -42,6 +42,8 @@
                   $.each(result.departments, function(i, d) {
                       $('<option>').val(d[0]).text(d[1]).appendTo($fromDepartment);
                   });
+                  $('#hidden_target').val($("form[action='import_shifts'] input[name='target_server']").val());
+                  $('#hidden_api').val($("form[action='import_shifts'] input[name='api_token']").val());
                   $departmentsBlock.show();
                 } else {
                   toastr.error('Did not find any results.');
@@ -115,10 +117,10 @@
   </div>
 </form>
 
-  <div class="departments_block" {% if not from_departments %}style="display: none;"{% endif %}>
+  <div class="departments_block">
   <form name="bulk_dept_import" action="bulk_dept_import" method="post" class="form">
-  <input type="hidden" name="target_server" value="{{ target_server }}" />
-  <input type="hidden" name="api_token" value="{{ api_token }}" />
+  <input type="hidden" id="hidden_target" name="target_server" value="{{ target_server }}" />
+  <input type="hidden" id="hidden_api" name="api_token" value="{{ api_token }}" />
     <p class="help-text">NOTE: Importing all departments takes a long time. Please be patient.</p>
   <input class="btn btn-info" type="submit" value="Import ALL Departments and Roles from {{ target_server }}" />
   </form>


### PR DESCRIPTION
The real reason the bulk import didn't seem to be working is that the way I'd coded the page, the parameters for the API token and server would only exist if an import had previously been done (as it places those values in the URL). This updates those fields automatically so that the bulk import actually works.