### PR TITLE
allow last chance email to go out

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -229,6 +229,7 @@ AutomatedEmailFixture(
     #     or_(Group.is_dealer == False, Group.status == c.APPROVED)),
     when=after(c.GROUP_PREREG_TAKEDOWN),
     needs_approval=False,
+    allow_at_the_con=True,
     ident='group_preassign_badges_reminder_last_chance',
     sender=c.REGDESK_EMAIL)
 


### PR DESCRIPTION
We used to closed group registration way before we closed normal prereg, like a week before the event starts.  So our automated emails about "last chance to claim badges" assumes that there's no way we'd already be in at-the-con mode.  This fixes that.