### PR TITLE
Implement limited and contact access levels

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -802,8 +802,8 @@ class Config(_Overridable):
                 return self.has_section_or_page_access(include_read_only=True)
 
             if access_name.endswith('_read'):
-                return access_name[:-5] in c.ADMIN_ACCESS_SET
-            return access_name in c.ADMIN_WRITE_ACCESS_SET
+                return access_name[:-5] in self.ADMIN_ACCESS_SET
+            return access_name in self.ADMIN_WRITE_ACCESS_SET
         elif name.endswith('_COUNT'):
             item_check = name.rsplit('_', 1)[0]
             badge_type = getattr(self, item_check, None)

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1244,6 +1244,13 @@ edited_prereg = string(default="edited_unpaid_prereg")
 auto_badge_shift = string(default="automatic badge-shift")
 page_viewed = string(default='pageview')
 
+[[access]]
+none = string(default="None")
+limited = string(default="Limited")
+contact = string(default="Contact Info")
+dept = string(default="All Info in Own Dept(s)")
+full = string(default="All Info")
+
 [[food_restriction]]
 vegan      = string(default="Vegan")
 

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -608,7 +608,7 @@ def attendee_view(func):
         if kwargs.get('id') != "None":
             with uber.models.Session() as session:
                 attendee = session.attendee(kwargs.get('id'), allow_invalid=True)
-                if not session.admin_can_see_staffer(attendee) and attendee not in session.viewable_attendees():
+                if not session.admin_attendee_max_access(attendee):
                     return "<div id='attendeeData' style='padding: 10px;'>" \
                            "You are not allowed to view this attendee. If you think this is an error, " \
                            "please email us at {}.</div>".format(cgi.escape(c.DEVELOPER_EMAIL))

--- a/uber/models/admin.py
+++ b/uber/models/admin.py
@@ -189,8 +189,10 @@ class AdminAccount(MagModel):
     def full_registration_admin(self):
         return any([group.has_full_access('registration') for group in self.access_groups])
 
-    def has_dept_level_access(self, site_section_or_page):
-        return any([group.has_access_level(site_section_or_page, AccessGroup.DEPT) for group in self.access_groups])
+    def max_level_access(self, site_section_or_page, read_only=False):
+        write_access_list = [int(group.access.get(site_section_or_page, 0)) for group in self.access_groups]
+        read_access_list = [int(group.read_only_access.get(site_section_or_page, 0)) for group in self.access_groups]
+        return max(write_access_list + read_access_list) if read_only else max(write_access_list)
 
     @presave_adjustment
     def disable_api_access(self):
@@ -265,12 +267,18 @@ class AccessGroup(MagModel):
     def has_any_access(self, access_to, read_only=False):
         return self.has_access_level(access_to, self.LIMITED, read_only)
 
-    def has_access_level(self, access_to, access_level, read_only=False):
-        if read_only:
-            return int(self.access.get(access_to, 0)) >= access_level \
-                   or int(self.read_only_access.get(access_to, 0)) >= access_level
+    def has_access_level(self, access_to, access_level, read_only=False, max_level=False):
+        import operator
+        if max_level:
+            compare = operator.eq
+        else:
+            compare = operator.ge
 
-        return int(self.access.get(access_to, 0)) >= access_level
+        if read_only:
+            return compare(int(self.access.get(access_to, 0)), access_level) \
+                   or compare(int(self.read_only_access.get(access_to, 0)), access_level)
+
+        return compare(int(self.access.get(access_to, 0)), access_level)
 
 
 class WatchList(MagModel):

--- a/uber/site_sections/shifts_admin.py
+++ b/uber/site_sections/shifts_admin.py
@@ -127,7 +127,7 @@ class Root:
             else [Attendee.dept_memberships.any(department_id=department_id)]
         attendees = session.staffers(pending=True).filter(*dept_filter).all()
         for attendee in attendees:
