### PR TITLE
Fix job.timespan() calls

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -477,7 +477,7 @@ class MagModel:
 
         return self
 
-    def timespan(self, minute_increment=60):
+    def timespan(self, minute_increment=1):
         def minutestr(dt):
             return ':30' if dt.minute == 30 else ''
 


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-942. Each minute of a job was being counted as an hour -- I've checked the code and it's safe to just change the default minute_increment.