### PR TITLE
Add 'cbox' class back to /accounts/bulk

### DIFF
--- a/uber/templates/accounts/bulk.html
+++ b/uber/templates/accounts/bulk.html
@@ -39,7 +39,7 @@ var mainMenuDropdownChanged = function () {
 {% for attendee in attendees %}
     <tr>
         <td width="20%" data-order="{{ attendee.full_name }}" data-search="{{ attendee.full_name }}"> <a href="#attendee_form?id={{ attendee.id }}&tab_view=Shifts">{{ attendee.full_name }}</a>        </td>
-        {% if c.HAS_ACCOUNTS_ACCESS %}<td width="10">{% if attendee.admin_account %}Enabled{% else %}<label for="{{ attendee.id }}" class="checkbox-label optional-field"><input type="checkbox" id="{{ attendee.id }}"> Enable?</label>{% endif %}</td>{% endif %}
+        {% if c.HAS_ACCOUNTS_ACCESS %}<td width="10">{% if attendee.admin_account %}Enabled{% else %}<label for="{{ attendee.id }}" class="checkbox-label optional-field"><input type="checkbox" class="cbox" id="{{ attendee.id }}"> Enable?</label>{% endif %}</td>{% endif %}
         <td width="10">{% if not attendee.badge_num %}<font size="-1">TBD</font>{% else %}{{ attendee.badge_num }}{% endif %}</td>
         <td width="10">{% if attendee.is_dept_head %}<font size="-1">[D]</font>{% endif %}</td>
         <td width="10">{% if attendee.trusted_here %}<font size="-1">[T]</font>{% endif %}</td>


### PR DESCRIPTION
Our Javascript for /accounts/bulk was apparently depending on a class I removed from checkboxes because it seemed pointless. Whoops.