### PR TITLE
Add "Show Info" step to MIVS Checklist

### DIFF
--- a/alembic/versions/53b71e7c45b5_add_fields_for_mivs_show_info_checklist_.py
+++ b/alembic/versions/53b71e7c45b5_add_fields_for_mivs_show_info_checklist_.py
@@ -1,0 +1,61 @@
+"""Add fields for MIVS show_info checklist item
+
+Revision ID: 53b71e7c45b5
+Revises: e822b20093c1
+Create Date: 2019-11-25 19:37:15.322579
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '53b71e7c45b5'
+down_revision = 'e822b20093c1'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('indie_studio', sa.Column('contact_phone', sa.Unicode(), server_default='', nullable=False))
+    op.add_column('indie_studio', sa.Column('show_info_updated', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('indie_studio', 'show_info_updated')
+    op.drop_column('indie_studio', 'contact_phone')

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -710,6 +710,11 @@ def mivs_unique_name(studio):
         if session.query(IndieStudio).filter(IndieStudio.name == studio.name, IndieStudio.id != studio.id).count():
             return "That studio name is already taken; " \
                 "are you sure you shouldn't be logged in with that studio's account?"
+                
+@validation.IndieStudio
+def mivs_studio_contact_phone(studio):
+    if studio.contact_phone and _invalid_phone_number(studio.contact_phone):
+        return 'Please enter a valid phone number'
 
 
 @validation.IndieDeveloper

--- a/uber/models/mivs.py
+++ b/uber/models/mivs.py
@@ -87,6 +87,8 @@ class IndieStudio(MagModel):
     needs_hotel_space = Column(Boolean, nullable=True, admin_only=True)  # "Admin only" preserves null default
     name_for_hotel = Column(UnicodeText)
     email_for_hotel = Column(UnicodeText)
+    contact_phone = Column(UnicodeText)
+    show_info_updated = Column(Boolean, default=False)
 
     games = relationship(
         'IndieGame', backref='studio', order_by='IndieGame.title')
@@ -153,6 +155,10 @@ class IndieStudio(MagModel):
         if self.needs_hotel_space is not None:
             return "Requested hotel space for {} with email {}".format(self.name_for_hotel, self.email_for_hotel)\
                 if self.needs_hotel_space else "Opted out"
+                
+    @property
+    def show_info_status(self):
+        return self.show_info_updated
 
     def checklist_deadline(self, slug):
         default_deadline = c.MIVS_CHECKLIST[slug]['deadline']
@@ -202,6 +208,10 @@ class IndieStudio(MagModel):
     @property
     def submitted_games(self):
         return [g for g in self.games if g.submitted]
+    
+    @property
+    def confirmed_games(self):
+        return [g for g in self.games if g.confirmed]
 
     @property
     def comped_badges(self):

--- a/uber/site_sections/guests.py
+++ b/uber/site_sections/guests.py
@@ -434,6 +434,26 @@ class Root:
             'guest': guest,
             'message': message,
         }
+        
+    def mivs_show_info(self, session, guest_id, message='', **params):
+        guest = session.guest_group(guest_id)
+        if cherrypy.request.method == 'POST':
+            if guest.group.studio:
+                if not params.get('show_info_updated'):
+                    message = "Please confirm you have updated your studio's and game's information."
+
+                if not message:
+                    guest.group.studio.show_info_updated = True
+                    session.add(guest)
+                    raise HTTPRedirect('index?id={}&message={}',
+                                       guest.id,
+                                       'Thanks for confirming your studio and game information is up-to-date!')
+            else:
+                message = "Something is wrong with your group -- please contact us at {}.".format(c.MIVS_EMAIL)
+        return {
+            'guest': guest,
+            'message': message,
+        }
 
     def view_inventory_file(self, session, id, item_id, name):
         guest_merch = session.guest_merch(id)

--- a/uber/site_sections/mivs.py
+++ b/uber/site_sections/mivs.py
@@ -264,6 +264,10 @@ class Root:
             game.apply(params, bools=['tournament_at_event', 'has_multiplayer', 'leaderboard_challenge'],
                        restricted=False)  # Setting restricted to false lets us define custom bools and checkgroups
             game.studio.name = params.get('studio_name', '')
+            if not params.get('contact_phone', ''):
+                message = "Please enter a phone number for MIVS staff to contact your studio."
+            else: 
+                game.studio.contact_phone = params.get('contact_phone', '')
             if promo_image:
                 image = session.indie_game_image(params)
                 image.game = game
@@ -276,14 +280,13 @@ class Root:
                         shutil.copyfileobj(promo_image.file, f)
             message = check(game) or check(game.studio)
             if not message:
-                if game.tournament_at_event and not game.promo_image and not promo_image:
-                    message = 'Please upload a high resolution image of cover art or the game logo.'
-                else:
-
-                    session.add(game)
-                    raise HTTPRedirect('index?message={}', 'Game information uploaded')
+                session.add(game)
+                if game.studio.group.guest:
+                    raise HTTPRedirect('../guests/mivs_show_info?guest_id={}&message={}', 
+                                       game.studio.group.guest.id, 'Game information uploaded')
+                raise HTTPRedirect('index?message={}', 'Game information uploaded')
 
         return {
             'message': message,
-            'game': game
+            'game': game,
         }

--- a/uber/templates/dept_checklist/placeholders.html
+++ b/uber/templates/dept_checklist/placeholders.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Placeholder Attendees{% endblock %}}
 {% block content %}
-<script src="../static/js/load-attendee-modal.js" type="text/javascript"></script>
 {% include "dept_checklist/dept_menu.html" %}
 
 <h2>{{ dept_name }} Unconfirmed Volunteers: {{ placeholders|length }}</h2>

--- a/uber/templates/guests/mivs_handbook.html
+++ b/uber/templates/guests/mivs_handbook.html
@@ -6,7 +6,7 @@
 
   <p>The MIVS Indie Handbook is here to give you information about being a MIVS Participant. Please read through the entire Handbook so that you know what is expected of you and your team at MAGFest.</p>
 
-  <p><a href="https://docs.google.com/document/d/14DX4wMIBWiAKmqcgV4GwoQo2FAwinYfoEWizrVeSTtQ/edit?usp=sharing" target="_handbook">(The MIVS Indie Handbook)</a></p>
+  <p><a href="https://docs.google.com/document/d/14DX4wMIBWiAKmqcgV4GwoQo2FAwinYfoEWizrVeSTtQ/edit?usp=sharing" target="_blank">(The MIVS Indie Handbook)</a></p>
 
   <form class="form form-horizontal" method="post" action="mivs_handbook">
     <input type="hidden" name="guest_id" value="{{ guest.id }}"/>

--- a/uber/templates/guests/mivs_show_info.html
+++ b/uber/templates/guests/mivs_show_info.html
@@ -1,0 +1,17 @@
+{% extends "guestbase.html" %}
+
+{% block body %}
+
+  <h3>Update Studio and Game Information</h3>
+
+  Please use the link{{ guest.group.studio.confirmed_games|length|pluralize }} below to update your information for MIVS so it can be displayed on the MAGFest website.<br/><br/>
+  
+  <form class="form form-horizontal" method="post" action="mivs_show_info">
+    <input type="hidden" name="guest_id" value="{{ guest.id }}"/>
+    {% for game in guest.group.studio.confirmed_games %}
+    <a href="../mivs/show_info?id={{ game.id }}" target="_blank">Update Studio and Game Information for {{ game.title }}</a><br/>
+    {% endfor %}
+    {{ macros.checkbox(guest.group.studio, 'show_info_updated', label="I have checked and updated my game and studio information.") }}
+    <br/><button type="submit" class="btn btn-primary">Confirm Info</button>
+  </form>
+{% endblock body %}

--- a/uber/templates/mivs/show_info.html
+++ b/uber/templates/mivs/show_info.html
@@ -118,71 +118,7 @@
       </div>
     </div>
 
-    <h4>Tournament Information</h4>
-    <div class="form-group">
-      <div class="col-sm-6 col-sm-offset-3">
-        {{ macros.checkbox(game, 'tournament_at_event', label="Yes, we'd like to run a tournament for this game
-      at the event.") }}
-      </div>
-    </div>
-
-    <div id="tournament-details">
-      <div class="form-group">
-        <label for="has_multiplayer" class="col-sm-3 control-label">Multiplayer</label>
-        <div class="checkbox col-sm-9">
-          {{ macros.checkbox(game, 'has_multiplayer', label="This game has a multiplayer mode.") }}
-        </div>
-      </div>
-
-      <div id="multiplayer-details">
-        <div class="form-group">
-          <label class="col-sm-3 control-label">Player Count</label>
-          <div class="col-sm-6">
-            <input class="form-control" type="text" name="player_count" value="{{ game.player_count }}" />
-            <p class="help-block">
-              How many players are supported? E.g., "2 or 4 players."
-            </p>
-          </div>
-        </div>
-        <div class="form-group">
-          <label class="col-sm-3 control-label">Multiplayer Game Length</label>
-          <div class="col-sm-6">
-            <input class="form-control" type="number" name="multiplayer_game_length" value="{{ game.multiplayer_game_length }}" />
-            <p class="help-block">
-              The length of each multiplayer game or match, in minutes.
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="col-sm-3 control-label">Promo Image</label>
-        <div class="col-sm-6">
-          <input class="form-control" type="file" name="promo_image" />
-          <p class="help-block">
-            Hi-res cover art or a game logo.
-          </p>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="col-sm-3 control-label optional-field">Tournament Prizes</label>
-        <div class="col-sm-6">
-          <textarea class="form-control" name="tournament_prizes" rows="4">{{ game.tournament_prizes }}</textarea>
-          <p class="help-block">
-            A description of the prizes you're willing to offer for the game tournament, if any.
-          </p>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="col-sm-3 control-label optional-field">Leaderboard Challenge</label>
-        <div class="checkbox col-sm-9">
-          {{ macros.checkbox(game, 'leaderboard_challenge', label="Yes, we would like to run a leaderboard challenge for
-        this game.") }}
-        </div>
-      </div>
-    </div>
+    {{ macros.form_group(game.studio, 'contact_phone', label="Studio Contact Phone #", help="Used only for MIVS staff to contact you.", is_required=True) }}
 
     <button type="submit" class="btn btn-primary">Upload Information</button>
   </form>


### PR DESCRIPTION
This fixes https://jira.magfest.net/browse/MAGDEV-628 -- we actually already had a page that combined the info MIVS studios need to update for their games and studio, so we used that instead of the pre-acceptance game and studio editing pages. To enable the step we'll simply need to add it to config.

Also includes a file I missed in the last pull request.