### PR TITLE
Unset watched status for attendees whose entries are inactive

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -476,6 +476,9 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @presave_adjustment
     def _status_adjustments(self):
+        if self.badge_status == c.WATCHED_STATUS and not self.banned:
+            self.badge_status = c.NEW_STATUS
+        
         if self.badge_status == c.NEW_STATUS and self.banned:
             self.badge_status = c.WATCHED_STATUS
             try:


### PR DESCRIPTION
Partially fixes https://jira.magfest.net/browse/MAGDEV-813. Now if you resave the attendee, the system will reset them off "on hold" status.