### PR TITLE
Fix MITS file URLs

### DIFF
--- a/uber/models/mits.py
+++ b/uber/models/mits.py
@@ -253,7 +253,7 @@ class MITSPicture(MagModel):
 
     @property
     def url(self):
-        return '{}/mits/view_picture?id={}'.format(c.PATH, self.id)
+        return '../mits/view_picture?id={}'.format(self.id)
 
     @property
     def filepath(self):
@@ -283,7 +283,7 @@ class MITSDocument(MagModel):
 
     @property
     def url(self):
-        return '{}/mits/download_doc?id={}'.format(c.PATH, self.id)
+        return '../mits/download_doc?id={}'.format(self.id)
 
     @property
     def filepath(self):


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-687. For some reason using c.PATH now generates broken urls, so these URLs need to be relative instead.