### PR TITLE
Add separate list of shirt sizes available for preorder

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -1023,8 +1023,8 @@ c.WEIGHT_OPTS = (
 )
 c.JOB_DEFAULTS = ['name', 'description', 'duration', 'slots', 'weight', 'visibility', 'required_roles_ids', 'extra15']
 
-c.PREREG_SHIRT_OPTS = sorted(c.SHIRT_OPTS)[1:]
-c.MERCH_SHIRT_OPTS = [(c.SIZE_UNKNOWN, 'select a size')] + list(c.PREREG_SHIRT_OPTS)
+c.PREREG_SHIRT_OPTS = sorted(c.PREREG_SHIRT_OPTS if c.PREREG_SHIRT_OPTS else c.SHIRT_OPTS)[1:]
+c.MERCH_SHIRT_OPTS = [(c.SIZE_UNKNOWN, 'select a size')] + sorted(list(c.SHIRT_OPTS))
 c.DONATION_TIER_OPTS = [(amt, '+ ${}: {}'.format(amt, desc) if amt else desc) for amt, desc in c.DONATION_TIER_OPTS]
 
 c.DONATION_TIER_ITEMS = {}

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1044,6 +1044,7 @@ __many__ = integer
 # These sections need to exist but can stay empty for events which are not using
 # the features they represent.
 [[shirt]]
+[[prereg_shirt]] # If this is blank, we just use [[shirt]], otherwise we only show these for pre-order
 [[staff_event_shirt]]
 [[donation_tier]]
 [[store_price]]

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -701,6 +701,7 @@
 {% set read_only = shirt_size_ro or page_ro %}
 {% if not admin_area or attendee.gets_any_kind_of_shirt %}
   {% set shirt_opts = c.PREREG_SHIRT_OPTS if not admin_area else c.SHIRT_OPTS %}
+  {% set warn_on_change = c.PREREG_SHIRTS and not admin_area and attendee.shirt not in c.PREREG_SHIRTS.keys() %}
   {% if not admin_area %}
     <div class="shirt-row extra-row form-group" style="display:none">
   {% elif attendee.gets_any_kind_of_shirt %}
@@ -710,10 +711,17 @@
   {% call macros.read_only_if(read_only, attendee.shirt_label) %}
 <div class="col-sm-{{ "3" if admin_area else "6" }}">
   <select name="shirt" class="form-control">
+    {% if warn_on_change %}<option value="{{ attendee.shirt }}">{{ attendee.shirt_label }}</option>{% endif %}
     {% if not admin_area %}<option value="{{ c.NO_SHIRT }}">Select a shirt size</option>{% endif %}
     {{ options(shirt_opts,attendee.shirt) }}
   </select>
 </div>
+{% if warn_on_change %}
+<p class="help-block col-sm-9 col-sm-offset-3">
+  <strong>Your shirt size has been reserved for you and is no longer available for pre-order.</strong>
+  <br/>If you change your selection now you will not be able to change it back.
+</p>
+{% endif %}
   {% endcall %}
 </div>
 {% endif %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-710 by altering how prereg_shirt_opts works. We can now populate it with only the shirt sizes we want to offer on the prereg page, which lets us preserve existing special shirt sizes without continuing to offer them.

If someone has a special shirt size that's no longer available, they'll see this message:
![image](https://user-images.githubusercontent.com/7198215/68251405-0655d380-fff1-11e9-8f55-94a83b45eee7.png)