### PR TITLE
Work around 500 error on attractions

### DIFF
--- a/uber/models/tracking.py
+++ b/uber/models/tracking.py
@@ -157,6 +157,11 @@ class Tracking(MagModel):
             who = 'server admin'
         else:
             who = AdminAccount.admin_name() or (current_thread().name if current_thread().daemon else 'non-admin')
+            
+        try:
+            snapshot = json.dumps(instance.to_dict(), cls=serializer)
+        except TypeError as e:
+            snapshot = "(Could not save JSON dump due to error: {}".format(e)
 
         def _insert(session):
             session.add(Tracking(
@@ -168,7 +173,7 @@ class Tracking(MagModel):
                 links=links,
                 action=action,
                 data=data,
-                snapshot=json.dumps(instance.to_dict(), cls=serializer)
+                snapshot=snapshot,
             ))
         if instance.session:
             _insert(instance.session)


### PR DESCRIPTION
If you try to update an attraction time when attendees are signed up, it throws a 500 error. We can't figure out why that error is happening in the middle of the event, so now we bypass the error instead.