### PR TITLE
Update cost reports and payment method dropdown

### DIFF
--- a/uber/site_sections/budget.py
+++ b/uber/site_sections/budget.py
@@ -19,14 +19,14 @@ class Root:
         sales_total = sum([sale.cash * 100 for sale in session.query(Sale).all()])
         arbitrary_charge_total = sum([charge.amount * 100 for charge in session.query(ArbitraryCharge).all()])
         return {
-            'receipt_items': session.query(ReceiptItem),
+            'receipt_items': receipt_items.filter_by(txn_type=c.REFUND),
             'arbitrary_charges': session.query(ArbitraryCharge),
             'sales': session.query(Sale),
             'total': receipt_total + sales_total + arbitrary_charge_total,
         }
         
     @log_pageview
-    def cost_breakdown(self, session):
+    def attendee_cost_breakdown(self, session):
         paid_attendees = session.query(Attendee.is_unassigned, 
                                        Attendee.purchased_items, 
                                        Attendee.first_name,
@@ -40,6 +40,11 @@ class Root:
         
         return {
             'paid_attendees': paid_attendees,
+        }
+        
+    @log_pageview
+    def group_cost_breakdown(self, session):
+        return {
             'paid_groups': session.query(Group.auto_recalc, Group.name, Group.tables, Group.cost).filter(Group.amount_paid > 0),
             'table_cost_matrix': [
                 (c.TABLE_PRICES[1], "First Table"),
@@ -66,8 +71,7 @@ class Root:
 
         refund_attendees = {}
         for refund in refunds:
-            refund_attendees[refund.id] = session.query(Attendee)\
-                .filter_by(id=refund.fk_id).first() if refund.fk_model == 'Attendee' else None
+            refund_attendees[refund.id] = refund.attendees[0].attendee if refund.attendees else None
 
         return {
             'refunds': refunds,

--- a/uber/templates/budget/attendee_cost_breakdown.html
+++ b/uber/templates/budget/attendee_cost_breakdown.html
@@ -1,0 +1,55 @@
+{% set admin_area=True %}
+{% extends "base.html" %}
+{% block title %}Attendee Cost Breakdown{% endblock %}
+{% block content %}
+<h3>Attendee Cost Breakdown</h3>
+<div class="panel panel-default">
+  <table class="table table-striped export-datatable">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Item</th>
+        <th>Cost</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for attendee in paid_attendees %}
+      {% set name = "Unassigned badge in {}".format(attendee.group_name) if attendee.is_unassigned else attendee.first_name ~ " " ~ attendee.last_name %}
+      {% for item in attendee.purchased_items %}
+        <tr>
+          <td>{{ name }}</td>
+          <td>{{ item[:-5]|replace('_', ' ')|title }}</td>
+          <td>${{ "{0:g}".format(attendee.purchased_items[item]) }}</td>
+        </tr>
+      {% endfor %}
+      {% if attendee.amount_unpaid %}
+        <tr>
+          <td>{{ name }}</td>
+          <td>Amount Owed</td>
+          <td>-${{ "{0:g}".format(attendee.amount_unpaid) }}</td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+<script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.2/js/dataTables.buttons.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.2/js/buttons.html5.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.2/css/buttons.dataTables.min.css">
+<script type="text/javascript">
+$().ready(function() {
+  var dtable = $('.export-datatable').DataTable({
+      dom: 'Bfrtipl',
+      buttons: [
+          {
+              extend: 'excelHtml5',
+              exportOptions: {
+                  columns: ':visible'
+              }
+          },
+      ]
+  });
+});
+</script>
+{% endblock %}

--- a/uber/templates/budget/group_cost_breakdown.html
+++ b/uber/templates/budget/group_cost_breakdown.html
@@ -1,40 +1,10 @@
 {% set admin_area=True %}
 {% extends "base.html" %}
-{% block title %}Cost Breakdown{% endblock %}
+{% block title %}Group Cost Breakdown{% endblock %}
 {% block content %}
-
+<h3>Group Cost Breakdown</h3>
 <div class="panel panel-default">
   <table class="table table-striped export-datatable">
-    <caption><h3>Attendees</h3></caption>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Item</th>
-        <th>Cost</th>
-      </tr>
-    </thead>
-    <tbody>
-    {% for attendee in paid_attendees %}
-      {% set name = "Unassigned badge in {}".format(attendee.group_name) if attendee.is_unassigned else attendee.first_name ~ " " ~ attendee.last_name %}
-      {% for item in attendee.purchased_items %}
-        <tr>
-          <td>{{ name }}</td>
-          <td>{{ item[:-5]|replace('_', ' ')|title }}</td>
-          <td>${{ "{0:g}".format(attendee.purchased_items[item]) }}</td>
-        </tr>
-      {% endfor %}
-      {% if attendee.amount_unpaid %}
-        <tr>
-          <td>{{ name }}</td>
-          <td>Amount Owed</td>
-          <td>-${{ "{0:g}".format(attendee.amount_unpaid) }}</td>
-        </tr>
-      {% endif %}
-    {% endfor %}
-    </tbody>
-  </table>
-  <table class="table table-striped export-datatable">
-    <caption><h3>Groups</h3></caption>
     <thead>
       <tr>
         <th>Name</th>

--- a/uber/templates/budget/index.html
+++ b/uber/templates/budget/index.html
@@ -14,10 +14,11 @@
 </div>
 
 <div class="panel panel-default">
-  <table class="table table-striped datatable">
-    <caption><h3>Receipt Items</h3></caption>
+<h3 class="center">Refund Receipt Items</h3>
+  <table class="table table-striped export-datatable">
     <thead>
       <tr>
+        <th>Attendee</th>
         <th>Item Type</th>
         <th>Amount</th>
         <th>Description</th>
@@ -26,6 +27,7 @@
     <tbody>
     {% for item in receipt_items %}
       <tr>
+        <td>{{ item.attendee|form_link }}</td>
         <td>{{ item.item_type_label }}</td>
         <td>{{ '-' if item.txn_type == c.REFUND else '' }}${{ '%0.2f' % (item.amount / 100) }}</td>
         <td>{{ item.desc }}</td>
@@ -33,8 +35,8 @@
     {% endfor %}
     </tbody>
   </table>
-  <table class="table table-striped datatable">
-    <caption><h3>Sales</h3></caption>
+  <h3 class="center">Sales</h3>
+  <table class="table table-striped export-datatable">
     <thead>
       <tr>
         <th>Amount</th>
@@ -50,8 +52,8 @@
     {% endfor %}
     </tbody>
   </table>
-  <table class="table table-striped datatable">
-    <caption><h3>Arbitrary Charges</h3></caption>
+  <h3 class="center">Arbitrary Charges</h3>
+  <table class="table table-striped export-datatable">
     <thead>
       <tr>
         <th>Amount</th>
@@ -68,5 +70,23 @@
     </tbody>
   </table>
 </div>
-
+<script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.2/js/dataTables.buttons.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.2/js/buttons.html5.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.2/css/buttons.dataTables.min.css">
+<script type="text/javascript">
+$().ready(function() {
+  var dtable = $('.export-datatable').DataTable({
+      dom: 'Bfrtipl',
+      buttons: [
+          {
+              extend: 'excelHtml5',
+              exportOptions: {
+                  columns: ':visible'
+              }
+          },
+      ]
+  });
+});
+</script>
 {% endblock %}

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1549,6 +1549,7 @@ $(window).on("runJavaScript", function(){
     {% call macros.read_only_if(read_only, attendee.payment_method) %}
     <div class="col-sm-3">
       <select id="payment_method" name="payment_method" class="form-control">
+        <option value="">N/A</option>
         {{ options(c.PAYMENT_METHOD_OPTS,attendee.payment_method) }}
       </select>
     </div>


### PR DESCRIPTION
Splits the attendee and group cost breakdowns so they'll load more consistently. Also makes the budget/index tables exportable, and restricts receipt items loaded to just be the refunds (which are the only thing to come out of receipt items we can actually use). Finally, tweaks the presave adjustment for purchased items and adds a null option to the payment method dropdown since payment_method is a nullable column.

Oh yea, I also finally fixed the report for self-service refunds.