### PR TITLE
Always get actual write/read access

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -721,10 +721,14 @@ class Attendee(MagModel, TakesPaymentMixin):
         return section_list
 
     def admin_read_access(self):
-        return self.session.admin_attendee_max_access(self) if self.session else False
+        from uber.models import Session
+        with Session() as session:
+            return session.admin_attendee_max_access(self)
     
     def admin_write_access(self):
-        return self.session.admin_attendee_max_access(self, read_only=False) if self.session else False
+        from uber.models import Session
+        with Session() as session:
+            return session.admin_attendee_max_access(self, read_only=False)
 
     @property
     def ribbon_and_or_badge(self):


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-964, which was caused by a false negative when checking admin access during attendee creation.