### PR TITLE
Make printed badge export more useful

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -338,7 +338,7 @@ def xlsx_file(func):
         if set_headers:
             cherrypy.response.headers['Content-Type'] = \
                 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-            _set_response_filename(func.__name__ + '.xlsx')
+            _set_response_filename(func.__name__ + datetime.now().strftime('%Y%m%d') + '.xlsx')
 
         return output
     return xlsx_out
@@ -360,7 +360,7 @@ def csv_file(func):
         # set headers last in case there were errors, so end user still see error page
         if set_headers:
             cherrypy.response.headers['Content-Type'] = 'application/csv'
-            _set_response_filename(func.__name__ + '.csv')
+            _set_response_filename(func.__name__ + datetime.now().strftime('%Y%m%d') + '.csv')
 
         return output
     return csvout

--- a/uber/reports.py
+++ b/uber/reports.py
@@ -11,7 +11,7 @@ class ReportBase:
     def write_row(self, row, out):
         if self._include_badge_nums:
             # add in the barcodes here
-            badge_num = row[0]
+            badge_num = row[1]
             barcode = generate_barcode_from_badge_num(badge_num)
             row.append(barcode)
 
@@ -23,20 +23,12 @@ class PersonalizedBadgeReport(ReportBase):
         self._include_badge_nums = include_badge_nums
 
     def run(self, out, session, *filters, order_by=None, badge_type_override=None):
-        badge_nums_seen = []
-
         for a in (session.query(Attendee)
                          .filter(Attendee.has_badge == True, *filters)
                          .order_by(order_by).all()):
 
-            # sanity check no duplicate badges
-            if a.badge_num:
-                if a.badge_num in badge_nums_seen:
-                    raise ValueError("duplicate badge number detected: %s" % a.badge_num)
-                badge_nums_seen += [a.badge_num]
-
             # write the actual data
-            row = [a.badge_num] if self._include_badge_nums else []
+            row = [a.id, a.badge_num] if self._include_badge_nums else [a.id]
             if badge_type_override:
                 if callable(badge_type_override):
                     badge_type_label = badge_type_override(a)
@@ -70,4 +62,4 @@ class PrintedBadgeReport(ReportBase):
         empty_customized_name = ''
 
         for badge_num in range(min_badge_num, max_badge_num):
-            self.write_row([badge_num, self._badge_type_name, empty_customized_name, ''], out)
+            self.write_row(['', badge_num, self._badge_type_name, empty_customized_name, ''], out)

--- a/uber/site_sections/badge_exports.py
+++ b/uber/site_sections/badge_exports.py
@@ -52,7 +52,8 @@ class Root:
         minimum_extra_amount = c.BLANK_STAFF_BADGES
 
         max_badges = max(c.BADGE_RANGES[c.STAFF_BADGE][1], c.BADGE_RANGES[c.CONTRACTOR_BADGE][1])
-        start_badge = max_badges - minimum_extra_amount + 1
+        last_taken_badge = session.query(Attendee).order_by(Attendee.badge_num.desc()).first().badge_num
+        start_badge = max(last_taken_badge, max_badges - minimum_extra_amount + 1)
         end_badge = max_badges
 
         generate_staff_badges(start_badge, end_badge, out, session)


### PR DESCRIPTION
Alters the printed badge export to include attendee IDs, so that if for some reason in the future we need to set the system back to the time we sent the badge data to the printer we can do that easier. Also fixes a bug where the extra badges might overlap existing badges, and adds YYYYMMDD to the filename of all CSV and XLSX exports.