### PR TITLE
Allow attraction check-ins with encrypted badge numbers

### DIFF
--- a/uber/site_sections/attractions_admin.py
+++ b/uber/site_sections/attractions_admin.py
@@ -382,7 +382,14 @@ class Root:
 
     @ajax
     def get_signups(self, session, badge_num, attraction_id=None):
+        from uber.barcode import get_badge_num_from_barcode
+        
         if cherrypy.request.method == 'POST':
+            try:
+                badge_num = int(badge_num)
+            except ValueError:
+                badge_num = get_badge_num_from_barcode(badge_num)['badge_num']
+                
             attendee = _attendee_for_badge_num(
                 session, badge_num,
                 subqueryload(Attendee.attraction_signups)


### PR DESCRIPTION
There's JavaScript on the attractions check-in page to convert encrypted barcodes into badge numbers, but for some reason it's not working. We now all process encrypted barcodes in the check-in page handler so we can still use the barcodes.