### PR TITLE
Restore development-defaults.ini

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -1,519 +1,186 @@
-cherrypy_mount_path = "/reggie"
-url_root = "https://%(hostname)s"
-organization_name = "MAGFest INC"
-event_year = 2020
-event_name = "MAGFest"
-event_timezone = "US/Eastern"
-event_venue = "The Gaylord National Hotel and Convention Center"
-event_venue_address = "201 Waterfront St, National Harbor, MD 20745"
-send_emails = True
-send_sms = False
-enable_pending_emails_report = True
-use_checkin_barcode = True
-badge_promo_codes_enabled = True
-prereg_confirm_email_enabled = True
-collect_exact_birthdate = True
-groups_enabled = True
-kiosk_cc_enabled = True
-only_prepay_at_door = False
-numbered_badges = True
-donations_enabled = True
-collect_full_address = False
-collect_extra_donation = True
-collect_interests = True
-volunteer_form_visible = False
-show_custom_badge_input = True
-shirt_sales_enabled = True
-show_affiliates = True
-student_discount = 0
-api_enabled = True
-hotels_enabled = True
-mits_enabled = True
-mivs_enabled = True
-panels_enabled = True
-attractions_enabled = True
-prereg_request_hotel_info_duration = 0
-prereg_hotel_info_email_sender = "Do Not Reply <noreply@magfest.org>"
-prereg_hotel_info_email_signature = "- MAGFest"
-hotel_req_hours = 30
-hours_for_refund = 24
-code_of_conduct_url = "http://super.magfest.org/codeofconduct"
-consent_form_url = "http://super.magfest.org/parentalconsentform"
-contact_url = "http://super.magfest.org/contact"
-prereg_faq_url = "http://super.magfest.org/faq"
-at_the_con = True
-post_con = False
-uber_shut_down = False
-admin_email = "MAGFest Sys Admin <sysadmin@magfest.org>"
-developer_email = "MAGFest Software <code@magfest.org>"
-security_email = "MAGFest Security <security@magfest.org>"
-regdesk_email = "MAGFest Registration <regsupport@magfest.org>"
-regdesk_email_signature = '''MAGFest Registration Department
+path = "/rams"
+hostname = "localhost"
+url_root = "https://localhost"
+
+consent_form_url = "http://magfest.org/parentalconsentform"
+
+
+
+regdesk_email_signature = ''' - Victoria Earl,
+MAGFest Registration Chair'''
+
+stops_email_signature = '''Staff Operations Department
+stops@magfest.org
 MAGFest Inc.
-http://super.magfest.org
-'''
-staff_email = "MAGFest Staffing <stops@magfest.org>"
-stops_email_signature = '''Thank You,
-Staff Operations: MAGFest Inc.
-http://super.magfest.org
-'''
-marketplace_email = "MAGFest Marketplace <marketplace@magfest.org>"
-marketplace_email_signature = '''- Danielle Pomfrey,
-MAGFest Marketplace Coordinator
-'''
-panels_email = "MAGFest Panels <panels@magfest.org>"
-peglegs_email_signature = '''- Tom Hyre,
-MAGFest Director of Panel Operations
-'''
-guest_email = "MAGFest Guests <guests@magfest.org>"
-guest_email_signature = '''- Steph Prader,
-MAGFest Guest Coordinator
-'''
-band_email = "MAGFest Music Department <music@magfest.org>"
-band_email_signature = "- MAGFest Music Department"
-out_of_shirts = False
-shirts_per_staffer = 2
-separate_staff_merch = True
-max_badge_sales = 22999
-max_dealers = 20
-max_dealer_apps = 515
-preassigned_badge_types = "staff_badge","contractor_badge"
-shiftless_depts = "dorsai","marketplace","simulations","merch_contractor","con_ops","arcade_crew"
-shift_custom_badges = True
-hide_prereg_open_date = True
-mivs_confirm_deadline = 14
-mivs_submission_grace_period = 10
-mivs_start_year = 2013
-treasury_dept_checklist_form_url = "https://docs.google.com/spreadsheets/d/1gw9ON-64XiHebVG_TnZEIA6DLMjAEOdyVD21W3XmIr0/edit?usp=sharing"
-techops_dept_checklist_form_url = "https://goo.gl/forms/PcG3dG7JwsD307sK2"
-expected_response = "December 2019"
-panel_rooms = "panels_1","panels_2","panels_3","panels_4","panels_5","tabletop_panels","the_forge"
-tabletop_locations = "tabletop_tournaments","tabletop_tournaments_2","tabletop_indie"
-music_rooms = "concerts","chiptunes","pose_lounge","lobby_bar","jamspace","jam_clinic","jam_shop"
-alt_schedule_url = "https://guidebook.com/guide/101720/schedule"
-require_dedicated_guest_table_presence = True
-rock_island_groups = "band","guest"
-default_loadin_minutes = 20
-default_performance_minutes = 40
-accessibility_services_enabled = True
-dealer_term = "seller"
-sqlalchemy_max_overflow = 15
-dealer_app_term = "marketplace application"
-panels_twilio_number = "+12405415595"
+http://www.magfest.org'''
+
+marketplace_email_signature = ''' - Danielle Pomfrey,
+MAGFest Marketplace Coordinator'''
+
+peglegs_email_signature = ''' -  Tom Hyre,
+MAGFest Director of Panel Operations'''
+
+guest_email_signature = ''' - Steph Prader,
+MAGFest Guest Coordinator'''
+
+mivs_email_signature = '''Thank you,
+- The MIVS Staff'''
+
+rooms_locked_in = True
+
+
+expected_response = "December 2016"
+
+alt_schedule_url = ""
+
 tabletop_twilio_number = "+15713646627"
