### PR TITLE
Save free attendees to the database

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -492,6 +492,8 @@ class Root:
                     raise HTTPRedirect('index?message={}', message)
                 elif c.ATTENDEE_ACCOUNTS_ENABLED:
                     session.add_attendee_to_account(attendee, new_or_existing_account)
+                else:
+                    session.add(attendee)
 
             for group in charge.groups:
                 session.add(group)


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1005. We were only adding attendees to the session if attendee accounts was turned on, whoops.