### PR TITLE
Populate depends_on so `alembic update heads` works from scratch

### DIFF
--- a/alembic/versions/07f752ec9b7c_rename_amount_paid_and_amount_refunded_.py
+++ b/alembic/versions/07f752ec9b7c_rename_amount_paid_and_amount_refunded_.py
@@ -11,7 +11,7 @@ Create Date: 2019-08-28 22:58:09.649117
 revision = '07f752ec9b7c'
 down_revision = '3c0edc37569e'
 branch_labels = None
-depends_on = None
+depends_on = 'd1ae7f4f7767'
 
 from alembic import op
 import sqlalchemy as sa

--- a/alembic/versions/2cd71c52889e_remove_access_column_from_admin_accounts.py
+++ b/alembic/versions/2cd71c52889e_remove_access_column_from_admin_accounts.py
@@ -11,7 +11,7 @@ Create Date: 2019-08-22 15:05:58.532275
 revision = '2cd71c52889e'
 down_revision = 'da22d6a6407c'
 branch_labels = None
-depends_on = None
+depends_on = '5ca0661d5081'
 
 from alembic import op
 import residue

--- a/alembic/versions/c36659e7f238_add_rehearsal_checklist_step_for_bands.py
+++ b/alembic/versions/c36659e7f238_add_rehearsal_checklist_step_for_bands.py
@@ -11,7 +11,7 @@ Create Date: 2019-09-25 14:10:35.730473
 revision = 'c36659e7f238'
 down_revision = '07f752ec9b7c'
 branch_labels = None
-depends_on = None
+depends_on = 'f619fbd56912'
 
 from alembic import op
 import sqlalchemy as sa

--- a/alembic/versions/e372e4daf771_add_many_to_many_tables_for_stripe_.py
+++ b/alembic/versions/e372e4daf771_add_many_to_many_tables_for_stripe_.py
@@ -11,7 +11,7 @@ Create Date: 2018-08-31 20:42:18.905795
 revision = 'e372e4daf771'
 down_revision = 'b574c0577253'
 branch_labels = None
-depends_on = None
+depends_on = 'ff7e7ae6d711'
 
 import residue
 import sqlalchemy as sa


### PR DESCRIPTION
The uber plugin's migrations have more heads than a goddamn hydra, and some of them break each other if not applied in the necessary order. These changes made `alembic update heads` work in one shot for me.