### PR TITLE
Allow non-registration admins to create attendees

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -648,7 +648,7 @@ def attendee_view(func):
         if cherrypy.session.get('account_id') is None:
             raise HTTPRedirect('../accounts/login?message=You+are+not+logged+in', save_location=True)
             
-        if kwargs.get('id') != "None":
+        if kwargs.get('id') and str(kwargs.get('id')) != "None":
             with uber.models.Session() as session:
                 attendee = session.attendee(kwargs.get('id'), allow_invalid=True)
                 if not session.admin_attendee_max_access(attendee):

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -700,10 +700,12 @@ class Session(SessionManager):
             if not admin:
                 return
                 
-            if admin.full_registration_admin or attendee.creator == admin.attendee or attendee == admin.attendee:
+            if admin.full_registration_admin or attendee.creator == admin.attendee or \
+                                                attendee == admin.attendee or attendee.is_new:
                 return AccessGroup.FULL
             
-            return max([admin.max_level_access(section, read_only=read_only) for section in attendee.access_sections])
+            if attendee.access_sections:
+                return max([admin.max_level_access(section, read_only=read_only) for section in attendee.access_sections])
 
         def admin_can_create_attendee(self, attendee):
             admin = self.current_admin_account()


### PR DESCRIPTION
We were erroneously checking if admins had access to an attendee even if that attendee was new -- this fixes that and adds an extra check to prevent the 500 error even if we run into something like this again.