### PR TITLE
Send guest badge confirmation email only to guests

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -334,7 +334,8 @@ AutomatedEmailFixture(
     Attendee,
     '{EVENT_NAME} Guest Badge Confirmation',
     'placeholders/guest.txt',
-    lambda a: a.placeholder and a.badge_type == c.GUEST_BADGE,
+    lambda a: a.placeholder and a.badge_type == c.GUEST_BADGE and (
+        not a.group or a.group.guest and a.group.guest.group_type == c.GUEST),
     # query=and_(Attendee.placeholder == True, Attendee.badge_type == c.GUEST_BADGE),
     sender=c.GUEST_EMAIL,
     ident='guest_badge_confirmation')


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-640 by changing the guest badge confirmation email to only send to people with Guest badges who either do not have a group or whose group has a GuestGroup of type c.GUEST.