### PR TITLE
Remove POST-only Guidebook exports from sitemap

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -248,7 +248,9 @@ def ajax_gettable(func):
 
 
 def multifile_zipfile(func):
-    func.site_mappable = True
+    parameters = inspect.getargspec(func)
+    if len(parameters[0]) == 3:
+        func.site_mappable = True
 
     @wraps(func)
     def zipfile_out(self, session, **kwargs):

--- a/uber/site_sections/schedule_reports.py
+++ b/uber/site_sections/schedule_reports.py
@@ -50,7 +50,7 @@ class Root:
             out.writerow(row)
 
     @multifile_zipfile
-    def export_guidebook_zip(self, zip_file, session, selected_model=None):
+    def export_guidebook_zip(self, zip_file, session, selected_model):
         model_list = _get_guidebook_models(session, selected_model).all()
 
         for model in model_list:

--- a/uber/site_sections/schedule_reports.py
+++ b/uber/site_sections/schedule_reports.py
@@ -32,7 +32,7 @@ class Root:
         }
 
     @xlsx_file
-    def export_guidebook_xlsx(self, out, session, selected_model=''):
+    def export_guidebook_xlsx(self, out, session, selected_model):
         model_list = _get_guidebook_models(session, selected_model).all()
 
         _set_response_filename('{}_guidebook_{}.xlsx'.format(
@@ -50,7 +50,7 @@ class Root:
             out.writerow(row)
 
     @multifile_zipfile
-    def export_guidebook_zip(self, zip_file, session, selected_model=''):
+    def export_guidebook_zip(self, zip_file, session, selected_model=None):
         model_list = _get_guidebook_models(session, selected_model).all()
 
         for model in model_list:


### PR DESCRIPTION
I thought we had an issue to track this but I can't find it. Our guidebook exports require a selected model, which means you need to use a page to choose which export to get, but the direct links were being displayed on the sitemap. This fixes that.