### PR TITLE
allow attraction signups without a badge before the event begins

### DIFF
--- a/uber/site_sections/attractions.py
+++ b/uber/site_sections/attractions.py
@@ -158,8 +158,8 @@ class Root:
     def signup_for_event(self, session, id, badge_num='', first_name='',
                          last_name='', email='', zip_code='', **params):
 
-        # Badge number during AT_THE_CON is a hard requirement for Autographs
-        if badge_num or c.AT_THE_CON:
+        # Badge number during the event is a hard requirement for Autographs
+        if badge_num or c.AFTER_EPOCH:
             attendee = _attendee_for_badge_num(session, badge_num)
             if not attendee:
                 return {


### PR DESCRIPTION
We have a button that says "Sign up without badge #" which is visible before the event begins, but then on the backend we check for ``c.AT_THE_CON``, which gets set to True the day before.

This fix makes things consistent and allows signups tonight.