### PR TITLE
Fix API config.info timezone

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -714,13 +714,8 @@ class ConfigLookup:
 
         # This is to allow backward compatibility with pre 1.0 code
         output['YEAR'] = c.EVENT_YEAR
-
         output['API_VERSION'] = __version__
-        
-        # EVENT_TIMEZONE is a TZINFO object, not a string so convert to string for JSON
-        # sample date can be anything, the tzname function wants a datetime object for some reason
-        sample_date = datetime(2020, 1, 3, 6, 0, 0)
-        output['EVENT_TIMEZONE'] = output['EVENT_TIMEZONE'].tzname(sample_date)
+        output['EVENT_TIMEZONE'] = str(output['EVENT_TIMEZONE'])
         return output
 
     def lookup(self, field):

--- a/uber/api.py
+++ b/uber/api.py
@@ -716,6 +716,11 @@ class ConfigLookup:
         output['YEAR'] = c.EVENT_YEAR
 
         output['API_VERSION'] = __version__
+        
+        # EVENT_TIMEZONE is a TZINFO object, not a string so convert to string for JSON
+        # sample date can be anything, the tzname function wants a datetime object for some reason
+        sample_date = datetime(2020, 1, 3, 6, 0, 0)
+        output['EVENT_TIMEZONE'] = output['EVENT_TIMEZONE'].tzname(sample_date)
         return output
 
     def lookup(self, field):


### PR DESCRIPTION
I previously added EVENT_TIMEZONE to the list returned by config.info.  Upon trying to actually use it, the JSON encoder returns an error because this is a TZINFO object and it doesn't know how to handle it.  This change adds code to convert this to a string equivalent before JSON encoding.