### PR TITLE
Fix prereg badge buttons

### DIFF
--- a/uber/site_sections/badge_printing.py
+++ b/uber/site_sections/badge_printing.py
@@ -1,7 +1,7 @@
 import math
 
 from uber.config import c
-from uber.decorators import all_renderable
+from uber.decorators import all_renderable, not_site_mappable
 from uber.errors import HTTPRedirect
 from uber.models import Attendee
 from uber.utils import localized_now
@@ -85,6 +85,7 @@ class Root:
             'numberOfPrinters': numberOfPrinters
         }
 
+    @not_site_mappable
     def reprint_fee(self, session, attendee_id=None, message='',
                     fee_amount=0, reprint_reason='', refund=''):
         attendee = session.attendee(attendee_id)

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -245,7 +245,9 @@
         // is a dealer or group leader.
         if ($(BADGE_TYPES.row).size()) {
             // Actually, don't show any buttons at all for dealers
-            $(BADGE_TYPES.row).toggle($.field('badge_type').val() != '{{ c.PSEUDO_DEALER_BADGE }}')
+            if ($.field('badge_type').val() != '{{ c.PSEUDO_DEALER_BADGE }}') {
+              $("#badge-types").hide();
+            }
             $.each(BADGE_TYPES.options, function (i, badgeType) {
                 if (badgeType.badge_type && badgeType.badge_type != {{ c.ATTENDEE_BADGE }}) {
                     var current_button = $(BADGE_TYPES.selector).slice(i, 1+i);


### PR DESCRIPTION
The badge buttons we don't use anymore were showing up if you clicked on the Attendee registration type, this should stop that. Also hides a spurious link on the sitemap.