### PR TITLE
Upgrade to Stripe.js v3 Elements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ celery==4.1.1
 python-dateutil==2.6.0
 psycopg2==2.7.3.2
 py3k-bcrypt==0.3
-stripe==1.25.0
+stripe==2.42.0
 pytz==2017.2
 alembic==0.9.1
 treepoem==1.0.1

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -739,6 +739,10 @@ sqlalchemy_max_overflow = integer(default=10)
 stripe_secret_key = string(default="sk_test_QHnlImUs68dQFxgTfVauz5Ue")
 stripe_public_key = string(default="pk_test_q4kSJVwk6LXKv2ahxuVn7VOK")
 
+# This is for the payment completion webhook; it will change for each Stripe account
+# Unfortunately, Stripe cannot call a webhook on a local server
+stripe_endpoint_secret = string(default="")
+
 # This list is checked when attendeees preregister and sign up as volunteers.
 # You should enter the full names including all common nicknames as separate
 # entries, e.g. if you banned "John Smith" then you should make sure to also
@@ -1184,12 +1188,14 @@ has_paid      = string(default="yes")
 need_not_pay  = string(default="doesn't need to")
 refunded      = string(default="paid and refunded")
 paid_by_group = string(default="paid by group")
+pending = string(default="pending")
 lost_badge    = string(default="lost badge")
 __many__ = string
 
 [[transaction_type]]
 payment = string(default="Paid")
 refund = string(default="Refunded")
+pending = string(default="Pending")
 
 [[pronoun]]
 she = string(default="She/Her")

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -599,33 +599,14 @@ def csrf_token():
 
 
 @JinjaEnv.jinja_export
-def stripe_form(action, charge):
-    payment_id = uuid4().hex
-    cherrypy.session[payment_id] = charge.to_dict()
+def stripe_form(action, model=None, **params):
+    new_params = {'params': {}}
+    for key, val in params.items():
+        new_params['params'][key] = val
+    new_params['action'] = action
+    new_params['id'] = model.id if model else None
 
-    email = None
-    if charge.models and charge.models[0].email:
-        email = charge.models[0].email[:255]
-
-    if not charge.models:
-        if c.AT_THE_CON:
-            regtext = 'On-Site Charge'
-        else:
-            regtext = 'Charge'
-    elif c.AT_THE_CON:
-        regtext = 'Registration'
-    else:
-        regtext = 'Preregistration'
-
-    params = {
-        'action': action,
-        'regtext': regtext,
-        'email': email,
-        'payment_id': payment_id,
-        'charge': charge
-    }
-
-    return safe_string(render('preregistration/stripeForm.html', params).decode('utf-8'))
+    return safe_string(render('preregistration/stripeForm.html', new_params).decode('utf-8'))
 
 
 @JinjaEnv.jinja_export

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -347,15 +347,10 @@ def check_shutdown(func):
 
 def credit_card(func):
     @wraps(func)
-    def charge(self, session, payment_id=None, stripeToken=None, stripeEmail='ignored', **ignored):
-        log.debug('PAYMENT: payment_id={}, stripeToken={}', payment_id or 'NONE', stripeToken or 'NONE')
-
-        if ignored:
-            log.debug('PAYMENT: received unexpected stripe parameters: {}', ignored)
-
+    def charge(self, session, id=None, **kwargs):
         try:
             try:
-                return func(self, session=session, payment_id=payment_id, stripeToken=stripeToken)
+                return func(self, session=session, id=id, **kwargs)
             except HTTPRedirect:
                 # Paranoia: we want to try commiting while we're INSIDE of the
                 # @credit_card decorator to ensure that we catch any database
@@ -369,11 +364,10 @@ def credit_card(func):
             raise
         except Exception:
             error_text = \
-                'Got an error while calling charge' \
-                '(self, payment_id={!r}, stripeToken={!r}, ignored={}):\n{}\n\n' \
-                'IMPORTANT: This could have resulted in an attendee paying and not being ' \
-                'marked as paid in the database. Definitely double check this.'\
-                .format(payment_id, stripeToken, ignored, traceback.format_exc())
+                'Got an error while calling charge:\n{}\n\n' \
+                'IMPORTANT: This is likely preventing someone from paying for' \
+                ' something with no error on their end. Look into this ASAP.'\
+                .format(traceback.format_exc())
 
             report_critical_exception(msg=error_text, subject='ERROR: MAGFest Stripe error (Automated Message)')
             return traceback.format_exc()

--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -76,7 +76,7 @@ class Sale(MagModel):
 
 class StripeTransaction(MagModel):
     stripe_id = Column(UnicodeText, nullable=True)
-    type = Column(Choice(c.TRANSACTION_TYPE_OPTS), default=c.PAYMENT)
+    type = Column(Choice(c.TRANSACTION_TYPE_OPTS), default=c.PENDING)
     amount = Column(Integer)
     when = Column(UTCDateTime, default=lambda: datetime.now(UTC))
     who = Column(UnicodeText)
@@ -110,7 +110,7 @@ class ReceiptItem(MagModel):
     stripe_transaction = relationship(
         StripeTransaction, backref='receipt_items',
         foreign_keys=txn_id, cascade='save-update,merge,refresh-expire,expunge')
-    txn_type = Column(Choice(c.TRANSACTION_TYPE_OPTS), default=c.PAYMENT)
+    txn_type = Column(Choice(c.TRANSACTION_TYPE_OPTS), default=c.PENDING)
     payment_method = Column(Choice(c.PAYMENT_METHOD_OPTS), default=c.STRIPE)
     amount = Column(Integer)
     when = Column(UTCDateTime, default=lambda: datetime.now(UTC))

