### PR TITLE
Fix attendee_shifts link

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -236,25 +236,25 @@ def form_link(model):
     page = 'form'
         
     if c.HAS_REGISTRATION_ACCESS:
-        attendee_section = 'registration'
+        attendee_section = '../registration/'
     else:
-        attendee_section = 'accounts'
-        page = 'homepage#attendee_form' if isinstance(model, Attendee) else page
+        attendee_section = ''
+        page = '#attendee_form' if isinstance(model, Attendee) else page
 
     site_sections = {
         Attendee: attendee_section,
-        Attraction: 'attractions_admin',
-        Department: 'dept_admin',
-        Group: 'group_admin',
-        Job: 'jobs',
-        PanelApplication: 'panels_admin'}
+        Attraction: '../attractions_admin/',
+        Department: '../dept_admin/',
+        Group: '../group_admin/',
+        Job: '../jobs/',
+        PanelApplication: '../panels_admin/'}
 
     cls = model.__class__
     site_section = site_sections.get(cls, form_link_site_sections.get(cls))
     name = getattr(model, 'name', getattr(model, 'full_name', model))
 
     if site_section:
-        return safe_string('<a href="../{}/{}?id={}">{}</a>'.format(site_section, page, model.id, jinja2.escape(name)))
+        return safe_string('<a href="{}{}?id={}">{}</a>'.format(site_section, page, model.id, jinja2.escape(name)))
     return name
 
 

--- a/uber/static/angular-apps/hotel/attendee.html
+++ b/uber/static/angular-apps/hotel/attendee.html
@@ -8,7 +8,7 @@
 <tr style="text-align:center">
     <td style="padding-bottom:15px"><a href="#/">Go back</a></td>
     <td>
-        <a href="../accounts/homepage#attendee_form?id={{ attendee.id }}">View registration form</a>
+        <a href="#attendee_form?id={{ attendee.id }}">View registration form</a>
         &nbsp;&nbsp;&nbsp;&nbsp;
         <a href="goto_staffer_requests?id={{ attendee.id }}">Edit Requested Nights</a>
     </td>

--- a/uber/static/angular-apps/hotel/schedule.html
+++ b/uber/static/angular-apps/hotel/schedule.html
@@ -65,13 +65,13 @@
     <td valign="top">
         <b>{{ unconfirmed.length }} haven't filled out<br/>the volunteer checklist</b>
         <div ng-repeat="attendee in lists.unconfirmed">
-            <a href="../accounts/homepage#attendee_form?id={{ attendee.id }}">{{ attendee.name }}</a>
+            <a href="#attendee_form?id={{ attendee.id }}">{{ attendee.name }}</a>
         </div>
     </td>
     <td valign="top">
         <br/> <b>{{ declined.length }} declined hotel space</b>
         <div ng-repeat="attendee in lists.declined">
-            <a href="../accounts/homepage#attendee_form?id={{ attendee.id }}">{{ attendee.name }}</a>
+            <a href="#attendee_form?id={{ attendee.id }}">{{ attendee.name }}</a>
         </div>
     </td>
 </table>

