### PR TITLE
attraction features now sort according to the start time of their first event

### DIFF
--- a/uber/site_sections/attractions.py
+++ b/uber/site_sections/attractions.py
@@ -1,6 +1,8 @@
 import uuid
+from datetime import datetime
 
 import cherrypy
+from pytz import UTC
 from pockets import sluggify
 from sqlalchemy.orm import subqueryload
 
@@ -87,8 +89,12 @@ class Root:
 
         if not attraction:
             raise HTTPRedirect('index')
+
+        no_events = datetime.max.replace(tzinfo=UTC)  # features with no events should sort to the end
+        features = attraction.public_features
         return {
             'attraction': attraction,
+            'features': sorted(features, key=lambda f: f.events[0].start_time if f.events else no_events),
             'show_all': params.get('show_all')}
 
     def events(self, session, id=None, slug=None, feature=None, **params):

--- a/uber/templates/attractions/features.html
+++ b/uber/templates/attractions/features.html
@@ -7,6 +7,7 @@
 <style type="text/css">
   .hover-btn h3 {
     margin: 5px 0;
+    font-weight: bold;
     font-size: 1.125em;
   }
 </style>
@@ -34,7 +35,7 @@
       </p>
       <hr>
       <div id="features">
-        {% for feature in attraction.public_features %}
+        {% for feature in features %}
           <div class="feature hover-btn"
               data-feature-id="{{ feature.id }}"
               data-feature-name="{{ feature.name }}">


### PR DESCRIPTION
Previously the features would display in an arbitrary order.  Now it's less arbitrary.  This was done at the suggestion of the autographs department.