### PR TITLE
Move volunteer checklist changes to main plugin

### DIFF
--- a/alembic/versions/b9aa7cc0b9ae_add_emergency_procedures_step_to_.py
+++ b/alembic/versions/b9aa7cc0b9ae_add_emergency_procedures_step_to_.py
@@ -1,0 +1,58 @@
+"""Add emergency procedures step to volunteer checklist
+
+Revision ID: b9aa7cc0b9ae
+Revises: 739fe558fde9
+Create Date: 2019-10-26 02:55:26.293925
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'b9aa7cc0b9ae'
+down_revision = 'a9b36ffb5ff7'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('reviewed_emergency_procedures', sa.Boolean(), server_default='False', nullable=False))
+
+def downgrade():
+    op.drop_column('attendee', 'reviewed_emergency_procedures')

--- a/alembic/versions/e822b20093c1_add_name_in_credits_field_for_volunteers.py
+++ b/alembic/versions/e822b20093c1_add_name_in_credits_field_for_volunteers.py
@@ -1,0 +1,59 @@
+"""Add name in credits field for volunteers
+
+Revision ID: e822b20093c1
+Revises: b9aa7cc0b9ae
+Create Date: 2019-11-12 23:35:56.117753
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'e822b20093c1'
+down_revision = 'b9aa7cc0b9ae'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('name_in_credits', sa.Unicode(), server_default=None, nullable=True))
+
+
+def downgrade():
+    op.drop_column('attendee', 'name_in_credits')

