### PR TITLE
Add badges left warnings for reg admins

### DIFF
--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -6,7 +6,7 @@
   {% if c.REG_USES_BARCODES %}
     {% include 'barcode_client.html' %}
   {% endif %}
-
+  <style> .badge_count { margin-left: 15px; } </style>
   <script>
     $(function() {
       $('#search_bar').select();
@@ -31,6 +31,16 @@
           showErrorMessageWhenHidden: false
         });
       {% endif %}
+      $('.badge_count').each(function () {
+        text = $(this).text()
+        num_badges_left = parseInt(text.substr(0,text.indexOf(' ')));
+        if ($(this).data('danger-threshold') && num_badges_left <= $(this).data('danger-threshold')) {
+          $(this).removeClass('btn').addClass('btn-danger');
+        }
+        else if ($(this).data('warning-threshold') && num_badges_left <= $(this).data('warning-threshold')) {
+          $(this).removeClass('btn').addClass('btn-warning');
+        }
+      });
     });
   </script>
   {% include "check_in.html" %}
@@ -84,6 +94,11 @@
     <div class="col-xs-12">
         <span style="margin-right: 15px;">{{ attendee_count }} Attendee{{ attendee_count|pluralize }}</span>
         <span><span id="checkin_count">{{ checkin_count }}</span> Checked In</span>
+        {% if c.HAS_REG_ADMIN_ACCESS %}
+        {% block badge_counts %}
+        <span class="badge_count btn" data-warning-threshold="1500" data-danger-thresold="250">{{ c.ATTENDEE_BADGE_STOCK - c.ATTENDEE_BADGE_COUNT }} Attendee badges left</span>
+        {% endblock %}
+        {% endif %}
     </div>
 </div>
 


### PR DESCRIPTION
We're not totally sure people will be checking their emails enough to get a warning about the number of badges left in time, so now we also display a warning on the search page. We only display it for reg admins because it requires polling the database for number of attendee badges.