### PR TITLE
Remove 'name in credits' from core plugin

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -350,7 +350,6 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     staffing = Column(Boolean, default=False)
     agreed_to_volunteer_agreement = Column(Boolean, default=False)
-    name_in_credits = Column(UnicodeText, nullable=True)
     nonshift_hours = Column(Integer, default=0, admin_only=True)
     past_years = Column(UnicodeText, admin_only=True)
     can_work_setup = Column(Boolean, default=False, admin_only=True)


### PR DESCRIPTION
This column is (currently) just for Super MAG, and that's also where the migration lives, so we're moving it there.