### PR TITLE
Use c.HIDE_SCHEDULE for public schedule pages

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -862,8 +862,6 @@ if "sqlite" in _config['secret']['sqlalchemy_url']:
     c.SQLALCHEMY_POOL_SIZE = -1
     c.SQLALCHEMY_MAX_OVERFLOW = -1
 
-c.HIDE_SCHEUDLE = True
-
 c.PRICE_BUMPS = {}
 c.PRICE_LIMITS = {}
 for _opt, _val in c.BADGE_PRICES['attendee'].items():

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -630,6 +630,16 @@ def attendee_view(func):
         return func(*args, **kwargs)
     return with_check
 
+def schedule_view(func):
+    func.public = True
+    @wraps(func)
+    def with_check(*args, **kwargs):
+        if c.HIDE_SCHEDULE and not c.HAS_READ_ACCESS:
+            return "The {} schedule is being developed and will be made public " \
+                   "when it's closer to being finalized.".format(c.EVENT_NAME)
+        return func(*args, **kwargs)
+    return with_check
+
 def restricted(func):
     @wraps(func)
     def with_restrictions(*args, **kwargs):

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -9,7 +9,7 @@ from pockets import listify
 from sqlalchemy.orm import joinedload
 
 from uber.config import c
-from uber.decorators import ajax, all_renderable, cached, csrf_protected, csv_file, render, public
+from uber.decorators import ajax, all_renderable, cached, csrf_protected, csv_file, render, schedule_view
 from uber.errors import HTTPRedirect
 from uber.models import AdminAccount, AssignedPanelist, Attendee, Event, PanelApplication
 from uber.utils import check, localized_now, normalize_newlines
@@ -61,19 +61,8 @@ def get_schedule_data(session, message):
 @all_renderable()
 class Root:
     @cached
-    @public
+    @schedule_view
     def index(self, session, message=''):
-        # show a public-facing view of the schedule
-        # anything returned here should be cache-friendly and ready to be shown to the public.
-
-        dont_allow_schedule_to_be_viewed = \
-            c.HIDE_SCHEDULE and not AdminAccount.get_access_set(include_read_only=True) \
-            and not cherrypy.session.get('staffer_id')
-
-        if dont_allow_schedule_to_be_viewed:
-            return "The {} schedule is being developed and will be made public " \
-                   "when it's closer to being finalized.".format(c.EVENT_NAME)
-
         if c.ALT_SCHEDULE_URL:
             raise HTTPRedirect(c.ALT_SCHEDULE_URL)
         else:
@@ -81,13 +70,13 @@ class Root:
             # we cache this view because it takes a while to generate
             return get_schedule_data(session, message)
 
-    @public
+    @schedule_view
     @csv_file
     def time_ordered(self, out, session):
         for event in session.query(Event).order_by('start_time', 'duration', 'location').all():
             out.writerow([event.timespan(30), event.name, event.location_label])
 
-    @public
+    @schedule_view
     def xml(self, session):
         cherrypy.response.headers['Content-type'] = 'text/xml'
         schedule = defaultdict(list)
@@ -97,7 +86,7 @@ class Root:
             'schedule': sorted(schedule.items(), key=lambda tup: c.ORDERED_EVENT_LOCS.index(tup[1][0].location))
         })
 
-    @public
+    @schedule_view
     def schedule_tsv(self, session):
         cherrypy.response.headers['Content-Type'] = 'text/tsv'
         cherrypy.response.headers['Content-Disposition'] = 'attachment;filename=Schedule-{}.tsv'.format(
@@ -190,7 +179,7 @@ class Root:
                     event.description,
                     panelist_names])
 
-    @public
+    @schedule_view
     def panels_json(self, session):
         cherrypy.response.headers['Content-Type'] = 'application/json'
         return json.dumps([
@@ -208,7 +197,7 @@ class Root:
             for event in sorted(session.query(Event).all(), key=lambda e: [e.start_time, e.location_label])
         ], indent=4).encode('utf-8')
 
-    @public
+    @schedule_view
     def now(self, session, when=None):
         if when:
             now = c.EVENT_TIMEZONE.localize(datetime(*map(int, when.split(','))))
@@ -338,7 +327,7 @@ class Root:
                           if a.paid == c.HAS_PAID or a.paid == c.PAID_BY_GROUP and a.group and a.group.amount_paid]
         }
 
-    @public
+    @schedule_view
     def panelist_schedule(self, session, id):
         attendee = session.attendee(id)
         events = defaultdict(lambda: defaultdict(lambda: (1, '')))
@@ -360,7 +349,7 @@ class Root:
             'locations': locations
         }
 
-    @public
+    @schedule_view
     @csv_file
     def panel_tech_needs(self, out, session):
         panels = defaultdict(dict)


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-733 by adding a new decorator that makes our previously-public schedule pages show only if hide_schedule is turned off or you are currently logged in as an admin with read access to the requested page.