### PR TITLE
Update reference to MIVS tournament email

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -882,7 +882,7 @@ if c.MIVS_ENABLED:
     MIVSEmailFixture(
         IndieGame,
         'MIVS: Tournaments and Leaderboard Challenges',
-        'mivs/2020/tournaments_2020.txt',
+        'mivs/confirmed/tournaments.txt',
         lambda game: game.confirmed,
         ident='mivs_tournaments'
     )


### PR DESCRIPTION
This will let us merge https://github.com/magfest/ubersystem/pull/3857 without breaking emails.