### PR TITLE
Make shift schedule use minutes instead of hours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ uploaded_files/*
 uber/static/analytics/extra-attendance-data.json
 uber/static/fonts/free3of9.pkl
 *.DS_Store
+.vscode/*

--- a/alembic/versions/f2ee72f8a1aa_convert_shift_and_max_consecutive_.py
+++ b/alembic/versions/f2ee72f8a1aa_convert_shift_and_max_consecutive_.py
@@ -1,0 +1,61 @@
+"""Convert shift and max consecutive duration to minutes
+
+Revision ID: f2ee72f8a1aa
+Revises: fa3b09b82899
+Create Date: 2020-07-30 02:36:17.911701
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'f2ee72f8a1aa'
+down_revision = 'fa3b09b82899'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.alter_column('attendee', 'nonshift_hours', new_column_name='nonshift_minutes')
+    op.alter_column('department', 'max_consecutive_hours', new_column_name='max_consecutive_minutes')
+
+
+def downgrade():
+    op.alter_column('attendee', 'nonshift_minutes', new_column_name='nonshift_hours')
+    op.alter_column('department', 'max_consecutive_minutes', new_column_name='max_consecutive_hours')

--- a/uber/api.py
+++ b/uber/api.py
@@ -787,7 +787,7 @@ class DepartmentLookup:
                 'is_shiftless': True,
                 'is_setup_approval_exempt': True,
                 'is_teardown_approval_exempt': True,
-                'max_consecutive_hours': True,
+                'max_consecutive_minutes': True,
                 'jobs': {
                     'id': True,
                     'type': True,

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -534,14 +534,14 @@ StopsEmailFixture(
         c.AFTER_SHIFTS_CREATED
         and days_after(30, max(a.registered_local, c.SHIFTS_CREATED))()
         and a.takes_shifts
-        and not a.hours),
+        and not a.shift_minutes),
     when=before(c.PREREG_TAKEDOWN),
     ident='volunteer_shift_signup_reminder')
 
 StopsEmailFixture(
     'Last chance to sign up for {EVENT_NAME} ({EVENT_DATE}) shifts',
     'shifts/reminder.txt',
-    lambda a: c.AFTER_SHIFTS_CREATED and c.BEFORE_PREREG_TAKEDOWN and a.takes_shifts and not a.hours,
+    lambda a: c.AFTER_SHIFTS_CREATED and c.BEFORE_PREREG_TAKEDOWN and a.takes_shifts and not a.shift_minutes,
     when=days_before(10, c.EPOCH),
     ident='volunteer_shift_signup_reminder_last_chance')
 
@@ -566,7 +566,7 @@ StopsEmailFixture(
 StopsEmailFixture(
     'Please review your worked shifts for {EVENT_NAME}!',
     'shifts/shifts_worked.html',
-    lambda a: (a.weighted_hours or a.nonshift_hours) and a.badge_type != c.CONTRACTOR_BADGE,
+    lambda a: (a.weighted_hours or a.nonshift_minutes) and a.badge_type != c.CONTRACTOR_BADGE,
     when=days_after(1, c.ESCHATON),
     ident='volunteer_shifts_worked',
     allow_post_con=True)

--- a/uber/config.py
+++ b/uber/config.py
@@ -987,28 +987,9 @@ c.CON_LENGTH = int((c.ESCHATON - c.EPOCH).total_seconds() // 3600)
 c.START_TIME_OPTS = [
     (dt, dt.strftime('%I %p %a')) for dt in (c.EPOCH + timedelta(hours=i) for i in range(c.CON_LENGTH))]
 
-c.DURATION_OPTS = [(i, '%i hour%s' % (i, ('s' if i > 1 else ''))) for i in range(1, 9)]
-c.SETUP_TIME_OPTS = [
-    (dt, dt.strftime('%I %p %a'))
-    for dt in (
-        c.EPOCH - timedelta(days=day) + timedelta(hours=hour)
-        for day in range(c.SETUP_SHIFT_DAYS, 0, -1)
-        for hour in range(24))]
-
-c.TEARDOWN_TIME_OPTS = [
-    (dt, dt.strftime('%I %p %a'))
-    for dt in (
-        c.ESCHATON + timedelta(days=day) + timedelta(hours=hour)
-        for day in range(0, 2, 1)  # Allow two full days for teardown shifts
-        for hour in range(24))]
-
-# code for all time slots
-c.CON_TOTAL_LENGTH = int((c.TEARDOWN_TIME_OPTS[-1][0] - c.SETUP_TIME_OPTS[0][0]).seconds / 3600)
-c.ALL_TIME_OPTS = [
-    (dt, dt.strftime('%I %p %a %d %b'))
-    for dt in (
-        (c.EPOCH - timedelta(days=c.SETUP_SHIFT_DAYS) + timedelta(hours=i))
-        for i in range(c.CON_TOTAL_LENGTH))]
+c.SETUP_JOB_START = c.EPOCH - timedelta(days=c.SETUP_SHIFT_DAYS)
+c.TEARDOWN_JOB_END = c.ESCHATON + timedelta(days=1, hours=23) # Allow two full days for teardown shifts
+c.CON_TOTAL_LENGTH = int((c.TEARDOWN_JOB_END - c.SETUP_JOB_START).seconds / 3600)
 c.PANEL_STRICT_LENGTH_OPTS = [opt for opt in c.PANEL_LENGTH_OPTS if opt != c.OTHER]
 
 c.EVENT_YEAR = c.EPOCH.strftime('%Y')

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -518,9 +518,9 @@ def slots(job):
 @validation.Job
 def time_conflicts(job):
     if not job.is_new:
-        original_hours = Job(start_time=job.orig_value_of('start_time'), duration=job.orig_value_of('duration')).hours
+        original_minutes = Job(start_time=job.orig_value_of('start_time'), duration=job.orig_value_of('duration')).minutes
         for shift in job.shifts:
-            if job.hours.intersection(shift.attendee.hours - original_hours):
+            if job.minutes.intersection(shift.attendee.shift_minutes - original_minutes):
                 return 'You cannot change this job to this time, because {} is already working a shift then'.format(
                     shift.attendee.full_name)
 

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -806,13 +806,13 @@ class Session(SessionManager):
                 'weighted_hours', 'restricted', 'extra15', 'taken',
                 'visibility', 'is_public', 'is_setup', 'is_teardown']
             jobs = self.logged_in_volunteer().possible_and_current
-            restricted_hours = set()
+            restricted_minutes = set()
             for job in jobs:
                 if job.required_roles:
-                    restricted_hours.add(frozenset(job.hours))
+                    restricted_minutes.add(frozenset(job.minutes))
             return [
                 job.to_dict(fields)
-                for job in jobs if (job.required_roles or frozenset(job.hours) not in restricted_hours)]
+                for job in jobs if (job.required_roles or frozenset(job.minutes) not in restricted_minutes)]
 
         def process_refund(self, stripe_log, model=Attendee):
             """
@@ -1513,6 +1513,9 @@ class Session(SessionManager):
 
             if not job.no_overlap(attendee):
                 return 'This volunteer is already signed up for a shift during that time'
+
+            if not job.working_limit_ok(attendee):
+                return 'This shift would put this volunteer over one of their department\'s max consecutive hours'
 
             self.add(Shift(attendee=attendee, job=job))
             self.commit()

--- a/uber/models/department.py
+++ b/uber/models/department.py
@@ -161,7 +161,7 @@ class Department(MagModel):
     parent_id = Column(UUID, ForeignKey('department.id'), nullable=True)
     is_setup_approval_exempt = Column(Boolean, default=False)
     is_teardown_approval_exempt = Column(Boolean, default=False)
-    max_consecutive_hours = Column(Integer, default=0)
+    max_consecutive_minutes = Column(Integer, default=0)
 
     jobs = relationship('Job', backref='department')
 
@@ -376,13 +376,13 @@ class Job(MagModel):
         return select([Department.name]).where(Department.id == cls.department_id).label('department_name')
 
     @hybrid_property
-    def max_consecutive_hours(self):
-        return self.department.max_consecutive_hours
+    def max_consecutive_minutes(self):
+        return self.department.max_consecutive_minutes
 
-    @max_consecutive_hours.expression
-    def max_consecutive_hours(cls):
-        return select([Department.max_consecutive_hours]) \
-            .where(Department.id == cls.department_id).label('max_consecutive_hours')
+    @max_consecutive_minutes.expression
+    def max_consecutive_minutes(cls):
+        return select([Department.max_consecutive_minutes]) \
+            .where(Department.id == cls.department_id).label('max_consecutive_minutes')
 
     @hybrid_property
     def restricted(self):
@@ -407,66 +407,66 @@ class Job(MagModel):
         self._set_relation_ids('required_roles', DeptRole, value)
 
     @property
-    def hours(self):
-        hours = set()
-        for i in range(self.duration):
-            hours.add(self.start_time + timedelta(hours=i))
-        return hours
+    def minutes(self):
+        minutes = set()
+        for i in range(int(self.duration)):
+            minutes.add(self.start_time + timedelta(minutes=i))
+        return minutes
 
     @property
     def end_time(self):
-        return self.start_time + timedelta(hours=self.duration)
+        return self.start_time + timedelta(minutes=self.duration)
 
     def working_limit_ok(self, attendee):
         """
-        Prevent signing up for too many shifts in a row. `hours_worked` is the
-        number of hours that the attendee is working immediately before plus
-        immediately after this job, plus this job's hours. `working_hour_limit`
-        is the *min* of Department.max_consecutive_hours for all the jobs we've
-        seen (including self). This means that if dept A has a limit of 3 hours,
-        and dept B has a limit of 2 hours, (for one-hour shifts), if we try to
+        Prevent signing up for too many shifts in a row. `minutes_worked` is the
+        number of minutes that the attendee is working immediately before plus
+        immediately after this job, plus this job's minutes. `working_minutes_limit`
+        is the *min* of Department.max_consecutive_minutes for all the jobs we've
+        seen (including self). This means that if dept A has a limit of 3 minutes,
+        and dept B has a limit of 2 minutes, (for one-hour shifts), if we try to
         sign up for the shift order of [A, A, B], B's limits will kick in and
         block the signup.
         """
 
-        attendee_hour_map = attendee.hour_map
-        hours_worked = self.duration
-        working_hour_limit = self.max_consecutive_hours
-        if working_hour_limit == 0:
-            working_hour_limit = 1000  # just default to something large
+        attendee_minute_map = attendee.shift_minute_map
+        minutes_worked = self.duration
+        working_minutes_limit = self.max_consecutive_minutes
+        if working_minutes_limit == 0:
+            working_minutes_limit = 60000  # just default to something large
 
-        # count the number of filled hours before this shift
-        current_shift_hour = self.start_time - timedelta(hours=1)
-        while current_shift_hour in attendee_hour_map:
-            hours_worked += 1
-            this_job_hour_limit = attendee_hour_map[current_shift_hour].max_consecutive_hours
-            if this_job_hour_limit > 0:
-                working_hour_limit = min(working_hour_limit, this_job_hour_limit)
-            current_shift_hour = current_shift_hour - timedelta(hours=1)
+        # count the number of filled minutes before this shift
+        current_shift_minute = self.start_time - timedelta(minutes=1)
+        while current_shift_minute in attendee_minute_map:
+            minutes_worked += 1
+            this_job_minute_limit = attendee_minute_map[current_shift_minute].max_consecutive_minutes
+            if this_job_minute_limit > 0:
+                working_minutes_limit = min(working_minutes_limit, this_job_minute_limit)
+            current_shift_minute = current_shift_minute - timedelta(minutes=1)
 
-        # count the number of filled hours after this shift
-        current_shift_hour = self.start_time + timedelta(hours=self.duration)
-        while current_shift_hour in attendee_hour_map:
-            hours_worked += 1
-            this_job_hour_limit = attendee_hour_map[current_shift_hour].max_consecutive_hours
-            if this_job_hour_limit > 0:
-                working_hour_limit = min(working_hour_limit, this_job_hour_limit)
-            current_shift_hour = current_shift_hour + timedelta(hours=1)
+        # count the number of filled minutes after this shift
+        current_shift_minute = self.start_time + timedelta(minutes=self.duration)
+        while current_shift_minute in attendee_minute_map:
+            minutes_worked += 1
+            this_job_minute_limit = attendee_minute_map[current_shift_minute].max_consecutive_minutes
+            if this_job_minute_limit > 0:
+                working_minutes_limit = min(working_minutes_limit, this_job_minute_limit)
+            current_shift_minute = current_shift_minute + timedelta(minutes=1)
 
-        return hours_worked <= working_hour_limit
+        return minutes_worked <= working_minutes_limit
 
     def no_overlap(self, attendee):
-        before = self.start_time - timedelta(hours=1)
-        after = self.start_time + timedelta(hours=self.duration)
-        return not self.hours.intersection(attendee.hours) and (
-            before not in attendee.hour_map
-            or not attendee.hour_map[before].extra15
-            or self.department_id == attendee.hour_map[before].department_id
+        before = self.start_time - timedelta(minutes=1)
+        after = self.start_time + timedelta(minutes=self.duration)
+        return not self.minutes.intersection(attendee.shift_minutes) and (
+            before not in attendee.shift_minute_map
+            or not attendee.shift_minute_map[before].extra15
+            or self.department_id == attendee.shift_minute_map[before].department_id
         ) and (
-            after not in attendee.hour_map
+            after not in attendee.shift_minute_map
             or not self.extra15
-            or self.department_id == attendee.hour_map[after].department_id
-        ) and self.working_limit_ok(attendee)
+            or self.department_id == attendee.shift_minute_map[after].department_id
+        )
 
     @hybrid_property
     def slots_taken(self):
@@ -506,11 +506,11 @@ class Job(MagModel):
 
     @property
     def real_duration(self):
-        return self.duration + (0.25 if self.extra15 else 0)
+        return self.duration + (15 if self.extra15 else 0)
 
     @property
     def weighted_hours(self):
-        return self.weight * self.real_duration
+        return self.weight * (self.real_duration / 60)
 
     @property
     def total_hours(self):
@@ -567,7 +567,8 @@ class Job(MagModel):
         Returns a list of volunteers who are allowed to sign up for
         this Job and have the free time to work it.
         """
-        return [s for s in self._potential_volunteers(order_by=Attendee.last_first) if self.no_overlap(s)]
+        return [s for s in self._potential_volunteers(order_by=Attendee.last_first) if self.no_overlap(s)
+                and self.working_limit_ok(s)]
 
 
 class Shift(MagModel):

--- a/uber/site_sections/dept_admin.py
+++ b/uber/site_sections/dept_admin.py
@@ -41,6 +41,7 @@ class Root:
                 params,
                 bools=Department.all_bools,
                 checkgroups=Department.all_checkgroups)
+            department.max_consecutive_minutes = int(float(params.get('max_consecutive_hours', 0) or 0) * 60)
             message = check(department)
             if not message:
                 session.add(department)
@@ -97,6 +98,7 @@ class Root:
         if cherrypy.request.method == 'POST':
             message = check_dept_admin(session)
             if not message:
+                department.max_consecutive_minutes = int(float(params.get('max_consecutive_hours', 0) or 0) * 60)
                 message = check(department)
             if not message:
                 attendee = session.admin_attendee()
@@ -194,39 +196,39 @@ class Root:
 
     @csv_file
     def overworked_attendees(self, out, session):
-        def single_sequence(attendee, start_hour, hour_map):
+        def single_sequence(attendee, start_minute, minute_map):
             all_depts_limit = 1000
-            hours_worked = 0
-            current_hour = start_hour
-            while current_hour in hour_map:
-                dept_limit = hour_map[current_hour].max_consecutive_hours
+            minutes_worked = 0
+            current_minute = start_minute
+            while current_minute in minute_map:
+                dept_limit = minute_map[current_minute].max_consecutive_minutes
                 if dept_limit > 0:
                     all_depts_limit = min(all_depts_limit, dept_limit)
-                hours_worked += 1
-                current_hour = current_hour + timedelta(hours=1)
+                minutes_worked += 1
+                current_minute = current_minute + timedelta(minutes=1)
 
-            if hours_worked > all_depts_limit:
+            if minutes_worked > all_depts_limit:
                 # reiterate over to gather department names
-                current_hour = start_hour
+                current_minute = start_minute
                 departments_overworked = set()
-                while current_hour in hour_map:
-                    dept_limit = hour_map[current_hour].max_consecutive_hours
-                    if dept_limit > 0 and hours_worked > dept_limit:
-                        departments_overworked.add(hour_map[current_hour].department_name)
-                    current_hour = current_hour + timedelta(hours=1)
+                while current_minute in minute_map:
+                    dept_limit = minute_map[current_minute].max_consecutive_minutes
+                    if dept_limit > 0 and minutes_worked > dept_limit:
+                        departments_overworked.add(minute_map[current_minute].department_name)
+                    current_minute = current_minute + timedelta(minutes=1)
                 out.writerow([attendee.full_name,
-                              start_hour.astimezone(c.EVENT_TIMEZONE),
-                              hours_worked] +
+                              start_minute.astimezone(c.EVENT_TIMEZONE),
+                              minutes_worked] +
                              list(departments_overworked))
 
         out.writerow(["Attendee name", "Start of overworked shift sequence",
                       "Length of shift sequence", "Departments overworked in"])
         for attendee in session.query(Attendee).filter(Attendee.staffing == True).all():  # noqa: E712
-            hour_map = attendee.hour_map
-            for start_hour in hour_map:
-                # only look at start-of-sequence hours
-                if start_hour - timedelta(hours=1) not in hour_map:
-                    single_sequence(attendee, start_hour, hour_map)
+            minute_map = attendee.minute_map
+            for start_minute in minute_map:
+                # only look at start-of-sequence minutes
+                if start_minute - timedelta(minutes=1) not in minute_map:
+                    single_sequence(attendee, start_minute, minute_map)
 
     @department_id_adapter
     def role(self, session, department_id=None, message='', **params):

--- a/uber/site_sections/dept_admin.py
+++ b/uber/site_sections/dept_admin.py
@@ -224,7 +224,7 @@ class Root:
         out.writerow(["Attendee name", "Start of overworked shift sequence",
                       "Length of shift sequence", "Departments overworked in"])
         for attendee in session.query(Attendee).filter(Attendee.staffing == True).all():  # noqa: E712
-            minute_map = attendee.minute_map
+            minute_map = attendee.shift_minute_map
             for start_minute in minute_map:
                 # only look at start-of-sequence minutes
                 if start_minute - timedelta(minutes=1) not in minute_map:

--- a/uber/site_sections/hotel_reports.py
+++ b/uber/site_sections/hotel_reports.py
@@ -91,11 +91,11 @@ def _hours_vs_rooms(session):
     for report in attendee_hotel_nights:
         attendee = report['attendee']
         report.update(
-            weighted_hours=attendee.weighted_hours - attendee.nonshift_hours,
-            worked_hours=attendee.worked_hours - attendee.nonshift_hours,
-            unweighted_hours=attendee.unweighted_hours - attendee.nonshift_hours,
-            unweighted_worked_hours=attendee.unweighted_worked_hours - attendee.nonshift_hours,
-            nonshift_hours=attendee.nonshift_hours,
+            weighted_hours=attendee.weighted_hours - attendee.nonshift_minutes / 60,
+            worked_hours=attendee.worked_hours - attendee.nonshift_minutes / 60,
+            unweighted_hours=attendee.unweighted_hours - attendee.nonshift_minutes / 60,
+            unweighted_worked_hours=attendee.unweighted_worked_hours - attendee.nonshift_minutes / 60,
+            nonshift_hours=attendee.nonshift_minutes / 60,
         )
     return attendee_hotel_nights
 
@@ -121,7 +121,7 @@ def _hours_vs_rooms_by_dept(session):
                 worked_hours=attendee.worked_hours_in(dept),
                 unweighted_hours=attendee.unweighted_hours_in(dept),
                 unweighted_worked_hours=attendee.unweighted_worked_hours_in(dept),
-                nonshift_hours=attendee.nonshift_hours,
+                nonshift_hours=attendee.nonshift_minutes / 60,
             )
 
             dept_report = departments[dept]

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -750,7 +750,7 @@ class Root:
         return {
             'order': Order(order),
             'message': message,
-            'taken_hours': sum([s.weighted_hours - s.nonshift_hours for s in staffers], 0.0),
+            'taken_hours': sum([s.weighted_hours - s.nonshift_minutes / 60 for s in staffers], 0.0),
             'total_hours': sum([j.weighted_hours * j.slots for j in session.query(Job).all()], 0.0),
             'staffers': sorted(staffers, reverse=order.startswith('-'), key=lambda s: getattr(s, order.lstrip('-')))
         }
@@ -857,7 +857,7 @@ class Root:
             'jobs': [
                 (job.id, '({}) [{}] {}'.format(job.timespan(), job.department_name, job.name))
                 for job in attendee.available_jobs
-                if job.start_time + timedelta(hours=job.duration + 2) > localized_now()],
+                if job.start_time + timedelta(minutes=job.duration + 120) > localized_now()],
         }
         
         if 'attendee_shifts' in cherrypy.url():

--- a/uber/site_sections/shifts_admin.py
+++ b/uber/site_sections/shifts_admin.py
@@ -157,12 +157,9 @@ class Root:
     @ajax
     def update_nonshift(self, session, id, nonshift_hours):
         attendee = session.attendee(id, allow_invalid=True)
-        if not re.match('^[0-9]+$', nonshift_hours):
-            return { 'success': False, 'message': 'Invalid integer' }
-        else:
-            attendee.nonshift_hours = int(nonshift_hours)
-            session.commit()
-            return { 'success': True, 'message': 'Non-shift hours updated' }
+        attendee.nonshift_minutes = int(float(nonshift_hours or 0) * 60)
+        session.commit()
+        return { 'success': True, 'message': 'Non-shift hours updated' }
 
     @ajax
     def update_notes(self, session, id, admin_notes, for_review=None):
@@ -202,6 +199,7 @@ class Root:
             allowed=['department_id', 'start_time', 'type'] + list(defaults.keys()))
 
         if cherrypy.request.method == 'POST':
+            job.duration = int(params.get('duration_hours', 0)) * 60 + int(params.get('duration_minutes', 0))
             message = check(job)
             if not message:
                 session.add(job)

--- a/uber/site_sections/staffing_admin.py
+++ b/uber/site_sections/staffing_admin.py
@@ -14,9 +14,13 @@ from uber.utils import get_api_service_from_server
 def _create_copy_department(from_department):
     to_department = Department()
     for field in ['name', 'description', 'solicits_volunteers', 'is_shiftless',
-                  'is_setup_approval_exempt', 'is_teardown_approval_exempt', 'max_consecutive_hours']:
+                  'is_setup_approval_exempt', 'is_teardown_approval_exempt', 'max_consecutive_minutes']:
         if field in from_department:
             setattr(to_department, field, from_department[field])
+
+        # Convert old years' max hours to minutes, this can eventually be removed
+        if 'max_consecutive_hours' in from_department:
+            setattr(to_department, 'max_consecutive_minutes', int(from_department['max_consecutive_hours']) * 60)
     return to_department
 
 

--- a/uber/site_sections/staffing_reports.py
+++ b/uber/site_sections/staffing_reports.py
@@ -122,8 +122,8 @@ class Root:
         untaken = defaultdict(lambda: defaultdict(list))
         for job in session.jobs():
             if job.restricted and job.slots_taken < job.slots:
-                for hour in job.hours:
-                    untaken[job.department_id][hour].append(job)
+                for minute in job.minutes:
+                    untaken[job.department_id][minute].append(job)
         flagged = []
         for attendee in session.staffers():
             if not attendee.is_dept_head:
@@ -131,20 +131,20 @@ class Root:
                 for shift in attendee.shifts:
                     if not shift.job.restricted:
                         for dept in attendee.assigned_depts:
-                            for hour in shift.job.hours:
-                                if attendee.trusted_in(dept) and hour in untaken[dept]:
-                                    overlapping[shift.job].update(untaken[dept][hour])
+                            for minute in shift.job.minutes:
+                                if attendee.trusted_in(dept) and minute in untaken[dept]:
+                                    overlapping[shift.job].update(untaken[dept][minute])
                 if overlapping:
                     flagged.append([attendee, sorted(overlapping.items(), key=lambda tup: tup[0].start_time)])
         return {'flagged': flagged}
 
     def consecutive_threshold(self, session):
         def exceeds_threshold(start_time, attendee):
-            time_slice = [start_time + timedelta(hours=i) for i in range(18)]
-            return len([h for h in attendee.hours if h in time_slice]) >= 12
+            time_slice = (start_time, start_time + timedelta(hours=18))
+            return len([h for h in attendee.shift_minutes if time_slice[0] < h < time_slice[1]]) >= 13 * 60
         flagged = []
         for attendee in session.staffers():
-            if attendee.staffing and attendee.weighted_hours >= 12:
+            if attendee.staffing and attendee.unweighted_hours >= 12:
                 for start_time, desc in c.START_TIME_OPTS[::6]:
                     if exceeds_threshold(start_time, attendee):
                         flagged.append(attendee)

--- a/uber/static/angular-apps/signups/possible.html
+++ b/uber/static/angular-apps/signups/possible.html
@@ -29,7 +29,7 @@
     </td>
     <td>{{ job.department_name }}</td>
     <td>{{ job.start_time_local|hourDay }}</td>
-    <td>{{ job.duration }} hours<span ng-if="job.extra15">, 15 minutes</span></td>
+    <td>{{ (job.duration / 60)|int }} hours{% if job.duration % 60 %}, {{ job.duration % 60 }} minutes{% endif %}</td>
     <td>x{{ job.weight }}</td>
     <td>
         <span ng-if="job.taken">

--- a/uber/static/angular-apps/signups/taken.html
+++ b/uber/static/angular-apps/signups/taken.html
@@ -30,7 +30,7 @@
     </td>
     <td>{{ job.department_name }}</td>
     <td>{{ job.start_time_local|hourDay }}</td>
-    <td>{{ job.duration }} hours<span ng-if="job.extra15">, 15 minutes</span></td>
+    <td>{{ (job.duration / 60)|int }} hours{% if job.duration % 60 %}, {{ job.duration % 60 }} minutes{% endif %}</span></td>
     <td>x{{ job.weight }}</td>
     <td>
         <span ng-if="job.taken">

--- a/uber/templates/dept_admin/form.html
+++ b/uber/templates/dept_admin/form.html
@@ -236,10 +236,21 @@
                 </div>
               </div>
             </div>
-            {{ macros.form_group(
-                department,
-                'max_consecutive_hours',
-                help='The maximum number of consecutive hours a staffer may work. Enter 0 for no limit.') }}
+            <div class="form-group">
+              <label class="col-sm-3 control-label optional-field">Max Consecutive Hours</label>
+              <div class="col-sm-6">
+                  <input
+                            class="form-control"
+                            type="text"
+                            name="max_consecutive_hours"
+                            value="{{ department.max_consecutive_minutes / 60 }}"
+                  />
+              </div>
+                <div class="clearfix"></div>
+                <p class="col-sm-9 col-sm-offset-3 help-block">
+                  The maximum number of consecutive hours a staffer may work. Enter 0 for no limit.
+                </p>
+            </div>
           </div>
           <div class="modal-footer">
             <button type="submit" class="btn btn-primary">Save</button>
@@ -280,10 +291,10 @@
 {% if department.is_shiftless -%}
   <p>This department is <b>shiftless</b>; it does not track staff hours using shifts.</p>
 {%- else -%}
-{% if department.max_consecutive_hours == 0 -%}
+{% if not department.max_consecutive_minutess -%}
   <p>Members of this department may work <strong>any number of hours</strong> in a row</p>
 {%- else -%}
-  <p>Members of this department may work <strong>{{ department.max_consecutive_hours }} hours</strong> in a row</p>
+  <p>Members of this department may work <strong>{{ department.max_consecutive_minutes / 60 }} hours</strong> in a row</p>
 {%- endif %}
 {%- endif %}
 <p>This department {% if department.solicits_volunteers %}solicits{% else %}<b>does not</b> solicit{% endif %} volunteers.</p>

--- a/uber/templates/dept_admin/form.html
+++ b/uber/templates/dept_admin/form.html
@@ -291,7 +291,7 @@
 {% if department.is_shiftless -%}
   <p>This department is <b>shiftless</b>; it does not track staff hours using shifts.</p>
 {%- else -%}
-{% if not department.max_consecutive_minutess -%}
+{% if not department.max_consecutive_minutes -%}
   <p>Members of this department may work <strong>any number of hours</strong> in a row</p>
 {%- else -%}
   <p>Members of this department may work <strong>{{ department.max_consecutive_minutes / 60 }} hours</strong> in a row</p>

--- a/uber/templates/dept_admin/index.html
+++ b/uber/templates/dept_admin/index.html
@@ -45,7 +45,7 @@
               <td>{{ department.solicits_volunteers|yesno("Yes,No") }}</td>
               <td>{{ department.is_setup_approval_exempt|yesno("Yes,No") }}</td>
               <td>{{ department.is_teardown_approval_exempt|yesno("Yes,No") }}</td>
-              <td>{{ department.max_consecutive_hours }}</td>
+              <td>{{ department.max_consecutive_minutes / 60 }}</td>
               <td>{{ department.member_count }}</td>
             </tr>
           {%- endfor -%}

--- a/uber/templates/dept_checklist/no_shows.html
+++ b/uber/templates/dept_checklist/no_shows.html
@@ -24,7 +24,7 @@ also shows their worked hours.
     <tr>
         <td> {{ attendee|form_link }} </td>
         <td> {{ attendee.assigned_depts_labels|join(" / ") }} </td>
-        <td> {{ attendee.worked_hours }} ({{ attendee.nonshift_hours }} nonshift) </td>
+        <td> {{ attendee.worked_hours }} ({{ attendee.nonshift_minutes / 60 }} nonshift) </td>
         <td> {{ attendee.hotel_requests.nights_display }} </td>
         <td>
             {% for ra in attendee.room_assignments %}

--- a/uber/templates/emails/shifts/shifts_worked.html
+++ b/uber/templates/emails/shifts/shifts_worked.html
@@ -39,12 +39,12 @@ We couldn't have done it without the help of every single one of our volunteers.
             {% elif shift.worked == c.SHIFT_UNWORKED %}No{% endif %}</td>
         </tr>
     {% endfor %}
-  {% if attendee.nonshift_hours %}
+  {% if attendee.nonshift_minutes %}
     {% if attendee.shifts %}
       <tr><td colspan="5"></td></tr>
     {% endif %}
     <tr>
-    <td colspan="5" align="right">{{ attendee.nonshift_hours }} Non-Shift Hours</td>
+    <td colspan="5" align="right">{{ attendee.nonshift_minutes / 60 }} Non-Shift Hours</td>
     </tr>
   {% endif %}
 {% endif %}

--- a/uber/templates/registration/attendee_shifts.html
+++ b/uber/templates/registration/attendee_shifts.html
@@ -79,7 +79,7 @@
         {{ csrf_token() }}
         <input type="hidden" name="id" value="{{ attendee.id }}" />
         <b>Non-shift hours:</b>
-        <input type="number" class="focus" name="nonshift_hours" value="{{ attendee.nonshift_hours }}" style="width:3.5em" />
+        <input type="text" class="focus" name="nonshift_hours" value="{{ attendee.nonshift_minutes / 60 }}" style="width:3.5em" />
         <input type="submit" value="Update" class="btn btn-xs btn-primary"/>
       </form>
     </td>
@@ -99,7 +99,7 @@
             {% endif %}
         {% endif %}
         ({{ attendee.weighted_hours }} weighted hours,
-        {{ attendee.hours|length + attendee.nonshift_hours }} actual hours): </b>
+        {{ (attendee.shift_minutes|length + attendee.nonshift_minutes) / 60 }} actual hours): </b>
         {% if c.AT_OR_POST_CON %}<br />{{ attendee.worked_hours }} hours worked.{% endif %}
     <br/> <br/>
     <table width="95%" align="center" class="table-striped">
@@ -126,8 +126,8 @@
             </td>
             <td>{{ hour_day_local(shift.job.start_time) }}</td>
             <td>{{ hour_day_local(shift.job.end_time) }}</td>
-            <td>{{ shift.job.duration }} (x{{ shift.job.weight }})</td>
-            <td>{{ shift.job.weighted_hours}}</td>
+            <td>{{ shift.job.duration / 60 }} (x{{ shift.job.weight }})</td>
+            <td>{{ shift.job.weighted_hours }}</td>
             <td id="shift_status_{{ shift.id }}"></td>
             <td id="shift_rating_{{ shift.id }}"></td>
             <td class="text-right">

--- a/uber/templates/shifts_admin/form.html
+++ b/uber/templates/shifts_admin/form.html
@@ -112,30 +112,49 @@
   <div class="form-group">
     <label class="col-sm-3 control-label">Start Time</label>
     <div class="col-sm-6">
-      <select name="start_time" class="form-control">
-        {% if job.type == c.SETUP %}
-          <!-- SETUP -->
-          {{ options(c.SETUP_TIME_OPTS, job.start_time) }}
-        {% elif job.type == c.TEARDOWN %}
-          <!-- TEARDOWN -->
-          {{ options(c.TEARDOWN_TIME_OPTS, job.start_time) }}
-        {% elif job.type == c.REGULAR %}
-          <!-- REGULAR -->
-          {{ options(c.START_TIME_OPTS, job.start_time) }}
-        {% else %}
-          <!-- ALL -->
-          {{ options(c.ALL_TIME_OPTS, job.start_time) }}
-        {% endif %}
-      </select>
+      <div class="input-group">
+        <input
+        id="start-time"
+        name="start_time"
+        type="text"
+        class="form-control"
+        value="{{ job.start_time.astimezone(c.EVENT_TIMEZONE).strftime('%-m/%-d/%Y %-I:%M %p') if job.start_time else '' }}">
+        <span class="input-group-addon">
+          <span class="glyphicon glyphicon-calendar"></span>
+        </span>
+      </div>
     </div>
   </div>
+  {% if job.type == c.SETUP %}
+    {% set min_date = c.SETUP_JOB_START %}
+    {% set max_date = c.EPOCH %}
+  {% elif job.type == c.TEARDOWN %}
+    {% set min_date = c.ESCHATON %}
+    {% set max_date = c.TEARDOWN_JOB_END %}
+  {% elif job.type == c.REGULAR %}
+    {% set min_date = c.EPOCH %}
+    {% set max_date = c.ESCHATON %}
+  {% else %}
+    {% set min_date = c.SETUP_JOB_START %}
+    {% set max_date = c.TEARDOWN_JOB_END %}
+  {% endif %}
+
+  <script type="text/javascript">
+    $('#start-time').datetimepicker({
+      sideBySide: true,
+      useCurrent: false,
+      defaultDate: '{{ min_date.isoformat() }}',
+      minDate: '{{ min_date.isoformat() }}',
+      maxDate: '{{ max_date.isoformat() }}',
+      format: 'M/D/Y h:mm A'
+    });
+  </script>
   <div class="form-group">
     <label class="col-sm-3 control-label">{% if job.type != c.REGULAR %}Expected Approximate {% endif %}Duration</label>
-    <div class="col-sm-6">
-      <select name="duration" class="form-control">
-        {{ options(c.DURATION_OPTS, job.duration) }}
-      </select>
-    </div>
+    <div class="col-sm-2"><input type="number" class="form-control" name="duration_hours" value="{{ ((job.duration or 0) / 60)|int }}" /></div>
+    <span class="col-sm-1 form-control-static"> hours</span>
+    <div class="col-sm-2"><input type="number" class="form-control" name="duration_minutes" value="{{ (job.duration or 0) % 60 }}" /></div>
+    <span class="col-sm-1 form-control-static"> minutes</span>
   </div>
   <div class="form-group">
     <label class="col-sm-3 control-label">Extra 15{{ macros.popup_link("../static_views/extra15.html") }}</label>

--- a/uber/templates/staffing_reports/consecutive_threshold.html
+++ b/uber/templates/staffing_reports/consecutive_threshold.html
@@ -10,7 +10,7 @@ The following {{ flagged|length }} volunteers have signed up for at least 13 hou
     {% for attendee in flagged %}
         <tr>
             <td><a href="#attendee_form?id={{ attendee.id }}&tab_view=Shifts">{{ attendee.full_name }}</a>:</td>
-            <td>{{ attendee.hours|length }} total (wall-clock) hours</td>
+            <td>{{ attendee.shift_minutes|length / 60 }} total (wall-clock) hours</td>
         </tr>
     {% endfor %}
 </table>

--- a/uber/templates/staffing_reports/ratings.html
+++ b/uber/templates/staffing_reports/ratings.html
@@ -5,7 +5,7 @@
 <h2>Poor Ratings From This Year</h2>
 {% for attendee in current %}
     <h3>{{ attendee.full_name }}</h3>  
-    <b>{{ attendee.worked_hours }}</b> hours worked ({{ attendee.nonshift_hours }} of them were nonshift hours) <br/>
+    <b>{{ attendee.worked_hours }}</b> hours worked ({{ attendee.nonshift_minutes / 60 }} of them were nonshift hours) <br/>
     <b>{{ attendee.weighted_hours }}</b> hours signed up for <br/>
     {% if attendee.admin_notes %}<br/><b>Admin Notes:</b><br/><pre>{{ attendee.admin_notes }}</pre>{% endif %}
     <table width="95%" align="center">


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-928 by tracking shifts per minute instead of per hour. This puts some extra load on some of our shift calculations -- particularly some of our reports -- but hopefully it won't actually be noticeable.

Because the old dropdowns for start times and duration options no longer makes sense at a minute level of granularity, I replaced them -- the start time uses the same datetimepicker used in our Attraction module:
![image](https://user-images.githubusercontent.com/7198215/88883451-638a5880-d202-11ea-9fe2-671c8a803d46.png)

And entering duration is done using dual inputs for hours and minutes:
![image](https://user-images.githubusercontent.com/7198215/88883433-540b0f80-d202-11ea-86be-bb318709e8be.png)

It's somewhat difficult to see in the datetimepicker popup, but invalid times and dates are disabled based on the type of shift being edited.

In other sections of the app, e.g., entering non-shift hours, we just use floats in an hour input.