### PR TITLE
Apply group discount to declined dealers

### DIFF
--- a/uber/site_sections/dealer_admin.py
+++ b/uber/site_sections/dealer_admin.py
@@ -67,7 +67,7 @@ def _decline_and_convert_dealer_group(session, group, status=c.DECLINED):
                 new_attendee = Attendee()
                 for attr in c.UNTRANSFERABLE_ATTRS:
                     setattr(new_attendee, attr, getattr(attendee, attr))
-                new_attendee.overridden_price = attendee.overridden_price
+                new_attendee.overridden_price = attendee.base_badge_price - c.GROUP_DISCOUNT
                 new_attendee.base_badge_price = attendee.base_badge_price
                 new_attendee.append_admin_note(admin_note)
                 session.add(new_attendee)


### PR DESCRIPTION
Reg/Marketplace has decided that dealers should get a group discount because applying and registering in a group are mutually exclusive. This applies that discount.