### PR TITLE
Add group_name to registration index

### DIFF
--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -156,6 +156,8 @@
                 <td id="group_{{ attendee.id }}">
                     {% if attendee.group %}
                     <a href="../group_admin/form?id={{ attendee.group.id }}">{{ attendee.group.name }}</a>
+                    {% elif attendee.group_name %}
+                    {{ attendee.group_name }}
                     {% endif %}
                 </td>
                   <td id="promo_code_group_{{ attendee.id }}">


### PR DESCRIPTION
We're trying out a new group_name property this year, so it'd be helpful if registration staff could actually see that name in the list. Note that the group_name property itself is actually defined inside the magprime plugin, but printing an undefined variable in a template shouldn't cause major issues.