--- a/uber/site_sections/api.py
+++ b/uber/site_sections/api.py
@@ -100,7 +100,7 @@ class Root:
     def stripe_webhook_handler(request=None):
         if not request or not request.body:
             return "Request required"
-        sig_header = request.META['HTTP_STRIPE_SIGNATURE']
+        sig_header = cherrypy.request.headers['HTTP_STRIPE_SIGNATURE']
         payload = request.body
         event = None
 

--- a/uber/site_sections/marketplace.py
+++ b/uber/site_sections/marketplace.py
@@ -1,4 +1,5 @@
 import cherrypy
+from six import string_types
 
 from uber.config import c
 from uber.decorators import ajax, all_renderable, render, credit_card
@@ -90,47 +91,46 @@ class Root:
             'message': message,
             'app': app,
             'return_to': 'edit',
-            'charge': Charge(app.attendee)
         }
 
     def confirmation(self, session, id):
         return {'app': session.marketplace_application(id)}
 
+    @ajax
     @credit_card
-    def process_marketplace_payment(self, session, payment_id, stripeToken):
-        charge = Charge.get(payment_id)
-        [attendee] = charge.attendees
-        attendee = session.merge(attendee)
-        apps = attendee.marketplace_applications
+    def process_marketplace_payment(self, session, id):
+        attendee = session.attendee(id)
+        charge = Charge(attendee, description="Marketplace application payment")
 
-        message = charge.charge_cc(session, stripeToken)
+        stripe_intent = charge.create_stripe_intent(session)
+        message = stripe_intent if isinstance(stripe_intent, string_types) else ''
         if message:
-            raise HTTPRedirect('edit?id={}&message={}',
-                               apps[0].id, message)
+            return {'error': message}
         else:
-            attendee_payment = charge.dollar_amount
             if attendee.marketplace_cost:
                 for app in attendee.marketplace_applications:
-                    attendee_payment -= app.amount_unpaid
-                    app.amount_paid += app.amount_unpaid
-            attendee.amount_paid_override += attendee_payment
+                    app.amount_paid += app.amount_unpaid  # This needs to accommodate payment cancellations
+                    send_email.delay(
+                        c.ADMIN_EMAIL,
+                        c.MARKETPLACE_APP_EMAIL,
+                        'Marketplace Payment Received',
+                        render('emails/marketplace/payment_notification.txt',
+                            {'app': app}, encoding=None),
+                        model=app.to_dict('id'))
+                    send_email.delay(
+                        c.MARKETPLACE_APP_EMAIL,
+                        app.email,
+                        'Marketplace Payment Received',
+                        render('emails/marketplace/payment_confirmation.txt',
+                            {'app': app}, encoding=None),
+                        model=app.to_dict('id'))
+            
             if attendee.paid == c.NOT_PAID:
                 attendee.paid = c.HAS_PAID
+            session.add(session.create_receipt_item(attendee, charge.amount, "Marketplace payment", charge.stripe_transaction))
         session.add(attendee)
-        send_email.delay(
-            c.ADMIN_EMAIL,
-            c.MARKETPLACE_APP_EMAIL,
-            'Marketplace Payment Received',
-            render('emails/marketplace/payment_notification.txt',
-                   {'app': app}, encoding=None),
-            model=app.to_dict('id'))
-        send_email.delay(
-            c.MARKETPLACE_APP_EMAIL,
-            app.email,
-            'Marketplace Payment Received',
-            render('emails/marketplace/payment_confirmation.txt',
-                   {'app': app}, encoding=None),
-            model=app.to_dict('id'))
-        raise HTTPRedirect('edit?id={}&message={}',
-                           app.id,
-                           'Your payment has been accepted!')
+        session.commit()
+        
+        return {'stripe_intent': stripe_intent,
+                'success_url': 'edit?id={}&message={}'.format(attendee.marketplace_applications[0].id,
+                                                              'Your payment has been accepted')}

--- a/uber/templates/art_show_admin/form.html
+++ b/uber/templates/art_show_admin/form.html
@@ -70,8 +70,8 @@ app, c.PAGE_PATH,
           </select>
           <span id="amount_paid">
             <div class="input-group">
-              <span class="input-group-addon">$</span><input type="text" class="form-control" name="app_paid" value="{{ app_paid }}" />
-            </div> (${{ app.attendee.amount_paid / 100 }} of ${{ app.attendee.total_cost }} total)
+              <span class="input-group-addon">$</span><input type="text" class="form-control" name="app_paid" value="{{ app_paid|int }}" />
+            </div> (${{ (app.attendee.amount_paid / 100)|int }} of ${{ app.attendee.total_cost }} total)
           </span>
           </div>
           {% else %}

--- a/uber/templates/art_show_admin/pieces_bought.html
+++ b/uber/templates/art_show_admin/pieces_bought.html
@@ -53,23 +53,6 @@ Invoice #{{ receipt.invoice_num }}
       </div>
     </div>
   </div>
-  {% elif charge %}
-  <div class="modal fade" id="charge_modal" role="dialog" tabindex="-1">
-    <div class="modal-dialog modal-lg" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title">Stripe Charge for ${{ '%0.2f' % (charge.amount / 100) }}</h4>
-        </div>
-
-        <div class="panel-body">
-          {{ stripe_form('purchases_charge', charge) }}
-          <br/><button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Nevermind</span></button>
-        </div>
-
-      </div>
-    </div>
-  </div>
   {% endif %}
   {% endif %}
   <div class="table-responsive">