-discountable_badge_types = "attendee_badge","child_badge"
-dealer_helper_term = "Marketplace Assistant"
-dealer_reg_term = "marketplace registration"
-mivs_training_password = "WHATISARUG"
-dev_box = True
-dealer_loc_term = "marketplace"
-path = ""
-event_qr_id = "sm19"
-social_media = "Social Media Info",
-sqlalchemy_pool_size = 10
-year = 2020
-hostname = "127.0.0.1:4443"
+tabletop_locations = ,
 
-[celery]
-beat_schedule_filename = "/tmp/celerybeat-schedule.db"
-
-[secret]
-stripe_public_key = "pk_test_q4kSJVwk6LXKv2ahxuVn7VOK"
-barcode_event_id = 255
-barcode_salt = 255
-barcode_key = "TEST ONLY!"
-stripe_secret_key = "sk_test_QHnlImUs68dQFxgTfVauz5Ue"
-sqlalchemy_url = "postgres://reggie:reggie@10.0.2.15:5432/reggie"
-broker_url = "amqp://reggie:reggie@10.0.2.15:5672/reggie"
-
-[data_dirs]
-uploaded_files_dir = "/srv/mnt/reggie/uploaded_files"
 
 [dates]
-prereg_open = "2019-08-28 12"
-shifts_created = "2019-11-02"
-room_deadline = "2019-11-14"
-shirt_deadline = "2019-11-25"
-supporter_deadline = "2019-11-18"
-placeholder_deadline = "2019-12-26"
-uber_takedown = "2020-01-07"
-epoch = "2020-01-02 08"
-eschaton = "2020-01-06 20"
-prereg_takedown = "2020-01-02"
-group_prereg_takedown = "2020-01-02"
-printed_badge_deadline = "2019-11-15"
-dealer_reg_start = "2019-08-16 20"
-dealer_reg_deadline = ""
-dealer_reg_shutdown = "2019-08-27 20"
-dealer_payment_due = "2019-11-04"
-badge_price_waived = "2020-01-05 16"
-mivs_start = "2019-09-01"
-mivs_deadline = "2019-09-22"
-mivs_judging_deadline = "2019-10-20"
-mivs_results_reveal = "2019-10-28"
-panels_deadline = "2019-10-31"
-rock_island_deadline = "2019-11-17"
-auction_start = "2020-01-08 11"
-band_panel_deadline = "2019-09-30"
-band_bio_deadline = "2019-09-07"
-band_info_deadline = "2019-09-07"
-band_taxes_deadline = "2019-08-31"
-band_merch_deadline = "2019-09-16"
-band_charity_deadline = "2019-12-15"
-band_badges_deadline = "2019-12-15"
-band_stage_plot_deadline = "2019-09-24"
-guest_panel_deadline = "2019-10-21"
-guest_bio_deadline = "2019-10-21"
-guest_info_deadline = "2019-11-01"
-guest_taxes_deadline = "2019-10-21"
-guest_merch_deadline = "2019-10-21"
-guest_charity_deadline = "2019-10-21"
-guest_badges_deadline = "2019-12-01"
-guest_autograph_deadline = "2019-10-21"
-guest_interview_deadline = "2019-10-21"
-guest_travel_plans_deadline = "2019-10-21"
-prereg_hotel_eligibility_cutoff = "2019-09-03"
-refund_start = "2019-09-19 8"
-mits_submission_deadline = "2019-11-14"
-mits_editing_deadline = "2019-12-28"
-dealer_waitlist_closed = ""
-band_mc_deadline = "2019-09-30"
-
-[badge_ranges]
-staff_badge = 25,2999
-guest_badge = 3000,3600
-attendee_badge = 3601,39999
-one_day_badge = 40000,49999
-child_badge = 50000,59999
+room_deadline = "2015-11-30"
+panels_deadline = "2016-10-31"
 
 [badge_prices]
