### PR TITLE
Stop loading viewable attendees on the homepage by default

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -186,7 +186,7 @@ default_url = string(default="%(path)s")
 default_url_priority = integer(default=1)
 
 # This determines how many rows we'll load at once for the homepage
-row_load_limit = integer(default=2000)
+row_load_limit = integer(default=500)
 
 # Venue name (hotel, convention center, etc) and physical mailing address
 event_venue = string(default="")

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -177,10 +177,21 @@ class Root:
     def homepage(self, session, message=''):
         if not cherrypy.session.get('account_id'):
             raise HTTPRedirect('login?message={}', 'You are not logged in')
-        attendees = session.viewable_attendees().limit(c.ROW_LOAD_LIMIT)
+        
         return {
-            'attendees': attendees.all(),
-            'message': message
+            'message': message,
+            'site_sections': [key for key in session.access_query_matrix().keys() if getattr(c, 'HAS_' + key.upper() + '_ACCESS')]
+            }
+        
+    @public
+    def attendees(self, session, query=''):
+        if not cherrypy.session.get('account_id'):
+            raise HTTPRedirect('login?message={}', 'You are not logged in')
+        
+        attendees = session.access_query_matrix()[query].limit(c.ROW_LOAD_LIMIT).all() if query else None
+        
+        return {
+            'attendees': attendees,
             }
 
     @public

--- a/uber/templates/accounts/attendees.html
+++ b/uber/templates/accounts/attendees.html
@@ -1,0 +1,49 @@
+{% if attendees == c.ROW_LOAD_LIMIT %}
+<div class="panel panel-body">
+This page only shows up to <strong>{{ c.ROW_LOAD_LIMIT }}</strong> attendees. You may need to use another view to find the attendee you need.
+</div>
+{% endif %}
+{% if attendees %}
+<div class="panel panel-default">
+  <table class="table table-striped datatable">
+    <thead>
+      <tr>
+        {% block tableheadings %}
+        <th>Status</th>
+        <th> Group Name </th>
+        <th> Full Name </th>
+        <th> Name on ID </th>
+        <th> Email </th>
+        {% if c.PREASSIGNED_BADGE_TYPES %}<th> Badge Name </th>{% endif %}
+        <th> Membership Type</th>
+        {% if c.NUMBERED_BADGES %}<th> Badge # </th> {% endif %}
+        <th> Badge Ribbons</th>
+        <th> Paid </th>
+        {% endblock tableheadings %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for attendee in attendees %}
+        <tr {% if attendee.badge_status == c.INVALID_STATUS %}bgcolor="#FFE4E1"{% endif %}>
+            {% block tablerows scoped %}
+            <td>{{ attendee.badge_status_label }}</td>
+            <td id="group_{{ attendee.id }}">
+                {{ attendee.group|form_link }}
+            </td>
+            <td id="name_{{ attendee.id }}" style="text-align:left"><a href="#attendee_form?id={{ attendee.id }}">{{ attendee.full_name }}</a></td>
+              <td id="name_{{ attendee.id }}" style="text-align:left">
+                  {{ attendee.legal_name }}
+              </td>
+              <td>{{ attendee.email }}</td>
+            {% if c.PREASSIGNED_BADGE_TYPES %}<td>{{ attendee.badge_printed_name }}</td>{% endif %}
+            <td><nobr>{{ attendee.badge_type_label }}</nobr></td>
+            {% if c.NUMBERED_BADGES %}<td>{{ attendee.badge_num }}</td>{% endif %}
+            <td id="ribbon_{{ attendee.id }}">{{ attendee.ribbon_labels|join(", ") }}</td>
+            <td id="paid_{{ attendee.id }}" ><nobr>{{ attendee.paid_label }}</nobr></td>
+          {% endblock tablerows %}
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}

--- a/uber/templates/accounts/attendees.html
+++ b/uber/templates/accounts/attendees.html
@@ -1,4 +1,4 @@
-{% if attendees == c.ROW_LOAD_LIMIT %}
+{% if attendees|length == c.ROW_LOAD_LIMIT %}
 <div class="panel panel-body">
 This page only shows up to <strong>{{ c.ROW_LOAD_LIMIT }}</strong> attendees. You may need to use another view to find the attendee you need.
 </div>

--- a/uber/templates/accounts/homepage.html
+++ b/uber/templates/accounts/homepage.html
@@ -4,7 +4,10 @@
 <div class="panel panel-body">
 <a href="#attendee_form?id=None" class="btn btn-primary">Add new attendee</a>
 {% if c.HAS_SHIFTS_ADMIN_ACCESS %}
-<a class="btn btn-info" href="../shifts_admin/staffers?department=All">View volunteers in your department(s)</a></p>
+<a class="btn btn-info" href="../shifts_admin/staffers?department=All">View volunteers in your department(s)</a>
+{% endif %}
+{% if c.HAS_REGISTRATION_ACCESS %}
+<a class="btn btn-success" href="../registration/">View all attendees</a>
 {% endif %}
 </div>
 <strong>View attendees by type:</strong>

--- a/uber/templates/accounts/homepage.html
+++ b/uber/templates/accounts/homepage.html
@@ -6,50 +6,29 @@
 {% if c.HAS_SHIFTS_ADMIN_ACCESS %}
 <a class="btn btn-info" href="../shifts_admin/staffers?department=All">View volunteers in your department(s)</a></p>
 {% endif %}