-            if session.admin_can_see_staffer(attendee) or department_id:
+            if session.admin_has_staffer_access(attendee) or department_id:
                 attendee.is_dept_head_here = attendee.is_dept_head_of(department_id) if department_id \
                     else attendee.is_dept_head
                 attendee.trusted_here = attendee.trusted_in(department_id) if department_id \

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1,4 +1,11 @@
-{% set page_ro = c.HAS_READ_ACCESS and not c.HAS_ACCESS %}
+{% set read_access_level = attendee.admin_read_access() %}
+{% set write_access_level = attendee.admin_write_access() %}
+{% set page_ro = c.HAS_READ_ACCESS and not c.HAS_ACCESS or write_access_level < 3 or read_access_level and not write_access_level %}
+
+{% set limited_read = read_access_level == 1 %}
+{% set full_read = read_access_level > 2 %}
+{% set limited_write = write_access_level == 1 %}
+{% set contact_write = write_access_level == 2 %}
 {% import 'macros.html' as macros with context %}
 
 {#- Setting some variables to keep the size of conditional clauses smaller. -#}
@@ -363,19 +370,23 @@
 </script>
   <div class="form-group">
     <label class="col-sm-3 control-label">Badge Type</label>
+    {% call macros.read_only_if(read_only, attendee.badge_type_label) %}
     <div class="col-sm-3">
         <select name="badge_type" class="form-control" onChange="boldOrRegular(); setBadgeNum();">
           {{ options(c.BADGE_OPTS, attendee.badge_type) }}
         </select>
     </div>
+    {% endcall %}
   </div>
   {% if c.NUMBERED_BADGES %}
   <div class="form-group">
-  <label class="col-sm-3 control-label">Badge #</label>
-  <div class="col-sm-3">
-  <input type="text" class="form-control" name="badge_num" placeholder="0000" onBlur="autoCheckBlank();" />
-  <div class="checkbox"><label class="checkbox"><input type="checkbox" name="no_badge_num" onChange="toggleBadgeNumField();"><span id="no_badge_num_text"></span></label></div>
-  </div>
+    <label class="col-sm-3 control-label">Badge #</label>
+    {% call macros.read_only_if(read_only, attendee.badge_num) %}
+    <div class="col-sm-3">
+    <input type="text" class="form-control" name="badge_num" placeholder="0000" onBlur="autoCheckBlank();" />
+    <div class="checkbox"><label class="checkbox"><input type="checkbox" name="no_badge_num" onChange="toggleBadgeNumField();"><span id="no_badge_num_text"></span></label></div>
+    </div>
+    {% endcall %}
   </div>
   {% endif %}
 {% elif c.AT_THE_CON and attendee.is_new %}
@@ -449,7 +460,7 @@
 
 
 {% set name %}
-{% set read_only = name_ro or page_ro %}
+{% set read_only = name_ro or (page_ro and not (limited_write or contact_write)) %}
 {% if not admin_area %}
   <script type="text/javascript">
       var sameLegalNameChecked = function () {
@@ -471,13 +482,17 @@
 {% endif %}
 <div class="form-group">
   <label for="first_name" class="col-sm-3 control-label">Name</label>
-  {% call macros.read_only_if(read_only, attendee.full_name) %}
+  {% call macros.read_only_if(read_only, attendee.masked_name if limited_read else attendee.full_name) %}
     <div class="col-sm-3">
       <input type="text" name="first_name" id="first_name" value="{{ attendee.first_name }}" class="form-control" placeholder="First Name" autocomplete="fname">
     </div>
+    {% if limited_read or limited_write %}
+    <div class="col-sm-3 form-control-static">{{ attendee.last_name[0] ~ '.' if limited_read else attendee.last_name }}</div>
+    {% else %}
     <div class="col-sm-3">
       <input type="text" name="last_name" id="last_name" value="{{ attendee.last_name }}" class="form-control" placeholder="Last Name" autocomplete="lname">
     </div>
+    {% endif %}
   {% endcall %}
 </div>
 
@@ -492,6 +507,7 @@
   </div>
 {% endif %}
 
+{% if full_read %}
 <div class="form-group">
   <label for="legal_name" class="col-sm-3 control-label">Name as appears on <span class="text-nowrap">Legal Photo ID</span></label>
   {% call macros.read_only_if(read_only, attendee.legal_name) %}
@@ -505,6 +521,7 @@
     </div>
   {% endcall %}
 </div>
+{% endif %}
 {% endset %}
 
 
@@ -875,6 +892,7 @@
 {% endset %}
 
 
+{% if not c.COLLECT_EXACT_BIRTHDATE or full_read %}
 {% set age %}
 {% set read_only = age_ro or page_ro %}
 <script type="text/javascript">
@@ -927,17 +945,22 @@
   {% endif %}
 </div>
 {% endset %}
+{% endif %}
 
 
 {% set email %}
-{% set read_only = email_ro or page_ro %}
+{% set read_only = email_ro or (page_ro and not contact_write) %}
 <div class="form-group">
   <label for="email" class="col-sm-3 control-label">Email Address</label>
+  {% if limited_read %}
+    <div class="col-sm-6 form-control-static">{{ attendee.masked_email }}</div>
+  {% else %}
   {% call macros.read_only_if(read_only, attendee.email) %}
   <div class="col-sm-6">
     <input type="email" name="email" id="email" value="{{ attendee.email }}" class="form-control" placeholder="Email Address">
   </div>
   {% endcall %}
+  {% endif %}
 </div>
 
 {% if is_prereg_confirm_email_enabled and not admin_area and not read_only %}
@@ -1038,7 +1061,7 @@
 {% endif %}
 {% endset %}
 
-
+{% if full_read %}
 {% set emergency_contact %}
 {% if attendee.is_new or not admin_area or c.HAS_REG_ADMIN_ACCESS %}
 {% set read_only = emergency_contact_ro or page_ro %}
@@ -1060,8 +1083,10 @@
 </div>
 {% endif %}
 {% endset %}
+{% endif %}
 
 
+{% if not limited_read %}
 {% set cellphone %}
 <script type="text/javascript">
 var noCellphoneClicked = function () {
@@ -1079,7 +1104,7 @@ $(window).on("runJavaScript", function () {
   }
 });
   </script>
-{% set read_only = cellphone_ro or page_ro %}
+{% set read_only = cellphone_ro or (page_ro and not contact_write) %}
 <div class="form-group">
   <label for="cellphone" class="col-sm-3 control-label">Your Phone Number</label>
 {% call macros.read_only_if(read_only, attendee.cellphone) %}
@@ -1094,6 +1119,7 @@ $(window).on("runJavaScript", function () {
   {% endif %}
 </div>
 {% endset %}
+{% endif %}
 
 
 {% set interests %}
@@ -1122,6 +1148,7 @@ $(window).on("runJavaScript", function () {
 {% endcall %}
 </div>
 {% endset %}
+
 
 {% set comments %}
 {% set read_only = comments_ro or page_ro %}
@@ -1482,6 +1509,7 @@ $(window).on("runJavaScript", function(){
 </div>
 {% endset %}
 
+
 {% set promo_code_group_link %}
 {# Always read-only #}
 {% if attendee.promo_code_groups or attendee.promo_code and attendee.promo_code.group %}
@@ -1498,6 +1526,7 @@ $(window).on("runJavaScript", function(){
   </div>
 {% endif %}
 {% endset %}
+
 
 {% set panel_app_link %}
 {# Always read-only #}
@@ -1709,6 +1738,7 @@ $(window).on("runJavaScript", function(){
 </div>
 {% endset %}
 
+
 {% set agreed_to_volunteer_agreement %}
 {# Always read-only #}
 <div class="form-group staffing staffing-checked">
@@ -1721,6 +1751,7 @@ $(window).on("runJavaScript", function(){
   </div>
 </div>
 {% endset %}
+
 
 {% set reviewed_emergency_procedures %}
 {# Always read-only #}
@@ -1735,6 +1766,7 @@ $(window).on("runJavaScript", function(){
 </div>
 {% endset %}
 
+
 {% set hotel_eligible %}
 {# Always read-only #}
 <div class="form-group staffing staffing-checked">
@@ -1747,6 +1779,7 @@ $(window).on("runJavaScript", function(){
   </div>
 </div>
 {% endset %}
+
 
 {% set attractions_opt_out %}
 {# Always read-only #}
@@ -1761,6 +1794,7 @@ $(window).on("runJavaScript", function(){
 </div>
 {% endset %}
 
+
 {% if c.BADGE_PRINTING_ENABLED %}
 {% set print_pending %}
 {% set read_only = print_pending_ro or page_ro %}
@@ -1771,6 +1805,7 @@ $(window).on("runJavaScript", function(){
     </div>
 </div>
 {% endset %}
+
 
 {% set reprint_fee %}
 {% if c.BADGE_REPRINT_FEE %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-599. Since the attendee form is a 'universal' pop-up, the access an admin has depends not on what site section they're in but on what site sections they access vs what sections the attendee would be viewable in. This is a first pass and focuses only on the attendee form.

The attendee form viewed with "Limited" read access:
![image](https://user-images.githubusercontent.com/7198215/86877461-ef520e80-c0b4-11ea-9174-7c0d1d8c4d2c.png)

The same form viewed with "Contact" read access:
![image](https://user-images.githubusercontent.com/7198215/86877490-fe38c100-c0b4-11ea-8a9b-291e6acf112e.png)