-one_days_enabled = False
-initial_attendee = 79
-dealer_badge_price = 50
-group_discount = 10
-presell_one_days = False
+
+[[single_day]]
 
 [[attendee]]
-2020-01-03 = 85
-2020-01-06 = 20
-2020-01-05 = 60
-2020-01-04 = 80
 
-[[stocks]]
-attendee_badge = 12388
 
 [table_prices]
-default_price = 350
-1 = 150
-2 = 250
-3 = 400
-4 = 550
+default_price = 300
+
+[badge_ranges]
+staff_badge = 1, 999
+guest_badge = 2000, 2999
+contractor_badge = 3000, 29999
+attendee_badge = 3000, 29999
+one_day_badge = 30000, 39999
+
+
+[age_groups]
+
+[[under_6]]
+desc            = "Under 6"
+min_age         = 0
+max_age         = 5
+discount        = 999
+can_volunteer   = False
+consent_form    = True
+wristband_color = "red"
+
+[[under_13]]
+desc            = "Between 6 and 13"
+min_age         = 6
+max_age         = 12
+discount        = 0
+can_volunteer   = False
+consent_form    = True
+wristband_color = "red"
+
+[[under_18]]
+desc            = "Between 13 and 18"
+min_age         = 13
+max_age         = 17
+discount        = 0
+can_volunteer   = False
+consent_form    = True
+wristband_color = "red"
+
+[[under_21]]
+desc            = "Between 18 and 21"
+min_age         = 18
+max_age         = 20
+discount        = 0
+can_volunteer   = True
+consent_form    = False
+wristband_color = "blue"
+
+[[over_21]]
+desc            = "21 or older"
+min_age         = 21
+max_age         = 99
+discount        = 0
+can_volunteer   = True
+consent_form    = False
+wristband_color = "green"
+
 
 [integer_enums]
-shirt_level = 25
-supporter_level = 75
-season_level = 200
-
-[[shirt]]
-no shirt = 0
-S Unisex = 1
-M Unisex = 2
-L Unisex = 3
-XL Unisex = 4
-2XL Unisex = 5
-3XL Unisex = 6
-4XL Unisex = 11
-5XL Unisex = 12
-S Unisex slim fit = 14
-M Unisex slim fit = 15
-L Unisex slim fit = 16
-XL Unisex slim fit = 17
-2XL Unisex slim fit = 18
-S Women's = 7
-M Women's = 8
-L Women's = 9
-XL Women's = 10
-2XL Women's = 13
-S Women's slim fit = 19
-M Women's slim fit = 20
-L Women's slim fit = 21
-XL Women's slim fit = 22
-2XL Women's slim fit = 23
+size_unknown = -1
+no_shirt     = 0
 
 [[donation_tier]]
-No thanks = 0
+'No thanks' = 0
 
-[[staff_event_shirt]]
-One Event Shirt and One Staff Shirt = 1
-Two Staff Shirts = 0
+[[shirt]]
+'no shirt' = NO_SHIRT
 
-[donation_tier_descriptions]
+[[fee_price]]
+'Badge Replacement' = 80
 
