### PR TITLE
Fix last-minute issues with at-con mode for West 2019

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -593,11 +593,23 @@ class Config(_Overridable):
 
     @property
     def DEFAULT_REGDESK_INT(self):
-        return getattr(self, 'REGDESK', getattr(self, 'REGISTRATION', 177161930))
+        from uber.models import Session, Department
+        with Session() as session:
+            dept = session.query(Department).filter(or_(
+                Department.name == "Registration",
+                Department.name == "Regdesk")).first()
+            return dept.id if dept else ''
+
 
     @property
     def DEFAULT_STOPS_INT(self):
-        return getattr(self, 'STOPS', 29995679)
+        from uber.models import Session, Department
+        with Session() as session:
+            dept = session.query(Department).filter(or_(
+                Department.name == "STOPS",
+                Department.name == "Staffing Ops",
+                Department.name == "Staffing Operations")).first()
+            return dept.id if dept else ''
 
     @property
     def HTTP_METHOD(self):

--- a/uber/site_sections/signups.py
+++ b/uber/site_sections/signups.py
@@ -61,14 +61,16 @@ class Root:
             'opts': [('', 'Enter your shirt size')] + c.SHIRT_OPTS[1:]
         }
 
-    @check_shutdown
     def volunteer_agreement(self, session, message='', agreed_to_terms=None, csrf_token=None):
         attendee = session.logged_in_volunteer()
         if csrf_token is not None:
             check_csrf(csrf_token)
             if agreed_to_terms:
                 attendee.agreed_to_volunteer_agreement = True
-                raise HTTPRedirect('index?message={}', 'Agreement received')
+                if c.AT_THE_CON:
+                    raise HTTPRedirect('onsite_jobs?message={}', 'Agreement received')
+                else:
+                    raise HTTPRedirect('index?message={}', 'Agreement received')
 
             message = "You must agree to the terms of the agreement"
 

--- a/uber/templates/signups/onsite_jobs.html
+++ b/uber/templates/signups/onsite_jobs.html
@@ -10,7 +10,16 @@
     <a href="printable">Click here</a> to see a printable schedule of the {{ attendee.weighted_hours }} weighted hours worth of shifts you are signed up for.
 </div>
 
-<br/>
+{% if c.VOLUNTEER_AGREEMENT_ENABLED %}
+{% if not attendee.agreed_to_volunteer_agreement %}
+  Please read and agree
+{% else %}
+  You have agreed
+{% endif %}
+to the terms of the <a href="volunteer_agreement">Volunteer Agreement</a>{% if not attendee.agreed_to_volunteer_agreement %} in order to sign up for shifts{% endif %}.
+  {% endif %}
+{% if attendee.agreed_to_volunteer_agreement or not c.VOLUNTEER_AGREEMENT_ENABLED %}
+<br/><br/>
 {{ c.EVENT_NAME }} has already started, so it's too late to drop shifts.  However, you can sign up for new shifts below.
 <br/> <br/>
 If you cannot make it to one or more of your existing shifts, contact {{ c.STAFF_EMAIL }}
@@ -52,5 +61,6 @@ If you cannot make it to one or more of your existing shifts, contact {{ c.STAFF
     {% endfor %}
     </tbody>
 </table>
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Fixes the bug that prevented Registration and STOPS heads from assigning a Staff badge, and enables and links to the volunteer agreement checklist step while in at-con mode.

West needs this Now so we'll merge this right away.