### PR TITLE
Add new FAQ link to and remove reference to Round Two from MIVS emails

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -625,7 +625,7 @@ if c.MIVS_ENABLED:
         IndieGame,
         'Reminder to submit your game to MIVS',
         'mivs/submission_reminder.txt',
-        lambda game: game.status == c.JUDGING and not game.submitted,
+        lambda game: not game.submitted,
         ident='mivs_game_submission_reminder',
         when=days_before(7, c.MIVS_DEADLINE))
 
@@ -633,7 +633,7 @@ if c.MIVS_ENABLED:
         IndieGame,
         'Final Reminder to submit your game to MIVS',
         'mivs/submission_reminder.txt',
-        lambda game: game.status == c.JUDGING and not game.submitted,
+        lambda game: not game.submitted,
         ident='mivs_game_submission_final_reminder',
         when=days_before(2, c.MIVS_DEADLINE))
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -688,12 +688,12 @@ class Config(_Overridable):
     @property
     @dynamic
     def CAN_SUBMIT_MIVS(self):
-        return self.MIVS_SUBMISSIONS_OPEN or c.HAS_MIVS_ADMIN_ACCESS
+        return self.MIVS_SUBMISSIONS_OPEN or self.HAS_MIVS_ADMIN_ACCESS
 
     @property
     @dynamic
     def MIVS_SUBMISSIONS_OPEN(self):
-        return not really_past_mivs_deadline(c.MIVS_DEADLINE) and c.AFTER_MIVS_START
+        return not really_past_mivs_deadline(c.MIVS_DEADLINE) and self.AFTER_MIVS_START
 
     # =========================
     # panels

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1252,8 +1252,7 @@ rc = string(default="Release Candidate")
 release = string(default="Release")
 
 [[mivs_game_status]]
-new = string(default="Round One")
-judging = string(default="Accepted Into Round Two")
+new = string(default="pending")
 declined = string(default="declined")
 waitlisted = string(default="waitlisted")
 accepted = string(default="accepted")

--- a/uber/templates/emails/mivs/game_submitted.txt
+++ b/uber/templates/emails/mivs/game_submitted.txt
@@ -1,6 +1,6 @@
 Ahoy {{ game.studio.primary_contact_first_names }},
 
-This is a confirmation that you have submitted your game {{ game.title }} to our panel of judges for Round Two of judging.
+This is a confirmation that you have submitted your game {{ game.title }} to our panel of judges for showcase selection.
 
 We expect to announce results around November 5th. 
 

--- a/uber/templates/emails/mivs/results_almost_ready.txt
+++ b/uber/templates/emails/mivs/results_almost_ready.txt
@@ -2,6 +2,6 @@
 
 Thanks again for submitting your game ({{ game.title }}) to the MAGFest Indie Videogame Showcase. In the few coming weeks, our judges are hard at work wrapping up their reviews and staff will be tallying up scores. You can expect to hear whether or not your game has made it into the showcase by {{ c.MIVS_RESULTS_REVEAL|datetime_local }}.
 
-If you have any questions on the judging process, you can visit https://magfest.org/mivsfaq for more information.
+If you have any questions on the judging process, you can visit https://super.magfest.org/indie-games-2019 for more information.
 
 {{ c.MIVS_EMAIL_SIGNATURE }}

--- a/uber/templates/emails/mivs/studio_registered.txt
+++ b/uber/templates/emails/mivs/studio_registered.txt
@@ -4,6 +4,6 @@ Thanks for registering your studio ({{ studio.name }}) with the MAGFest Indie Vi
 
 As your studio's representative, you are eligible to submit one or more games for consideration.  You can continue your application at any time at {{ c.URL_BASE }}/mivs/continue_app?id={{ studio.id }}
 
-As always, the latest information including dates and submission criteria are available at http://magfest.org/mivsfaq
+As always, the latest information including dates and submission criteria are available at https://super.magfest.org/indie-games-2019
 
 {{ c.MIVS_EMAIL_SIGNATURE }}

--- a/uber/templates/mivs_admin/game_results.html
+++ b/uber/templates/mivs_admin/game_results.html
@@ -32,7 +32,7 @@
                         $showLink.hide();
                     })
                 ).append('.');
-        {% elif game.status == c.JUDGING %}
+        {% else %}
             $('#mark-form').show();
         {% endif %}
     });


### PR DESCRIPTION
The old link redirects to a 404 on our website, and since I had to edit the Game Submitted email anyway I updated it here.