### PR TITLE
Use a property name besides 'group_name'

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -115,7 +115,7 @@ class Root:
                 if attendee.promo_code:
                     real_code = session.query(PromoCode).filter_by(code=attendee.promo_code.code).first()
                     if real_code and real_code.group:
-                        attendee.group_name = real_code.group.name
+                        attendee.promo_group_name = real_code.group.name
             return {
                 'message': message,
                 'charge': charge

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -85,7 +85,7 @@
               {% endfor %}
               {% if attendee.promo_code and not attendee.badges %}
                 {% if attendee.promo_code.group_id %}
-                  <li>Claiming a badge in group "{{ attendee.group_name }}"</li>
+                  <li>Claiming a badge in group "{{ attendee.promo_group_name }}"</li>
                 {% else %}
                 <li>{{ attendee.promo_code.discount_str }} with promo code "{{ attendee.promo_code.code }}"</li>
                 {% endif %}


### PR DESCRIPTION
Now that group_name has been defined as a property, we can't use it here to add on an extra attribute to the attendee or it will throw a 500 error.