### PR TITLE
Make arbitrary charges return to the form by default

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -869,7 +869,7 @@ class Root:
 
     @public
     @credit_card
-    def arbitrary_charge(self, session, payment_id, stripeToken, return_to='new'):
+    def arbitrary_charge(self, session, payment_id, stripeToken, return_to='arbitrary_charge_form'):
         charge = Charge.get(payment_id)
         message = charge.charge_cc(session, stripeToken)
         if message:


### PR DESCRIPTION
I'd made a change a while back to support processing fees through the at-door registration page, but what we need instead is a link to send attendees. We shouldn't redirect them to an admin-only page when they're done paying.