### PR TITLE
Improve attendee search and add export for searched attendees

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1547,12 +1547,12 @@ class Session(SessionManager):
 
             def check_text_fields(search_text):
                 check_list = [
-                    Group.name.ilike('%' + text + '%'),
-                    aliased_pcg.name.ilike('%' + text + '%')
+                    Group.name.ilike('%' + search_text + '%'),
+                    aliased_pcg.name.ilike('%' + search_text + '%')
                 ]
 
                 for attr in Attendee.searchable_fields:
-                    check_list.append(getattr(Attendee, attr).ilike('%' + text + '%'))
+                    check_list.append(getattr(Attendee, attr).ilike('%' + search_text + '%'))
                 
                 return check_list
 
@@ -1563,6 +1563,7 @@ class Session(SessionManager):
 
                 for search_text in list_of_attr_searches:
                     if ':' not in search_text:
+                        last_term = search_text
                         search_text = search_text.replace('AND', '').replace('OR', '').strip()
                         or_checks.extend(check_text_fields(search_text))
                     else:
@@ -1610,11 +1611,13 @@ class Session(SessionManager):
                 or_checks.extend(check_text_fields(text))
             
             if or_checks and and_checks:
-                return attendees.filter(and_(or_(*or_checks), and_(*and_checks))), ''
+                return attendees.filter(or_(*or_checks), and_(*and_checks)), ''
             elif or_checks:
                 return attendees.filter(or_(*or_checks)), ''
-            else:
+            elif and_checks:
                 return attendees.filter(and_(*and_checks)), ''
