### PR TITLE
Make free preregistrations work without a promo code

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -364,7 +364,7 @@ class Root:
             'id': id
         }
 
-    def process_free_prereg(self, session):
+    def process_free_prereg(self, session, message=''):
         charge = Charge(listify(Charge.unpaid_preregs.values()))
         if charge.total_cost <= 0:
             for attendee in charge.attendees:


### PR DESCRIPTION
Having a free preregistration without a promo code is practically impossible, but we should still make it work just in case.