### PR TITLE
Add itemized cost breakdown report

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -583,6 +583,18 @@ class Attendee(MagModel, TakesPaymentMixin):
     @property
     def badge_type_real(self):
         return uber.badge_funcs.get_real_badge_type(self.badge_type)
+    
+    @property
+    def badge_cost_real(self):
+        """
+        The actual cost of this attendee's badge, regardless of whether they themselves are paying for it.
+        Accounts for promo code group member and group overridden cost
+        """
+        if self.group and (not self.group.auto_recalc or self.group.cost == 0):
+            return 0
+        if self.in_promo_code_group:
+            return self.promo_code.cost
+        return self.badge_cost
 
     @cost_property
     def badge_cost(self):

--- a/uber/templates/budget/cost_breakdown.html
+++ b/uber/templates/budget/cost_breakdown.html
@@ -1,0 +1,103 @@
+{% set admin_area=True %}
+{% extends "base.html" %}
+{% block title %}Cost Breakdown{% endblock %}
+{% block content %}
+
+<div class="panel panel-default">
+  <table class="table table-striped export-datatable">
+    <caption><h3>Attendees</h3></caption>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Item</th>
+        <th>Cost</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for attendee in paid_attendees %}
+      {% set name = "Unassigned badge in {}".format(attendee.group) if attendee.unassigned_name else attendee.full_name %}
+      {% for item, cost in [("Badge", attendee.badge_cost_real), ("Extra Donation", attendee.extra_donation), ("Kick-in Level", attendee.amount_extra)] %}
+      {% if cost %}
+        <tr>
+          <td>{{ name }}</td>
+          <td>{{ item }}</td>
+          <td>${{ "{0:g}".format(cost) }}</td>
+        </tr>
+      {% endif %}
+      {% endfor %}
+      {% if attendee.amount_unpaid %}
+        <tr>
+          <td>{{ name }}</td>
+          <td>Amount Owed</td>
+          <td>-${{ "{0:g}".format(attendee.amount_unpaid) }}</td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+  <table class="table table-striped export-datatable">
+    <caption><h3>Groups</h3></caption>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Item</th>
+        <th>Cost</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for group in paid_groups %}
+    {% if not group.auto_recalc %}
+    <tr>
+      <td>{{ group.name }}</td>
+      <td>Total Cost</td>
+      <td>{{ group.cost }}</td>
+      <td>Group price set by admin and cannot be itemized.</td>
+    </tr>
+    {% elif group.tables %}
+    {% for table_num in range(1, group.tables|int) %}
+      {% if table_num < 5 %}
+      {% set cost, desc = table_cost_matrix[table_num - 1] %}
+      {% else %}
+      {% set extra_tables = table_num - 4 %}
+      {% set cost, desc = c.TABLE_PRICES[5] * extra_tables + table_cost_matrix[3], "{} More Table{}".format(extra_tables, "s" if extra_tables > 1 else "") %}
+      {% endif %}
+      <tr>
+        <td>{{ group.name }}</td>
+        <td>{{ desc }}</td>
+        <td>${{ "{0:g}".format(cost) }}</td>
+        <td></td>
+      </tr>
+      {% endfor %}
+    {% endif %}
+    {% if group.amount_unpaid %}
+    <tr>
+        <td>{{ group.name }}</td>
+        <td>Amount Owed</td>
+        <td>-${{ "{0:g}".format(group.amount_unpaid) }}</td>
+      </tr>
+    {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+<script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.2/js/dataTables.buttons.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.2/js/buttons.html5.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.2/css/buttons.dataTables.min.css">
+<script type="text/javascript">
+$().ready(function() {
+  var dtable = $('.export-datatable').DataTable({
+      dom: 'Bfrtipl',
+      buttons: [
+          {
+              extend: 'excelHtml5',
+              exportOptions: {
+                  columns: ':visible'
+              }
+          },
+      ]
+  });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
Receipt items turned out to not be quite what we want because of the unexpected ways attendees can switch out payments (e.g. pay $10 for a donation, then reduce it to $0 but add a kick-in level and pay the difference), so we're adding a 'snapshot' style report that breaks the costs down as the system understands them at report run.