### PR TITLE
Use secure document portals for guest W9s

### DIFF
--- a/alembic/versions/ad26fcaafb78_replace_w9_upload_with_checkbox.py
+++ b/alembic/versions/ad26fcaafb78_replace_w9_upload_with_checkbox.py
@@ -1,0 +1,63 @@
+"""Replace W9 upload with checkbox
+
+Revision ID: ad26fcaafb78
+Revises: 691be8fa880d
+Create Date: 2019-11-19 01:10:46.057942
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'ad26fcaafb78'
+down_revision = 'd42d4e52cfab'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('guest_taxes', sa.Column('w9_sent', sa.Boolean(), server_default='False', nullable=False))
+    op.drop_column('guest_taxes', 'w9_content_type')
+    op.drop_column('guest_taxes', 'w9_filename')
+
+
+def downgrade():
+    op.add_column('guest_taxes', sa.Column('w9_filename', sa.VARCHAR(), server_default=sa.text("''::character varying"), autoincrement=False, nullable=False))
+    op.add_column('guest_taxes', sa.Column('w9_content_type', sa.VARCHAR(), server_default=sa.text("''::character varying"), autoincrement=False, nullable=False))
+    op.drop_column('guest_taxes', 'w9_sent')

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -663,6 +663,9 @@ slow_load_check = boolean(default=True)
 # user's web browser.  Put options in this section you would never want being
 # public such as email crendtials and lists of banned attendees.
 
+# Link to a secure document portal for guest groups to upload sensitive documents to.
+secure_document_url = string(default='')
+
 # Used to connect to our celery task queue broker, for example RabbitMQ
 broker_url = string(default="amqp://localhost//")
 

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -980,6 +980,23 @@ def at_least_one_slot(event):
 # guests
 # =============================
 
+@validation.GuestGroup
+def payment_nan(guest_group):
+    try:
+        payment = int(float(guest_group.payment if guest_group.payment else 0))
+    except Exception:
+        return "What you entered for Payment ({}) isn't even a number".format(guest_group.payment)
+    
+@validation.GuestGroup
+def vehicles_nan(guest_group):
+    if not str(guest_group.vehicles).isdigit():
+        return "Please enter a whole number of comped parking spaces for vehicles."
+    
+@validation.GuestGroup
+def hotel_rooms_nan(guest_group):
+    if not str(guest_group.num_hotel_rooms).isdigit():
+        return "Please enter a whole number of comped hotel rooms."
+
 @validation.GuestMerch
 def is_merch_checklist_complete(guest_merch):
     if not guest_merch.selling_merch:

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -153,6 +153,15 @@ class Root:
         if cherrypy.request.method == 'POST':
             if event_id:
                 guest.event_id = event_id
+            message = check(guest)
+            if not message:
+                for field in ['estimated_loadin_minutes', 'estimated_performance_minutes']:
+                    if field in params:
+                        field_name = "load-in" if field == 'estimated_loadin_minutes' else 'performance'
+                        if not params.get(field):
+                            message = "Please enter more than 0 estimated {} minutes".format(field_name)
+                        elif not str(params.get(field, '')).isdigit():
+                            message = "Please enter a whole number for estimated {} minutes".format(field_name)
             if not message:
                 raise HTTPRedirect('index?message={}{}', guest.group.name, ' data uploaded')
 

--- a/uber/site_sections/guest_reports.py
+++ b/uber/site_sections/guest_reports.py
@@ -34,7 +34,6 @@ class Root:
         ])
         for guest in [guest for guest in session.query(GuestGroup).all() if session.admin_can_see_guest_group(guest)]:
             absolute_pic_url = convert_to_absolute_url(getattr(guest.bio, 'pic_url', ''))
-            absolute_w9_url = convert_to_absolute_url(getattr(guest.taxes, 'w9_url', ''))
             absolute_stageplot_url = convert_to_absolute_url(getattr(guest.stage_plot, 'url', ''))
             out.writerow([
                 guest.group.name, guest.email,
@@ -48,7 +47,7 @@ class Root:
                 getattr(guest.panel, 'wants_panel', ''), getattr(guest.panel, 'name', ''),
                 getattr(guest.panel, 'length', ''), getattr(guest.panel, 'desc', ''),
                 ' / '.join(getattr(guest.panel, 'panel_tech_needs_labels', '')),
-                absolute_w9_url, absolute_stageplot_url,
+                getattr(guest.taxes, 'w9_sent', ''), absolute_stageplot_url,
                 getattr(guest.merch, 'selling_merch_label', ''),
                 getattr(guest.charity, 'donating_label', ''), getattr(guest.charity, 'desc', '')
             ])

--- a/uber/site_sections/guests.py
+++ b/uber/site_sections/guests.py
@@ -79,16 +79,12 @@ class Root:
         guest = session.guest_group(guest_id)
         guest_taxes = session.guest_taxes(params, restricted=True)
         if cherrypy.request.method == 'POST':
-            guest_taxes.w9_filename = w9.filename
-            guest_taxes.w9_content_type = w9.content_type.value
-            if guest_taxes.w9_extension not in c.ALLOWED_W9_EXTENSIONS:
-                message = 'Uploaded file type must be one of ' + ', '.join(c.ALLOWED_W9_EXTENSIONS)
+            if not guest_taxes.w9_sent:
+                message = 'You must confirm that you have uploaded your W9 at the secure document portal'
             else:
-                with open(guest_taxes.w9_fpath, 'wb') as f:
-                    shutil.copyfileobj(w9.file, f)
                 guest.taxes = guest_taxes
                 session.add(guest_taxes)
-                raise HTTPRedirect('index?id={}&message={}', guest.id, 'W9 uploaded')
+                raise HTTPRedirect('index?id={}&message={}', guest.id, 'Thank you for sending in your W9!')
 
         return {
             'guest': guest,
@@ -464,14 +460,6 @@ class Root:
             disposition="attachment",
             name=guest.bio.download_filename,
             content_type=guest.bio.pic_content_type)
-
-    def view_w9(self, session, id):
-        guest = session.guest_group(id)
-        return serve_file(
-            guest.taxes.w9_fpath,
-            disposition="attachment",
-            name=guest.taxes.download_filename,
-            content_type=guest.taxes.w9_content_type)
 
     def view_stage_plot(self, session, id):
         guest = session.guest_group(id)

--- a/uber/templates/band_admin/checklist_info.html
+++ b/uber/templates/band_admin/checklist_info.html
@@ -4,7 +4,7 @@
 
 <h2>Band Info for <a href="../guests/index?id={{ guest.id }}">{{ guest.group.name }}</a></h2>
 
-<form class="form-horizontal" role="form" method="post" action="group_info">
+<form class="form-horizontal" role="form" method="post" action="checklist_info">
   {{ csrf_token() }}
   <input type="hidden" name="id" value="{{ guest.id }}" />
 
@@ -32,10 +32,8 @@
       <div class="form-control-static">
         {% if not guest.payment %}
           This band isn't being paid and thus doesn't need a W9 tax form.
-        {% elif guest.taxes_status %}
-          <a href="{{ guest.taxes.w9_url }}">Click here to view the band's uploaded W9 tax form</a>
         {% else %}
-          This band is supposed to be paid, but has not uploaded a W9 tax form yet.
+          This band has{% if not guest.taxes.w9_sent %} <strong>not</strong>{% endif %} uploaded their W9 form.
         {% endif %}
       </div>
     </div>

--- a/uber/templates/guest_admin/checklist_info.html
+++ b/uber/templates/guest_admin/checklist_info.html
@@ -4,7 +4,7 @@
 
 <h2>Guest Info for <a href="../guests/index?id={{ guest.id }}">{{ guest.group.name }}</a></h2>
 
-<form class="form-horizontal" role="form" method="post" action="group_info">
+<form class="form-horizontal" role="form" method="post" action="checklist_info">
   {{ csrf_token() }}
   <input type="hidden" name="id" value="{{ guest.id }}" />
 
@@ -75,20 +75,18 @@
   {% if guest.travel_plans.modes_text %}{{ macros.form_group(guest.travel_plans, 'modes_text', label='Travel Modes (Other)', is_readonly=True) }}{% endif %}
   {{ macros.form_group(guest.travel_plans, 'details', label='Arrival and Departure Times', is_readonly=True) }}
 
-  {% if guest.payment %}
-    <div class="form-group">
-      <label class="col-sm-3 control-label">W9</label>
-      <div class="col-sm-6">
-        <div class="form-control-static">
-          {% if guest.taxes.w9_url  %}
-            <a href="{{ guest.taxes.w9_url }}">Click here to view the guests's uploaded W9 tax form</a>
-          {% else %}
-            This guest is supposed to be paid, but has not uploaded a W9 tax form yet.
-          {% endif %}
-        </div>
+  <div class="form-group">
+    <label class="col-sm-3 control-label">W9</label>
+    <div class="col-sm-6">
+      <div class="form-control-static">
+        {% if not guest.payment %}
+          This guest isn't being paid and thus doesn't need a W9 tax form.
+        {% else %}
+          This guest has{% if not guest.taxes.w9_sent %} <strong>not</strong>{% endif %} uploaded their W9 form.
+        {% endif %}
       </div>
     </div>
-  {% endif %}
+  </div>
 
   {{ macros.form_group(guest, 'payment', type='number',
         help="""The number of dollars we're paying the guest.  If you leave this

