### PR TITLE
Add "Badges 4 Life" through a config var

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -690,6 +690,10 @@ stripe_public_key = string(default="pk_test_q4kSJVwk6LXKv2ahxuVn7VOK")
 # include "Jonathan Smith" and "Johnny Smith" in the list.
 banned_staffers = string_list(default=list())
 
+# This list is checked when attendeees preregister.
+# You should enter the valid email addresses.
+badge_for_life_recipients = string_list(default=list())
+
 # Turn SEND_EMAILS on and set our AWS keys to allow emails to be sent.  Note
 # that if the DEV_BOX setting is True, emails will show up in the database as if
 # they were sent (and those emails will be logged), but no emails will be sent

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -555,6 +555,11 @@ class Attendee(MagModel, TakesPaymentMixin):
                 self.paid = c.NEED_NOT_PAY
 
     @presave_adjustment
+    def _apply_badge_for_life(self):
+        if self.email in c.BADGE_FOR_LIFE_RECIPIENTS and not self.overridden_price and self.is_unpaid:
+            self.paid = c.NEED_NOT_PAY
+
+    @presave_adjustment
     def assign_creator(self):
         if self.is_new and not self.creator_id:
             self.creator_id = self.session.admin_attendee().id if self.session.admin_attendee() else None


### PR DESCRIPTION
This pull request will allow a list of emails for people who deserve badges for life to MAGFest events to receive them without human intervention. 

The emails must be loaded securely to the config settings for the privacy of individuals who receive badges for life.

Who decides the list is not up to me. 

Personal Opinions:
My suggestion would be the acting executive director of MAGFest, but I leave this up to the powers that be.

Also, Brendan Becker needs to be in this list.

I haven't tested this unfortunately, but its a straight copy of the `_use_promo_code` function above it. 

I read through the logic on the forms, and this should work. 

It ain't easy to setup Uber, but I hope this helps.