### PR TITLE
Add email date changes to admin interface

### DIFF
--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -14,7 +14,7 @@ from sqlalchemy.types import Boolean, Integer
 
 from uber import utils
 from uber.config import c
-from uber.decorators import renderable_data
+from uber.decorators import presave_adjustment, renderable_data
 from uber.jinja import JinjaEnv
 from uber.models import MagModel
 from uber.models.types import DefaultColumn as Column
@@ -78,6 +78,18 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
     active_before = Column(UTCDateTime, nullable=True, default=None)
 
     emails = relationship('Email', backref='automated_email', order_by='Email.id')
+    
+    @presave_adjustment
+    def date_adjustments(self):
+        if self.active_after == '':
+            self.active_after = None
+        elif isinstance(self.active_after, str):
+            self.active_after = datetime.strptime(self.active_after, c.DATE_FORMAT)
+        
+        if self.active_before == '':
+            self.active_before = None
+        elif isinstance(self.active_before, str):
+            self.active_before = datetime.strptime(self.active_before, c.DATE_FORMAT)
 
     @classproperty
     def filters_for_allowed(cls):

--- a/uber/site_sections/email_admin.py
+++ b/uber/site_sections/email_admin.py
@@ -143,7 +143,9 @@ class Root:
             automated_email.approved = True
             raise HTTPRedirect(
                 'pending?message={}',
-                '"{}" approved and will be sent out shortly'.format(automated_email.subject))
+                '"{}" approved and will be sent out {}'.format(automated_email.subject, 
+                                                               "shortly" if not automated_email.active_when_label
+                                                               else automated_email.active_when_label))
         raise HTTPRedirect('pending?message={}{}', 'Unknown automated email: ', ident)
 
     @csrf_protected

--- a/uber/site_sections/email_admin.py
+++ b/uber/site_sections/email_admin.py
@@ -44,14 +44,13 @@ class Root:
             'automated_emails': emails_by_sender,
         }
 
-    def pending_examples(self, session, ident):
+    def pending_examples(self, session, ident, message=''):
         email = session.query(AutomatedEmail).filter_by(ident=ident).first()
         examples = []
         model = email.model_class
         query = AutomatedEmailFixture.queries.get(model)(session).order_by(model.id)
-        limit = 100
-        offset = 0
-        for model_instance in query.limit(limit).offset(offset):
+        limit = 1000
+        for model_instance in query.limit(limit):
             if email.would_send_if_approved(model_instance):
                 # These examples are never added to the session or saved to the database.
                 # They are only used to render an example of the automated email.
@@ -69,13 +68,20 @@ class Root:
                 )
                 examples.append((model_instance, example))
                 example_count = len(examples)
-                if example_count > 1 or (example_count == 1 and offset > 0):
+                if example_count > 10:
                     break
-            offset += limit
         return {
             'email': email,
             'examples': examples,
+            'message': message,
         }
+    
+    def update_dates(self, session, ident, **params):
+        email = session.query(AutomatedEmail).filter_by(ident=ident).first()
+        email.apply(params, restricted=False)
+        session.add(email)
+        session.commit()
+        raise HTTPRedirect('pending_examples?ident={}&message={}', ident, 'Email send dates updated')
 
     def test_email(self, session, subject=None, body=None, from_address=None, to_address=None, **params):
         """

--- a/uber/templates/email_admin/pending_examples.html
+++ b/uber/templates/email_admin/pending_examples.html
@@ -8,11 +8,47 @@
   <a href="pending">Return to pending email list</a>
 </div>
 <br>
+{% if not email.active_when_label %}
+{% set active_when_text = "It will be sent as soon as it's approved." %}
+{% else %}
+{% set active_when_text = "It will be sent " + email.active_when_label + "." %}
+{% endif %}
+{% if not email.needs_approval %}
+    This email is pre-approved. {{ active_when_text }}<br/><br/>
+{% else %}
+    {% if not email.approved %}
+        <form method="post" action="approve">
+        {{ csrf_token() }}
+        This email is currently <b>unapproved</b>. {{ active_when_text }}
+        <input type="hidden" name="ident" value="{{ email.ident }}" />
+        <input type="submit" value="Approve" class="btn btn-sm btn-success"/>
+        </form>
+    {% else %}
+        <form method="post" action="unapprove">
+        {{ csrf_token() }}
+        This email is currently <b>approved</b>. {{ active_when_text }}
+        <input type="hidden" name="ident" value="{{ email.ident }}" />
+        <input type="submit" value="Undo Approval" class="btn btn-sm btn-warning"/>
+        </form>
+    {% endif %}<br/>
+{% endif %}
+
+<form method="post" action="update_dates">
+{{ csrf_token() }}
+<input type="hidden" name="ident" value="{{ email.ident }}" />
+
+<label for="active_after">Send only after</label>
+<input type='text' class="date" name="active_after" value="{{ email.active_after|datetime("%Y-%m-%d") }}"/>
+and <label for="active_after">don't send after</label>
+<input type='text' class="date" name="active_before" value="{{ email.active_before|datetime("%Y-%m-%d") }}"/>
+    
+<input type="submit" value="Update Send Date(s)" class="btn btn-sm btn-warning"/>
+</form><br/>
 
 {% if email.unapproved_count > 0 %}
   There are {{ email.unapproved_count }} copies of this email that will be sent once it's approved.<br><br>
 {% elif examples %}
-  Congratulations! There are no unsent copies of this email waiting to be approved!<br><br>
+  There are no unsent copies of this email waiting to be approved.<br><br>
 {% endif %}
 
 {% if examples %}
@@ -22,7 +58,7 @@
     {{ macros.preview_email(example) }}
   {% endfor %}
 {% else %}
-  No recepients match the email criteria.<br><br>
+  We couldn't find recipients matching the email criteria in the first 1000 possible recipients.<br><br>
   Here's what the template looks like though:<br>
   {{ macros.preview_email(email) }}
 {% endif %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-835.

Admins can now approve, unapprove, and update email dates using the pending_examples page.
![image](https://user-images.githubusercontent.com/7198215/74410543-9b126d80-4e39-11ea-859a-209436967d38.png)

I also altered the message on the pending_examples page for when the system can't render any examples. Sadly, fixing the email example generation is out of scope for this PR as it's actually a core problem with how we select emails for sending.