--- a/uber/templates/guest_checklist/taxes_deadline.html
+++ b/uber/templates/guest_checklist/taxes_deadline.html
@@ -3,7 +3,7 @@
     <tr>
       <td width="25">{{ macros.checklist_image(guest.taxes_status) }}</td>
       <td><b><a href="taxes?guest_id={{ guest.id }}">
-        {% block deadline_headline %}Completed W9{% endblock %}</a></b></td>
+        {% block deadline_headline %}Upload W9{% endblock %}</a></b></td>
       <td><i>Deadline:</i> {{ guest.deadline_from_model('taxes')|datetime_local }}</td>
     </tr>
     <tr>
@@ -24,25 +24,20 @@
   <h2>{% block form_title %}Completed W9 for {{ guest.group.name }}{% endblock %}</h2>
 
   {% block form_desc %}
-    {% if guest.taxes_status %}
-      <a href="{{ guest.taxes.w9_url }}">Click here to view the W9 tax form you uploaded.</a>
-      <br/><br/>
-      Need to update this form?
-    {% endif %}
-
-    You can find a blank W9 form <a target="_blank" href="https://www.irs.gov/pub/irs-pdf/fw9.pdf">here</a>.
-    Please upload a filled out copy of this form.
+    Please use our secure document portal below to upload a W9 for the person to whom the check will be issued. We will issue 1099 forms to applicable parties at the end of the tax year.
+    <br/><br/>You can find a blank W9 form <a target="_blank" href="https://www.irs.gov/pub/irs-pdf/fw9.pdf">here</a>.
   {% endblock %}
 
