### PR TITLE
Fix the mass decline-and-convert function

### DIFF
--- a/uber/site_sections/dealer_admin.py
+++ b/uber/site_sections/dealer_admin.py
@@ -126,7 +126,7 @@ class Root:
                     _decline_and_convert_dealer_group(session, group)
                 message = 'All waitlisted {}s have been declined and converted to regular attendee badges'\
                     .format(c.DEALER_TERM)
-            raise HTTPRedirect('index?order=name&show=tables&message={}', message)
+            raise HTTPRedirect('../group_admin/index?message={}#dealers', message)
 
         return {'groups': query.all()}
 

--- a/uber/templates/dealer_admin/waitlist.html
+++ b/uber/templates/dealer_admin/waitlist.html
@@ -15,8 +15,8 @@
         backdrop: true,
         title: 'Decline All Waitlisted {{ c.DEALER_TERM|title }}s?',
         message: '<p>Are you sure you want to decline <b>EVERY</b> waitlisted {{ c.DEALER_TERM }}?</p>' +
-          '<p>This will delete the groups and convert the badges to normal Attendee badges ' +
-          'at the price of registration when they first applied. An email will be sent to ' +
+          '<p>This will convert the badges to normal Attendee badges at the price of registration ' +
+          'when they first applied, minus the group discount. An email will be sent to ' +
           'each declined {{ c.DEALER_TERM }}.</p>' +
           '<p>This <b>CANNOT</b> be undone.</p>',
         buttons: {


### PR DESCRIPTION
I forgot to test the mass version of declining and converting dealers -- it was redirecting to the wrong page and the warning said we would delete dealers.