--- a/uber/static/angular-apps/tabletop_checkins/app.js
+++ b/uber/static/angular-apps/tabletop_checkins/app.js
@@ -9,7 +9,7 @@ angular.module('tabletop.checkins', ['ngRoute', 'magfest', 'ui.bootstrap'])
         return {
             restrict: 'E',
             template: '<span>' +
-                          '<a target="_blank" href="../accounts/homepage#attendee_form?id={{ attendee.id }}">{{ attendee.name }}</a>' +
+                          '<a target="_blank" href="#attendee_form?id={{ attendee.id }}">{{ attendee.name }}</a>' +
                           '<span ng-if="badge"> (Badge #{{ attendee.badge }})</span>' +
                       '</span>',
             scope: {

--- a/uber/templates/accounts/bulk.html
+++ b/uber/templates/accounts/bulk.html
@@ -38,7 +38,7 @@ var mainMenuDropdownChanged = function () {
 </thead>
 {% for attendee in attendees %}
     <tr>
-        <td width="20%" data-order="{{ attendee.full_name }}" data-search="{{ attendee.full_name }}"> <a href="../shifts_admin/attendee_shifts?id={{ attendee.id }}">{{ attendee.full_name }}</a>        </td>
+        <td width="20%" data-order="{{ attendee.full_name }}" data-search="{{ attendee.full_name }}"> <a href="#attendee_form?id={{ attendee.id }}&tab_view=Shifts">{{ attendee.full_name }}</a>        </td>
         {% if c.HAS_ACCOUNTS_ACCESS %}<td width="10">{% if attendee.admin_account %}Enabled{% else %}<input type="checkbox" class="cbox" id="{{ attendee.id }}"> Enable?{% endif %}</td>{% endif %}
         <td width="10">{% if not attendee.badge_num %}<font size="-1">TBD</font>{% else %}{{ attendee.badge_num }}{% endif %}</td>
         <td width="10">{% if attendee.is_dept_head %}<font size="-1">[D]</font>{% endif %}</td>

--- a/uber/templates/accounts/homepage.html
+++ b/uber/templates/accounts/homepage.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Homepage{% endblock %}
 {% block content %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 <div class="panel panel-body">
 <a href="#attendee_form?id=None" class="btn btn-primary">Add new attendee</a>
 {% if c.HAS_SHIFTS_ADMIN_ACCESS %}

--- a/uber/templates/accounts/index.html
+++ b/uber/templates/accounts/index.html
@@ -141,5 +141,4 @@ $(document).ready(function() {
     });
 });
 </script>
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 {% endblock %}

--- a/uber/templates/barcode/index.html
+++ b/uber/templates/barcode/index.html
@@ -32,7 +32,7 @@
         .done(function(data) {
             txt = "badge_num: " + data['badge_num']
             if (!data['attendee']) {
-                txt += '<br/>name: <a href="../accounts/homepage#attendee_form?id=' + data['attendee_id'] + '">' + data['attendee_name'] + '</a>';
+                txt += '<br/>name: <a href="#attendee_form?id=' + data['attendee_id'] + '">' + data['attendee_name'] + '</a>';
             }
             $("#result").html(txt);
             $("#result_msg").html(data.message);

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -399,7 +399,7 @@
                             </a>
                             <ul class="dropdown-menu" role="menu">
                                 {% if 'admin_account' in c.CURRENT_ADMIN %}
-                                  <li><a href="../accounts/homepage#attendee_form?id={{ c.CURRENT_ADMIN.id }}">My Registration</a></li>
+                                  <li><a href="#attendee_form?id={{ c.CURRENT_ADMIN.id }}">My Registration</a></li>
                                   {% if c.HAS_DEPT_ADMIN_ACCESS and c.CURRENT_ADMIN.assigned_depts %}
                                     <li><a href="../dept_admin/?filtered=1">My Departments</a></li>
                                     {% for dept in c.CURRENT_ADMIN.assigned_depts %}
@@ -470,6 +470,7 @@
               })
           });
       </script>
+      <script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
     {% endblock %}
     {% block additional_scripts %}
         {% block page_scripts %} {% endblock %}

--- a/uber/templates/budget/mpoints.html
+++ b/uber/templates/budget/mpoints.html
@@ -25,7 +25,7 @@
                     <li>
                         ${{ '%0.2f' % mpu.amount }} from
                         {% if mpu.attendee %}
-                            <a href="../accounts/homepage#attendee_form?id={{ mpu.attendee.id }}">{{ mpu.attendee.full_name }}</a>
+                            <a href="#attendee_form?id={{ mpu.attendee.id }}">{{ mpu.attendee.full_name }}</a>
                         {% else %}
                             {{ mpu.identifier }}
                         {% endif %}

--- a/uber/templates/dept_admin/form.html
+++ b/uber/templates/dept_admin/form.html
@@ -447,7 +447,7 @@
                 {%- set weighted_hours = attendee.weighted_hours -%}
                 <tr>
                   <td data-order="{{ attendee.full_name }}" data-search="{{ attendee.full_name }}">
-                    {{ attendee|form_link }}
+                    <a href="#attendee_form?id={{ attendee.id }}">{{ attendee.full_name }}</a>
                   </td>
                   <td>{{ attendee.badge }}</td>
                   <td>{{ attendee.paid_label }}</td>
@@ -455,11 +455,11 @@
                     {{ hours_here }}
                   </td>
                   <td data-order="{{ weighted_hours }}" data-search="{{ weighted_hours }}">
-                    <a href="../shifts_admin/attendee_shifts?id={{ attendee.id }}">{{ weighted_hours }}</a>
+                    <a href="#attendee_form?id={{ attendee.id }}&tab_view=Shifts">{{ weighted_hours }}</a>
                   </td>
                   {% if c.AT_OR_POST_CON %}
                     <td data-order="{{ attendee.worked_hours }}" data-search="{{ attendee.worked_hours }}">