-  <br/><br/>
+  <br/><br/><a href="{{ c.SECURE_DOCUMENT_URL }}" class="btn btn-info" target="_blank">Secure Document Portal</a>
 
-  <form method="post" action="w9" enctype="multipart/form-data">
+  <br/><br/><form method="post" action="w9">
     <input type="hidden" name="guest_id" value="{{ guest.id }}" />
     <input type="hidden" name="id" value="{{ guest_taxes.db_id }}" />
+    
     {{ csrf_token() }}
-    <input type="file" name="w9" />
+    {{ macros.checkbox(guest_taxes, 'w9_sent', label='I confirm that I have uploaded my W9 form at the document portal above.')}}
     <br/>
     {% block form_extra %}{% endblock %}
-    <input type="submit" class="btn btn-primary" value="Upload Completed Form" />
+    <input type="submit" class="btn btn-primary" value="Confirm Upload" />
   </form>
 {% endif %}

--- a/uber/templates/guest_reports/rock_island.html
+++ b/uber/templates/guest_reports/rock_island.html
@@ -122,7 +122,7 @@
       <div class="panel panel-default inventory-table-panel">
         <div class="panel-body">
           <h2>
-            <span>Inventory for <a href="../guest_admin/group_info?id={{ guest.id }}">{{ guest.group.name }}</a></span>
+            <span>Inventory for <a href="../guest_admin/checklist_info?id={{ guest.id }}">{{ guest.group.name }}</a></span>
             {% if guest_merch.inventory -%}
               <small><a href="{{ guest_merch.rock_island_csv_url }}">Download CSV for {{ guest.group.name }}</a></small>
             {%- endif %}
@@ -138,7 +138,7 @@
     {%- set guest_merch = guest.merch -%}
     {%- import 'guests_macros.html' as guests_macros with context -%}
     <h1>
-      <span>Rock Island Inventory for <a href="../guest_admin/group_info?id={{ guest.id }}">{{ guest.group.name }}</a></span>
+      <span>Rock Island Inventory for <a href="../guest_admin/checklist_info?id={{ guest.id }}">{{ guest.group.name }}</a></span>
       {% if guest_merch.inventory -%}
         <small><a href="{{ guest_merch.rock_island_csv_url }}">Download CSV for {{ guest.group.name }}</a></small>
       {%- endif %}

--- a/uber/templates/mivs_admin/checklist_info.html
+++ b/uber/templates/mivs_admin/checklist_info.html
@@ -1,6 +1,6 @@
 <h2>MIVS Checklist Info for <a href="../guests/index?id={{ guest.id }}">{{ guest.group.name }}</a></h2>
 
-<form class="form-horizontal" role="form" method="post" action="group_info">
+<form class="form-horizontal" role="form" method="post" action="checklist_info">
   {{ csrf_token() }}
   <input type="hidden" name="id" value="{{ guest.id }}" />
 


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-645. Requires secure_document_url to be set in secret config. Also fixes several other bugs I found while testing this, including one that prevented changing guest group metadata.