### PR TITLE
Actually update existing attendees when converting dealer badges

### DIFF
--- a/uber/site_sections/dealer_admin.py
+++ b/uber/site_sections/dealer_admin.py
@@ -60,6 +60,7 @@ def _decline_and_convert_dealer_group(session, group, status=c.DECLINED):
     badges_converted = 0
 
     for attendee in list(group.attendees):
+        session.add(attendee)
         if _is_dealer_convertible(attendee):
             attendee.badge_status = c.INVALID_STATUS
 


### PR DESCRIPTION
While testing the prior PR I realized that attendees don't actually get set to invalid status, which appears to be because they aren't actually added to the session (only the replacement attendee is). This should fix that.