### PR TITLE
Send MIVS reminder email 3 days BEFORE deadline

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -673,7 +673,7 @@ if c.MIVS_ENABLED:
         lambda game: (
             game.status == c.ACCEPTED
             and not game.confirmed
-            and (localized_now() - timedelta(days=2)) > game.studio.confirm_deadline),
+            and (localized_now() + timedelta(days=2)) > game.studio.confirm_deadline),
         ident='mivs_accept_booth_reminder')
 
     MIVSEmailFixture(

--- a/uber/models/mivs.py
+++ b/uber/models/mivs.py
@@ -115,7 +115,7 @@ class IndieStudio(MagModel):
         sorted_games = sorted(
             [g for g in self.games if g.accepted], key=lambda g: g.accepted)
         confirm_deadline = timedelta(days=c.MIVS_CONFIRM_DEADLINE)
-        return sorted_games[0].accepted + confirm_deadline
+        return sorted_games[0].accepted + confirm_deadline if len(sorted_games) else None
 
     @property
     def after_confirm_deadline(self):

--- a/uber/templates/mivs_admin/index.html
+++ b/uber/templates/mivs_admin/index.html
@@ -62,6 +62,7 @@
             {% if game.has_issues %}
                 <a href="problems?game_id={{ game.id }}">!</a>
             {% endif %}
+            {% if game.status == c.ACCEPTED %}Confirm deadline: {{ game.studio.confirm_deadline|datetime_local('%x %-I:%M%p') }}{% endif %}
         </td>
         <td><a href="../mivs/continue_app?id={{ game.studio.id }}" target="_blank">{{ game.studio.name }}</a></td>
         <td>{{ game.studio.primary_contacts[0].full_name }}</td>


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-708. I had the polarity reversed on this automated email, so it was waiting until three days _after_ a studio's confirmation deadline before telling them to confirm their game before the deadline. Also adds the confirmation deadline to the list of indie games for better visibility.