### PR TITLE
Fix shift time in confirmation pop-up

### DIFF
--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -193,6 +193,7 @@
             events: eventList,
             eventDidMount: function(arg) {
                 var event = arg.event;
+                console.log(event.extendedProps);
                 var element = $(arg.el);
                 var view = arg.view;
                 var eventDesc = "";
@@ -213,7 +214,7 @@
                 }
 
                 buttonTag += "onclick=\"click_shift('" + event.extendedProps.taken + "','" + event.id + "','" +
-                moment(event.extendedProps.start).toISOString() + "','" + $('<div/>').text(event.title).html() + "')\"";
+                moment(event.start).toISOString() + "','" + $('<div/>').text(event.title).html() + "')\"";
 
                 buttonTag += '>';
                 if(event.extendedProps.taken) {


### PR DESCRIPTION
We were accessing the wrong property for events in the shift signup calendar, so the "Are you sure" popup was always listing the current time instead of the shift time. This fixes that.