### PR TITLE
Stop sending emails to everyone on the planet

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -100,7 +100,7 @@ class AutomatedEmailFixture:
             .replace('{EVENT_DATE}', c.EPOCH.strftime('%b %Y'))
         self.template = template
         self.format = 'text' if template.endswith('.txt') else 'html'
-        self.filter = filter and (lambda x: x.gets_emails)
+        self.filter = lambda x: (x.gets_emails and filter(x))
         self.ident = ident
         self.query = listify(query)
         self.query_options = listify(query_options)


### PR DESCRIPTION
We discovered two important things today:
1. Two lambda functions taken together are always truthy
2. The pending emails page does not always correctly report how many emails it has or wants to send out, which can trick testers into thinking emails are working correctly when they are not.
This gets around the first point by making two lambda functions into one.