### PR TITLE
Fix placeholders report attendee links

### DIFF
--- a/uber/templates/dept_checklist/placeholders.html
+++ b/uber/templates/dept_checklist/placeholders.html
@@ -38,7 +38,7 @@ We create placeholder registrations for volunteers and ask them to fill out the 
 </tr>
 {% for attendee in placeholders %}
     <tr>
-        <td><a href="#attendee_form?id={{ attendee.id }}&return_to=../dept_checklist/placeholders">{{ attendee.full_name }}</a></td>
+        <td><a href="#attendee_form?id={{ attendee.id }}">{{ attendee.full_name }}</a></td>
         <td>{{ attendee.badge }}</td>
         <td>
             {% if attendee.group %}


### PR DESCRIPTION
On the placeholders report, an invalid parameter was accidentally included in the URL to open an attendee form. Now department heads should be able to view their placeholder attendees.