### PR TITLE
Fix shirt report for very old attendees

### DIFF
--- a/uber/site_sections/merch_reports.py
+++ b/uber/site_sections/merch_reports.py
@@ -60,7 +60,7 @@ class Root:
         def status(got_merch):
             return 'picked_up' if got_merch else 'outstanding'
 
-        sales_by_week = OrderedDict([(i, 0) for i in range(50)])
+        sales_by_week = OrderedDict([(i, 0) for i in range(52)])
 
         for attendee in session.all_attendees():
             shirt_label = attendee.shirt_label or 'size unknown'
@@ -73,7 +73,8 @@ class Root:
             counts['free_event_shirts'][label(shirt_label)][status(attendee.got_merch)] += attendee.num_free_event_shirts
             if attendee.paid_for_a_shirt:
                 counts['paid_event_shirts'][label(shirt_label)][status(attendee.got_merch)] += 1
-                sales_by_week[(min(datetime.now(UTC), c.ESCHATON) - attendee.registered).days // 7] += 1
+                sale_week = (min(datetime.now(UTC), c.ESCHATON) - attendee.registered).days // 7
+                sales_by_week[min(sale_week, 52)] += 1
 
         for week in range(48, -1, -1):
             sales_by_week[week] += sales_by_week[week + 1]

--- a/uber/templates/merch_reports/shirt_counts.html
+++ b/uber/templates/merch_reports/shirt_counts.html
@@ -28,6 +28,8 @@
             <li>
                 {% if weeks_ago == 0 %}
                     We have currently sold {{ count }} shirts.
+                {% elif weeks_age == 52 %}
+                    <b>{{ weeks_ago }} week{{ weeks_ago|pluralize }} or more ago:</b> {{ count }} shirt{{ count|pluralize }}
                 {% else %}
                     <b>{{ weeks_ago }} week{{ weeks_ago|pluralize }} ago:</b> {{ count }} shirt{{ count|pluralize }}
                 {% endif %}


### PR DESCRIPTION
Attendees whose 'registered' date was greater than 50 weeks ago were breaking our shirt sales by week report -- this should fix that.