### PR TITLE
fixed migration order

### DIFF
--- a/alembic/versions/2cd71c52889e_remove_access_column_from_admin_accounts.py
+++ b/alembic/versions/2cd71c52889e_remove_access_column_from_admin_accounts.py
@@ -9,7 +9,7 @@ Create Date: 2019-08-22 15:05:58.532275
 
 # revision identifiers, used by Alembic.
 revision = '2cd71c52889e'
-down_revision = 'da22d6a6407c'
+down_revision = '5ca0661d5081'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
When upping a fresh vagrant environment, I ran into an issue with this migration - it depends on a MIVS migration rather than the migration that adds the ``access_group`` table, so I changed this to use the correct ordering.