### PR TITLE
Fix 500 error on creating multiple badges

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -555,8 +555,8 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @presave_adjustment
     def assign_creator(self):
-        if self.is_new and not self.creator:
-            self.creator = self.session.admin_attendee()
+        if self.is_new and not self.creator_id:
+            self.creator_id = self.session.admin_attendee().id if self.session.admin_attendee() else None
 
     def unset_volunteering(self):
         self.staffing = False


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-673, which was happening if you tried to add more than one badge to a group at a time. Relationships in SQLAlchemy are weird.