### PR TITLE
Set all vendor emails to need approval

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -258,7 +258,7 @@ if c.DEALER_REG_START:
         'dealers/approved.html',
         lambda g: g.status == c.APPROVED,
         # query=Group.status == c.APPROVED,
-        needs_approval=False,
+        needs_approval=True,
         ident='dealer_reg_approved')
 
     MarketplaceEmailFixture(


### PR DESCRIPTION
We can't turn off emails that are automatically approved, so just to be safe we're going to require approval for these emails again.