### PR TITLE
Remove references to Supporter badge in unit tests

### DIFF
--- a/tests/uber/conftest.py
+++ b/tests/uber/conftest.py
@@ -147,7 +147,7 @@ def init_db(request):
                 first_name=name,
                 last_name=name,
                 paid=c.NEED_NOT_PAY,
-                badge_type=c.SUPPORTER_BADGE
+                badge_type=c.CONTRACTOR_BADGE
             ))
             session.commit()
 

--- a/tests/uber/models/test_attendee.py
+++ b/tests/uber/models/test_attendee.py
@@ -409,7 +409,7 @@ def test_must_contact():
 def test_has_personalized_badge():
     assert not Attendee().has_personalized_badge
     assert Attendee(badge_type=c.STAFF_BADGE).has_personalized_badge
-    assert Attendee(badge_type=c.SUPPORTER_BADGE).has_personalized_badge
+    assert Attendee(badge_type=c.CONTRACTOR_BADGE).has_personalized_badge
     for badge_type in [c.ATTENDEE_BADGE, c.ONE_DAY_BADGE, c.GUEST_BADGE]:
         assert not Attendee(badge_type=badge_type).has_personalized_badge
 

--- a/tests/uber/models/test_badge_funcs.py
+++ b/tests/uber/models/test_badge_funcs.py
@@ -15,7 +15,7 @@ def session(request):
     session = Session().session
     request.addfinalizer(session.close)
     check_ranges(session)
-    for badge_type, badge_name in [(c.STAFF_BADGE, 'Staff'), (c.SUPPORTER_BADGE, 'Supporter')]:
+    for badge_type, badge_name in [(c.STAFF_BADGE, 'Staff'), (c.CONTRACTOR_BADGE, 'Contractor')]:
         for number in ['One', 'Two', 'Three', 'Four', 'Five']:
             setattr(session, '{}_{}'.format(badge_name, number).lower(),
                     session.attendee(badge_type=badge_type, first_name=number))
@@ -37,7 +37,7 @@ def teardown_range_check(request):
 
 
 def check_ranges(session):
-    for badge_type in [c.STAFF_BADGE, c.SUPPORTER_BADGE]:
+    for badge_type in [c.STAFF_BADGE, c.CONTRACTOR_BADGE]:
         actual = [a.badge_num for a in session.query(Attendee)
                                               .filter_by(badge_type=badge_type)
                                               .order_by(Attendee.badge_num).all()
@@ -242,7 +242,7 @@ class TestAutoBadgeNum:
         assert 3002 == session.auto_badge_num(c.ATTENDEE_BADGE)
 
     def test_diff_type_with_num_in_range(self, session, monkeypatch):
-        session.add(Attendee(badge_type=c.SUPPORTER_BADGE, badge_num=6))
+        session.add(Attendee(badge_type=c.CONTRACTOR_BADGE, badge_num=6))
 
         # We want to force the badge number we set even though it's incorrect
         @presave_adjustment
@@ -434,14 +434,14 @@ class TestShiftOnChange:
         assert [1, 3, 4, 5, 6] == self.staff_badges(session)
 
     def test_shift_on_badge_type_change(self, session):
-        session.staff_one.badge_type = c.SUPPORTER_BADGE
+        session.staff_one.badge_type = c.CONTRACTOR_BADGE
         session.staff_one.badge_num = None
         assert 'Badge updated' == session.update_badge(session.staff_one, c.STAFF_BADGE, 1)
         assert session.staff_two.badge_num == 1
         assert [1, 2, 3, 4, 505] == self.staff_badges(session)
 
     def test_shift_both_badge_types(self, session):
-        session.staff_one.badge_type = c.SUPPORTER_BADGE
+        session.staff_one.badge_type = c.CONTRACTOR_BADGE
         session.staff_one.badge_num = 503
         assert 'Badge updated' == session.update_badge(session.staff_one, c.STAFF_BADGE, 1)
         assert session.staff_two.badge_num == 1

--- a/tests/uber/models/test_config.py
+++ b/tests/uber/models/test_config.py
@@ -203,8 +203,8 @@ class TestBadgeOpts:
         assert c.PREREG_BADGE_TYPES == [c.ATTENDEE_BADGE, c.PSEUDO_DEALER_BADGE]
 
     def test_prereg_badge_opts_with_extra(self, monkeypatch):
-        monkeypatch.setattr(c, 'BADGE_TYPE_PRICES', {c.SUPPORTER_BADGE: 55})
-        assert c.PREREG_BADGE_TYPES == [c.ATTENDEE_BADGE, c.PSEUDO_DEALER_BADGE, c.SUPPORTER_BADGE]
+        monkeypatch.setattr(c, 'BADGE_TYPE_PRICES', {c.CONTRACTOR_BADGE: 55})
+        assert c.PREREG_BADGE_TYPES == [c.ATTENDEE_BADGE, c.PSEUDO_DEALER_BADGE, c.CONTRACTOR_BADGE]
 
     def test_at_door_badge_opts_plain(self, monkeypatch):
         monkeypatch.setattr(c, 'ONE_DAYS_ENABLED', False)
@@ -221,8 +221,8 @@ class TestBadgeOpts:
         assert dict(c.AT_THE_DOOR_BADGE_OPTS).keys() == {c.ATTENDEE_BADGE, c.FRIDAY, c.SATURDAY, c.SUNDAY}
 
     def test_at_door_badge_opts_with_extra(self, monkeypatch):
-        monkeypatch.setattr(c, 'BADGE_TYPE_PRICES', {c.SUPPORTER_BADGE: 55})
-        assert dict(c.AT_THE_DOOR_BADGE_OPTS).keys() == {c.ATTENDEE_BADGE, c.ONE_DAY_BADGE, c.SUPPORTER_BADGE}
+        monkeypatch.setattr(c, 'BADGE_TYPE_PRICES', {c.CONTRACTOR_BADGE: 55})
+        assert dict(c.AT_THE_DOOR_BADGE_OPTS).keys() == {c.ATTENDEE_BADGE, c.ONE_DAY_BADGE, c.CONTRACTOR_BADGE}
 
 
 class TestStaffGetFood:


### PR DESCRIPTION
Our unit tests still don't work, but it's good to try to keep them updated a little bit.