@@ -132,13 +115,12 @@ Invoice #{{ receipt.invoice_num }}
         </form>
       </td></tr>
       <tr><td colspan="8" class="text-right">
-        <form role="form" method="post" class="form form-inline" action="pieces_bought">
-          <input type="hidden" name="id" value="{{ receipt.id }}" />
+      <div class="form form-inline">
           <div class="input-group">
-            <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % (receipt.owed / 100) }}" />
+            <span class="input-group-addon">$</span><input type="text" class="form-control" id="stripe_amount" placeholder="{{ '%0.2f' % (receipt.owed / 100) }}" />
           </div>
-          <button type="submit" class="btn btn-success">Begin Card Payment</button>
-        </form>
+          {{ stripe_form('purchases_charge', receipt.attendee, receipt_id=receipt.id) }}
+      </div>
       </td></tr>
       {% endif %}
       <tr><td colspan="8" class="text-right">
@@ -184,6 +166,16 @@ Invoice #{{ receipt.invoice_num }}
   {{ csrf_token() }}
 </form>
 <script type="text/javascript">
+    var resumeStripeAction = callStripeAction;
+    var callStripeAction = function() {
+      var credit_amt = $('#stripe_amount').val();
+      if (credit_amt == 0) {
+        credit_amt = {{ receipt.owed }} / 100;
+      }
+      stripe_action_params.amount = credit_amt * 100;
+      resumeStripeAction();
+    }
+
     var printReceipt = function() {
         window.open('', 'print_receipt_target', 'width=400,height=400,resizeable,scrollbars');
         $('#print_form').attr('target', 'print_receipt_target').submit();
@@ -198,8 +190,6 @@ Invoice #{{ receipt.invoice_num }}
             window.location.assign('?id={{ receipt.id }}');
         });
     });
-    {% elif charge %}
-    $('.modal').modal('show');
     {% endif %}
 
     $(document).ready(function() {

--- a/uber/templates/art_show_admin/sales_charge_form.html
+++ b/uber/templates/art_show_admin/sales_charge_form.html
@@ -21,7 +21,7 @@
 {% if charge %}
     <h2>${{ amount }}: {{ description }}</h2>
     <div class="center">
-        {{ stripe_form('sales_charge',charge) }}
+        {{ stripe_form('sales_charge',None,amount=amount,description=description) }}
         {% if sale_id %}<a href="#" onClick="undoSale('{{ sale_id }}'); return false">Undo</a>{% endif %}
     </div>
 {% else %}

--- a/uber/templates/art_show_applications/edit.html
+++ b/uber/templates/art_show_applications/edit.html
@@ -10,11 +10,11 @@
       {% if app.status in [c.APPROVED, c.PAID] %}
       {% if app.status == c.APPROVED %}Congratulations, your application has been approved!{% endif %}
         {% if not app.incomplete_reason and app.is_unpaid %}
-          In order to complete your application, please pay ${{ app.attendee.amount_unpaid }} using the button below.
+          In order to complete your application, please pay ${{ '%0.2f' % app.attendee.amount_unpaid }} using the button below.
           {% if app.attendee.badge_cost %}This total includes the cost of your badge, if you have not paid for it
           already.{% endif %}<br/><br/>
           <div style="text-align:center">
-              {{ stripe_form('process_art_show_payment', charge) }}
+              {{ stripe_form('process_art_show_payment', app.attendee) }}
           </div><br/><br/>
         {% elif app.attendee.placeholder and app.attendee.badge_status != c.NOT_ATTENDING %}
           Before completing your application, please finish filling out your information

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -5,6 +5,7 @@
     {{ macros.ie7_compatibility_check() }}
     <title>{{ c.EVENT_NAME }} - {% block title %}{% endblock %}</title>
     <link rel="icon" href="../static/images/favicon.png" type="image/x-icon" />
+    <script src="https://js.stripe.com/v3/"></script>
 
     {% block head_styles %}
         <link rel="stylesheet" href="../static/deps/combined.min.css" />

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -5,7 +5,7 @@
     {{ macros.ie7_compatibility_check() }}
     <title>{{ c.EVENT_NAME }} - {% block title %}{% endblock %}</title>
     <link rel="icon" href="../static/images/favicon.png" type="image/x-icon" />
-    <script src="https://js.stripe.com/v3/"></script>
+    <script src="https://js.stripe.com/v3/" async></script>
 
     {% block head_styles %}
         <link rel="stylesheet" href="../static/deps/combined.min.css" />

--- a/uber/templates/check_in.html
+++ b/uber/templates/check_in.html
@@ -16,6 +16,9 @@ var loadCheckInModal = function (attendeeID) {
                 field_order: 'MDY',
                 show_tooltips: false
             });
+            checkInModal.on('hidden.bs.modal', function (e) {
+                $('#stripeModal').remove();
+            });
         } else {
             toastr.error("Form loading failed.");
             checkInModal.modal('hide');

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -46,7 +46,7 @@
         <li>${{ '%0.2f' % (group.amount_paid / 100) }} paid{% if group.amount_unpaid %} so far</li>
           <li>${{ '%0.2f' % group.amount_unpaid }} unpaid</li>
           </ul>
-          <br/>{{ stripe_form('process_group_payment',charge) }}
+          <br/>{{ stripe_form('process_group_payment',group) }}
         {% else %}
           </li></ul>
         {% endif %}

--- a/uber/templates/marketplace/edit.html
+++ b/uber/templates/marketplace/edit.html
@@ -11,10 +11,10 @@
       {% if app.status in [c.APPROVED, c.PAID] %}
       {% if app.status == c.APPROVED %}Congratulations, your application has been approved!{% endif %}
         {% if not app.incomplete_reason and app.amount_unpaid %}
-          In order to complete your application, please pay ${{ app.attendee.amount_unpaid }} using the button below.
+          In order to complete your application, please pay ${{ '%0.2f' % app.attendee.amount_unpaid }} using the button below.
           {% if payment_includes_badge %}This total includes the cost of your badge.{% endif %}<br/><br/>
           <div style="text-align:center">
-              {{ stripe_form('process_marketplace_payment', charge) }}
+              {{ stripe_form('process_marketplace_payment', app.attendee) }}
           </div>
         {% elif app.attendee.placeholder %}
           Before completing your application, please finish filling out your information

--- a/uber/templates/merch_admin/arbitrary_charge_form.html
+++ b/uber/templates/merch_admin/arbitrary_charge_form.html
@@ -13,7 +13,7 @@
 {% if charge %}
     <h2>${{ '%0.2f' % amount|float }}: {{ description }}</h2>
     <div class="center">
-        {{ stripe_form('arbitrary_charge',charge) }}
+        {{ stripe_form('arbitrary_charge',None,amount=amount,description=description) }}
         {% if sale_id %}<a href="#" onClick="undoSale('{{ sale_id }}'); return false">Undo</a>{% endif %}
     </div>
 {% else %}

--- a/uber/templates/preregistration/add_group_members.html
+++ b/uber/templates/preregistration/add_group_members.html
@@ -7,11 +7,11 @@
   <div class="panel-body">
     <h2> Add Members to {{ group.name }} </h2>
 
-    You've indicated you'd like to add {{ count }} {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}, at a cost of ${{ '%0.2f' % charge.dollar_amount }}.
+    You've indicated you'd like to add {{ count }} {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}, at a cost of ${{ '%0.2f' % (count|int * group.new_badge_cost) }}.
 
     <table style="width: auto; margin: 15px auto 0;">
       <tr>
-        <td>{{ stripe_form('pay_for_extra_members',charge) }}</td>
+        <td>{{ stripe_form('pay_for_extra_members',group,count=count) }}</td>
         <td style="width:100px ; text-align:center">or</td>
         <td><a href="group_members?id={{ group.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
       </tr>

--- a/uber/templates/preregistration/add_promo_codes.html
+++ b/uber/templates/preregistration/add_promo_codes.html
@@ -7,10 +7,10 @@
     <div class="panel-body">
       <h2> Add Badge Codes to {{ group.name }} </h2>
 
-      You've indicated you'd like to add {{ count }} promo code{{ count|int|pluralize }}, at a cost of ${{ '%0.2f' % charge.dollar_amount }}.
+      You've indicated you'd like to add {{ count }} promo code{{ count|int|pluralize }}, at a cost of ${{ '%0.2f' % (count|int * c.GROUP_PRICE) }}.
       <table style="width: auto; margin: 15px auto 0;">
         <tr>
-          <td>{{ stripe_form('pay_for_extra_codes',charge) }}</td>
+          <td>{{ stripe_form('pay_for_extra_codes',group,count=count) }}</td>
           <td style="width:100px ; text-align:center">or</td>
           <td><a href="group_promo_codes?id={{ group.id }}">{{ macros.stripe_button("Cancel") }}</a></td>
         </tr>

--- a/uber/templates/preregistration/attendee_donation_form.html
+++ b/uber/templates/preregistration/attendee_donation_form.html
@@ -11,8 +11,8 @@
       You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ '%0.2f' % attendee.badge_cost }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|round(2) }}.
 
       <table style="width: auto; margin: 15px auto 0;">