-[[no_thanks]]
-name = "No thanks"
-icon = ""
-description = "No thanks"
-link = ""
+[[store_price]]
+'MAGFest 2016 tshirt'            = 20
+'Squarewave tshirt'              = 15
+'Polo Shirt'                     = 25
+'Hoodie'                         = 30
+'Scarf'                          = 25
+'Beanie'                         = 15
+'Pin (MAGBadge)'                 = 8
+'Pin (MAGFest Logo)'             = 8
+'Pin set of 2'                   = 15
+'Poster'                         = 3
+'Lanyard'                        = 5
+'Wristband'                      = 1
+'MAGnet (indoor)'                = 2
+'MAGnet (outdoor)'               = 4
+'Bumper Sticker'                 = 3
+'Squarewave Bumper Sticker'      = 2
+'MAGFest 2016 Car Decal (Small)' = 3
+'MAGFest 2016 Car Decal (Large)' = 5
+'Squarewave Car Decal (Small)'   = 3
+'Squarewave Car Decal (Large)'   = 5
+'Other Sticker'                  = 1
+
 
 [enums]
 
-[[badge]]
-attendee_badge = "Attendee"
-child_badge = "Minor"
-staff_badge = "Staff"
-guest_badge = "Guest"
-one_day_badge = "One Day"
+[[sale]]
+merch  = "Merch"
+cash   = "Cash"
+credit = "Credit Card"
 
-[[ribbon]]
-band = "RockStar"
-mivs = "Indie Dev"
-under_13 = "12 & Under"
+[[payment_method]]
+cash   = "Cash"
+stripe = "Stripe"
+square = "Square"
+manual = "Stripe (Manual)"
+group  = "Group"
+stripe_error = "Stripe (Error Override)"
 
-[[job_location]]
-marketplace = "Marketplace"
-regdesk = "Registration"
-loadin = "Logistics"
-film_fest = "Games on Film"
-signage = "Signage"
-lan = "LAN"
-dispatch = "Dispatch"
-challenges = "Challenges"
-attendee_service = "Attendee Services"
-vrzone = "VRZone"
-tabletop = "Tabletop"
-simulations = "Simulations"
-tech_ops = "Tech Ops"
-con_ops = "Fest Ops"
-loudr = "Rock Island"
-larp = "LARP"
-console = "Consoles"
-concert_tech = "Main Theater Tech"
-arcade = "Arcade"
-reg_managers = "Reg Managers"
-museum = "Museum"
-concert_ops = "Main Theater Operations"
-shedspace = "Jam Clinic"
-stops = "Staffing Ops"
-mops = "MEDIATRON!"
-indie_arcade = "Indie Arcade"
-zombie_tag = "Zombie Tag"
-treasury = "Treasury"
-music = "Music"
-jamspace = "Jam Space"
-indie_tabletop = "Indie Tabletop"
-autographs = "Autographs"
-events = "Events"
-tabletop_rpg = "Tabletop (Pathfinder)"
-indie_games = "Indie Games"
-rescuers = "Rescuers"
-hotel = "Hotel"
-public_safety = "Public Safety"
-chipspace = "Chipspace"
-dorsai = "Dorsai"
-food_prep = "Staff Suite"
-tabletop_ccg = "Tabletop (CCG)"
-charity = "Charity"
-staff_support = "Staff Support"
-arcade_crew = "Arcade_Crew"
-tabletop_ddal = "Tabletop (DDAL)"
-merch = "Merchandise"
-tea_room = "Staff Tea Room"
-merch_contractor = "Yetee Staff"
-mages = "MAGES"
-security = "Security"
-panels = "Panels"
-escape_room = "Escape Room"
+[[fee_payment_method]]
+cash   = "cash"
+credit = "credit"
 
-[[job_interest]]
-anything = "Anything"
-lan = "LAN"
-security = "Security"
-console = "Consoles"
-arcade = "Arcade"
-regdesk = "Registration"
-film_fest = "Film Festival"
-panels = "Panels"
-indie_games = "Indie Showcase"
-challenges = "Challenges Booth"
-charity = "Charity"
-other = "Other"
-tea_room = "Staff Tea Room"
-chipspace = "Chipspace"
-staff_support = "Staff Support"
-tabletop = "Tabletop"
-tech_ops = "Tech Ops"
-jamspace = "Jam Space"
-food_prep = "Staff Suite"
-museum = "Museum"
-loudr = "Rock Island (Merch)"
+[[new_reg_payment_method]]
+cash   = "Cash"
+square = "Square"
+stripe_error = "Stripe Error Override"
 
