### PR TITLE
Use PNG for tile backgrounds

### DIFF
--- a/uber/static/theme/prereg.css
+++ b/uber/static/theme/prereg.css
@@ -33,7 +33,7 @@ html, body {
 
 body {
     background-color: GhostWhite;
-    background-image: url("../theme/tile-background.jpg");
+    background-image: url("../theme/tile-background.png");
 }
 
 /* Form Wizard */


### PR DESCRIPTION
We use PNG files for most of our assets nowadays, including the tile background.