### PR TITLE
Don't count attendees with paid group if they're not paid-by-group

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -743,7 +743,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     @property
     def paid_for_badge(self):
         return self.paid == c.HAS_PAID or \
-                self.group_id and self.group and self.group.amount_paid or \
+                self.paid == c.PAID_BY_GROUP and self.group and self.group.amount_paid or \
                 self.in_promo_code_group and self.promo_code.cost
                 
     @property


### PR DESCRIPTION
We found that the volunteers owed refunds page was listing someone who had not paid us anything as needing a refund, because they were in a paid group. This only looks at attendees' groups if they're "paid by group."