-[[interest]]
-lan = "LAN"
-tournaments = "Tournaments"
-console = "Consoles"
-dealers = "Marketplace"
-arcade = "Arcade"
-Jams = "Jam Space"
-music = "Concerts"
-tabletop = "Tabletop games"
-panels = "Guests/Panels"
-
-[[dealer_wares]]
-prints = "Prints"
-vgames = "Video Games"
-tshirts = "T-shirts"
-handmade = "General Handmade"
-general = "General Merchandise"
-lanyards = "Lanyards/Keychains"
-plushes = "Plushes"
-figures = "Figures"
-perler = "Perler Beads"
-bath = "Bath Products"
-jewelry = "Jewelry"
+[[door_payment_method]]
+cash   = "Pay with cash"
+stripe = "Pay with credit card now (faster, can use prereg line)"
+manual = "Pay with credit card at the registration desk"
 
 [[event_location]]
-concerts = "Concerts (Potomac Ballrooms)"
-panels_1 = "Panels 1 (Cherry Blossom Ballroom)"
-panels_2 = "Panels 2 (Woodrow Wilson Ballroom)"
-panels_3 = "Panels 3 (Woodrow Wilson Ballroom)"
-panels_4 = "Panels 4 (Annapolis 1-3)"
-panels_5 = "Panels 5 (National Harbor 14-15)"
-lobby_bar = "Belvedere Lobby Bar"
-Museum = "Museum (Chesapeake D,E,F)"
-mages_2 = "MAGES 2 (Chesapeake 10,11,12)"
-mages_1 = "MAGES 1 (Chesapeake 7,8,9)"
-ddal = "D&D Adventurers League, 5th edition (National Harbor 4,5,8)"
-vrzone = "VRZone (Baltimore 1,2)"
-simulations = "Artemis (National Harbor 10,11)"
-tabletop_tournaments = "Tabletop Tournaments 1 (Riverview Ballroom)"
-console_tournament = "Console (Gameroom Tournaments 1)"
-starship_horizons = "Starship Horizons (National Harbor 10,11)"
-console_tournament_2 = "Console (Gameroom Tournaments 3)"
-lan_2 = "LAN 2"
-magfest_vs = "Indie Arcade Tournaments (Expo Hall B)"
-tabletop_panels = "Tabletop Discussions (Riverview Ballroom)"
-the_forge = "Makerspace (Baltimore 3,4)"
-tabletop_tournaments_2 = "Tabletop Tournaments 2 (Riverview Ballroom)"
-zombie_tag = "Zombie Tag (Magnolia 1)"
-console_tournament_4 = "Console (Gameroom Tournaments 4)"
-console_tournament_5 = "Console (Smash Bros Tournaments)"
-demoparty = "Demoparty (Magnolia 3)"
-autographs = "Autographs Red (Expo Hall E)"
-autographs_1 = "Autographs Blue (Expo Hall E)"
-lan_1 = "LAN 1"
-rock_island = "Rock Island - Band Merch (Potomac 1)"
-arcade_tournaments_1 = "Arcade (Tournaments 1)"
-arcade_tournaments_2 = "Arcade (Tournaments 2)"
-arcade_tournaments_3 = "Arcade (Tournaments 3)"
-arcade_tournaments_4 = "Arcade (Pinball)"
-arcade_tournaments_5 = "Arcade (Tournaments 4)"
-laser_tag = "Laser Tag (Chesapeake A,B,C)"
-pathfinder = "Pathfinder (National Harbor 6,7)"
-larp = "LARP (National Harbor 14,15)"
-film_fest = "MAGES Workshop (Chesapeake 1,2)"
-tabletop_indie = "Tabletop Indie Showcase (Riverview Ballroom)"
-tabletop_ccg = "Tabletop CCG (National Harbor 1,2,3)"
-chiptunes = "Chipspace (Potomac Hallway)"
-soapbox = "The Soapbox (Magnolia 2)"
-forum = "Forum (Chesapeake H,I)"
-jamspace = "Jamspace + Community Curated Stage (Eastern Shore 1,2,3)"
-pose_lounge = "POSE Lounge"
-console_stage = "Arena (Maryland C)"
-lan_theater = "LAN Theater"
-jam_shop = "Jam Shop (Chesapeake 3)"
-console_attendee = "Console (Gameroom Tournaments 2)"
-jam_clinic = "Jam Clinic (Chesapeake 4,5,6)"
-MegaManathon = "Mega Man-athon/MAGFast (Maryland Hallway)"
-escape_room = "Robotics (Expo Hall E)"
 
