### PR TITLE
Fix custom badge override for Reg and STOPS

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -639,14 +639,6 @@ class Config(_Overridable):
         return list(c.ADMIN_DEPARTMENTS.keys())[0] if c.ADMIN_DEPARTMENTS else 0
 
     @property
-    def DEFAULT_REGDESK_INT(self):
-        return getattr(self, 'REGDESK', getattr(self, 'REGISTRATION', 177161930))
-
-    @property
-    def DEFAULT_STOPS_INT(self):
-        return getattr(self, 'STOPS', 29995679)
-
-    @property
     def HTTP_METHOD(self):
         return cherrypy.request.method.upper()
 

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -470,8 +470,8 @@ def no_more_custom_badges(attendee):
     if (attendee.badge_type != attendee.orig_value_of('badge_type') or attendee.is_new) \
             and attendee.has_personalized_badge and c.AFTER_PRINTED_BADGE_DEADLINE:
         with Session() as session:
-            required_depts = [c.DEFAULT_REGDESK_INT, c.DEFAULT_STOPS_INT]
-            if all(not session.admin_attendee().is_dept_head_of(d) for d in required_depts):
+            admin = session.current_admin_account()
+            if not admin.full_registration_admin and not admin.full_shifts_admin:
                 return 'Custom badges have already been ordered so you cannot use this badge type'
 
 


### PR DESCRIPTION
The old override to create custom badges after the deadline was hacky and relied on specific department names. We now use the new permissions system to do the same thing.