### PR TITLE
Fix tracking links and get around bad tracking

### DIFF
--- a/uber/models/tracking.py
+++ b/uber/models/tracking.py
@@ -151,7 +151,9 @@ class Tracking(MagModel):
 
         links = ', '.join(
             '{}({})'.format(list(column.foreign_keys)[0].column.table.name, getattr(instance, name))
-            for name, column in instance.__table__.columns.items() if column.foreign_keys and getattr(instance, name))
+            for name, column in instance.__table__.columns.items() if column.foreign_keys
+                                                                   and 'creator' not in str(column)
+                                                                   and getattr(instance, name))
 
         if sys.argv == ['']:
             who = 'server admin'

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -331,10 +331,10 @@ class Root:
                                 .filter(or_(Email.to == attendee.email,
                                             and_(Email.model == 'Attendee', Email.fk_id == id)))
                                 .order_by(Email.when).all(),
-            'changes':   session.query(Tracking)
-                                .filter(or_(Tracking.links.like('%attendee({})%'.format(id)),
-                                            and_(Tracking.model == 'Attendee', Tracking.fk_id == id)))
-                                .order_by(Tracking.when).all(),
+            # TODO: Remove `, Tracking.model != 'Attendee'` for next event
+            'changes': session.query(Tracking).filter(
+                or_(and_(Tracking.links.like('%attendee({})%'.format(id)), Tracking.model != 'Attendee'),
+                    and_(Tracking.model == 'Attendee', Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'pageviews': session.query(PageViewTracking).filter(PageViewTracking.what == "Attendee id={}".format(id))
         }
 
@@ -841,8 +841,9 @@ class Root:
             'emails': session.query(Email).filter(
                 or_(Email.to == attendee.email,
                     and_(Email.model == 'Attendee', Email.fk_id == id))).order_by(Email.when).all(),
+            # TODO: Remove `, Tracking.model != 'Attendee'` for next event
             'changes': session.query(Tracking).filter(
-                or_(Tracking.links.like('%attendee({})%'.format(id)),
+                or_(and_(Tracking.links.like('%attendee({})%'.format(id)), Tracking.model != 'Attendee'),
                     and_(Tracking.model == 'Attendee', Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'pageviews': session.query(PageViewTracking).filter(PageViewTracking.what == "Attendee id={}".format(id)),
         }


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1035, mostly.

The tracking table links each entry to other models by way of a `links` list and automatically builds this list by looking at foreign keys for the instance it is tracking. However, since added the `creator` field to Attendees and Groups, admins would be linked to every single attendee and group they ever made, and all THOSE attendee/groups' changes would be linked to that admin.

Creators of attendees/groups are now excluded from the `links` list, but there's already thousands upon thousands of rows in the tracking table with erroneous links. There's no clean way to fix the data, so we are now also filtering out tracking results for any attendees that are linked to the admin attendee (other linked models' changes are still included). This doesn't fix groups' changes appearing, but we don't want to hide tracking data for those since that will also hide tracking data for groups you're the leader of. That is probably the best we can do for this year.

In the future we should probably look a little closer at the implication of how we build the `links` list while tracking changes, as there are a lot of relationships on the attendee table that shouldn't necessarily show up in that attendee's history.