### PR TITLE
Remove clientside barcode interpretation

### DIFF
--- a/uber/templates/attractions_admin/checkin.html
+++ b/uber/templates/attractions_admin/checkin.html
@@ -94,12 +94,6 @@
         $showCheckedInButton = $('#filter'),
         $attendee = $('#attendee');
 
-    $('input[name=badge_num]').barcodeField({
-      blurOnKeys: ['~', '\\'],
-      detectBadgeNum: true,
-      autoSubmitForm: 'form.badge-num-form'
-    });
-
     var updateAttendee = function(attendee) {
       $container.toggleClass('has-attendee', !!attendee);
       if(attendee) {


### PR DESCRIPTION
We still were having trouble scanning the encrypted badge number barcodes, we're hoping this will solve it.

Note that this means all interpretation is done on the server, so the text you submit won't look like a barcode. See below.
![image](https://user-images.githubusercontent.com/7198215/71762545-5c82ae00-2e9e-11ea-9561-fcd641fac5f9.png)
