### PR TITLE
Revert "Actually update existing attendees when converting dealer badges"

### DIFF
--- a/uber/site_sections/dealer_admin.py
+++ b/uber/site_sections/dealer_admin.py
@@ -60,7 +60,6 @@ def _decline_and_convert_dealer_group(session, group, status=c.DECLINED):
     badges_converted = 0
 
     for attendee in list(group.attendees):
-        session.add(attendee)
         if _is_dealer_convertible(attendee):
             attendee.badge_status = c.INVALID_STATUS
 


### PR DESCRIPTION
Reverts magfest/ubersystem#3569 -- this just broke the conversion script more. I'll have to fix this locally instead of via the web editor.