### PR TITLE
Fix 500 error for new MITS applications

### DIFF
--- a/alembic/versions/4036e1fdb9ee_add_stage_two_mits_team_fields.py
+++ b/alembic/versions/4036e1fdb9ee_add_stage_two_mits_team_fields.py
@@ -54,7 +54,7 @@ sqlite_reflect_kwargs = {
 def upgrade():
     op.add_column('mits_team', sa.Column('concurrent_attendees', sa.Integer(), nullable=True))
     op.add_column('mits_team', sa.Column('days_available', sa.Integer(), nullable=True))
-    op.add_column('mits_team', sa.Column('hours_available', sa.Integer(), server_default='0', nullable=False))
+    op.add_column('mits_team', sa.Column('hours_available', sa.Integer(), nullable=True))
 
 
 def downgrade():


### PR DESCRIPTION
We had the alembic migration set up wrong for a MITS column, so the bug is just now cropping up on servers. This will fix the error after you downgrade and re-upgrade alembic versions.