### PR TITLE
Only check if admins can create group badges on admin page

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1391,8 +1391,6 @@ class Session(SessionManager):
                         paid=paid,
                         **extra_create_args)
                     group.attendees.append(new_attendee)
-                    if not self.admin_can_create_attendee(new_attendee):
-                        new_attendee.badge_status = c.PENDING_STATUS
                     
             elif diff < 0:
                 if len(group.floating) < abs(diff):

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -56,12 +56,16 @@ class Root:
                 if group.is_new and params.get('group_type'):
                     group.auto_recalc = False
                 session.add(group)
-                new_ribbon = c.BAND if params.get('group_type') == str(c.BAND) else None
+                new_ribbon = params.get('ribbon', c.BAND if params.get('group_type') == str(c.BAND) else None)
+                new_badge_type = params.get('badge_type', c.ATTENDEE_BADGE)
+                test_permissions = Attendee(badge_type=new_badge_type, ribbon=new_ribbon, paid=c.PAID_BY_GROUP)
+                new_badge_status = c.PENDING_STATUS if not self.admin_can_create_attendee(test_permissions) else c.NEW_STATUS
                 message = session.assign_badges(
                     group,
                     int(params.get('badges', 0)) or int(new_with_leader),
-                    new_badge_type=params.get('badge_type', c.ATTENDEE_BADGE),
-                    new_ribbon_type=params.get('ribbon', new_ribbon),
+                    new_badge_type=new_ribbon,
+                    new_ribbon_type=new_badge_type,
+                    badge_status=new_badge_status,
                     )
 
             if not message:

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import subqueryload
 from uber.config import c
 from uber.decorators import ajax, all_renderable, csrf_protected, log_pageview, site_mappable
 from uber.errors import HTTPRedirect
-from uber.models import Email, Event, Group, GuestGroup, GuestMerch, PageViewTracking, Tracking
+from uber.models import Attendee, Email, Event, Group, GuestGroup, GuestMerch, PageViewTracking, Tracking
 from uber.utils import check, convert_to_absolute_url
 
 
@@ -59,12 +59,12 @@ class Root:
                 new_ribbon = params.get('ribbon', c.BAND if params.get('group_type') == str(c.BAND) else None)
                 new_badge_type = params.get('badge_type', c.ATTENDEE_BADGE)
                 test_permissions = Attendee(badge_type=new_badge_type, ribbon=new_ribbon, paid=c.PAID_BY_GROUP)
-                new_badge_status = c.PENDING_STATUS if not self.admin_can_create_attendee(test_permissions) else c.NEW_STATUS
+                new_badge_status = c.PENDING_STATUS if not session.admin_can_create_attendee(test_permissions) else c.NEW_STATUS
                 message = session.assign_badges(
                     group,
                     int(params.get('badges', 0)) or int(new_with_leader),
-                    new_badge_type=new_ribbon,
-                    new_ribbon_type=new_badge_type,
+                    new_badge_type=new_badge_type,
+                    new_ribbon_type=new_ribbon,
                     badge_status=new_badge_status,
                     )
 


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-778. We were checking for an admin's permission to create badges whenever we used assign_badges, but that's used in prereg functions too... like groups buying more badges. Whoops.