### PR TITLE
Fix MIVS Versus email

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -795,14 +795,14 @@ if c.MIVS_ENABLED:
             ident='mivs_checklist_overdue_{}'.format(deadline.strftime('%m_%d')),
         )
         
-        # start year specific MIVS Emails
-        MIVSEmailFixture(
-            IndieGame,
-            'MIVS: Participating in MAGFest Versus and an Indie Game Preservation Panel',
-            'mivs/2020/strong_versus_2020.txt',
-            lambda game: game.confirmed,
-            ident='mivs_2020_versus'
-        )
+    # start year specific MIVS Emails
+    MIVSEmailFixture(
+        IndieGame,
+        'MIVS: Participating in MAGFest Versus and an Indie Game Preservation Panel',
+        'mivs/2020/strong_versus_2020.txt',
+        lambda game: game.confirmed,
+        ident='mivs_2020_versus'
+    )
 
 # =============================
 # mits


### PR DESCRIPTION
The new email was one indent too far, which caused it to be registered more than once, which apparently prevents the server from starting. Whoops.