### PR TITLE
Fix department checklist hotel approval page render

### DIFF
--- a/uber/site_sections/dept_checklist.py
+++ b/uber/site_sections/dept_checklist.py
@@ -341,7 +341,7 @@ class Root:
             *dept_filter) \
             .order_by(Attendee.full_name).all()
         
-        attendee = session.logged_in_volunteer()
+        attendee = session.admin_attendee()
 
         return {
             'admin_has_room_access': c.HAS_HOTEL_ADMIN_ACCESS,


### PR DESCRIPTION
Apparently the method to get an attendee object I was using only works if you have already viewed an attendee checklist page first, which meant this was passing my tests earlier. I think this method is the correct one?