-        <tr>
-          <td>{{ stripe_form('process_attendee_donation', charge) }}</td>
+        <tr class="stripe_form">
+          <td>{{ stripe_form('process_attendee_donation', attendee) }}</td>
           {% if attendee.amount_extra %}
             <td style="width:100px ; text-align:center">or</td>
             <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Undo Extra Money") }}</a></td>
@@ -41,8 +41,8 @@
       </ul>
 
       <table style="width:auto ; margin-left:auto ; margin-right: auto">
-        <tr>
-          <td>{{ stripe_form('process_attendee_donation', charge) }}</td>
+        <tr class="stripe_form">
+          <td>{{ stripe_form('process_attendee_donation', attendee) }}</td>
           <td style="width:100px ; text-align:center">or</td>
           <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
         </tr>

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -16,7 +16,6 @@
 <div class="panel panel-default">
   <div class="panel-body">
   {{ attendee_fields.prereg_intro }}
-  {{ session_vars }}
 
 {#- The action is set to "post_form" or "post_dealer" in order to bypass the NGINX cache. -#}
 {% set post_action = 'post_dealer' if attendee.is_dealer else 'post_form' %}

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -16,6 +16,7 @@
 <div class="panel panel-default">
   <div class="panel-body">
   {{ attendee_fields.prereg_intro }}
+  {{ session_vars }}
 
 {#- The action is set to "post_form" or "post_dealer" in order to bypass the NGINX cache. -#}
 {% set post_action = 'post_dealer' if attendee.is_dealer else 'post_form' %}

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -88,7 +88,7 @@
 
 {% if group.amount_unpaid and not group.is_dealer %}
     <div style="text-align:center">
-        {{ stripe_form('process_group_payment',charge) }}
+        {{ stripe_form('process_group_payment',group) }}
     </div>
 {% endif %}
 

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -5,28 +5,37 @@
 
 <script type="text/javascript">
     $().ready(function() {
-        $("a[href^='delete']").click(function(event){
-            var urlToUse = $(this).attr('href');
-            event.preventDefault();
-            bootbox.confirm({
-                message: "Are you sure you want to delete this preregistration?",
-                buttons: {
-                    confirm: {
-                        label: 'Delete Preregistration',
-                        className: 'btn-danger'
-                    },
-                    cancel: {
-                        label: 'Nevermind',
-                        className: 'btn-default'
-                    }
-                },
-                callback: function (result) {
-                    if(result) {
-                        window.location.href = urlToUse
-                    }
-                }
-            });
-        })
+      $('#cancel_payment').click(function(event) {
+        event.preventDefault();
+        $.post('cancel_prereg_payment', {csrf_token: csrf_token},
+        function(result) {
+            if (result.message) {
+                window.location.replace('index?message=Payment%20reset');
+            }
+        });
+      })
+      $("a[href^='delete']").click(function(event){
+          var urlToUse = $(this).attr('href');
+          event.preventDefault();
+          bootbox.confirm({
+              message: "Are you sure you want to delete this preregistration?",
+              buttons: {
+                  confirm: {
+                      label: 'Delete Preregistration',
+                      className: 'btn-danger'
+                  },
+                  cancel: {
+                      label: 'Nevermind',
+                      className: 'btn-default'
+                  }
+              },
+              callback: function (result) {
+                  if(result) {
+                      window.location.href = urlToUse
+                  }
+              }
+          });
+      })
     });
 </script>
 
@@ -36,11 +45,33 @@
   <div class="panel-body">
     {{ macros.prereg_wizard(c.PAGE_PATH, c.PREREG_REQUEST_HOTEL_INFO_OPEN) }}
 
+  {% if pending_attendees %}
     <div class="row">
-        <div class="col-sm-8 col-sm-offset-2">
+      <div class="col-md-offset-1 col-md-10">
+      {% if c.DEV_BOX %}<p>Since this is a test server, the message below could have a few causes:
+      <ul><li>The Payment Intent Succeeded Stripe webhook may not be set up to point to this server's stripe_webhook_handler yet.</li>
+      <li>This is a local server, so Stripe cannot call any of its webhooks.</li>
+      <li>The stripe_webhook_handler is broken, possibly due to a breaking change in Stripe's API.</li>
+      </ul>
+       You can run the registration.check_missed_stripe_payments task (which should run on its own, albeit infrequently) to force payments to complete.</p>{% endif %}
+        <div class="alert alert-warning">
+          <p>
+            Your payment is still marked as pending completion. 
+            If you canceled your payment before completion, you can <a href="index" id="cancel_payment">pay here</a>.
+            Otherwise, if you have not received your confirmation email after an hour, please contact us at {{ c.REGDESK_EMAIL|email_only|email_to_link }}.
+          </p>
+        </div>
+
+        </div>
+        </div>
+      {% endif %}
+
+      {% if charge.attendees or charge.groups %}
+        <div class="row">
+            <div class="col-sm-8 col-sm-offset-2">
             <div class="col-sm-5 text-center">
                 {% if charge.total_cost > 0 %}
-                    {{ stripe_form('prereg_payment',charge) }}
+                    {{ stripe_form('prereg_payment') }}
                 {% else %}
                     <a href="process_free_prereg">{{ macros.stripe_button("Complete Registration!") }}</a>
                 {% endif %}
@@ -138,6 +169,7 @@
       </tfoot>
     {% endif %}
   </table>
+  {% endif %}
 
   <div class="panel-body">
     {% include "preregistration/disclaimers.html" %}

--- a/uber/templates/preregistration/stripeForm.html
+++ b/uber/templates/preregistration/stripeForm.html
@@ -112,7 +112,7 @@ var collectStripePayment = function (client_secret, stripe_id, success_url, canc
             fontSmoothing: 'antialiased',
             fontSize: '16px',
             '::placeholder': {
-            color: '#aab7c4'
+                color: '#aab7c4'
             }
         },
         invalid: {
@@ -126,9 +126,9 @@ var collectStripePayment = function (client_secret, stripe_id, success_url, canc
     card.addEventListener('change', ({error}) => {
         const displayError = $('#card-errors');
         if (error) {
-        displayError.textContent = error.message;
+            displayError.textContent = error.message;
         } else {
-        displayError.textContent = '';
+            displayError.textContent = '';
         }
     });
 

--- a/uber/templates/preregistration/stripeForm.html
+++ b/uber/templates/preregistration/stripeForm.html
@@ -1,16 +1,161 @@
-<form class="stripe" method="post" action="{{ action }}">
-    <input type="hidden" name="payment_id" value="{{ payment_id }}" />
-    {{ csrf_token() }}
-    <script
-        src="https://checkout.stripe.com/v2/checkout.js" class="stripe-button"
-        data-key="{{ c.STRIPE_PUBLIC_KEY }}"
-        {% if email %} data-email="{{ email }}"{% endif %}
-        {% if c.DEV_BOX %} data-bitcoin="true" {% endif %}
-        data-zip-code="true"
-        data-allow-remember-me="false"
-        data-amount="{{ charge.amount }}"
-        data-name="{{ c.EVENT_NAME_AND_YEAR }} {{ regtext }}"
-        data-description="{{ charge.description }}"
-        data-image="../static/theme/stripe-logo.png">
-    </script>
-</form>
+
+<style>
+.StripeElement {
+  box-sizing: border-box;
+
+  height: 40px;
+
+  padding: 10px 12px;
+
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: white;
+
+  box-shadow: 0 1px 3px 0 #e6ebf1;
+  -webkit-transition: box-shadow 150ms ease;
+  transition: box-shadow 150ms ease;
+}
+
+.StripeElement--focus {
+  box-shadow: 0 1px 3px 0 #cfd7df;
+}
+
+.StripeElement--invalid {
+  border-color: #fa755a;
+}
+
+.StripeElement--webkit-autofill {
+  background-color: #fefde5 !important;
+}
+</style>
+<button class="btn btn-info" onClick="callStripeAction();">
+<span class="display: block; min-height: 30px;">Pay with Card</span>
+</button>
+<div id="stripeModal" class="modal" style="color:black;" tabindex="-1" role="dialog" data-backdrop="static">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+        <div class="modal-header">
+        <h4 class="modal-title text-center"></h4>
+        </div>
+        <div class="modal-body text-left jumbotron">
+        <div class="charge_desc" style="margin-bottom:10px;"></div>
+        <form action="/charge" method="post" id="payment-form" class="hidden">
+        <div class="form-row">
+            <label for="card-element">
+            Credit or debit card
+            </label>
+            <div id="card-element">
+            <!-- A Stripe Element will be inserted here. -->
+            </div>
+
+            <!-- Used to display form errors. -->
+            <div id="card-errors" role="alert"></div>
+        </div>
+        <div style="margin-top:10px;"><button class="btn btn-success">Submit Payment</button>
+        <button class="btn btn-default" data-dismiss="modal">Cancel</button></div>
+        </form>
+        </div>
+    </div>
+  </div>
+</div>
+<script type="text/javascript">
+stripe_action_params = {id: '{{ id }}'};
+
+var callStripeAction = function () {
+    var $btn = $(this);
+    $btn.prop('disabled', true);
+    {% for key, val in params.items() %}
+        stripe_action_params['{{ key }}'] = '{{ val }}';
+    {% endfor %}
+    stripe_action_params.csrf_token = csrf_token;
+    $.post('{{ action }}', stripe_action_params, 
+    function(result) {
+        $btn.prop('disabled', false);
+        if (result.error) {
+            toastr.error(result.error);
+        } else if (result.stripe_intent) {
+            var dollars = result.stripe_intent.amount / 100;
+            dollars = dollars.toLocaleString("en-US", {style:"currency", currency:"USD"});
+            var cancel_url = result.cancel_url || '../preregistration/cancel_payment'
+            $('#stripeModal').find('.modal-title').text('Paying ' + dollars + ' to {{ c.ORGANIZATION_NAME }}');
+            $('#stripeModal').find('.charge_desc').text(result.stripe_intent.description);
+            collectStripePayment(result.stripe_intent.client_secret, result.stripe_intent.id, result.success_url, cancel_url);
+        }
+        });
+};
+
+var collectStripePayment = function (client_secret, stripe_id, success_url, cancel_url) {
+    $('#stripeModal').modal('show');
+    toastr.clear();
+    var form = document.getElementById('payment-form');
+    var stripe = Stripe('{{ c.STRIPE_PUBLIC_KEY }}');
+    var elements = stripe.elements();
+    var card = elements.create("card");
+
+    $('#stripeModal').on('hidden.bs.modal', function (e) {
+        card.destroy();
+        $.post(cancel_url, {stripe_id: stripe_id, csrf_token: csrf_token},
+        function(result) {
+            if (result.message) {
+                toastr.error(result.message);
+                $(form).addClass('hidden');
+                $('#stripeModal').off('hidden.bs.modal');
+            }
+        });
+    })
+
+    // Set up Stripe.js and Elements to use in checkout form
+    var style = {
+        base: {
+            color: '#32325d',
+            fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+            fontSmoothing: 'antialiased',
+            fontSize: '16px',
+            '::placeholder': {
+            color: '#aab7c4'
+            }
+        },
+        invalid: {
+            color: '#fa755a',
+            iconColor: '#fa755a'
+        }
+    };
+
+    card.mount("#card-element");
+
+    card.addEventListener('change', ({error}) => {
+        const displayError = $('#card-errors');
+        if (error) {
+        displayError.textContent = error.message;
+        } else {
+        displayError.textContent = '';
+        }
+    });
+
+    $(form).removeClass('hidden');
+
+    form.addEventListener('submit', function(event) {
+        event.preventDefault();
+        stripe.confirmCardPayment(client_secret, {
+            payment_method: {
+                card: card
+            }
+            }).then(function(result) {
+            if (result.error) {
+                // Show error to your customer (e.g., insufficient funds)
+                toastr.error(result.error.message);
+            } else {
+                // The payment has been processed!
+                if (result.paymentIntent.status === 'succeeded') {
+                    if(success_url == '') {
+                        // Special override for at-door check-in modal payment workflow
+                        window[loadCheckInForm()];
+                    } else {
+                        window.location.replace(success_url);
+                    }
+                }
+            };
+        });
+    });
+}
+</script>

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -53,20 +53,20 @@ $().ready(function() {
 
 <div class="panel panel-body"><h3>Add Payment or Refund</h3>
 <p>Use the Stripe Payment History table at the bottom of this page to associate a payment or refund with a Stripe transaction. Please <b>only</b> add payments if the attendee has paid.</p>
-{% if attendee.purchased_items %}<p>This attendee has purchased the following:
-<br/> {% for name, val in attendee.purchased_items.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}<br/>{% endfor %}
+{% if model.purchased_items %}<p>This attendee has purchased the following:
+<br/> {% for name, val in model.purchased_items.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}<br/>{% endfor %}
 </p>{% endif %}
-{% if attendee.refunded_items %}<p>We have marked the following items as refunded:
-<br/> {% for name, val in attendee.refunded_items.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}<br/>{% endfor %}
+{% if model.refunded_items %}<p>We have marked the following items as refunded:
+<br/> {% for name, val in model.refunded_items.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}<br/>{% endfor %}
 </p>{% endif %}
 <form class="form" method="post" action="add_receipt_item" id="add_receipt_item" role="form">
 <input type="hidden" name="id" value="{{ model.id }}" />
 {{ csrf_token() }}
-{% if attendee.amount_unpaid %}
-{% set amount = amount or attendee.amount_unpaid %}
+{% if model.amount_unpaid %}
+{% set amount = amount or model.amount_unpaid %}
 {% set default_txn_type = c.PAYMENT %}
 {% else %}
-{% set amount = amount or (attendee.amount_paid - attendee.amount_refunded) / 100 %}
+{% set amount = amount or (model.amount_paid - model.amount_refunded) / 100 %}
 {% set default_txn_type = c.REFUND %}
 {% endif %}
 <table class="table">
@@ -133,7 +133,7 @@ $().ready(function() {
         <td>{{ item.who }}</td>
         <td>{{ item.desc }}{% if item.fk_id %}({{ item.model }}){% endif %}</td>
         <td>${{ '%0.2f' % (item.amount / 100) }} {{ item.type_label }}</td>
-        <td>{{ 'N/A' if item.cost_snapshot == {} }}{% for name, val in item.cost_snapshot.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}{% endfor %}</td>
+        <td>{{ 'N/A' if item.cost_snapshot == {} }}{% for name, val in item.cost_snapshot.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}<br/>{% endfor %}</td>
         <td>{{ 'N/A' if item.refund_snapshot == {} }}{% for name, val in item.refund_snapshot.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}{% endfor %}</td>
         <td>{{ item.txn_type_label }}</td>
         <td>
@@ -159,8 +159,8 @@ $().ready(function() {
     <th>Amount</th>
     <th></th>
   </tr></thead>
-  {% for name, val in attendee.purchased_items.items() %}
-  {% if name not in attendee.refunded_items %}
+  {% for name, val in model.purchased_items.items() %}
+  {% if not model.refunded_items or name not in model.refunded_items %}
   <tr>
   <td>
     {{ name[:-5]|replace('_', ' ')|title }}
@@ -180,7 +180,8 @@ $().ready(function() {
   </tr>
   {% endif %}
   {% endfor %}
-  {% for name, val in attendee.refunded_items.items() %}
+  {% if model.refunded_items %}
+  {% for name, val in model.refunded_items.items() %}
   <tr>
   <td>
     {{ name[:-5]|replace('_', ' ')|title }}
@@ -199,6 +200,7 @@ $().ready(function() {
   </td>
   </tr>
   {% endfor %}
+  {% endif %}
 </table>
 </div>
 {% endif %}

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -17,7 +17,7 @@
 </form>
 
     <strong>OR</strong> <br/>
-{{ stripe_form('manual_reg_charge', Charge(attendee)) }}
+{{ stripe_form('manual_reg_charge', attendee) }}
 </div>
 <iframe id="stripe_frame" name="stripe_frame" style="display:none"></iframe>
 </div>
@@ -33,12 +33,24 @@ var toggleMarkButton = function (dropdown) {
         $button.attr('disabled', 'disabled');
     }
 };
-var loadCheckInForm = function () {
+loadCheckInForm = function () {
+    $('#stripeModal').off('hidden.bs.modal');
+    $('#stripeModal').modal('hide');
+    $('#stripeModal').remove();
+    $('#checkin_modal').modal('show');
     $('#checkin_modal .modal-content').load('check_in_form?id={{ attendee.id }}', function () {
         createDateTextEntries();
     });
 }
-$("form[action='manual_reg_charge']").prop('target', 'stripe_frame');
+var resumeStripeAction = callStripeAction;
+var callStripeAction = function() {
+    $('#checkin_modal').off('hidden.bs.modal');
+    $('#checkin_modal').modal('hide');
+    $('#stripeModal').on('hidden.bs.modal', function (e) {
+        $('#stripeModal').remove();
+    })
+    resumeStripeAction();
+}
 $("form[action='mark_as_paid']").submit(function (e) {
     e.preventDefault();
 
@@ -81,6 +93,7 @@ $('#stripe_frame').load(function() {
     }
 });
 $().ready(function() {
+    $('#stripeModal').detach().appendTo($('#checkin_modal').parent());
     $('select[name=payment_method]').each(function (i, dropdown) {
         toggleMarkButton(dropdown);
     });

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -124,7 +124,7 @@
 <div class="alert alert-warning center" role="alert" id="payment-warning">
 <h4>{{ attendee.full_name }} currently owes <strong>${{ '%0.2f' % attendee.amount_unpaid }}</strong>.</h4>
 {% if Charge %}
-{{ stripe_form('manual_reg_charge', Charge(attendee)) }}
+{{ stripe_form('manual_reg_charge', attendee) }}
 {% else %}
 Please instruct them to pay at an at-door or manager station.
 {% endif %}

--- a/uber/templates/registration/pay.html
+++ b/uber/templates/registration/pay.html
@@ -11,9 +11,9 @@
   <h2>Payment for {{ attendee.full_name }}</h2>
 
   <div class="center">
-    {{ stripe_form('take_payment',charge) }}
+    {{ stripe_form('take_payment',attendee) }}
     {% if not c.ONLY_PREPAY_AT_DOOR %}
-      <br/>
+      <br/><br/>
       <a href="register?message=Please+queue+in+the+cash+line+and+have+your+photo+ID+and+cash+ready.">{{ macros.stripe_button("Nevermind, I'll Pay Cash") }}</a>
       <br/> <br/>
       <a href="register?message=Please+queue+in+the+credit+card+line+and+have+your+photo+ID+and+credit+card+ready.">{{ macros.stripe_button("Nevermind, I'll Use My Credit Card at the Desk") }}</a>

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -867,11 +867,15 @@ class Charge:
 
     @classproperty
     def paid_preregs(cls):
-        return cherrypy.session.setdefault('paid_preregs', [])
+        return cherrypy.session.get('paid_preregs', [])
 
     @classproperty
     def unpaid_preregs(cls):
         return cherrypy.session.setdefault('unpaid_preregs', OrderedDict())
+    
+    @classproperty
+    def pending_preregs(cls):
+        return cherrypy.session.get('pending_preregs', OrderedDict())
     
     @classproperty
     def universal_promo_codes(cls):
@@ -1001,7 +1005,7 @@ class Charge:
 
     @cached_property
     def amount(self):
-        return self._amount or self.total_cost or 0
+        return int(self._amount or self.total_cost or 0)
 
     @cached_property
     def description(self):
@@ -1044,41 +1048,32 @@ class Charge:
     def stripe_transaction(self):
         return self._stripe_transaction
 
-    def charge_cc(self, session, token):
+    def create_stripe_intent(self, session):
+        log.debug('PAYMENT: !!! attempting to charge {} cents for {}', self.amount, self.description)
         try:
-            log.debug('PAYMENT: !!! attempting to charge stripeToken {} {} cents for {}',
-                      token, self.amount, self.description)
-
-            self.response = stripe.Charge.create(
-                card=token,
+            stripe_intent = stripe.PaymentIntent.create(
+                payment_method_types=['card'],
+                amount=self.amount,
                 currency='usd',
-                amount=int(self.amount),
                 description=self.description,
-                receipt_email=self.receipt_email
             )
 
-            log.info('PAYMENT: !!! SUCCESS: charged stripeToken {} {} cents for {}, responseID={}',
-                     token, self.amount, self.description, getattr(self.response, 'id', None))
-
-        except stripe.CardError as e:
-            msg = 'Your card was declined with the following error from our processor: ' + str(e)
-            log.error('PAYMENT: !!! FAIL: {}', msg)
-            return msg
-        except stripe.StripeError as e:
-            error_txt = 'Got an error while calling charge_cc(self, token={!r})'.format(token)
-            report_critical_exception(msg=error_txt, subject='ERROR: MAGFest Stripe invalid request error')
-            return 'An unexpected problem occurred while processing your card: ' + str(e)
-        else:
             if self.models:
-                self._stripe_transaction = self.stripe_transaction_from_charge()
+                self._stripe_transaction = self.stripe_transaction_from_charge(stripe_intent.id)
                 session.add(self._stripe_transaction)
                 for model in self.models:
                     multi = len(self.models) > 1
                     session.add(self.stripe_transaction_for_model(model, self._stripe_transaction, multi))
 
-    def stripe_transaction_from_charge(self, type=c.PAYMENT):
+            return stripe_intent
+        except Exception as e:
+            error_txt = 'Got an error while calling create_stripe_intent()'
+            report_critical_exception(msg=error_txt, subject='ERROR: MAGFest Stripe invalid request error')
+            return 'An unexpected problem occurred while processing your card: ' + str(e)
+
+    def stripe_transaction_from_charge(self, stripe_id='', type=c.PENDING):
         return uber.models.StripeTransaction(
-            stripe_id=self.response.id or None,
+            stripe_id=stripe_id,
             amount=self.amount,
             desc=self.description,
             type=type,
@@ -1098,3 +1093,34 @@ class Charge:
                 group_id=model.id,
                 share=self.amount if not multi else model.amount_unpaid * 100
             )
+
+    @staticmethod
+    def mark_paid_from_stripe(payment_intent):
+        stripe_id = payment_intent.id
+
+        with uber.models.Session() as session:
+            matching_stripe_txns = session.query(uber.models.StripeTransaction).filter_by(stripe_id=stripe_id)
+
+            for txn in matching_stripe_txns:
+                txn.type = c.PAYMENT
+                session.add(txn)
+
+                for item in txn.receipt_items:
+                    item.txn_type = c.PAYMENT
+                    session.add(item)
+
+                for group_log in txn.groups:
+                    group = group_log.group
+                    if not group.amount_pending:
+                        group.paid = c.HAS_PAID
+                        session.add(group)
+
+                for attendee_log in txn.attendees:
+                    attendee = attendee_log.attendee
+                    if not attendee.amount_pending:
+                        if attendee.badge_status == c.PENDING_STATUS:
+                            attendee.badge_status = c.NEW_STATUS
+                        attendee.paid = c.HAS_PAID
+                        session.add(attendee)
+
+            session.commit()


### PR DESCRIPTION
This is a massive change, all but rewriting our Charge class and related payment methods. This replaces the old Stripe payment workflow with a new one based on webhooks, where payments are set to 'pending' before completion. Besides being SCA-compatible, this ends the possibility of people paying us and not having their badge created, group updated, etc -- we make the updates first and mark payments as complete later.

We ended up using Stripe.js/Elements rather than Stripe Checkout because the redirect-offsite workflow proved to be too difficult to work with. Chiefly, users could cancel their payment (thus deleting payment-related objects in our database), then simply press the 'back' button and send payment through Stripe. Luckily, Elements still puts us in the same legal position that Checkout did -- it's just an iframe being mounted rather than a redirect.