### PR TITLE
Stop redirecting to the first assigned dept for dept views

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -720,7 +720,7 @@ class Config(_Overridable):
                 of key/value pairs for each page inside that section.
                 Example: 
                     pages['registration'] = [
-                        {'name': 'Arbitrary Charge Form', 'path': '/registration/arbitrary_charge_form'},
+                        {'name': 'Arbitrary Charge Form', 'path': '/merch_admin/arbitrary_charge_form'},
                         {'name': 'Comments', 'path': '/registration/comments'},
                         {'name': 'Discount', 'path': '/registration/discount'},
                     ]

--- a/uber/config.py
+++ b/uber/config.py
@@ -720,7 +720,7 @@ class Config(_Overridable):
                 of key/value pairs for each page inside that section.
                 Example: 
                     pages['registration'] = [
-                        {'name': 'Arbitrary Charge Form', 'path': '/merch_admin/arbitrary_charge_form'},
+                        {'name': 'Arbitrary Charge Form', 'path': '/registration/arbitrary_charge_form'},
                         {'name': 'Comments', 'path': '/registration/comments'},
                         {'name': 'Discount', 'path': '/registration/discount'},
                     ]

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -554,8 +554,7 @@ def redirect_to_allowed_dept(session, department_id, page):
         return
 
     if not department_id:
-        department_id = cherrypy.session.get('prev_department_id') or c.DEFAULT_DEPARTMENT_ID
-        raise HTTPRedirect('{}?department_id={}', page, department_id)
+        raise HTTPRedirect('{}?department_id=All', page, department_id)
     if 'shifts_admin' in c.PAGE_PATH:
         can_access = session.admin_attendee().can_admin_shifts_for(department_id)
     elif 'dept_checklist' in c.PAGE_PATH:


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-809 by making the 'default' view be "All" departments. This isn't ideal, since there's something wrong with that page, but it's better than someone not being able to use the link at all.