### PR TITLE
Add license badge to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/magfest/ubersystem.svg)](https://travis-ci.org/magfest/ubersystem) [![Coverage Status](https://coveralls.io/repos/github/magfest/ubersystem/badge.svg?branch=master)](https://coveralls.io/github/magfest/ubersystem?branch=master)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Build Status](https://travis-ci.org/magfest/ubersystem.svg)](https://travis-ci.org/magfest/ubersystem) [![Coverage Status](https://coveralls.io/repos/github/magfest/ubersystem/badge.svg?branch=master)](https://coveralls.io/github/magfest/ubersystem?branch=master)
 
 
 # The Ubersystem Project


### PR DESCRIPTION
A discussion about licensing of the project made us realize that we weren't actually putting the license front and center, so this fixes that!