### PR TITLE
Don't mark actions as badge shifts if badge shifting is turned off

### DIFF
--- a/uber/models/tracking.py
+++ b/uber/models/tracking.py
@@ -142,7 +142,7 @@ class Tracking(MagModel):
         elif action == c.UPDATED:
             diff = cls.differences(instance)
             data = cls.format(diff)
-            if len(diff) == 1 and 'badge_num' in diff:
+            if len(diff) == 1 and 'badge_num' in diff and c.SHIFT_CUSTOM_BADGES:
                 action = c.AUTO_BADGE_SHIFT
             elif not data:
                 return


### PR DESCRIPTION
The tracking database code is so naive that admins changing badge numbers on purpose is marked as an automatic badge shift, even if the shift custom badge setting is False. This makes it at least smart enough to not scare people reviewing the tracking table into thinking that have shift_custom_badges set wrong.