### PR TITLE
Automatically log in MIVS studios completing their checklist

### DIFF
--- a/uber/site_sections/mivs.py
+++ b/uber/site_sections/mivs.py
@@ -260,6 +260,7 @@ class Root:
 
     def show_info(self, session, id, message='', promo_image=None, **params):
         game = session.indie_game(id=id)
+        cherrypy.session['studio_id'] = game.studio.id
         if cherrypy.request.method == 'POST':
             game.apply(params, bools=['tournament_at_event', 'has_multiplayer', 'leaderboard_challenge'],
                        restricted=False)  # Setting restricted to false lets us define custom bools and checkgroups


### PR DESCRIPTION
MIVS studios need to edit their screenshots while completing their checklist, but the system was redirecting them to the studio login page, which isn't editable after the deadline. We now automatically log in a studio once they load their show_info page -- this isn't perfect, because passing around a direct link will still end up redirecting them, but it's 80% of what we need.