### PR TITLE
Add new views to promo code page and allow removing codes from attendees

### DIFF
--- a/uber/site_sections/promo_codes.py
+++ b/uber/site_sections/promo_codes.py
@@ -16,9 +16,17 @@ from uber.utils import check, check_all, localized_now
 class Root:
     @site_mappable
     @log_pageview
-    def index(self, session, message='', **params):
-        promo_codes = session.query(PromoCode).options(joinedload(PromoCode.used_by)).all()
+    def index(self, session, message='', show='admin'):
+        which = {
+            'all': [],
+            'admin': [PromoCode.group_id == None],
+            'group': [PromoCode.group_id != None],
+            'overused': [PromoCode.uses_remaining < 0]
+        }[show]
+
+        promo_codes = session.query(PromoCode).filter(*which).options(joinedload(PromoCode.used_by)).all()
         return {
+            'show': show,
             'message': message,
             'promo_codes': promo_codes
         }

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -14,6 +14,13 @@ from uber.utils import get_api_service_from_server
 
 @all_renderable()
 class Root:
+    def remove_promo_code(self, session, id=''):
+        attendee = session.attendee(id)
+        attendee.paid = c.NOT_PAID
+        attendee.promo_code = None
+        attendee.badge_status = c.NEW_STATUS
+        raise HTTPRedirect('../registration/form?id={}&message={}', id, "Promo code removed.")
+
     def import_attendees(self, session, target_server='', api_token='', query='', message=''):
         service, service_message, target_url = get_api_service_from_server(target_server, api_token)
         message = message or service_message

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1160,6 +1160,29 @@
 
 {% set promo_code %}
 {% set read_only = promo_code_ro or page_ro %}
+{% if not read_only and c.HAS_REG_ADMIN_ACCESS %}
+  <script type="text/javascript">
+      var removePromoCode = function(event) {
+          event.preventDefault();
+          bootbox.confirm({
+              backdrop: true,
+              title: 'Remove "{{ attendee.promo_code_code }}" from "{{ attendee.full_name }}"?',
+              message: 'This will remove the promo code\'s discount from the attendee and ' +
+              'set them to unpaid. They will be asked to pay the difference to complete their registration.',
+              buttons: {
+                  confirm: { label: 'Remove Promo Code', className: 'btn-danger' },
+                  cancel: { label: 'Nevermind', className: 'btn-default' }
+              },
+              callback: function(result) {
+                  if (result) {
+                      window.location.href = '../reg_admin/remove_promo_code?id={{ attendee.id }}'
+                  }
+              }
+          });
+      };
+  </script>
+{% endif %}
+
 {% if c.BADGE_PROMO_CODES_ENABLED and not group_id and (attendee.is_unpaid or attendee.promo_code_code) %}
   <div class="non_group_fields form-group">
     <label for="promo_code" class="col-sm-3 control-label optional-field">Promo Code</label>
@@ -1168,7 +1191,12 @@
         <input type="textarea" name="promo_code" value="{{ attendee.promo_code_code or promo_code }}" class="form-control" placeholder="Promo Code">
       {% else %}
         <input type="hidden" name="promo_code" value="{{ attendee.promo_code_code }}">
-        <p class="form-control-static">{{ attendee.promo_code_code }}</p>
+        <p class="form-control-static">
+          {{ attendee.promo_code_code }}
+          {% if not read_only and c.HAS_REG_ADMIN_ACCESS %}
+            [<a href="" id="remove_promo_code" onClick="removePromoCode(event)">Remove</a>]
+          {% endif %}
+        </p>
       {% endif %}
     </div>
   </div>

--- a/uber/templates/promo_codes/index.html
+++ b/uber/templates/promo_codes/index.html
@@ -50,6 +50,13 @@ $(document).ready(function() {
     Delete Unused
   </button>
 </h1>
+  <ul class="nav nav-tabs" role="tablist">
+  <li {% if show == "admin" %}class="active"{% endif %}><a href="index?show=admin">Discount Codes</a></li>
+  <li {% if show == "group" %}class="active"{% endif %}><a href="index?show=group">Promo Code Group Codes</a></li>
+  <li {% if show == "overused" %}class="active"{% endif %}><a href="index?show=overused">Overused</a></li>
+  <li {% if show == "all" %}class="active"{% endif %}><a href="index?show=all">All</a></li>
+</ul>
+<br/>
 <div id="modal-delete-unused" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="title-delete-unused">
   <div class="modal-dialog modal-sm" role="document">
     <div class="modal-content">
@@ -68,7 +75,7 @@ $(document).ready(function() {
   </div>
 </div>
 <div class="table-responsive">
-  <table class="table table-striped datatable form-horizontal">
+  <table id="promo_code_list" class="table table-striped datatable form-horizontal">
     <thead>
       <tr>
         <th>Promo Code</th>
@@ -77,6 +84,9 @@ $(document).ready(function() {
         <th>Discount</th>
         <th>Allowed Uses</th>
         <th>Number of Uses</th>
+        {% if show != 'admin' %}
+        <th>Promo Code Group</th>
+        {% endif %}
         <th></th>
       </tr>
     </thead>
@@ -115,6 +125,11 @@ $(document).ready(function() {
           <a href="../registration/form?id={{ attendee.id }}">{{ attendee.full_name }}</a>{% if not loop.last %}, {% endif %}
           {% endfor %}
         </td>
+        {% if show != 'admin' %}
+        <td>
+          <a href="promo_code_group_form?id={{ promo_code.group.id }}" target="_blank">{{ promo_code.group.name }}</a>
+        </td>
+        {% endif %}
         <td class="text-nowrap">
           <form id="update_promo_code_{{ promo_code.id }}" method="post" action="update_promo_code">
             {{ csrf_token() }}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-591 and fixes https://jira.magfest.net/browse/MAGDEV-513 by adding new views to the promo code page to filter out group codes and show only overused codes. Also adds the ability to remove promo codes from attendees if the current admin has access to reg_admin