### PR TITLE
Fix 500 error when buying two promo code groups

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -684,7 +684,9 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @hybrid_property
     def amount_paid(self):
-        return sum([item.amount for item in self.receipt_items if item.txn_type == c.PAYMENT])
+        return max(sum([item.amount for item in self.receipt_items if item.txn_type == c.PAYMENT]),
+                   sum([txn.share for txn in self.stripe_txn_share_logs if txn.stripe_transaction.type == c.PAYMENT]),
+                   self.amount_paid_override * 100)
 
     @amount_paid.expression
     def amount_paid(cls):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -184,6 +184,8 @@ class Root:
                 'copy_address': params.get('copy_address'),
                 'promo_code': params.get('promo_code', ''),
                 'pii_consent': params.get('pii_consent'),
+                'name': params.get('name', ''),
+                'badges': params.get('badges', 0),
             }
 
         if 'first_name' in params:
@@ -275,7 +277,8 @@ class Root:
         return {
             'message':    message,
             'attendee':   attendee,
-            'badges': params['badges'] if 'badges' in params else 0,
+            'badges': params.get('badges', 0),
+            'name': params.get('name', ''),
             'group':      group,
             'promo_code_group': promo_code_group,
             'edit_id':    edit_id,
@@ -378,7 +381,6 @@ class Root:
         # from this point on, the credit card has actually been charged but we haven't marked anything as charged yet.
         # be ultra-careful until the attendees/groups are marked paid and written to the DB or we could end up in a
         # situation where we took the payment, but didn't mark the cards charged
-
         for attendee in charge.attendees:
             attendee.paid = c.HAS_PAID
             attendee_name = 'PLACEHOLDER' if attendee.is_unassigned else attendee.full_name
@@ -388,7 +390,6 @@ class Root:
             if attendee.badges:
                 pc_group = session.create_promo_code_group(attendee, attendee.name, int(attendee.badges) - 1)
                 session.add(pc_group)
-                session.commit()
 
             session.add_receipt_items_by_model(charge, attendee)
             attendee.amount_paid_override = attendee.total_cost

--- a/uber/templates/dealer_admin/form.html
+++ b/uber/templates/dealer_admin/form.html
@@ -65,7 +65,7 @@
 <input type="hidden" name="id" value="{{ group.db_id }}" />
 <input type="hidden" name="new_dealer" value="{{ new_dealer }}" />
 
-{{ group_fields.name }}
+{{ group_fields.group_name }}
 
 <!-- we need to register a placeholder group leader for new dealers -->
 {% if new_dealer %}

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -64,14 +64,14 @@
 {% endset %}
 
 
-{% set name %}
+{% set group_name %}
 {% set read_only = group_name_ro or page_ro %}
 <div class="group_fields">
   <div class="form-group">
     <label for="name" class="col-sm-3 control-label">{{ "Table" if attendee_or_group.is_dealer else "Group" }} Name</label>
     {% call macros.read_only_if(read_only, attendee_or_group.name) %}
       <div class="col-sm-6">
-        <input type="text" name="name" class="form-control" value="{{ attendee_or_group.name }}" maxlength="40" />
+        <input type="text" name="name" class="form-control" value="{{ name|default(attendee_or_group.name) }}" maxlength="40" />
       </div>
     {% endcall %}
   </div>
@@ -122,7 +122,7 @@
     <label for="badges" class="col-sm-3 control-label">Badges</label>
     {% call macros.read_only_if(read_only, attendee_or_group.badges, post_text=post_text) %}
       <div class="col-sm-6">
-        <select name="badges" class="form-control">{{ int_options(0 if admin_area else min_badges, max_badges, attendee_or_group.badges) }}</select>
+        <select name="badges" class="form-control">{{ int_options(0 if admin_area else min_badges, max_badges, badges|default(attendee_or_group.badges)) }}</select>
         {% if post_text %}<span class="form-control-static">{{ post_text }}</span>{% endif %}
       </div>
     {% endcall %}

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -25,7 +25,7 @@
     <input type="hidden" name="edit_id" value="{{ edit_id }}" />
 {% endif %}
 
-  {{ group_fields.name }}
+  {{ group_fields.group_name }}
   {{ group_fields.badges_dropdown }}
   {% if is_prereg_dealer %}
     {{ group_fields.tables }}

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -66,7 +66,7 @@
       <h2>"{{ group.name }}" Information</h2>
       <form method="post" action="group_members" class="form-horizontal" role="form">
         <input type="hidden" name="id" value="{{ group.id }}" />
-        {% if not page_ro %}{{ group_fields.name }}{% endif %}
+        {% if not page_ro %}{{ group_fields.group_name }}{% endif %}
         {{ group_fields.categories }}
         {{ group_fields.wares }}
         {{ group_fields.description }}

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1079,11 +1079,11 @@ class Charge:
             return uber.models.commerce.StripeTransactionAttendee(
                 txn_id=txn.id,
                 attendee_id=model.id,
-                share=self.amount if not multi else model.amount_unpaid
+                share=self.amount if not multi else model.amount_unpaid * 100
             )
         elif model.__class__.__name__ == "Group":
             return uber.models.commerce.StripeTransactionGroup(
                 txn_id=txn.id,
                 group_id=model.id,
-                share=self.amount if not multi else model.amount_unpaid
+                share=self.amount if not multi else model.amount_unpaid * 100
             )


### PR DESCRIPTION
Also fixes a UX bug where your group buyer badge would turn back into an attendee badge if you got any validation errors. Unfortunately, I was not able to fix a bug where the attendee's personal badge wasn't being recorded as a receipt item -- instead, we're relying on amount_paid_override to keep the system from asking attendees for money it shouldn't ask them for.