### PR TITLE
Fix lingering errors with attendee form

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -242,9 +242,15 @@ def form_link(model):
         page = 'group_form' if model == Group else page
     else:
         group_section = ''
+        
+    if c.HAS_REGISTRATION_ACCESS:
+        attendee_section = 'registration'
+    else:
+        attendee_section = 'accounts'
+        page = 'homepage#attendee_form' if model == Attendee else page
 
     site_sections = {
-        Attendee: 'registration',
+        Attendee: attendee_section,
         Attraction: 'attractions_admin',
         Department: 'dept_admin',
         Group: group_section,

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -1050,8 +1050,8 @@ class Root:
             'badges_price': c.BADGE_PRICE
         })
     
-    @attendee_view
     @log_pageview
+    @attendee_view
     @cherrypy.expose(['attendee_data'])
     def attendee_form(self, session, message='', **params):
         attendee = session.attendee(params, allow_invalid=True)
@@ -1067,8 +1067,8 @@ class Root:
         else:
             return return_dict
     
-    @attendee_view
     @log_pageview
+    @attendee_view
     def attendee_history(self, session, id, **params):
         attendee = session.attendee(id)
         
@@ -1097,8 +1097,8 @@ class Root:
                 if job.start_time + timedelta(hours=job.duration + 2) > localized_now()],
         }
     
-    @attendee_view
     @log_pageview
+    @attendee_view
     def attendee_watchlist(self, session, id, **params):
         attendee = session.attendee(id)
         return {
@@ -1106,7 +1106,7 @@ class Root:
             'active_entries': session.guess_attendee_watchentry(attendee, active=True),
             'inactive_entries': session.guess_attendee_watchentry(attendee, active=False),
         }
-        
+    
     @ajax
     @attendee_view
     def update_attendee(self, session, message='', success=False, **params):


### PR DESCRIPTION
Our form_link custom tags were still using the old link for attendees, and the page parameter wasn't filling in properly. Also, saving the attendee would return an error.