### PR TITLE
Remove default donation tiers

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -242,9 +242,6 @@ XL Women's slim fit = 22
 
 [[donation_tier]]
 No thanks = 0
-T-Shirt Bundle = "SHIRT_LEVEL"
-Supporter = "SUPPORTER_LEVEL"
-Barrel Roller = 200
 
 [[staff_event_shirt]]
 One Event Shirt and One Staff Shirt = 1
@@ -257,25 +254,6 @@ name = "No thanks"
 icon = ""
 description = "No thanks"
 link = ""
-
-[[barrel_roller]]
-merch_items = "Sun Cats",
-link = "../static_views/barrel_roller.html|../static_views/secret.html"
-description = "Sun Cats Figure Set|Secret Invitation"
-name = "Barrel Roller"
-icon = "../static/icons/barrel_roller.png"
-
-[[supporter]]
-link = "../static_views/supporter.html|../static_views/swadge.html"
-description = "Super Swag Bag|Swadge"
-name = "Supporter"
-icon = "../static/icons/supporter.png"
-
-[[shirt]]
-link = "../static_views/ribbon.html|../static_views/tshirt.html|../static_views/tshirt.html"
-description = "Ribbon|T-Shirt|Event Pin"
-name = "T-Shirt Bundle"
-icon = "../static/icons/iconshirt.png"
 
 [enums]
 


### PR DESCRIPTION
You can't remove enums in default config, so the donation tier descriptions in this file were being applied to all events, including ones that shouldn't have them. This was causing a 500 error on startup.