-                      <a href="../shifts_admin/attendee_shifts?id={{ attendee.id }}">{{ attendee.worked_hours }}</a>
+                      <a href="#attendee_form?id={{ attendee.id }}&tab_view=Shifts">{{ attendee.worked_hours }}</a>
                     </td>
                   {% endif %}
                   {% if c.AT_THE_CON %}
@@ -494,5 +494,4 @@
     </div>
   </div>
 </div>
-
 {% endblock %}

--- a/uber/templates/dept_checklist/hotel_requests.html
+++ b/uber/templates/dept_checklist/hotel_requests.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Hotel Requests{% endblock %}
 {% block content %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 <script type="text/javascript">
     function setApproved(approved, id, btn) {
         var $td = $(btn).parent("td");

--- a/uber/templates/dept_checklist/hours.html
+++ b/uber/templates/dept_checklist/hours.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Unfilled Hotel Requirements{% endblock %}
 {% block content %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 <h2> {{ staffers|length }} Staffers With Hotel Space Need More Hours </h2>
 
 <table class="list">

--- a/uber/templates/group_admin/deletion_confirmation.html
+++ b/uber/templates/group_admin/deletion_confirmation.html
@@ -8,7 +8,7 @@ This group still has unassigned badges:
 <ul>
     {% for attendee in group.attendees %}
         {% if not attendee.is_unassigned %}
-            <li> <a href="../accounts/homepage#attendee_form?id={{ attendee.id }}">{{ attendee.full_name }}</a> </li>
+            <li> <a href="#attendee_form?id={{ attendee.id }}">{{ attendee.full_name }}</a> </li>
         {% endif %}
     {% endfor %}
 </ul>

--- a/uber/templates/group_admin/form.html
+++ b/uber/templates/group_admin/form.html
@@ -168,7 +168,6 @@
         </div>
         {% endif %}
         </div>
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 <script src="../static/js/window-hash-tabload.js" type="text/javascript"></script>
 {% if group.is_new %}
 <script type="text/javascript">

--- a/uber/templates/group_admin/history.html
+++ b/uber/templates/group_admin/history.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Group History - {{ group.name }}{% endblock %}
 {% block content %}
 {% include "group_admin/nav_menu.html" %}
 {% include "model_history_base.html" %}

--- a/uber/templates/group_admin/index.html
+++ b/uber/templates/group_admin/index.html
@@ -95,6 +95,5 @@
   {% endif %}
   </div>
   </div>
-  <script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
   <script src="../static/js/window-hash-tabload.js" type="text/javascript"></script>
 {% endblock %}

--- a/uber/templates/mivs_admin/studios.html
+++ b/uber/templates/mivs_admin/studios.html
@@ -48,5 +48,4 @@
 {% endfor %}
 </tbody>
 </table>
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 {% endblock %}

--- a/uber/templates/panels_admin/app.html
+++ b/uber/templates/panels_admin/app.html
@@ -236,5 +236,4 @@
 
     {{ panel_macros.app_panelists_form(app, is_readonly=True, is_admin=True) }}
 </div>
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 {% endblock %}

--- a/uber/templates/promo_codes/index.html
+++ b/uber/templates/promo_codes/index.html
@@ -157,5 +157,4 @@ $(document).ready(function() {
     </tbody>
   </table>
 </div>
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 {% endblock %}

--- a/uber/templates/registration/attendee_form.html
+++ b/uber/templates/registration/attendee_form.html
@@ -68,6 +68,15 @@ var refreshTab = function() {
   var currentTab = $('.tab-pane.active');
   loadForm(currentTab.attr('id').slice(8));
 };
+{% if tab_view %}
+var tab = $('.nav-tabs a[href="#attendee{{ tab_view }}"]');
+if(tab.length) {
+  tab.tab('show');
+} else {
+  $('.nav-tabs a').first().tab('show');
+}
+loadForm("{{ tab_view }}");
+{% endif %}
 </script>
 <div class="modal-header">
   <button type="button" class="close" data-dismiss="modal">&times;</button>

--- a/uber/templates/registration/menu.html
+++ b/uber/templates/registration/menu.html
@@ -1,7 +1,7 @@
 {{ macros.nav_menu(
     attendee, c.PAGE_PATH,
     "../registration/form?id={id}", "Attendee Data", True,
-    "../shifts_admin/attendee_shifts?id={id}&return_to=../registration/index", "Shifts", attendee.staffing and c.HAS_SHIFTS_ADMIN_ACCESS,
+    "../registration/shifts?id={id}&return_to=../registration/index", "Shifts", attendee.staffing and c.HAS_SHIFTS_ADMIN_ACCESS,
     "../registration/history?id={id}", "History", True,
     "../reg_admin/receipt_items?id={id}", "Receipt Items", c.HAS_REG_ADMIN_ACCESS,
     "../security_admin/watchlist?attendee_id={id}", "Watch List Entry", attendee.banned and c.HAS_SECURITY_ADMIN_ACCESS,

--- a/uber/templates/registration/pending_badges.html
+++ b/uber/templates/registration/pending_badges.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panelist Badges{% endblock %}}
 {% block content %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
   <script>
       var hideRows = function (id) {
           $('#' + id).hide('slow');

--- a/uber/templates/registration/promo_code_group_form.html
+++ b/uber/templates/registration/promo_code_group_form.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Promo Code Group: {{ group.name }}{% endblock %}
 {% block content %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
   <script type="text/javascript">
   var setBuyerLink = function () {
         if ($.field('buyer_id')) {

--- a/uber/templates/registration/reg_take_report.html
+++ b/uber/templates/registration/reg_take_report.html
@@ -83,5 +83,4 @@
     {% endfor %}
     </table>
 {% endif %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 {% endblock %}

--- a/uber/templates/registration/shifts.html
+++ b/uber/templates/registration/shifts.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% block title %}Attendee History - {{ attendee.full_name }}{% endblock %}
+{% block title %}Attendee Shifts - {{ attendee.full_name }}{% endblock %}
 {% block content %}
 {% include "registration/menu.html" %}
-{% include "model_history_base.html" %}
+{% include "registration/attendee_shifts.html" %}
 {% endblock %}

--- a/uber/templates/shifts_admin/job_renderer.html
+++ b/uber/templates/shifts_admin/job_renderer.html
@@ -75,7 +75,7 @@
             .empty()
             .append(
                 $('<td class="attendee-name"></td>').append(
-                    $('<a href="attendee_shifts?id=' + shift.attendee_id + '"></a>').text(
+                    $('<a href="#attendee_form?id=' + shift.attendee_id + '&tab_view=Shifts"></a>').text(
                         shift.attendee_name  + ' (#' + (shift.attendee_badge || 'TBD') + ')'
                     )
                 ))

--- a/uber/templates/shifts_admin/staffers.html
+++ b/uber/templates/shifts_admin/staffers.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Staffer Summary{% endblock %}
 {% block content %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 {% include "shifts_admin/main_menu.html" %}
 
 <div class="row">

--- a/uber/templates/shifts_admin/staffers_by_job.html
+++ b/uber/templates/shifts_admin/staffers_by_job.html
@@ -28,7 +28,7 @@
     {% for shift in job.shifts %}
         <tr>
             <td> <ul><li></li></ul> </td>
-            <td> <a href="attendee_shifts?id={{ shift.attendee.id }}">{{ shift.attendee.full_name }}</a> </td>
+            <td> <a href="#attendee_form?id={{ shift.attendee.id }}&tab_view=Shifts">{{ shift.attendee.full_name }}</a> </td>
             <form method="post" action="unassign_from_job">
             {{ csrf_token() }}
             <input type="hidden" name="id" value="{{ shift.id }}" />

--- a/uber/templates/staffing_admin/pending_badges.html
+++ b/uber/templates/staffing_admin/pending_badges.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Panelist Badges{% endblock %}}
 {% block content %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
   <script>
       var hideRows = function (id) {
           $('#' + id).hide('slow');

--- a/uber/templates/staffing_reports/consecutive_threshold.html
+++ b/uber/templates/staffing_reports/consecutive_threshold.html
@@ -9,7 +9,7 @@ The following {{ flagged|length }} volunteers have signed up for at least 13 hou
 <table style="width:auto">
     {% for attendee in flagged %}
         <tr>
-            <td><a href="../shifts_admin/attendee_shifts?id={{ attendee.id }}">{{ attendee.full_name }}</a>:</td>
+            <td><a href="#attendee_form?id={{ attendee.id }}&tab_view=Shifts">{{ attendee.full_name }}</a>:</td>
             <td>{{ attendee.hours|length }} total (wall-clock) hours</td>
         </tr>
     {% endfor %}

--- a/uber/templates/staffing_reports/departments.html
+++ b/uber/templates/staffing_reports/departments.html
@@ -47,5 +47,4 @@
         </td>
     </tr></table>
 {% endfor %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 {% endblock %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-681 by:
1. Recreating the registration/shifts for the 'old' registration form
2. Implementing a way to load the attendee form modal with a specific tab selected, then using that for direct links to attendees' shifts view

I also moved the javascript to load the attendee form modal to base.html, as we access the modal on a ton of pages and it's a pain to always redirect to the homepage.