### PR TITLE
Enable shirt step before food restrictions are filled out

### DIFF
--- a/uber/templates/staffing/shirt_item.html
+++ b/uber/templates/staffing/shirt_item.html
@@ -2,7 +2,7 @@
 {% if c.HOURS_FOR_SHIRT and attendee.gets_any_kind_of_shirt %}
 <li>
     {{ macros.checklist_image(attendee.shirt_info_marked) }}
-    {% if not attendee.placeholder and attendee.food_restrictions_filled_out %}
+    {% if not attendee.placeholder %}
         <a href="shirt_size">Let us know</a>
     {% else %}
         Let us know


### PR DESCRIPTION
We re-ordered these steps again so we have to edit their prerequisites.