### PR TITLE
Pass through promo code correctly on prereg form

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -182,7 +182,7 @@ class Root:
                 'affiliates': session.affiliates(),
                 'cart_not_empty': Charge.unpaid_preregs,
                 'copy_address': params.get('copy_address'),
-                'promo_code': params.get('promo_code', ''),
+                'promo_code_code': params.get('promo_code', ''),
                 'pii_consent': params.get('pii_consent'),
                 'name': params.get('name', ''),
                 'badges': params.get('badges', 0),
@@ -285,7 +285,7 @@ class Root:
             'affiliates': session.affiliates(),
             'cart_not_empty': Charge.unpaid_preregs,
             'copy_address': params.get('copy_address'),
-            'promo_code': params.get('promo_code', ''),
+            'promo_code_code': params.get('promo_code', ''),
             'pii_consent': params.get('pii_consent'),
         }
 

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1188,7 +1188,7 @@
     <label for="promo_code" class="col-sm-3 control-label optional-field">Promo Code</label>
     <div class="col-sm-6">
       {% if attendee.is_unpaid and not read_only %}
-        <input type="textarea" name="promo_code" value="{{ attendee.promo_code_code or promo_code }}" class="form-control" placeholder="Promo Code">
+        <input type="textarea" name="promo_code" value="{{ attendee.promo_code_code or promo_code_code }}" class="form-control" placeholder="Promo Code">
       {% else %}
         <input type="hidden" name="promo_code" value="{{ attendee.promo_code_code }}">
         <p class="form-control-static">


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-600. Yet another instance of a variable being over-set by our modular fields... I should probably do an audit of these or just rename them all or something.