### PR TITLE
Make MIVS email not crash the server and also sendable post-con

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -864,14 +864,14 @@ if c.MIVS_ENABLED:
         lambda game: game.confirmed,
         ident='mivs_2020_mixer_reminder'
     )
-	
-	# mivs feedback 
-	MIVSEmailFixture(
+
+    MIVSEmailFixture(
         IndieGame,
         'MIVS {EVENT_NAME}: Request for Feedback',
         'mivs/feedback/indie_survey.txt',
-        lambda game: game.status == c.CONFIRMED,
-        ident='mivs_feedback_survey'
+        lambda game: game.confirmed,
+        ident='mivs_feedback_survey',
+        allow_post_con=True,
     )
 
 # =============================


### PR DESCRIPTION
There were still some tabs in the email file, which prevented the server for running. Also, any email that we intend to send in post-con mode needs `allow_post_con` to be set.