### PR TITLE
shifts: Add day-of-week to list-view day header.

### DIFF
--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -182,7 +182,8 @@
                 listConDuration: {
                     type: 'list',
                     duration: { days: {{ cal_length }} },
-                    buttonText: 'List'
+                    buttonText: 'List',
+                    listDaySideFormat: { weekday: 'long' }
                 }
             },
             initialView: 'listConDuration',


### PR DESCRIPTION
Shows the long day-of-week (e.g., "Wednesday") on the right-hand side of the day headers in the list view, under the `staffing/shifts` page.