### PR TITLE
Add placeholder code for linking to Tuber in dept head checklist

### DIFF
--- a/uber/templates/dept_checklist/hotel_eligible.html
+++ b/uber/templates/dept_checklist/hotel_eligible.html
@@ -22,7 +22,10 @@
         {% endif %}
     {% endif %}
 </div>
-
+{% if c.HOTEL_REQUESTS_URL %}
+<br>
+<a href="{{ c.HOTEL_REQUESTS_URL }}"><h2>Click here to review the list of your hotel-eligible staffers</h2></a>
+{% else %}
 <table style="width:auto ; margin-left:25px">
 {% for attendee in attendees %}
     <tr>
@@ -31,5 +34,6 @@
     </tr>
 {% endfor %}
 </table>
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Tuber doesn't have a page for the "hotel eligible" checklist step, but we don't want it to show the old hotel system, which would have the wrong information. This is just a placeholder for when we add the page to Tuber later.