### PR TITLE
Add badge_num_required and signups_open to Attractions

### DIFF
--- a/alembic/versions/26bc228319d2_add_columns_for_attractions_requiring_.py
+++ b/alembic/versions/26bc228319d2_add_columns_for_attractions_requiring_.py
@@ -1,0 +1,63 @@
+"""Add columns for attractions requiring badge number and being read-only
+
+Revision ID: 26bc228319d2
+Revises: a3e65433bd72
+Create Date: 2022-01-01 23:01:12.406456
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '26bc228319d2'
+down_revision = 'a3e65433bd72'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attraction', sa.Column('badge_num_required', sa.Boolean(), server_default='False', nullable=False))
+    op.add_column('attraction_event', sa.Column('signups_open', sa.Boolean(), server_default='True', nullable=False))
+    op.add_column('attraction_feature', sa.Column('badge_num_required', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('attraction_feature', 'badge_num_required')
+    op.drop_column('attraction_event', 'signups_open')
+    op.drop_column('attraction', 'badge_num_required')

--- a/uber/models/attraction.py
+++ b/uber/models/attraction.py
@@ -75,6 +75,7 @@ class Attraction(MagModel):
     advance_notices = Column(JSON, default=[], server_default='[]')
     advance_checkin = Column(Integer, default=0)  # In seconds
     restriction = Column(Choice(_RESTRICTION_OPTS), default=_NONE)
+    badge_num_required = Column(Boolean, default=False)
     department_id = Column(UUID, ForeignKey('department.id'), nullable=True)
     owner_id = Column(UUID, ForeignKey('admin_account.id'))
 
@@ -218,6 +219,7 @@ class AttractionFeature(MagModel):
     slug = Column(UnicodeText)
     description = Column(UnicodeText)
     is_public = Column(Boolean, default=False)
+    badge_num_required = Column(Boolean, default=False)
     attraction_id = Column(UUID, ForeignKey('attraction.id'))
 
     events = relationship(
@@ -297,6 +299,7 @@ class AttractionEvent(MagModel):
     start_time = Column(UTCDateTime, default=c.EPOCH)
     duration = Column(Integer, default=900)  # In seconds
     slots = Column(Integer, default=1)
+    signups_open = Column(Boolean, default=True)
 
     signups = relationship('AttractionSignup', backref='event', order_by='AttractionSignup.checkin_time')
 

--- a/uber/site_sections/attractions.py
+++ b/uber/site_sections/attractions.py
@@ -167,9 +167,11 @@ class Root:
     @ajax
     def signup_for_event(self, session, id, badge_num='', first_name='',
                          last_name='', email='', zip_code='', **params):
+        event = _model_for_id(session, AttractionEvent, id)
+        if not event:
+            return {'error': 'Unrecognized event id: {}'.format(id)}
 
-        # Badge number during the event is a hard requirement for Autographs
-        if badge_num or c.AFTER_EPOCH:
+        if badge_num or event.feature.badge_num_required:
             attendee = _attendee_for_badge_num(session, badge_num)
             if not attendee:
                 return {
@@ -187,10 +189,6 @@ class Root:
         if attendee.attractions_opt_out:
             return {'error': 'That attendee has disabled attraction signups'}
 
-        event = _model_for_id(session, AttractionEvent, id)
-        if not event:
-            return {'error': 'Unrecognized event id: {}'.format(id)}
-
         old_remaining_slots = event.remaining_slots
 
         if event not in attendee.attraction_events:
@@ -206,6 +204,9 @@ class Root:
 
             if event.is_sold_out:
                 return {'error': '{} is already sold out'.format(event.label)}
+            
+            if not event.signups_open:
+                return {'error': '{} is not yet available for signups'.format(event.label)}
 
             event.attendee_signups.append(attendee)
             session.commit()

--- a/uber/site_sections/attractions_admin.py
+++ b/uber/site_sections/attractions_admin.py
@@ -1,3 +1,4 @@
+from re import T
 import uuid
 from datetime import datetime, timedelta
 
@@ -77,6 +78,32 @@ class Root:
             'message': message,
             'attraction': attraction
         }
+
+    @ajax
+    def open_signups(self, session, **params):
+        feature = session.attraction_feature(params.get('feature_id'))
+        if not feature:
+            return {'error': 'Feature not found!'}
+
+        for event in feature.events_by_location_by_day[int(params.get('location'))][params.get('day')]:
+            event.signups_open = True
+            session.add(event)
+        
+        session.commit()
+        return {'success': True}
+
+    @ajax
+    def close_signups(self, session, **params):
+        feature = session.attraction_feature(params.get('feature_id'))
+        if not feature:
+            return {'error': 'Feature not found!'}
+
+        for event in feature.events_by_location_by_day[int(params.get('location'))][params.get('day')]:
+            event.signups_open = False
+            session.add(event)
+        
+        session.commit()
+        return {'success': True}
 
     def new(self, session, message='', **params):
         if params.get('id', 'None') != 'None':

--- a/uber/templates/attractions/attractions_common.html
+++ b/uber/templates/attractions/attractions_common.html
@@ -44,7 +44,7 @@
     color: #fff;
   }
 
-  .event.soldout {
+  .event.soldout .event.unavailable {
     display: none;
   }
 
@@ -158,6 +158,7 @@
     background-color: #fff;
   }
 
+  .unavailable .btn-next,
   .soldout .btn-next,
   .btn-next:disabled,
   .btn-next[disabled] {
@@ -249,6 +250,7 @@
   }
 
   .hover-btn.soldout:hover,
+  .hover-btn.unavailable:hover,
   .hover-btn:hover:disabled,
   .hover-btn:hover[disabled] {
     background-color: #f6f6f6;

--- a/uber/templates/attractions/events.html
+++ b/uber/templates/attractions/events.html
@@ -70,7 +70,7 @@
           eventId = $event.data('eventId'),
           isSoldout = $event.hasClass('soldout');
 
-      if (isSoldout) {
+      if (isSoldout || $event.hasClass('unavailable')) {
         return;
       }
 
@@ -247,8 +247,7 @@
         {{ attractions_macros.badge_num_form('All we need is your badge number!') }}
       </div>
       <div class="modal-footer">
-        {# Signups with a badge number during the event is a hard requirement for Autographs #}
-        {% if c.BEFORE_EPOCH %}
+        {% if not feature.badge_num_required %}
           <button class="btn btn-default btn-lg btn-xl modal-form-switch">Sign up without badge #</button>
         {% endif %}
         <button class="btn btn-default btn-lg btn-xl" data-dismiss="modal">Nevermind</button>
@@ -398,7 +397,8 @@
           <h2 id="{{ day }}">{{ day }}</h2>
           {% for event in events %}
             {%- set is_soldout = event.is_sold_out -%}
-            <div class="event hover-btn{% if is_soldout %} soldout{% endif %}"
+            {%- set is_unavailable = not event.signups_open -%}
+            <div class="event hover-btn{% if is_soldout %} soldout{% endif %}{% if is_unavailable %} unavailable{% endif %}"
                 id="{{ event.id }}"
                 data-event-id="{{ event.id }}"
                 data-event-name="{{ event.name }}"
@@ -426,10 +426,16 @@
                     <em class="slots">{{ event.slots }}</em>
                     slot{{ event.slots|pluralize }} taken
                   </span>
+                  {% if event.signups_open %}
                   <span class="hidden-soldout">
                     <em class="slots remaining-slots">{{ event.remaining_slots }}</em> out of
                     <em class="slots total-slots">{{ event.slots }}</em> slot{{ event.slots|pluralize }} available
                   </span>
+                  {% else %}
+                  <span class="hidden-soldout">
+                    <em>This event is not open for signups right now.</em>
+                  </span>
+                  {% endif %}
                 </p>
                 <p class="visible-signedup-inline"><em class="text-success">You are signed up for this event!</em></p>
               </div>

--- a/uber/templates/attractions_admin/event.html
+++ b/uber/templates/attractions_admin/event.html
@@ -145,6 +145,14 @@
     </div>
   </div>
   <div class="form-group">
+    <label class="col-sm-3 control-label optional-field">Signups Open</label>
+    <div class="checkbox col-sm-6">
+        <label class="checkbox-label">
+        {{ macros.checkbox(event, 'signups_open', is_readonly=read_only, clientside_bool=clientside_bool) }}
+        Attendees can currently sign up for this event.
+    </div>
+  </div>
+  <div class="form-group">
     <label class="col-sm-3 control-label">Location</label>
     <div class="col-sm-6">
       <select name="location" class="form-control">

--- a/uber/templates/attractions_admin/feature.html
+++ b/uber/templates/attractions_admin/feature.html
@@ -48,6 +48,18 @@
     </div>
   </div>
   <div class="form-group">
+    <div class="col-sm-offset-3 col-sm-9">
+      <label class="checkbox-label">
+        <input type="checkbox" name="badge_num_required" value="1"
+            {%- if (not is_class and feature.badge_num_required) or attraction.badge_num_required %} checked="checked"{% endif %}/>
+        Require badge number for signups
+      </label>
+      <p class="help-block">
+        The events in this feature will require a badge number to sign up.
+      </p>
+    </div>
+  </div>
+  <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
       <input type="submit" name="save" class="btn btn-primary" value="Save">
       <a href="form?id={{ attraction.id }}" type="button" class="btn btn-default">Cancel</a>

--- a/uber/templates/attractions_admin/form.html
+++ b/uber/templates/attractions_admin/form.html
@@ -357,7 +357,7 @@
       });
     };
 
-    $('.room-col').on('click', '.btn-danger', function(event) {
+    $('.room-col').on('click', '.delete-event', function(event) {
       event.preventDefault();
       var $button = $(this);
           eventId = $button.data('eventId'),
@@ -410,6 +410,87 @@
         }
       });
     };
+
+    openSignups = function(featureId, location, day) {
+      bootbox.confirm({
+        backdrop: true,
+        message: '<p><strong>Open ' + features[featureId] + ' signups in ' + allLocations[location] + ' for ' + day + '?</strong></p>' +
+                 'This will allow attendees to sign up for all the events in this location on this day' +
+                 '{% if not attraction.is_public %} once this attraction is made public and{% endif %}'+ 
+                 ' as long as this feature is open to the public.',
+        buttons: {
+          confirm: { label: 'Open Signups', className: 'btn-success' },
+          cancel: { label: 'Nevermind', className: 'btn-default' }
+        },
+        callback: function(result) {
+          if (result) {
+            $.ajax({
+              method: 'POST',
+              url: 'open_signups',
+              data: {
+                feature_id: featureId,
+                location: location,
+                day: day,
+                csrf_token: csrf_token
+              },
+              success: function(response, status) {
+                if (response['error']) {
+                    toastr.error('There was an error opening signups: ' + response['error']);
+                } else {
+                    toastr.success('Signups for all ' + features[featureId] + ' events on ' + day + ' opened!', {timeOut: 2000});
+                    $('#' + featureId + '_' + location + '_' + day + ' .open-signups').hide();
+                    $('#' + featureId + '_' + location + '_' + day + ' .close-signups').show();
+                }
+              },
+              error: function(response, status) {
+                toastr.error(response);
+              }
+          });
+          }
+        }
+      });
+      return false;
+    }
+
+    closeSignups = function(featureId, location, day) {
+      bootbox.confirm({
+        backdrop: true,
+        message: '<p><strong>Close ' + features[featureId] + ' signups in ' + allLocations[location] + ' for ' + day + '?</strong></p>' +
+                 'This will allow attendees to see the events but not sign up for them.' + 
+                 ' Events are automatically closed to signups when the event starts or when check-in closes.',
+        buttons: {
+          confirm: { label: 'Close Signups', className: 'btn-danger' },
+          cancel: { label: 'Nevermind', className: 'btn-default' }
+        },
+        callback: function(result) {
+          if (result) {
+            $.ajax({
+              method: 'POST',
+              url: 'close_signups',
+              data: {
+                feature_id: featureId,
+                location: location,
+                day: day,
+                csrf_token: csrf_token
+              },
+              success: function(response, status) {
+                if (response['error']) {
+                    toastr.error('There was an error closing signups: ' + response['error']);
+                } else {
+                    toastr.success('Signups for all ' + features[featureId] + ' events on ' + day + ' closed!', {timeOut: 2000});
+                    $('#' + featureId + '_' + location + '_' + day + ' .close-signups').hide();
+                    $('#' + featureId + '_' + location + '_' + day + ' .open-signups').show();
+                }
+              },
+              error: function(response, status) {
+                toastr.error(response);
+              }
+          });
+          }
+        }
+      });
+      return false;
+    }
 
     $('.room-title > select').on('change', function(event) {
       var $select = $(this);
@@ -631,6 +712,9 @@
       <b>NOT</b> open to the public.
     {% endif %}
   </p>
+  {% if attraction.badge_num_required %}
+  <p>Features will require a badge number by default.</p>
+  {% endif %}
   {% if attraction.department_id -%}
     <p class="help-block">
       <em>The {{ attraction.name }} attraction belongs to the {{ attraction.department|form_link }} department.</em>
@@ -721,6 +805,13 @@
                     <b>NOT</b> open to the public.
                   {% endif %}
                 </p>
+                <p>
+                  {% if feature.badge_num_required %}
+                  Attendees <b>MUST</b> sign up with their badge number.
+                  {% else %}
+                  Attendees may sign up with a badge number or their personal information.
+                  {% endif %}
+                </p>
               </div>
               {%- set events_by_location_by_day = feature.events_by_location_by_day -%}
               {% if events_by_location_by_day %}
@@ -758,7 +849,16 @@
                                 {% endfor %}
                               </div>
                             {% endif %}
-                            <h2 id="{{ feature.id }}_{{ location }}_{{ day }}">{{ day }}</h2>
+                            <h2 id="{{ feature.id }}_{{ location }}_{{ day }}">{{ day }} 
+                                <button class="btn btn-sm btn-success open-signups" 
+                                        onClick="openSignups('{{ feature.id }}', '{{ location }}', '{{ day }}')"
+                                        {% if events|rejectattr("signups_open")|list %}{% else %}style="display:none"{% endif %}>
+                                        Open Signups for This Day's Events</button>
+                                <button class="btn btn-sm btn-danger close-signups"
+                                        onClick="closeSignups('{{ feature.id }}', '{{ location }}', '{{ day }}')"
+                                        {% if feature.is_public and events|selectattr("signups_open")|list and not events|selectattr("signups")|list %}{% else %}style="display:none"{% endif %}>
+                                        Close Signups for This Day's Events</button>
+                            </h2>
                             {% for event in events %}
                               <div class="event {% if event.remaining_slots > 0 %} info-block{% else %} success-block{% endif%}"
                                   style="min-height: {{ (event.duration // 90) - 6 }}px">
@@ -769,7 +869,7 @@
                                         href="event?id={{ event.id }}">
                                       <span class="glyphicon glyphicon-cog"></span>
                                     </a>
-                                    <button type="submit" class="btn btn-xs btn-danger btn-fade" data-event-id="{{ event.id }}" data-event-label="{{ feature.name }} at {{ event.start_time_label }}">
+                                    <button type="submit" class="btn btn-xs btn-danger btn-fade delete-event" data-event-id="{{ event.id }}" data-event-label="{{ feature.name }} at {{ event.start_time_label }}">
                                       <span class="glyphicon glyphicon-remove"></span>
                                     </button>
                                   </div>

--- a/uber/templates/attractions_macros.html
+++ b/uber/templates/attractions_macros.html
@@ -162,6 +162,18 @@
     </div>
   </div>
   <div class="form-group">
+    <div class="col-sm-offset-3 col-sm-9">
+      <label class="checkbox-label">
+        <input type="checkbox" name="badge_num_required" value="1"
+          {%- if not is_class and attraction.badge_num_required %} checked="checked"{% endif %}/>
+          Require badge number for signups
+      </label>
+      <p class="help-block">
+        The features in this attraction will require a badge number to sign up by default.
+      </p>
+    </div>
+  </div>
+  <div class="form-group">
     <label class="col-sm-3 control-label">Belongs to Department</label>
     <div class="col-sm-6">
       <select name="department_id" class="form-control">


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1058. Fixes https://jira.magfest.net/browse/MAGDEV-1057.

Attractions can now always be signed up for without a badge number unless a feature is set otherwise. You can also set an Attraction to require badge numbers to change the default when creating features.

Events can now also be set to have signups open or closed (AKA, "read-only"). To make managing this easier, there's a new set of buttons on the features overview that allows you to close or open signups for all events per location, per day.