### PR TITLE
updated staff merch label on admin form

### DIFF
--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1656,7 +1656,7 @@ $(window).on("runJavaScript", function(){
     </div>
   </div>
   <div class="form-group">
-    <label class="col-sm-3 control-label">Received Merch</label>
+    <label class="col-sm-3 control-label">Received Staff Merch</label>
     <div class="checkbox col-sm-6">
       {{ macros.checkbox(attendee, 'got_staff_merch', label='Yes', is_readonly=read_only, clientside_bool=clientside_bool) }}
     </div>


### PR DESCRIPTION
I was seeing this on the admin form:
![image](https://user-images.githubusercontent.com/651592/71631266-bdc42c00-2bd5-11ea-820f-bf77e9ac1250.png)

I assumed it was a bug, but it turned out that the labeling was just confusing, so I adjusted the label.
