### PR TITLE
Fix error on payment cancellation

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -234,7 +234,7 @@ def total_cost_over_paid(attendee):
 @validation.Attendee
 def reasonable_total_cost(attendee):
     if attendee.total_cost >= 999999:
-        return 'We cannot charge ${}. Please reduce extras so the total is below $999,999.'.format(
+        return 'We cannot charge {}. Please reduce extras so the total is below $999,999.'.format(
             format_currency(attendee.total_cost))
 
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -70,10 +70,11 @@ def rollback_prereg_session(session):
         cherrypy.session['unpaid_preregs'] = Charge.pending_preregs.copy()
 
         attendee = session.attendee(Charge.pending_preregs.popitem()[0])
-        account = attendee.managers[0]
-        if account and not any(attendee.badge_status != c.PENDING_STATUS for attendee in account.attendees):
-            session.delete(account)
-            cherrypy.session['attendee_account_id'] = ''
+        if attendee.managers:
+            account = attendee.managers[0]
+            if account and not any(attendee.badge_status != c.PENDING_STATUS for attendee in account.attendees):
+                session.delete(account)
+                cherrypy.session['attendee_account_id'] = ''
 
         Charge.pending_preregs.clear()
     session.commit()


### PR DESCRIPTION
If an attendee cancelled payment we were trying to delete their account even if they didn't have one, which was throwing an error. This should fix that.