### PR TITLE
Take placeholder badges into account for guest groups

### DIFF
--- a/uber/models/guests.py
+++ b/uber/models/guests.py
@@ -69,7 +69,7 @@ class GuestGroup(MagModel):
 
     @property
     def all_badges_claimed(self):
-        return not any(a.is_unassigned for a in self.group.attendees)
+        return not any(a.is_unassigned or a.placeholder for a in self.group.attendees)
 
     @property
     def estimated_performer_count(self):


### PR DESCRIPTION
This makes it so we only check off the 'badges' step in guest checklists if all badges in the guest's group are not unassigned AND not placeholder.