### PR TITLE
Update payment method for preregistered attendees

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -563,7 +563,11 @@ class Attendee(MagModel, TakesPaymentMixin):
                     self.purchased_items[name] = value
             if self.amount_extra:
                 self.purchased_items['amount_extra_cost'] = self.amount_extra
-            
+    
+    @presave_adjustment
+    def set_payment_method(self):
+        if not self.payment_method and self.stripe_txn_share_logs:
+            self.payment_method = c.STRIPE
 
     @presave_adjustment
     def assign_creator(self):

--- a/uber/templates/budget/cost_breakdown.html
+++ b/uber/templates/budget/cost_breakdown.html
@@ -49,11 +49,11 @@
     <tr>
       <td>{{ group.name }}</td>
       <td>Total Cost</td>
-      <td>{{ group.cost }}</td>
+      <td>${{ group.cost }}</td>
       <td>Group price set by admin and cannot be itemized.</td>
     </tr>
     {% elif group.tables %}
-    {% for table_num in range(1, group.tables|int) %}
+    {% for table_num in range(1, group.tables|int + 1) %}
       {% if table_num < 5 %}
       {% set cost, desc = table_cost_matrix[table_num - 1] %}
       {% else %}


### PR DESCRIPTION
Our payment_method field used to just be for at-door attendees, but we now would prefer it to be accurate for everyone. This adds the relevant presave adjustment. This also fixes a bug on the cost breakdown page.