### PR TITLE
Fix Dealer address bugs

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -142,6 +142,13 @@ def dealer_address(group):
             return 'Please provide your full address for tax purposes. Missing: {}'.format(', '.join(missing))
 
 
+@prereg_validation.Group
+def dealer_region(group):
+    if group.country in ['Canada', 'United States'] and len(group.region) < 3:
+        return 'Please enter the full name of your {}.'.format(
+            'state' if group.country == 'United States' else 'province or region')
+
+
 @validation.Group
 def group_money(group):
     if not group.auto_recalc:

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -260,6 +260,8 @@
 
 {% set address %}
 {% set read_only = group_address_ro or page_ro %}
+{% set required = not admin_area %}
+{% set prefix = '' if 'dealer_admin' in c.PAGE_PATH else 'group_' %}
 {% if not read_only %}
   {% if not c.COLLECT_FULL_ADDRESS or not attendee %}
     <script type="text/javascript">
@@ -276,7 +278,7 @@
   {% endif %}
 {% endif %}
 
-{{ macros.address_form(group, name_prefix="group_", is_readonly=read_only, is_required=True) }}
+{{ macros.address_form(group, name_prefix='group_', is_readonly=read_only, is_required=required) }}
 {% endset %}
 
 


### PR DESCRIPTION
Attempts to fix https://jira.magfest.net/browse/MAGDEV-554 and some related bugs. Admins were unable to actually update dealer addresses, and some attendees somehow entered an invalid region/state when applying as a dealer. This fixes the former and adds a model check to try to capture the latter.