### PR TITLE
Update check-in message for attendees in Watched status

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -867,6 +867,12 @@ class Attendee(MagModel, TakesPaymentMixin):
         Returns None if we are ready for checkin, otherwise a short error
         message why we can't check them in.
         """
+        
+        if self.badge_status == c.WATCHED_STATUS:
+            if self.banned or not self.regdesk_info:
+                regdesk_info_append = " [{}]".format(self.regdesk_info) if self.regdesk_info else ""
+                return "MUST TALK TO SECURITY before picking up badge{}".format(regdesk_info_append)
+            return self.regdesk_info or "Badge status is {}".format(self.badge_status_label)
 
         if self.badge_status not in [c.COMPLETED_STATUS, c.NEW_STATUS]:
             return "Badge status is {}".format(self.badge_status_label)

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -70,7 +70,7 @@ class Root:
         if c.DEV_BOX and not int(page):
             page = 1
 
-        filter = Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS]) if not invalid else None
+        filter = Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS, c.WATCHED_STATUS]) if not invalid else None
         attendees = session.query(Attendee) if invalid else session.query(Attendee).filter(filter)
         total_count = attendees.count()
         count = 0


### PR DESCRIPTION
In order to provide better flexibility and clarity for Watched attendees, we change the "can't checkin" message to display either:
1. A message saying the attendee must talk to security, if the attendee has a matching watchlist entry OR they have no special regdesk instructions.
2. The special regdesk instructions, if the attendee does not have a matching watchlist entry but does have special regdesk instructions.
3. Both, if the attendee has both a matching watchlist entry and special regdesk instructions.

We also now always show watched attendees in search.