+            else:
+                return attendees
 
         def delete_from_group(self, attendee, group):
             """

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1466,8 +1466,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @classproperty
     def searchable_bools(cls):
-        return ['placeholder', 'requested_accessibility_services', 'can_spam', 
-                'got_merch', 'got_staff_merch', 'confirmed', 'checked_in', 'staffing', 
+        return ['placeholder', 'can_spam', 'got_merch', 'got_staff_merch', 'confirmed', 'checked_in', 'staffing', 
                 'agreed_to_volunteer_agreement', 'reviewed_emergency_procedures', 'walk_on_volunteer', 
                 'can_work_setup', 'can_work_teardown', 'hotel_eligible', 'attractions_opt_out']
     

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1458,6 +1458,23 @@ class Attendee(MagModel, TakesPaymentMixin):
     def _extra_apply_attrs_restricted(cls):
         return set(['requested_depts_ids'])
 
+    @classproperty
+    def searchable_attrs(cls):
+        # List of fields for the attendee search to check search terms against
+        return ['first_name', 'last_name', 'legal_name', 'badge_printed_name',
+                'email', 'comments', 'admin_notes', 'for_review', 'promo_code_group_name']
+
+    @classproperty
+    def searchable_bools(cls):
+        return ['placeholder', 'requested_accessibility_services', 'can_spam', 
+                'got_merch', 'got_staff_merch', 'confirmed', 'checked_in', 'staffing', 
+                'agreed_to_volunteer_agreement', 'reviewed_emergency_procedures', 'walk_on_volunteer', 
+                'can_work_setup', 'can_work_teardown', 'hotel_eligible', 'attractions_opt_out']
+    
+    @classproperty
+    def searchable_choices(cls):
+        return ['age_group', 'badge_type', 'badge_status', 'paid', 'amount_extra']
+
     @property
     def assigned_depts_labels(self):
         return [d.name for d in self.assigned_depts]

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -167,8 +167,11 @@ class Root:
         
         search_text = search_text.strip()
         if search_text:
-            attendees = session.search(search_text) if invalid else session.search(search_text, filter)
+            attendees, error = session.search(search_text) if invalid else session.search(search_text, filter)
 
+        if error:
+            raise HTTPRedirect('../registration/index?search_text={}&order={}&invalid={}&message={}'
+                              ).format(search_text, order, invalid, error)
         attendees = attendees.order(order)
 
         rows = devtools.prepare_model_export(Attendee, filtered_models=attendees)

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -9,9 +9,10 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from uber.config import c, _config
 from uber.custom_tags import pluralize
-from uber.decorators import ajax, all_renderable, not_site_mappable, site_mappable
+from uber.decorators import ajax, all_renderable, csv_file, not_site_mappable, site_mappable
 from uber.errors import HTTPRedirect
 from uber.models import Attendee, Department, DeptMembership, DeptMembershipRequest
+from uber.site_sections import devtools
 from uber.utils import get_api_service_from_server, normalize_email
 
 
@@ -158,6 +159,21 @@ class Root:
         return {
             'attendees': unpaid_attendees,
         }
+
+    @csv_file
+    @not_site_mappable
+    def attendee_search_export(self, out, session, search_text='', order='last_first', invalid=''):
+        filter = Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS, c.WATCHED_STATUS]) if not invalid else None
+        
+        search_text = search_text.strip()
+        if search_text:
+            attendees = session.search(search_text) if invalid else session.search(search_text, filter)
+
+        attendees = attendees.order(order)
+
+        rows = devtools.prepare_model_export(Attendee, filtered_models=attendees)
+        for row in rows:
+            out.writerow(row)
 
     def import_attendees(self, session, target_server='', api_token='', query='', message=''):
         service, service_message, target_url = get_api_service_from_server(target_server, api_token)

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -78,7 +78,9 @@ class Root:
         count = 0
         search_text = search_text.strip()
         if search_text:
-            attendees = session.search(search_text) if invalid else session.search(search_text, filter)
+            search_results, message = session.search(search_text) if invalid else session.search(search_text, filter)
+            if search_results:
+                attendees = search_results
             count = attendees.count()
         if not count:
             attendees = attendees.options(joinedload(Attendee.group))
@@ -89,7 +91,7 @@ class Root:
         page = int(page)
         if search_text:
             page = page or 1
-            if search_text and count == total_count:
+            if search_text and count == total_count and not message:
                 message = 'No matches found'
             elif search_text and count == 1 and (not c.AT_THE_CON or search_text.isdigit()):
                 raise HTTPRedirect(

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -68,11 +68,14 @@
         <a class="btn btn-primary" href="form?id=None">Add an attendee</a>
 
         {% if invalid  %}
-            <a class="btn btn-info" href="index?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode }}">Hide invalid badges</a>
+            <a class="btn btn-info" href="index?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode }}">Hide Invalid Badges</a>
         {% else %}
-            <a class="btn btn-info" href="index?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode }}&invalid=True">Show all badge statuses</a>
+            <a class="btn btn-info" href="index?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode }}&invalid=True">Show All Badges</a>
         {% endif %}
 
+        {% if c.HAS_REG_ADMIN_ACCESS and search_results and attendees %}
+        <a class="btn btn-success" href="#" onClick="exportSearch()">Export Current Search</a>
+        {% endif %}
         <div class="form-group">
         <style type="text/css">
         .collapse.in {
@@ -89,6 +92,26 @@
       </form>
     </div>
 </div>
+
+<script type="text/javascript">
+  var exportSearch = function exportSearch () {
+    bootbox.confirm({
+        backdrop: true,
+        message: '<p>Are you sure you want to export all attendees from this search?' +
+                 ' Searches with large numbers of results will slow down the system!</p>',
+        buttons: {
+          confirm: { label: 'Yes, Export All The Data!', className: 'btn-success' },
+          cancel: { label: 'Nevermind', className: 'btn-default' }
+        },
+        callback: function (result) {
+          if (result) {
+            window.location = '../reg_admin/attendee_search_export?order={{ order }}&search_text={{ search_text|urlencode }}&invalid={{ invalid }}'
+          }
+        }
+      });
+      return false;
+  };
+</script>
 
 <div class="row" style="margin-top: 15px;">
     <div class="col-xs-12">


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1064. You can now search attendees by several attributes, and reg admins can export search results into a CSV file. It is also possible to include both AND and OR conditions in a search.

To search by attributes, use `attribute_name:search_text`. Most attributes will be either `true` or `false`, e.g., `staffing:true` or `placeholder:false`, but badge type, badge status, paid status, and amount_extra (the column for kick-ins) are all searchable by labels, e.g., `badge_type:staff`, `paid:yes`, or `badge_status:deferred`. These labels will correspond to the text associated with that attribute in the system, e.g., all the labels for badge type can be viewed in the badge type dropdown box. `amount_extra` can also be searched by dollar value, e.g., `amount_extra:200`. Finally, you can search for attendees with a certain ribbon by using `has_ribbon:volunteer`

Searches can be either comma-separated, connected by AND, or connected by OR. AND/OR must be in all caps to count as a connecting term. Any search terms with OR before or after them will be or-searches, and all other terms will be and-searches. So a search of `badge_type:staff AND placeholder:true OR badge_status:deferred` will pull only staff badges, but the badges can either be placeholder badges or Deferred badges.

Right now the true/false attribute names are:
- placeholder
- can_spam
- got_merch
- got_staff_merch
- confirmed
- checked_in
- staffing
- agreed_to_volunteer_agreement
- reviewed_emergency_procedures
- walk_on_volunteer
- can_work_setup
- can_work_teardown
- hotel_eligible
- attractions_opt_out

The attribute names for label searches are:
- has_ribbon
- age_group
- badge_type
- badge_status
- paid
- amount_extra

You can also search for `email:email@example.com` or `group:Group Name`, which you could already do, but I thought I'd mention it.

Note that AND and OR do not apply to freeform text field searches (i.e., search terms that DON'T look like `attribute_name:search_text`) except when combined with attribute searches. So `GuestGroupName AND badge_type:staff` is a valid search, but `GuestGroupName AND AttendeeFirstName AND badge_type:staff` will just search text fields on Staff type badges for the full string `GuestGroupName AND AttendeeFirstName`.