### PR TITLE
MAGDEV-766: fixed nonshift hour form

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -847,6 +847,7 @@ class Root:
         
         return_dict = {
             'attendee': attendee,
+            'message': params.get('message', ''),
             'shifts': {s.id: s.to_dict(attrs) for s in attendee.shifts},
             'jobs': [
                 (job.id, '({}) [{}] {}'.format(job.timespan(), job.department_name, job.name))

--- a/uber/templates/registration/attendee_shifts.html
+++ b/uber/templates/registration/attendee_shifts.html
@@ -12,29 +12,37 @@
 
 <script type="text/javascript" src="../static_views/ratings.js"></script>
 <script type="text/javascript">
-$("form[action*='/shifts_admin/']").submit(function(event){
-  event.preventDefault();
-  toastr.clear();
-  var formURL = $(this).attr('action');
-  var old_hash = window.location.hash;
-  $.ajax({
-      method: 'POST',
-      url: formURL,
-      data: $(this).serializeArray(),
-      success: function (json) {
-        window.location.hash = old_hash;
-        if (json.success) {
-          toastr.info(json.message);
-          loadForm('Shifts');
-        } else {
-          toastr.error(json.message);
-        }
-      },
-      error: function () {
-          toastr.error('Unable to connect to server, please try again.');
-      }
-  });
-});
+    $(function () {
+        $("form[action*='/shifts_admin/']").submit(function(event){
+            event.preventDefault();
+            toastr.clear();
+            var formURL = $(this).attr('action');
+            var old_hash = window.location.hash;
+            $.ajax({
+                method: 'POST',
+                url: formURL,
+                data: $(this).serializeArray(),
+                success: function (json) {
+                    window.location.hash = old_hash;
+                    if (json.success) {
+                        // non-modal pages don't have a loadForm function, so we
+                        // use that to tell whether we're in a modal form
+                        if (window.loadForm) {
+                            toastr.info(json.message);
+                            window.loadForm('Shifts');
+                        } else {
+                            location.search += '&message=' + json.message;
+                        }
+                    } else {
+                        toastr.error(json.message);
+                    }
+                },
+                error: function () {
+                    toastr.error('Unable to connect to server, please try again.');
+                }
+            });
+        });
+    });
 
     var SHIFTS = {{ shifts|jsonize }};
     $(function() {


### PR DESCRIPTION
There were three issues here:

1) The jquery filter was being run before the DOM elements were loaded, so I put it inside of a ``$(function () { })`` block.  This is the reason why the JSON was being displayed.

2) The ``loadForm`` function doesn't exist on the "old-school" shifts page, so I added an if-check for that.

3) Because of this, the other forms on that page would show a success message but not update their contents, so I've fixed this to basically do a page refresh with the success message.