### PR TITLE
Add ability to let attendees self-defer badges

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -373,6 +373,13 @@ collect_full_address = boolean(default=False)
 # donations during pre-reg.
 collect_extra_donation = boolean(default=False)
 
+# If true, attendees not in groups can opt to defer their own badge.
+self_service_deferrals_open = boolean(default=False)
+
+# If this is set, deferring attendees will be prompted for a mailing address 
+# and asked to pay this fee.
+merch_shipping_fee = integer(default=15)
+
 # This URL, if set, will show up alongside or without the above extra donation field
 extra_donation_url = string(default="")
 

--- a/uber/site_sections/attractions.py
+++ b/uber/site_sections/attractions.py
@@ -139,7 +139,7 @@ class Root:
             raise HTTPRedirect('index')
         if attendee.amount_unpaid:
             raise HTTPRedirect(
-                '../preregistration/attendee_donation_form?id={}', attendee.id)
+                '{}?id={}', attendee.payment_page, attendee.id)
         return {
             'attractions': session.query(Attraction).order_by('name').all(),
             'attendee': attendee,

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -549,7 +549,7 @@
 
 {% set amount_extra %}
 {% set read_only = amount_extra_ro or page_ro %}
-{% if c.DONATIONS_ENABLED and not admin_area %}
+{% if c.DONATIONS_ENABLED and not admin_area and not read_only %}
   {% if c.PREREG_DONATION_OPTS and c.PREREG_DONATION_OPTS|length > 1 or attendee.amount_extra or attendee.gets_any_kind_of_shirt %}
     <script type="text/javascript">
         var donationChanged = function () {
@@ -685,7 +685,7 @@
     <div class="form-control-static">{{ macros.popup_link("../static_views/affiliates.html", "What's an affiliate?") }}</div>
   </div>
 {% endif %}
-{% if admin_area %}
+{% if admin_area or read_only %}
   <div class="form-group">
     <label class="col-sm-3 control-label">Kick-in/Upgrade</label>
     {% call macros.read_only_if(read_only, attendee.amount_extra_label or "None") %}
@@ -1044,7 +1044,7 @@ If you're interested in kicking in an extra donation, you can{% if c.COLLECT_EXT
 
 {% set address %}
 {% set read_only = address_ro or page_ro %}
-{% if c.COLLECT_FULL_ADDRESS %}
+{% if c.COLLECT_FULL_ADDRESS or attendee.shipping_fee_cost %}
   <script type="text/javascript">
       {% include "region_opts.html" %}
 

--- a/uber/templates/preregistration/attendee_donation_form.html
+++ b/uber/templates/preregistration/attendee_donation_form.html
@@ -6,7 +6,7 @@
 <div class="panel panel-default">
   <div class="panel-body">
     {% if attendee.paid == c.NOT_PAID %}
-      <h2> Badge Payment for {{ attendee.full_name }} </h2>
+      <h3> Badge Payment for {{ attendee.full_name }} </h3>
 
       You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of {{ attendee.badge_cost|format_currency }}{% if attendee.amount_extra %} and you've also kicked in {{ attendee.amount_extra|format_currency }}{% endif %}; your total outstanding balance is {{ attendee.amount_unpaid|format_currency }}.
 
@@ -30,8 +30,18 @@
           <input type="hidden" name="id" value="{{ attendee.id }}"/>
         </form>
       {% endif %}
-    {% else %}
-      <h2> Extra Payment for {{ attendee.full_name }} </h2>
+    {% elif payment_label %}
+      <h3>{{ payment_label|replace('_', ' ')|title }} Payment for {{ attendee.full_name }}</h3>
+      <p>Please pay {{ attendee.amount_unpaid|format_currency }} for your {{ payment_label|replace('_', ' ') }} below.</p>
+      <table style="width:auto ; margin-left:auto ; margin-right: auto">
+        <tr class="stripe_form">
+          <td>{{ stripe_form('process_attendee_donation', attendee) }}</td>
+          <td style="width:100px ; text-align:center">or</td>
+          <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
+        </tr>
+      </table>
+    {% elif attendee.amount_extra %}
+      <h3> Extra Payment for {{ attendee.full_name }} </h3>
 
       Thanks for offering to kick in money to help make {{ c.EVENT_NAME }} better.  As thanks, your total donation (of which {{ attendee.amount_unpaid|format_currency }} is outstanding) entitles you to the following:
       <ul>
@@ -40,6 +50,16 @@
         {% endfor %}
       </ul>
 
+      <table style="width:auto ; margin-left:auto ; margin-right: auto">
+        <tr class="stripe_form">
+          <td>{{ stripe_form('process_attendee_donation', attendee) }}</td>
+          <td style="width:100px ; text-align:center">or</td>
+          <td><a href="undo_attendee_donation?id={{ attendee.id }}">{{ macros.stripe_button("Nevermind") }}</a></td>
+        </tr>
+      </table>
+    {% else %}
+      <h3>Payment for {{ attendee.full_name }}</h3>
+      <p>Please pay {{ attendee.amount_unpaid|format_currency }} below.</p>
       <table style="width:auto ; margin-left:auto ; margin-right: auto">
         <tr class="stripe_form">
           <td>{{ stripe_form('process_attendee_donation', attendee) }}</td>

--- a/uber/templates/preregistration/badge_refund.html
+++ b/uber/templates/preregistration/badge_refund.html
@@ -13,16 +13,16 @@
             As a leader of a group, you cannot abandon your badge.
         {% elif attendee.amount_paid %}
             We cannot automatically refund your badge at the moment due to technical difficulties.
-        {% elif attendee.badge_type == c.STAFF_BADGE %}
+        {% elif attendee.badge_type in [c.STAFF_BADGE, c.CONTRACTOR_BADGE] %}
             Please contact {{ c.STAFF_EMAIL|email_only }} to cancel or defer your badge.
         {% elif attendee.paid == c.NEED_NOT_PAY %}
             You cannot abandon a comped badge.
         {% elif attendee.checked_in %}
             This badge has already been picked up.
         {% endif %}
-    {% if not c.BEFORE_REFUND_CUTOFF %}Please {% if attendee.is_transferable %}transfer your badge instead or
-    {% endif %}contact us at {{ c.REGDESK_EMAIL|email_only }}{% if c.SELF_SERVICE_REFUNDS_OPEN %} to make sure your refund gets processed.{% endif %}
-    {% endif %}
+        {% if attendee.badge_type not in [c.STAFF_BADGE, c.CONTRACTOR_BADGE] and not c.BEFORE_REFUND_CUTOFF %}Please {% if attendee.is_transferable %}transfer your badge instead or
+        {% endif %}contact us at {{ c.REGDESK_EMAIL|email_only }}{% if c.SELF_SERVICE_REFUNDS_OPEN %} to make sure your refund gets processed.{% endif %}
+        {% endif %}
     {% endset %}
     <span class="tooltip-wrapper" tabindex="0" data-toggle="tooltip" data-placement="top"{% if must_keep %} title="{{ abandon_hover_text }}"{% endif %}>
     {% endif %}

--- a/uber/templates/preregistration/badge_updated.html
+++ b/uber/templates/preregistration/badge_updated.html
@@ -7,7 +7,7 @@
   <div class="panel-body">
     <h2>{{ message }}!</h2>
     <p>
-      You have successfully {% if 'registered' or 'confirmed' in message %}confirmed{% elif 'transferred' in message %}transferred{% else %}updated{% endif %} your registration.
+      You have successfully {% if 'registered' or 'confirmed' in message %}confirmed{% elif 'transferred' in message %}transferred{% elif 'deferred' %}deferred{% else %}updated{% endif %} your registration.
       Thank you{% if 'payment' in message %} for your payment{% endif %}!
     </p>
     {% if 'transferred' not in message %}<a href="confirm?id={{ id }}" class="btn btn-primary">Go Back to My Badge</a>{% endif %}

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -1,6 +1,7 @@
 {% extends "preregistration/preregbase.html" %}
 {% set name_ro = not attendee.placeholder %}
 {% set assigned_depts_ro = True %}
+{% set amount_extra_ro = True if attendee.badge_status == c.DEFERRED_STATUS else False %}
 {% import "fields/attendee.html" as attendee_fields with context %}
 {% block title %}Confirm Your Details{% endblock %}
 {% block backlink %}
@@ -47,11 +48,11 @@
 
       {% block form_top %}{% endblock %}
 
-      {% if not attendee.placeholder and attendee.amount_unpaid and c.HTTP_METHOD == 'GET' and 'attendee_donation_form' in attendee.payment_page %}
+      {% if not attendee.placeholder and (attendee.amount_unpaid - attendee.amount_pending) > 0 and c.HTTP_METHOD == 'GET' and 'attendee_donation_form' in attendee.payment_page %}
           <div class="alert alert-danger">
             You currently have an outstanding balance of <strong>{{ attendee.amount_unpaid|format_currency }}</strong>{% if attendee.amount_extra %} due to having requested
             registration add-ons and then not completing the payment form{% endif %}.  Please either
-            <a href="attendee_donation_form?id={{ attendee.id }}">click here</a> to pay, or alter your registration below to
+            <a href="{{ attendee.payment_page }}">click here</a> to pay, or alter your registration below to
             eliminate whichever addons you've decided not to select.
           </div>
       {% elif attendee.badge_status == c.PENDING_STATUS %}
@@ -59,6 +60,14 @@
             Your registration has not finished processing, likely because we don't have a verified completed payment. 
             Please contact us at {{ c.REGDESK_EMAIL|email_only|email_to_link }} if this issue persists or if you have any questions.
           </div>
+      {% endif %}
+      {% if attendee.badge_status == c.DEFERRED_STATUS %}
+        <div class="alert alert-warning">
+          Your registration has been deferred to {{ c.EVENT_NAME }} {{ c.EVENT_YEAR|int + 1 }}.
+          You can {% if attendee.shipping_fee_cost %}update your mailing address
+          for your badge and kick-in merch below{% else %}update your information below for next year{% endif %}.
+          Please contact us at {{ c.REGDESK_EMAIL|email_only|email_to_link }} if you have any questions.
+        </div>
       {% endif %}
 
       {% if attendee.is_dealer and attendee.is_group_leader %}
@@ -117,9 +126,12 @@
             {% if attendee.placeholder %}Register{% else %}Update My Info{% endif %}
           </button>
           {% if attendee.is_transferable %}
-            <button type="button" class="btn btn-primary" onClick='location.href="transfer_badge?id={{ attendee.id }}"'>Transfer my Badge</button>
+            <a href="transfer_badge?id={{ attendee.id }}" class="btn btn-primary">Transfer my Badge</a>
           {% endif %}
           {% include '/preregistration/badge_refund.html' %}
+          {% if attendee.can_defer_badge %}
+          <a href="defer_badge?id={{ attendee.id }}" class="btn btn-warning">Defer my Badge</a>
+          {% endif %}
         </div>
       </div>
 

--- a/uber/templates/preregistration/defer_badge.html
+++ b/uber/templates/preregistration/defer_badge.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% import "fields/attendee.html" as attendee_fields with context %}
+{% block backlink %}{% endblock %}
+{% block title %}Defer Your {{ c.EVENT_NAME }} Registration{% endblock %}
+{% block content %}
+
+{% include 'prereg_masthead.html' %}
+<div class="panel panel-default">
+  <div class="panel-body">
+    <h3> Defer {{ attendee.full_name }}'s Registration </h3>
+
+    <p>
+      Are you sure you want to defer your {{ c.EVENT_NAME_AND_YEAR }} registration
+      to a {{ c.EVENT_NAME }} {{ c.EVENT_YEAR|int + 1 }} registration?
+      {% if attendee.calculate_shipping_fee_cost() %}
+        Your badge and kick-in merch will be shipped to you after the event for a 
+        ${{ attendee.calculate_shipping_fee_cost() }} fee. You will receive a tracking number
+        via {{ attendee.email }} by the end of {{ c.EVENT_MONTH }}.
+      {% else %}
+        You will no longer have a badge for {{ c.EVENT_NAME_AND_YEAR }}.
+      {% endif %}
+      <strong>This cannot be undone!</strong>
+    </p>
+
+    <form method="post" action="defer_badge" class="form-horizontal">
+      {{ csrf_token() }}
+      <input type="hidden" name="id" value="{{ attendee.id }}" />
+      {% if attendee.calculate_shipping_fee_cost() %}
+      <div class="row"><label class="col-sm-6 col-sm-offset-3">Mailing Address</label></div>
+      {{ macros.address_form(attendee, is_required=True) }}
+      {% endif %}
+
+      <div class="form-group">
+        <div class="col-sm-6 col-sm-offset-3">
+          <button type="submit" class="btn btn-warning">Yes, Defer My Badge to {{ c.EVENT_NAME }} {{ c.EVENT_YEAR|int + 1 }}</button>
+        
+          <a href="confirm?id={{ attendee.id }}" class="btn btn-default">Nevermind</a>
+        </div>
+      </div>
+
+    </form>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Adds a workflow for deferring your own badge to the next year if self_service_deferrals_open is set to True. We'll collect a shipping fee and mailing address for attendees with kick-ins, if a shipping fee is set.

Also improves the extra payment page so you can avoid the often erroneous "thanks for kicking in" message by providing a "payment_label" to the page handler. Also adds a notice to confirmation pages for deferred badges, and slightly improves the logic for refunding/abandoning your badge.