-[[sandwich]]
-turkey = "Turkey"
-cheese = "Cheese"
-ham = "Ham"
-salad = "Prefer salad instead of sandwich"
-jelly = "Jelly"
-peanut_butter = "Peanut Butter"
-
-[[food_restriction]]
-pork = "No pork"
-nuts = "No nuts"
-gluten = "No gluten"
-vegan = "Vegetarian/Vegan"
-
-[[presentation]]
-physical_activity = "Physical Activity (either group participation or performance)"
-mivs = "Indie Developer Showcase"
-gameshow = "Gameshow"
-movie = "Movie Screening"
-karaoke = "Karaoke/Sing a Long"
-qa = "Question & Answer"
-workshop = "Workshop"
-music = "Music Performance (Jam Clinic)"
-learn_to_play = "Learn to Play"
-basic = "Lecture"
-performance = "Comedy Performance"
-group_discussion = "Group Discussion with Moderator"
-other = "Other"
-participation = "Audience Participation"
-advanced_av = "Podcast/Vodcast Recording"
-
-[[guest_merch]]
-no_merch = "Not selling merch"
-own_table = "Dedicated table"
-rock_island = "Rock Island"
-
-[[sweatpants]]
-2xl = "2XL"
-xl = "XL"
-m = "M"
-l = "L"
-s = "S"
-no_sweatpants = "Select a sweatpants size"
+[[dept_head_overrides]]
+security = "The Dorsai Irregulars"
 
 [dept_head_checklist]
 
-[volunteer_checklist]
-99 = "staffing/shifts_item.html"
-2 = "staffing/food_item.html"
-3 = "staffing/hotel_item.html"
-4 = "staffing/shirt_item.html"
-[age_groups]
-[social_media_urls]
-social_media_info = ""
-[mivs_checklist]
-[[training]]
-start = "2019-12-15"
-editable = True
-name = "MIVS Training"
-deadline = "2019-12-30"
-description = "MIVS Training is a google form to help you learn about being an Indie at MAGFest."
-[[selling_at_event]]
-editable = True
-deadline = "2019-12-01"
-name = "Selling at MAGFest"
-description = '''We are allowing Indies to sell items directly related to your game or studio in MIVS. Studios will need to sign a waiver and provide some information for tax purposes.
-'''
-[[discussion]]
-editable = True
-deadline = "2019-11-27"
-name = "MIVS Discussion Group"
-description = '''The primary contact for your game will be added to a MIVS Google Discussion group. You may enter emails for any team members associated with your game who you think should also be added to the group.
-'''
-[[core_hours]]
-deadline = "2019-11-27"
-name = "Accept Core Hours"
-description = '''In exchange for your space and two free badges, MIVS expects your studio to have your booth area up-and-running during core hours. You also must have at least one representative from your studio present, in your booth, during core hours.
-'''
-[[hotel_space]]
-editable = True
-deadline = "2019-11-27"
-name = "Hotel Signups"
-description = '''As a part of MIVS, you may purchase one hotel room for the Gaylord. This room is for your use and you are not allowed to transfer your reservation to someone else unless authorized by MAGFest. Dropping out of MIVS may cause your room to be canceled.
-'''
-[[handbook]]
-start = "2019-12-15"
-deadline = "2019-12-30"
-name = "Indie Handbook"
-description = "The MIVS Indie Handbook is here to give you information about being a MIVS Participant."
-[social_media_placeholders]
-social_media_info = "List social media sites you use and include a link to your page, or your username."
+
+[secret]
+test_db_file = "/tmp/uber.db"
+sqlalchemy_url = "sqlite+pysqlite:///%(test_db_file)s"


### PR DESCRIPTION
Effectively reverts the change in https://github.com/magfest/ubersystem/pull/3753 -- we need to at some point figure out how to merge this version and that version so that new deployments work without existing deployments breaking.

This should also fix the 500 error we're getting on MAGWest right now when you try to view attendees.