### PR TITLE
Fix email template for West

### DIFF
--- a/uber/templates/emails/shifts/schedule.html
+++ b/uber/templates/emails/shifts/schedule.html
@@ -40,7 +40,7 @@
     {% if c.SHIRTS_PER_STAFFER > 0 and c.STAFF_EVENT_SHIRT_OPTS %}
         <br><br>
         You may choose to receive a {{ c.EVENT_NAME }} swag shirt instead of
-        {% if c.SHIRTS_PER_STAFFER > 1 %}one of {% end %}your staff shirt{{ c.SHIRTS_PER_STAFFER|pluralize }}.
+        {% if c.SHIRTS_PER_STAFFER > 1 %}one of {% endif %}your staff shirt{{ c.SHIRTS_PER_STAFFER|pluralize }}.
         This is the same shirt that attendees can buy and is provided as a perk for staffing.
     {% endif %}
 {% endif %}


### PR DESCRIPTION
MAGWest emails won't run without this template fix, which is already in master.