### PR TITLE
Require email during and after the event

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -314,7 +314,7 @@ def allowed_to_register(attendee):
 def email(attendee):
     if len(attendee.email) > 255:
         return 'Email addresses cannot be longer than 255 characters.'
-    elif not attendee.email and not c.AT_OR_POST_CON:
+    elif not attendee.email:
         return 'Please enter an email address.'
 
 

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -964,7 +964,7 @@
   <div class="form-group">
     <label for="confirm_email" class="col-sm-3 control-label">Confirm Email</label>
     <div class="col-sm-6">
-      <input type="email" name="confirm_email" id="confirm_email" value="{{ attendee.email }}" class="form-control" placeholder="Confirm your email address">
+      <input type="email" name="confirm_email" id="confirm_email" required value="{{ attendee.email }}" class="form-control" placeholder="Confirm your email address">
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-509. We send some emails, including a confirmation email, while at-con so it doesn't make sense to stop requiring a valid email address. Also fixes/works around a bug where the email confirmation box wasn't being validated if the attendee didn't type anything in it