--- a/alembic/versions/fa3b09b82899_add_walk_on_volunteer_boolean.py
+++ b/alembic/versions/fa3b09b82899_add_walk_on_volunteer_boolean.py
@@ -1,0 +1,59 @@
+"""Add walk on volunteer boolean
+
+Revision ID: fa3b09b82899
+Revises: e822b20093c1
+Create Date: 2019-12-18 21:42:57.800753
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'fa3b09b82899'
+down_revision = 'e822b20093c1'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('walk_on_volunteer', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('attendee', 'walk_on_volunteer')

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -413,6 +413,18 @@ group_update_grace_period = integer(default=24)
 # By default this is turned off.
 volunteer_agreement_enabled = boolean(default=False)
 
+# Much like the volunteer agreement, but for an emergency procedures document.
+emergency_procedures_enabled = boolean(default=False)
+
+# This controls whether we ask volunteers to provide a name for a credits roll.
+volunteer_credits_roll = boolean(default=False)
+
+# These are just text telling volunteers when they should complete certain steps
+# on the volunteer checklist.
+volunteer_placeholder_deadline = string(default="November 6")
+volunteer_checklist_deadline = string(default="November 13")
+emergency_procedures_deadline = string(default="December 18")
+
 # Attendees kicking in extra can enter their own new "affiliate" or select
 # from a list of all affiliates which have already been entered.  This is
 # the list of the top affiliates from last year which we use to prepopulate

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -350,7 +350,9 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     staffing = Column(Boolean, default=False)
     agreed_to_volunteer_agreement = Column(Boolean, default=False)
+    reviewed_emergency_procedures = Column(Boolean, default=False)
     name_in_credits = Column(UnicodeText, nullable=True)
+    walk_on_volunteer = Column(Boolean, default=False)
     nonshift_hours = Column(Integer, default=0, admin_only=True)
     past_years = Column(UnicodeText, admin_only=True)
     can_work_setup = Column(Boolean, default=False, admin_only=True)
@@ -1687,7 +1689,9 @@ class Attendee(MagModel, TakesPaymentMixin):
         return not self.placeholder and self.food_restrictions_filled_out and self.shirt_info_marked and (
             not self.hotel_eligible
             or self.hotel_requests
-            or not c.BEFORE_ROOM_DEADLINE)
+            or not c.BEFORE_ROOM_DEADLINE) and (
+            not c.VOLUNTEER_AGREEMENT_ENABLED or self.agreed_to_volunteer_agreement) and (
+            not c.EMERGENCY_PROCEDURES_ENABLED or self.reviewed_emergency_procedures)
 
     @property
     def hotel_nights(self):

--- a/uber/site_sections/staffing_reports.py
+++ b/uber/site_sections/staffing_reports.py
@@ -195,3 +195,10 @@ class Root:
 
     def volunteer_checklists(self, session):
         return volunteer_checklists(session)
+    
+    @csv_file
+    def name_in_credits(self, out, session):
+        out.writerow(["Name submitted for credits"])
+        for attendee in session.all_attendees():
+            if attendee.name_in_credits:
+                out.writerow([attendee.name_in_credits])

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1722,6 +1722,19 @@ $(window).on("runJavaScript", function(){
 </div>
 {% endset %}
 
+{% set reviewed_emergency_procedures %}
+{# Always read-only #}
+<div class="form-group staffing staffing-checked">
+  <label class="col-sm-3 control-label">Reviewed Emergency Procedures</label>
+  <div class="col-sm-9">
+    <div class="form-control-static">
+      {% if c.VOLUNTEER_AGREEMENT_ENABLED and admin_area %}{{ attendee.reviewed_emergency_procedures|yesno("Yes,No") }}{% endif %}
+      <input type="hidden" name="reviewed_emergency_procedures" value="{{ attendee.reviewed_emergency_procedures|yesno("1,0") }}" />
+    </div>
+  </div>
+</div>
+{% endset %}
+
 {% set hotel_eligible %}
 {# Always read-only #}
 <div class="form-group staffing staffing-checked">

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -86,6 +86,7 @@
       {{ attendee_fields.job_interests }}
       {{ attendee_fields.assigned_depts }}
       {{ attendee_fields.agreed_to_volunteer_agreement }}
+      {{ attendee_fields.reviewed_emergency_procedures }}
       {{ attendee_fields.age }}
       {{ attendee_fields.email }}
       {{ attendee_fields.address }}

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -67,6 +67,7 @@
 {{ attendee_fields.setup_teardown }}
 {{ attendee_fields.hotel_eligible }}
 {{ attendee_fields.agreed_to_volunteer_agreement }}
+{{ attendee_fields.reviewed_emergency_procedures }}
 
 {{ attendee_fields.got_merch }}
 

--- a/uber/templates/staffing/credits.html
+++ b/uber/templates/staffing/credits.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Volunteer Agreement{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+
+<h1>Name in Credits</h1>
+
+<p>
+We wish to run a credits roll for our amazing volunteers. Enter your name below to be in a public credits roll alongside other volunteers, or leave it blank to opt out.
+</p>
+
+
+<form method="post" action="credits">
+    {{ csrf_token() }}
+    <input type="text" name="name_in_credits" value="{{ attendee.name_in_credits or '' }}" placeholder="N/A" />
+    <span class="help-block">By entering a name I acknowledge that if I give an inappropriate name, my first and last name will be used instead.</span><br/>
+    <input class="btn btn-primary" type="submit" value="Save" />
+</form>
+
+{% endblock %}

--- a/uber/templates/staffing/credits_item.html
+++ b/uber/templates/staffing/credits_item.html
@@ -1,0 +1,14 @@
+{% import 'macros.html' as macros %}
+{% if c.VOLUNTEER_CREDITS_ROLL %}
+<li>
+    {{ macros.checklist_image(attendee.name_in_credits != None) }}
+    {% if attendee.name_in_credits == None %} 
+        Please provide a name for or opt-out of our
+    {% elif not attendee.name_in_credits %}
+        You have opted out of our
+    {% else %}
+        You have provided a name for our
+    {% endif %}
+    {% if attendee.reviewed_emergency_procedures %}<a href="credits">credits roll for volunteers</a>{% else %}credits roll for volunteers{% endif %}.
+</li>
+{% endif %}

--- a/uber/templates/staffing/emergency_procedures.html
+++ b/uber/templates/staffing/emergency_procedures.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Volunteer Agreement{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+
+<h1>Emergency Procedures</h1>
+
+<p>
+<a href="../static/emergency-procedures.pdf" class="btn btn-info" download>Download and Review Emergency Procedures</a>
+</p>
+
+{% if not attendee.reviewed_emergency_procedures %}
+    <form method="post" action="emergency_procedures">
+        {{ csrf_token() }}
+        <label for="reviewed_procedures">
+          I have reviewed these procedures: <input type="checkbox" id="reviewed_procedures" name="reviewed_procedures" />
+        </label>
+        <br><br>
+        <input class="btn btn-primary" type="submit" value="Save" />
+    </form>
+{% else %}
+    <p>You have already told us that you reviewed our emergency procedures.</p>
+{% endif %}
+
+{% endblock %}

--- a/uber/templates/staffing/emergency_procedures_item.html
+++ b/uber/templates/staffing/emergency_procedures_item.html
@@ -1,0 +1,14 @@
+{% import 'macros.html' as macros %}
+{% if c.EMERGENCY_PROCEDURES_ENABLED %}
+<li>
+    {{ macros.checklist_image(attendee.reviewed_emergency_procedures) }}
+    {% if not attendee.reviewed_emergency_procedures %}
+        Please review
+    {% else %}
+        You have acknowledged that you reviewed our
+    {% endif %}
+    {% if attendee.shirt_info_marked or (not attendee.gets_any_kind_of_shirt and attendee.food_restrictions_filled_out) %}<a href="emergency_procedures">Emergency Procedures</a>{% else %}Emergency Procedures{% endif %}
+    {% if not attendee.reviewed_emergency_procedures %} and acknowledge that you have done so{% endif %}. 
+    (Deadline: {% c.EMERGENCY_PROCEDURES_DEADLINE %})
+</li>
+{% endif %}

--- a/uber/templates/staffing/food_item.html
+++ b/uber/templates/staffing/food_item.html
@@ -2,11 +2,11 @@
 {% if c.HOURS_FOR_FOOD %}
 <li>
     {{ macros.checklist_image(attendee.food_restrictions) }}
-    {% if not attendee.placeholder %}
+    {% if (not c.VOLUNTEER_AGREEMENT_ENABLED or attendee.agreed_to_volunteer_agreement) and not attendee.placeholder %}
         <a href="food_restrictions">Let us know</a>
     {% else %}
         Let us know
     {% endif %}
-    about any dietary restrictions.
+    about any dietary restrictions. (Deadline: {% c.VOLUNTEER_CHECKLIST_DEADLINE %})
 </li>
 {% endif %}

--- a/uber/templates/staffing/placeholder_item.html
+++ b/uber/templates/staffing/placeholder_item.html
@@ -7,6 +7,6 @@
     {% else %}
         Confirm
     {% endif %}
-    you are coming to {{ c.EVENT_NAME }}.
+    you are coming to {{ c.EVENT_NAME }}. (Deadline: {% c.VOLUNTEER_PLACEHOLDER_DEADLINE %})
     {% if not attendee.placeholder %}(you can still <a href="../preregistration/confirm?return_to=../staffing/index&id={{ attendee.id }}">edit your info</a>){% endif %}
 </li>

--- a/uber/templates/staffing/shirt_item.html
+++ b/uber/templates/staffing/shirt_item.html
@@ -1,8 +1,8 @@
 {% import 'macros.html' as macros %}
-{% if not attendee.badge_type == c.CONTRACTOR_BADGE and c.HOURS_FOR_SHIRT %}
+{% if c.HOURS_FOR_SHIRT and attendee.gets_any_kind_of_shirt %}
 <li>
     {{ macros.checklist_image(attendee.shirt_info_marked) }}
-    {% if not attendee.placeholder and attendee.food_restrictions_filled_out and (not attendee.hotel_eligible or attendee.hotel_requests or not c.BEFORE_ROOM_DEADLINE) %}
+    {% if not attendee.placeholder and attendee.food_restrictions_filled_out %}
         <a href="shirt_size">Let us know</a>
     {% else %}
         Let us know

--- a/uber/templates/staffing/volunteer_agreement_item.html
+++ b/uber/templates/staffing/volunteer_agreement_item.html
@@ -8,6 +8,6 @@
         {% else %}
             You have agreed
         {% endif %}
-        to the terms of the <a href="volunteer_agreement">Volunteer Agreement</a>
+        to the terms of the {% if not attendee.placeholder %}<a href="volunteer_agreement">Volunteer Agreement</a>{% else %}Volunteer Agreement{% endif %}. (Deadline: {% c.VOLUNTEER_CHECKLIST_DEADLINE %})
     </li>
 {% endif %}


### PR DESCRIPTION
Several changes to the volunteer checklist were made for Super in the magprime plugin, but putting them there was messy (and is causing problems for MAGStock). Moving them and their migrations to the main plugin.