### PR TITLE
Fix payments for MIVS groups

### DIFF
--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1066,7 +1066,8 @@ class Charge:
 
     @cached_property
     def receipt_email(self):
-        return self.models[0].email if self.models and self.models[0].email else self._receipt_email
+        email = self.models[0].email if self.models and self.models[0].email else self._receipt_email
+        return email[0] if isinstance(email, list) else email   
 
     @cached_property
     def names(self):


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1022. We were inadvertently sending Stripe a list instead of a string object, but only for MIVS groups (most models have just a single email address).