### PR TITLE
Hide declined dealers by default

### DIFF
--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -21,7 +21,7 @@ class Root:
                 's' if len(missing) > 1 else '')
         return ''
 
-    def index(self, session, message=''):
+    def index(self, session, message='', show_all=None):
         groups = session.viewable_groups().limit(c.ROW_LOAD_LIMIT)
         dealer_groups = [group for group in groups if group.is_dealer]
         return {
@@ -32,6 +32,7 @@ class Root:
             'dealer_groups':      len(dealer_groups),
             'dealer_badges':      sum(g.badges for g in dealer_groups),
             'tables':            sum(g.tables for g in dealer_groups),
+            'show_all': show_all,
             'unapproved_tables': sum(g.tables for g in dealer_groups if g.status == c.UNAPPROVED),
             'waitlisted_tables': sum(g.tables for g in dealer_groups if g.status == c.WAITLISTED),
             'approved_tables':   sum(g.tables for g in dealer_groups if g.status == c.APPROVED)

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -1072,7 +1072,7 @@ class Root:
     @log_pageview
     @attendee_view
     def attendee_history(self, session, id, **params):
-        attendee = session.attendee(id)
+        attendee = session.attendee(id, allow_invalid=True)
         
         return {
             'attendee': attendee,
@@ -1088,7 +1088,7 @@ class Root:
     @attendee_view
     @cherrypy.expose(['shifts'])
     def attendee_shifts(self, session, id, **params):
-        attendee = session.attendee(id)
+        attendee = session.attendee(id, allow_invalid=True)
         attrs = Shift.to_dict_default_attrs + ['worked_label']
         
         return_dict = {
@@ -1108,7 +1108,7 @@ class Root:
     @log_pageview
     @attendee_view
     def attendee_watchlist(self, session, id, **params):
-        attendee = session.attendee(id)
+        attendee = session.attendee(id, allow_invalid=True)
         return {
             'attendee': attendee,
             'active_entries': session.guess_attendee_watchentry(attendee, active=True),

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -177,8 +177,9 @@
           try {
               // Replace the query parameter in the web browser's address bar
               if (history && history.replaceState) {
+                  var hash = window.location.hash;
                   var queryString = replaceQueryParam(queryParam, value);
-                  history.replaceState({}, document.title, window.location.pathname + queryString);
+                  history.replaceState({}, document.title, window.location.pathname + queryString + hash);
                   return true;
               }
           } catch(ex) {

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -63,7 +63,7 @@
 {% endif %}
 <script type="text/javascript">
   var unapprove = function(action, convert) {
-    if (!$.val("email")) {
+    if (!$.val("email_text")) {
       $("#setstatus").prepend('<div style="color:red">You must enter an email message.</div>');
     } else {
       $("button").attr("disabled", true);
@@ -72,10 +72,10 @@
         action: action,
         convert: convert,
         csrf_token: csrf_token,
-        email: $.val("email")
+        email_text: $.val("email_text")
       }, function(json) {
         if (json.message) {
-          window.location = "index?message="+ json.message;
+          window.location = "index?message="+ json.message + "#dealers";
         } else {
           $("#status").text("Waitlisted");
         }

--- a/uber/templates/group_admin/dealers.html
+++ b/uber/templates/group_admin/dealers.html
@@ -11,9 +11,10 @@
 <div class="panel panel-default">
   <div class="panel-body">
     {{ dealer_groups }} {{ c.DEALER_TERM }} groups ({{ dealer_badges }} badges, {{ tables }} tables)
+    <span class="pull-right"><a href="index?show_all=true#dealers" class="btn btn-info">Show Declined Dealers</a></span>
     <br/> <br/>
     {{ approved_tables }} approved tables / {{ waitlisted_tables }} waitlisted tables / {{ unapproved_tables }} unapproved tables
-  </div>
+  </div>  
 </div>
 
 <div class="table-responsive">
@@ -31,7 +32,7 @@
     </tr>
   </thead>
   <tbody>
-{% for group in groups if group.is_dealer %}
+{% for group in groups if group.is_dealer and (show_all or group.status != c.DECLINED) %}
     <tr>
         <td style="text-align:left" data-order="{{ group.name }}" data-search="{{ group.name }}"> <a href="form?id={{ group.id }}">{{ group.name|default('?????', boolean=True) }}</a> </td>
         <td>


### PR DESCRIPTION
Part of fixing https://jira.magfest.net/browse/MAGDEV-660 -- deleting declined dealers was causing issues, so now we just hide them on the Dealers tab instead. Also adds a button to show them, some frontend fixes for the decline function not firing properly, and some quality of life updates to fix things I noticed while testing my changes.