-{% if attendees == c.ROW_LOAD_LIMIT %}
-This page only shows up to <strong>{{ c.ROW_LOAD_LIMIT }}</strong> attendees. You may need to use another view to find the attendee you need.
-{% endif %}
 </div>
-<div class="panel panel-default">
-  <table class="table table-striped datatable">
-    <thead>
-      <tr>
-        {% block tableheadings %}
-        <th>Status</th>
-        <th> Group Name </th>
-        <th> Full Name </th>
-        <th> Name on ID </th>
-        <th> Email </th>
-        {% if c.PREASSIGNED_BADGE_TYPES %}<th> Badge Name </th>{% endif %}
-        <th> Membership Type</th>
-        {% if c.NUMBERED_BADGES %}<th> Badge # </th> {% endif %}
-        <th> Badge Ribbons</th>
-        <th> Paid </th>
-        {% endblock tableheadings %}
-      </tr>
-    </thead>
-    <tbody>
-      {% for attendee in attendees %}
-        <tr {% if attendee.badge_status == c.INVALID_STATUS %}bgcolor="#FFE4E1"{% endif %}>
-            {% block tablerows scoped %}
-            <td>{{ attendee.badge_status_label }}</td>
-            <td id="group_{{ attendee.id }}">
-                {{ attendee.group|form_link }}
-            </td>
-            <td id="name_{{ attendee.id }}" style="text-align:left"><a href="#attendee_form?id={{ attendee.id }}">{{ attendee.full_name }}</a></td>
-              <td id="name_{{ attendee.id }}" style="text-align:left">
-                  {{ attendee.legal_name }}
-              </td>
-              <td>{{ attendee.email }}</td>
-            {% if c.PREASSIGNED_BADGE_TYPES %}<td>{{ attendee.badge_printed_name }}</td>{% endif %}
-            <td><nobr>{{ attendee.badge_type_label }}</nobr></td>
-            {% if c.NUMBERED_BADGES %}<td>{{ attendee.badge_num }}</td>{% endif %}
-            <td id="ribbon_{{ attendee.id }}">{{ attendee.ribbon_labels|join(", ") }}</td>
-            <td id="paid_{{ attendee.id }}" ><nobr>{{ attendee.paid_label }}</nobr></td>
-          {% endblock tablerows %}
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+<strong>View attendees by type:</strong>
+<div class="btn-group" style="padding-bottom:10px;">
+<button class="btn btn-default attendee-types" id="created" onClick="loadViewableAttendees('created')">Created By You</button>
+{% for section in site_sections %}
+<button class="btn btn-default attendee-types" id="{{ section }}" onClick="loadViewableAttendees('{{ section }}')">{{ section[:-6]|title }}</button>
+{% endfor %}
 </div>
+<div id="viewable_attendees"></div>
+<script type="text/javascript">
+var loadViewableAttendees = function(query) {
+  $('.attendee-types').removeClass('btn-primary btn-default').addClass('btn-default');
+  $('#' + query).addClass('btn-primary').removeClass('btn-default');
+    $('#viewable_attendees').load('../accounts/attendees?query=' + query, function(){
+      if ($('#viewable_attendees').length) {
+          $(window).trigger( 'runJavaScript' );
+      } else {
+          // We got redirected -- likely to the login page -- so load it properly
+          toastr.error("Loading failed.");
+          window.location.hash = ""; // prevent refresh loops
+          window.location.reload();
+      }
+      });
+    }
+</script>
 {% endblock %}

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -236,14 +236,14 @@
                 toastr.info(message);
             }
 
-            {#
+            /*
               If datetextentries are contained inside of a multi-page
               datatable, the datetextentries that aren't on the first page
               won't be rendered. To overcome this, we attempt to instantiate
               datetextentries every time the datatable finishes drawing.
-            -#}
+            */
             createDateTextEntries = function() {
-                {# Only create datetextentry if it wasn't already created. -#}
+                // Only create datetextentry if it wasn't already created.
                 $('.date:not(.jq-dte .date)').datetextentry({
                     field_order: 'MDY',
                     min_year: '1890',
@@ -262,7 +262,7 @@
                 });
             };
 
-            $('.datatable').each(function() {
+            loadDataTables = function() {$('.datatable').each(function() {
                 if (! $.fn.DataTable.isDataTable($(this))) {
                 var table = $(this).DataTable({
                     aLengthMenu: [
@@ -304,9 +304,15 @@
                     }
                 } );
                 }
-            });
+            });}
 
+            loadDataTables();
             createDateTextEntries();
+
+            $(window).on("runJavaScript", function() {
+            loadDataTables();
+            createDateTextEntries();
+        });
 
             $('.geolocator').geocomplete({
                 details: '.address_details',


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-793. This was initially going to just be an at-the-con flag, but then I realized that would mean no one without registration access could see non-volunteers during the event. Instead I replaced the old giant load with a set of buttons to load attendees by type.

![image](https://user-images.githubusercontent.com/7198215/71551766-da394c00-29bc-11ea-9474-06eae51ab22f.png)
(buttons are hidden if you do not have access to view that type of attendee)

![image](https://user-images.githubusercontent.com/7198215/71551765-d1487a80-29bc-11ea-919f-d09524921efe.png)
