### PR TITLE
fixed focus and enter key behavior on check-in form

### DIFF
--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -194,7 +194,29 @@ $().ready(function() {
                     </div>
                 {% else %}
                 <div class="col-sm-6">
-                  # <input class="num" id="checkin-badge" name="badge_num" type="text" size="10" autofocus/>
+                  # <input class="num" id="checkin-badge" name="badge_num" type="text" size="10" />
+                </div>
+                <script>
+                    /**
+                     * We can't just use "autofocus" because that doesn't work if there's already a focused
+                     * element on the page.  Calling $.focus() won't work until the element is visible, so
+                     * we need to keep trying until that happens.  We also use this opportunity to set a
+                     * keypress handler on the element.
+                     */
+                    var focusBadgeNum = function () {
+                        var $num = $('#checkin-badge:text');
+                        if ($num.is(':visible')) {
+                            $num.focus().keypress(function (event) {
+                                if (event.keyCode === 13) {
+                                    checkIn('{{ attendee.id }}');
+                                }
+                            });
+                        } else {
+                            setTimeout(focusBadgeNum, 100);
+                        }
+                    };
+                    focusBadgeNum();
+                </script>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
The badge number form field on the check-in form wasn't autofocusing consistently, because the ``autofocus`` element only works if there's not already something selected.  I also made the Enter key attempt to check-in the form.