### PR TITLE
Hide approval for setup/teardown on irrelevant emails

### DIFF
--- a/uber/templates/emails/shifts/dept_checklist.txt
+++ b/uber/templates/emails/shifts/dept_checklist.txt
@@ -2,9 +2,9 @@
 
 As a department head for {{ attendee.assigned_depts_labels|readable_join }} we need some information from you about: {{ conf.name|safe }}
 
-{{ conf.description|safe }}
+{{ conf.description|safe }}{% if conf.slug == 'approve_setup_teardown' %}
 
-Approvals here will affect setup/teardown permissions for your volunteers. We can manually update those settings for those who aren't using staff crash space during those times, but this will be the bulk of your approvals. Note that this year, hotel night approvals are done on a department-by-department basis, so your denial or approval of a given volunteer will not affect their status in another department.
+Approvals here will affect setup/teardown permissions for your volunteers. We can manually update those settings for those who aren't using staff crash space during those times, but this will be the bulk of your approvals. Note that this year, hotel night approvals are done on a department-by-department basis, so your denial or approval of a given volunteer will not affect their status in another department.{% endif %}
 
 Please fill out the following forms by {{ conf.deadline|datetime_local }}:
 


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-736. All department head checklist items use the same base template and pull from config. We added text that only applies to one of the steps without realizing this, so now we hide that text for steps it doesn't apply to.