### PR TITLE
Preserve unassigned group badges' staffing status

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -598,6 +598,12 @@ class Root:
         # Safe to ignore csrf tokens here, because an attacker would need to know the group id a priori
         group = session.group(group_id, ignore_csrf=True)
         attendee = session.attendee(params, restricted=True, ignore_csrf=True)
+        must_be_staffing = False
+        
+        if group.unassigned[0].staffing:
+            must_be_staffing = True
+            attendee.staffing = True
+            params['staffing'] = True
 
         message = check_pii_consent(params, attendee) or message
         if not message and 'first_name' in params:
@@ -644,7 +650,8 @@ class Root:
             'group': group,
             'attendee': attendee,
             'affiliates': session.affiliates(),
-            'badge_cost': 0
+            'badge_cost': 0,
+            'must_be_staffing': must_be_staffing,
         }
 
     @credit_card

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -796,7 +796,7 @@
   <div class="checkbox col-sm-6">
     {% set staffing_readonly = not admin_area and attendee.shifts %}
     <label for="staffing" {% if staffing_readonly %}title="Please {{ 'see Staffing Operations to change your volunteer status' if c.AT_THE_CON else 'unassign yourself from shifts before changing your volunteer status' }}"{% endif %}>
-      {{ macros.checkbox(attendee, 'staffing', is_readonly=staffing_readonly or read_only, clientside_bool=clientside_bool) }}
+      {{ macros.checkbox(attendee, 'staffing', is_readonly=staffing_readonly, clientside_bool=clientside_bool) }}
       {% if admin_area %}
         This attendee is
         {% if attendee.is_new or not attendee.staffing %}

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -772,14 +772,6 @@
             }
         {% endif %}
     };
-    var noCellphoneClicked = function () {
-        if ($.field('no_cellphone') && $.field('cellphone')) {
-            $.field('cellphone').prop('disabled', $.field('no_cellphone').prop('checked'));
-            if($.field('no_cellphone').prop('checked')) {
-                $.field('cellphone').val('');
-            }
-        }
-    };
     {% if admin_area %}
         var toggleStaffingAdminRows = function () {
             setVisible('.staffing-checked', $.field('staffing').prop('checked'));
@@ -789,16 +781,13 @@
         if ($.field('staffing')) {
             $.field('staffing').on('click', staffingClicked);
         }
-        noCellphoneClicked();
-        if ($.field('no_cellphone')) {
-            $.field('no_cellphone').on('click', noCellphoneClicked);
-        }
         {% if admin_area %}
             if($.field('staffing')) {
                 toggleStaffingAdminRows();
                 $.field('staffing').on('click', toggleStaffingAdminRows);
             }
         {% endif %}
+        staffingClicked();
     });
 </script>
 <div class="form-group staffing">
@@ -807,7 +796,7 @@
   <div class="checkbox col-sm-6">
     {% set staffing_readonly = not admin_area and attendee.shifts %}
     <label for="staffing" {% if staffing_readonly %}title="Please {{ 'see Staffing Operations to change your volunteer status' if c.AT_THE_CON else 'unassign yourself from shifts before changing your volunteer status' }}"{% endif %}>
-      {{ macros.checkbox(attendee, 'staffing', is_readonly=staffing_readonly, clientside_bool=clientside_bool) }}
+      {{ macros.checkbox(attendee, 'staffing', is_readonly=staffing_readonly or read_only, clientside_bool=clientside_bool) }}
       {% if admin_area %}
         This attendee is
         {% if attendee.is_new or not attendee.staffing %}
@@ -1072,6 +1061,22 @@
 
 
 {% set cellphone %}
+<script type="text/javascript">
+var noCellphoneClicked = function () {
+  if ($.field('no_cellphone') && $.field('cellphone')) {
+    $.field('cellphone').prop('disabled', $.field('no_cellphone').prop('checked'));
+    if($.field('no_cellphone').prop('checked')) {
+      $.field('cellphone').val('');
+    }
+  }
+};
+$(window).on("runJavaScript", function () {
+  noCellphoneClicked();
+  if ($.field('no_cellphone')) {
+    $.field('no_cellphone').on('click', noCellphoneClicked);
+  }
+});
+  </script>
 {% set read_only = cellphone_ro or page_ro %}
 <div class="form-group">
   <label for="cellphone" class="col-sm-3 control-label">Your Phone Number</label>

--- a/uber/templates/preregistration/register_group_member.html
+++ b/uber/templates/preregistration/register_group_member.html
@@ -20,8 +20,10 @@
       {{ attendee_fields.badge_printed_name }}
       {{ attendee_fields.shirt_size }}
       {{ attendee_fields.extra_donation }}
-      {{ attendee_fields.staffing }}
-      {{ attendee_fields.job_interests }}
+      {% if not must_be_staffing %}
+        {{ attendee_fields.staffing }}
+        {{ attendee_fields.job_interests }}
+      {% endif %}
       {{ attendee_fields.age }}
       {{ attendee_fields.email }}
       {{ attendee_fields.address }}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-789. When someone would claim an unassigned group badge, even if that badge was 'staffing' the form would default to an unchecked staffing checkbox. People should never be able to opt out of staffing when claiming a Contractor or Staff badge in a group, so we hide the checkbox and force staffing to be true.