### PR TITLE
Add cost breakdown to Attendee table for better performance

### DIFF
--- a/alembic/versions/0b4ad67a27be_add_purchased_items_for_cost_tracking.py
+++ b/alembic/versions/0b4ad67a27be_add_purchased_items_for_cost_tracking.py
@@ -1,0 +1,59 @@
+"""Add purchased items for cost tracking
+
+Revision ID: 0b4ad67a27be
+Revises: 53b71e7c45b5
+Create Date: 2020-01-10 05:31:46.035375
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '0b4ad67a27be'
+down_revision = '53b71e7c45b5'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('purchased_items', postgresql.JSONB(astext_type=sa.Text()), server_default='{}', nullable=False))
+
+
+def downgrade():
+    op.drop_column('attendee', 'purchased_items')

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -11,6 +11,8 @@ from residue import CoerceUTF8 as UnicodeText, UTCDateTime, UUID
 from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.dialects.postgresql.json import JSONB
 from sqlalchemy.orm import backref, subqueryload
 from sqlalchemy.schema import Column as SQLAlchemyColumn, ForeignKey, Index, UniqueConstraint
 from sqlalchemy.types import Boolean, Date, Integer
@@ -238,6 +240,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     payment_method = Column(Choice(c.PAYMENT_METHOD_OPTS), nullable=True)
     amount_refunded_override = Column(Integer, default=0, admin_only=True)
     stripe_txn_share_logs = relationship('StripeTransactionAttendee', backref='attendee')
+    purchased_items = Column(MutableDict.as_mutable(JSONB), default={}, server_default='{}')
 
     badge_printed_name = Column(UnicodeText)
 
@@ -550,6 +553,17 @@ class Attendee(MagModel, TakesPaymentMixin):
                 self.overridden_price = self.badge_cost
             else:
                 self.paid = c.NEED_NOT_PAY
+                
+    @presave_adjustment
+    def add_purchased_items(self):
+        if self.purchased_items:
+            for name in self.cost_property_names:
+                value = getattr(self, name, 0)
+                if value:
+                    self.purchased_items[name] = value
+            if self.amount_extra:
+                self.purchased_items['amount_extra_cost'] = self.amount_extra
+            
 
     @presave_adjustment
     def assign_creator(self):

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -556,7 +556,7 @@ class Attendee(MagModel, TakesPaymentMixin):
                 
     @presave_adjustment
     def add_purchased_items(self):
-        if self.purchased_items:
+        if not self.purchased_items:
             for name in self.cost_property_names:
                 value = getattr(self, name, 0)
                 if value:

--- a/uber/site_sections/budget.py
+++ b/uber/site_sections/budget.py
@@ -27,7 +27,12 @@ class Root:
         
     @log_pageview
     def cost_breakdown(self, session):
-        paid_attendees = session.query(Attendee).filter(Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS]),
+        paid_attendees = session.query(Attendee.is_unassigned, 
+                                       Attendee.purchased_items, 
+                                       Attendee.first_name,
+                                       Attendee.last_name,
+                                       Group.name.label('group_name')).outerjoin(Attendee.group)\
+                    .filter(Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS]),
                                                         or_(Attendee.amount_paid > 0, 
                                                             and_(Attendee.group_id == Group.id, 
                                                                  Group.amount_paid > 0, 
@@ -35,7 +40,7 @@ class Root:
         
         return {
             'paid_attendees': paid_attendees,
-            'paid_groups': session.query(Group).filter(Group.amount_paid > 0),
+            'paid_groups': session.query(Group.auto_recalc, Group.name, Group.tables, Group.cost).filter(Group.amount_paid > 0),
             'table_cost_matrix': [
                 (c.TABLE_PRICES[1], "First Table"),
                 (sum(c.TABLE_PRICES[i] for i in range(1, 3)), "Second Table"),

--- a/uber/templates/budget/cost_breakdown.html
+++ b/uber/templates/budget/cost_breakdown.html
@@ -15,15 +15,13 @@
     </thead>
     <tbody>
     {% for attendee in paid_attendees %}
-      {% set name = "Unassigned badge in {}".format(attendee.group) if attendee.unassigned_name else attendee.full_name %}
-      {% for item, cost in [("Badge", attendee.badge_cost_real), ("Extra Donation", attendee.extra_donation), ("Kick-in Level", attendee.amount_extra)] %}
-      {% if cost %}
+      {% set name = "Unassigned badge in {}".format(attendee.group_name) if attendee.is_unassigned else attendee.first_name ~ " " ~ attendee.last_name %}
+      {% for item in attendee.purchased_items %}
         <tr>
           <td>{{ name }}</td>
-          <td>{{ item }}</td>
-          <td>${{ "{0:g}".format(cost) }}</td>
+          <td>{{ item[:-5]|replace('_', ' ')|title }}</td>
+          <td>${{ "{0:g}".format(attendee.purchased_items[item]) }}</td>
         </tr>
-      {% endif %}
       {% endfor %}
       {% if attendee.amount_unpaid %}
         <tr>


### PR DESCRIPTION
Attendees' costs were always calculated on the fly, which made a report on all attendees' costs effectively impossible. Now we record these costs via a JSONB column that we can pull much more efficiently.