### PR TITLE
Replace max_badges with attendee_badge stocks

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -232,12 +232,19 @@ class Config(_Overridable):
 
     @request_cached_property
     @dynamic
-    def ATTENDEE_BADGES_SOLD(self):
+    def ATTENDEE_BADGE_COUNT(self):
+        """
+        c.ATTENDEE_BADGE_COUNT is already provided via getattr, but redefining it here lets us cache it per request.
+        """
         return self.get_badge_count_by_type(c.ATTENDEE_BADGE)
 
     @request_cached_property
     @dynamic
     def BADGES_SOLD(self):
+        """
+        The number of badges that we've sold, including all badge types and promo code groups' badges.
+        This is used for bucket-based pricing and to estimate year-over-year sales.
+        """
         from uber.models import Session, Attendee, Group, PromoCode, PromoCodeGroup
         if self.BADGES_SOLD_ESTIMATE_ENABLED:
             with Session() as session:
@@ -274,10 +281,7 @@ class Config(_Overridable):
 
         if current_price_tier != -1 and c.ORDERED_PRICE_LIMITS[current_price_tier] == c.ORDERED_PRICE_LIMITS[-1] \
                 or not c.ORDERED_PRICE_LIMITS:
-            if c.MAX_BADGE_SALES:
-                difference = c.MAX_BADGE_SALES - c.BADGES_SOLD
-            else:
-                return -1
+            return -1
         else:
             for key, val in c.PRICE_LIMITS.items():
                 if c.ORDERED_PRICE_LIMITS[current_price_tier+1] == val:
@@ -649,7 +653,7 @@ class Config(_Overridable):
     @property
     @dynamic
     def REMAINING_BADGES(self):
-        return max(0, self.MAX_BADGE_SALES - self.BADGES_SOLD)
+        return max(0, self.ATTENDEE_BADGE_STOCK - self.ATTENDEE_BADGE_COUNT)
 
     @request_cached_property
     @dynamic

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -391,12 +391,6 @@ min_group_addition = integer(default=5)
 # Set this to 0 or less to completely disable the grace period.
 group_update_grace_period = integer(default=24)
 
-# This is NOT our attendance cap; this is merely the number of paid attendee
-# and group registrations which we support.  In other words, we will only
-# cut off preregistration once that sum meets this number no matter how
-# many other registrations (Staff, Dealers, Guests, etc) are in the system.
-max_badge_sales = integer(default=20000)
-
 # Some events require an explicit legal agreement for volunteers as part of
 # the volunteer checklist. For evernts where this is true, set this to true
 # and make sure staffing/volunteer_agreement_item.html is included in the
@@ -958,10 +952,12 @@ __many__ = integer
 __many__ = integer
 
 [[stocks]]
-# Use this to set limits on how many copies of each badge can be issues, e.g.
+# Use this to set limits on how many copies of each badge can be sold, e.g.
 # if you only have 200 Friday badges you'd say "friday = 200".  Although you
 # can list arbitrary things here, the intention is for options in this section
-# to correspond to badge types, e.g. "attendee_badge = 2000", etc.
+# to correspond to badge types.
+# We shut down ALL badge sales if attendee badges run out, so this is the event cap.
+attendee_badge = 20000
 __many__ = integer
 
 

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -957,7 +957,7 @@ __many__ = integer
 # can list arbitrary things here, the intention is for options in this section
 # to correspond to badge types.
 # We shut down ALL badge sales if attendee badges run out, so this is the event cap.
-attendee_badge = 20000
+attendee_badge = integer(default=20000)
 __many__ = integer
 
 

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -86,18 +86,7 @@ def check_if_can_reg(func):
                 return render('static_views/dealer_reg_closed.html')
             else:
                 return render('static_views/dealer_reg_not_open.html')
-        elif c.ATTENDEE_BADGES_SOLD >= c.MAX_BADGE_SALES:
-            # ===============================================================
-            # TODO: MAKE THIS COMPARE THE SPECIFIC BADGE TYPE AGAINST OUR
-            # STOCKS OF THAT TYPE. LUMPING ALL THE BADGE TYPES TOGETHER
-            # AND COMPARING AGAINST A SINGLE NUMBER DOESN'T MAKE SENSE,
-            # BECAUSE WE HAVE DIFFERENT NUMBERS OF PHYSICAL BADGES FOR EACH
-            # BADGE TYPE.
-            #
-            # FOR NOW, THIS IS COOL, BECAUSE THE ONLY BADGE TYPE WE ARE
-            # WORRIED ABOUT SELLING OUT IS ATTENDEE_BADGE. BUT THAT MAY NOT
-            # ALWAYS BE THE CASE.
-            # ===============================================================
+        elif not c.ATTENDEE_BADGE_AVAILABLE:
             return render('static_views/prereg_soldout.html')
         elif c.BEFORE_PREREG_OPEN and not is_dealer_reg:
             return render('static_views/prereg_not_yet_open.html')

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -62,7 +62,7 @@ class Root:
 
     def check_prereg(self):
         return json.dumps({
-            'force_refresh': not c.AT_THE_CON and (c.AFTER_PREREG_TAKEDOWN or c.BADGES_SOLD >= c.MAX_BADGE_SALES)})
+            'force_refresh': not c.AT_THE_CON and (c.AFTER_PREREG_TAKEDOWN or not c.ATTENDEE_BADGE_AVAILABLE)})
 
     def check_if_preregistered(self, session, message='', **params):
         if 'email' in params:

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -17,7 +17,7 @@
       <div class="form-group row">
         <p class="col-sm-9 col-sm-offset-3">
           <strong> You are on a development box.
-            {% if c.BADGES_SOLD >= c.MAX_BADGE_SALES %}
+            {% if not c.ATTENDEE_BADGE_AVAILABLE %}
               Otherwise, you would be automatically redirected to <a href="../static_views/prereg_soldout.html">the "badges sold out" page</a>.
             {% elif c.BEFORE_PREREG_OPEN %}
               Otherwise, you would be automatically redirected to <a href="../static_views/prereg_not_yet_open.html">the "prereg not yet open" page</a>.


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-761. Fixes https://jira.magfest.net/browse/MAGDEV-765. We now use the stocks system, which counts actual badges promised, to limit sales -- this works better for selling out on-site, and will also work for selling out during prereg. Probably.