### PR TITLE
Update volunteer checklist for virtual events

### DIFF
--- a/uber/templates/staffing/hotel_item.html
+++ b/uber/templates/staffing/hotel_item.html
@@ -1,5 +1,5 @@
 {% import 'macros.html' as macros %}
-
+{% if c.HOTELS_ENABLED %}
 {% if attendee.hotel_eligible and c.AFTER_ROOM_DEADLINE and c.HAS_HOTEL_ADMIN_ACCESS %}
     <li>
         {% if c.HOTEL_REQUESTS_URL %}
@@ -21,7 +21,7 @@
         {% endif %}
         this staffer's hotel room space requests.
     </li>
-{% elif attendee.hotel_eligible and attendee.registered < c.ROOM_DEADLINE %}
+{% elif c.ROOM_DEADLINE and attendee.hotel_eligible and attendee.registered < c.ROOM_DEADLINE %}
     {% if c.BEFORE_ROOM_DEADLINE %}
         <li>
             {% if not attendee.placeholder and (attendee.agreed_to_volunteer_agreement or not c.VOLUNTEER_AGREEMENT_ENABLED) and not attendee.hotel_requests %}
@@ -63,4 +63,5 @@
             {% endif %}
         </li>
     {% endif %}
+{% endif %}
 {% endif %}

--- a/uber/templates/staffing/placeholder_item.html
+++ b/uber/templates/staffing/placeholder_item.html
@@ -7,6 +7,6 @@
     {% else %}
         Confirm
     {% endif %}
-    you are coming to {{ c.EVENT_NAME }}. (Deadline: {{ c.VOLUNTEER_PLACEHOLDER_DEADLINE }})
+    you are attending {{ c.EVENT_NAME }}. (Deadline: {{ c.VOLUNTEER_PLACEHOLDER_DEADLINE }})
     {% if not attendee.placeholder %}(you can still <a href="../preregistration/confirm?return_to=../staffing/index&id={{ attendee.id }}">edit your info</a>){% endif %}
 </li>

--- a/uber/templates/staffing/shirt_item.html
+++ b/uber/templates/staffing/shirt_item.html
@@ -8,12 +8,12 @@
         Let us know
     {% endif %}
     your shirt size
-    {% if attendee.gets_staff_shirt %}
+    {% if c.STAFF_EVENT_SHIRT_OPTS and attendee.gets_staff_shirt %}
         and your preference of staff or event shirt
     {% endif %}
     {% if c.SHIRT_DEADLINE %}
         <b>no later than {{ c.SHIRT_DEADLINE|datetime_local }}</b>
     {% endif %}
-    so that we can set aside shirts in the right sizes at our merch booth.
+    so that we can set aside shirts in the right sizes.
 </li>
 {% endif %}


### PR DESCRIPTION
Part of fixing https://jira.magfest.net/browse/MAGDEV-879 -- tweaks the wording and hides the hotel step if hotels_enabled is false.