### PR TITLE
Add data privacy and CoC agreement to panel application

### DIFF
--- a/uber/site_sections/panels.py
+++ b/uber/site_sections/panels.py
@@ -28,7 +28,11 @@ def check_extra_verifications(**params):
     Panelists submitting an application not associated with an attendee have some extra checkboxes they have
     to tick, so we validate them all here.
     """
-    if 'verify_unavailable' not in params:
+    if 'coc_agreement' not in params:
+        return 'You must check the box to agree to be bound by our Code of Conduct'
+    elif 'data_agreement' not in params:
+        return 'You must check the box to agree for your information to be used for determining panels selection'
+    elif 'verify_unavailable' not in params:
         return 'You must check the box to confirm that you are only unavailable at the specified times'
     elif 'verify_waiting' not in params:
         return 'You must check the box to verify you understand that you will not hear back until {}'.format(
@@ -83,6 +87,8 @@ class Root:
             'message': message,
             'panelist': panelist,
             'other_panelists': other_panelists,
+            'coc_agreement': params.get('coc_agreement'),
+            'data_agreement': params.get('data_agreement'),
             'verify_tos': params.get('verify_tos'),
             'verify_poc': params.get('verify_poc'),
             'verify_waiting': params.get('verify_waiting'),

--- a/uber/templates/panels/index.html
+++ b/uber/templates/panels/index.html
@@ -104,7 +104,7 @@
           <div class="form-group">
             <div class="col-sm-9 col-sm-offset-3">
               <label class="checkbox-label" style="font-weight: normal;">
-                <input type="checkbox" name="verify_unavailable" {% if verify_unavailable %}checked{% endif %} />
+                <input type="checkbox" name="verify_unavailable"{% if verify_unavailable %} checked{% endif %} />
                 I verify I am available at any time during the event EXCEPT for the times listed above.
               </label>
             </div>
@@ -122,10 +122,28 @@
           <div class="form-group">
             <div class="col-sm-9 col-sm-offset-3">
               <label class="checkbox-label" style="font-weight: normal;">
-                <input type="checkbox" name="verify_waiting" {% if verify_waiting %}checked{% endif %} />
+                <input type="checkbox" name="verify_waiting"{% if verify_waiting %} checked{% endif %} />
                 I understand that I will not hear back until {{ c.EXPECTED_RESPONSE }},
                 <b>and I will not prematurely email {{ c.EVENT_NAME }} to check my panel status.</b>
               </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-9 col-sm-offset-3">
+              <label class="checkbox-label" style="font-weight: normal;">
+                <input type="checkbox" name="coc_agreement"{% if coc_agreement %} checked{% endif %} />
+                I agree to be bound by the <a href="{{ c.CODE_OF_CONDUCT_URL }}">Code of Conduct</a>.
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-9 col-sm-offset-3">
+              <label class="checkbox-label" style="font-weight: normal;">
+                <input type="checkbox" name="data_agreement"{% if data_agreement %} checked{% endif %} />
+                I agree that I am submitting my information to the panels department for the sole purpose of determining the panels
+                selections for {{ c.EVENT_NAME_AND_YEAR }}. My information will not be shared with any outside parties.
+              </label>
+            <p class="help-block">For more information on our privacy practices please contact us via <a href='{{ c.CONTACT_URL }}'>{{ c.CONTACT_URL }}</a>.</p>
             </div>
           </div>
 
@@ -143,7 +161,7 @@
             </p>
             <div class="col-sm-9 col-sm-offset-3">
               <label class="checkbox-label" style="font-weight: normal;">
-                <input type="checkbox" name="verify_poc" {% if verify_poc %}checked{% endif %} />
+                <input type="checkbox" name="verify_poc"{% if verify_poc %} checked{% endif %} />
                 I have read and agree to the terms above.
               </label>
             </div>
@@ -160,7 +178,7 @@
             </p>
             <div class="col-sm-9 col-sm-offset-3">
               <label class="checkbox-label" style="font-weight: normal;">
-                <input type="checkbox" name="verify_tos" {% if verify_tos %}checked{% endif %} />
+                <input type="checkbox" name="verify_tos"{% if verify_tos %} checked{% endif %} />
                 I have read and agree to the terms above.
               </label>
             </div>


### PR DESCRIPTION
This is the last thing we need for Super 2020 panels launch! This text was provided by legal and comes in the form of the two checkboxes at the bottom here:
![image](https://user-images.githubusercontent.com/7198215/64030575-e1d30c00-cb14-11e9-9bcb-bcc8260d8a4f.png)
