### PR TITLE
Revert "fixed migration order"

### DIFF
--- a/alembic/versions/2cd71c52889e_remove_access_column_from_admin_accounts.py
+++ b/alembic/versions/2cd71c52889e_remove_access_column_from_admin_accounts.py
@@ -9,7 +9,7 @@ Create Date: 2019-08-22 15:05:58.532275
 
 # revision identifiers, used by Alembic.
 revision = '2cd71c52889e'
-down_revision = '5ca0661d5081'
+down_revision = 'da22d6a6407c'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Reverts magfest/ubersystem#3507.

I can't deploy to any servers right now because of this change, and I need to update the kick-in tiers ASAP.