### PR TITLE
Process encrypted badge numbers for attraction sign-ups

### DIFF
--- a/uber/site_sections/attractions.py
+++ b/uber/site_sections/attractions.py
@@ -14,11 +14,15 @@ from uber.site_sections.preregistration import check_post_con
 
 
 def _attendee_for_badge_num(session, badge_num, options=None):
+    from uber.barcode import get_badge_num_from_barcode
+    
     if not badge_num:
         return None
 
     try:
         badge_num = int(badge_num)
+    except ValueError:
+        badge_num = get_badge_num_from_barcode(badge_num)['badge_num']
     except Exception:
         return None
 

--- a/uber/templates/attractions_macros.html
+++ b/uber/templates/attractions_macros.html
@@ -32,7 +32,7 @@
         <div class="badge-num-row row">
           <div class="col-xs-6" style="padding-right: 7px;">
             <input class="form-control input-lg text-center"
-                type="number"
+                type="text"
                 name="badge_num"
                 placeholder="Badge #"
                 required="required"


### PR DESCRIPTION
It seems we weren't doing anything to process encrypted barcodes for attendees' badge numbers during attraction signups -- now we do.