### PR TITLE
Minor text fixes for MIVS 2020

### DIFF
--- a/uber/templates/mivs/game_build_info.html
+++ b/uber/templates/mivs/game_build_info.html
@@ -15,8 +15,9 @@
   <div class="col-sm-6">
     <input class="form-control" type="text" name="link_to_game" value="{{ game.link_to_game }}" />
     <p class="help-block">
-      This does not need to be a public link, but if it's restricted somehow, you must include
-      the password or other instructions for how to access it below.
+      This does not need to be a public link, but if it's restricted somehow, you must include the password
+      or other instructions for how to access it below. Allowed game download sites include: self hosted, steam,
+      itch.io, dropbox, google drive, apple app store, google play store.
     </p>
   </div>
 </div>

--- a/uber/templates/mivs/index.html
+++ b/uber/templates/mivs/index.html
@@ -129,7 +129,7 @@
         </table>
         <a class="btn btn-primary" href="screenshot?game_id={{ game.id }}">Upload a Screenshot</a>
 
-        {% if c.AFTER_MIVS_START %}
+        {% if c.CAN_SUBMIT_MIVS %}
           <h4>Game Submission</h4>
           {% if game.submitted %}
             This game has been submitted.

--- a/uber/templates/mivs/studio.html
+++ b/uber/templates/mivs/studio.html
@@ -15,9 +15,13 @@
             </font></b>
         {% endif %}
     {% else %}
-        The round one deadline has passed, so no new studios may be registered for this year's showcase.  If you would
+        {% if c.BEFORE_MIVS_START %}MAGFest Indie Videogame Showcase applications open {{ c.MIVS_START|datetime_local }}.
+          Please check back then!
+        {% else %} The deadline for submitting to the MAGFest Indie Videogame Showcase was {{ c.MIVS_DEADLINE|datetime_local }},
+          so no new studios may be registered for this year's showcase. If you would
         like to continue an existing registration, you may do so using the link sent to you in the email you received
         when you first registered your studio.
+        {% endif %}
     {% endif %}
 {% else %}
     <h2>Edit Your Studio Information</h2>


### PR DESCRIPTION
Updates the help text for "link to game" and removes a reference to round one deadlines that we didn't catch earlier. Also, the game submission button will now appear for MIVS admins, whereas before it would only appear after the actual MIVS state date. Fixes https://jira.magfest.net/browse/MAGDEV-557.