### PR TITLE
Actually register new ScheduleLookup API

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -918,3 +918,4 @@ if c.API_ENABLED:
     register_jsonrpc(GuestLookup(), 'guest')
     register_jsonrpc(MivsLookup(), 'mivs')
     register_jsonrpc(HotelLookup(), 'hotel')
+    register_jsonrpc(ScheduleLookup(), 'schedule')


### PR DESCRIPTION
I don't know off the top of my head if this is needed to actually use the new API class, but at the very least it should put it on our API help page.