### PR TITLE
Allow adding numbers to attendees during at-con mode

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -535,7 +535,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         old_type = self.orig_value_of('badge_type')
         old_num = self.orig_value_of('badge_num')
 
-        if not needs_badge_num(self):
+        if not needs_badge_num(self) and not c.AT_THE_CON:
             self.badge_num = None
 
         if old_type != self.badge_type or old_num != self.badge_num:

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -85,11 +85,11 @@
 
 <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
-    {% if c.AT_THE_CON and not attendee.checked_in and not attendee.is_not_ready_to_checkin and not attendee.amount_unpaid %}
-        <button class="btn btn-success" name="save" value="save_check_in">Save & Check In</button>
-    {% endif %}
         <button type="submit" name="save" class="btn btn-primary" value="save_return_to_search">Save & Return{% if not return_to %} to Search{% endif %}</button>
         <button type="submit" name="save" class="btn btn-primary" value="save">Save</button>
+        {% if c.AT_THE_CON and not attendee.checked_in and not attendee.is_not_ready_to_checkin and not attendee.amount_unpaid %}
+        <button class="btn btn-success" name="save" value="save_check_in">Save & Check In</button>
+    {% endif %}
     </div>
 </div>
 


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/3703. Normally we zero out a badge number if an attendee doesn't need one. This doesn't make sense for at-the-con, when we may need to assign badge numbers ahead of time. So if we're at the con, we don't zero out the number. We also don't auto-assign badge numbers -- we throw an error if you try to check in someone without one. Also also, we no longer make "save and check-in" the default action when you press enter on the form.