### PR TITLE
Revert "Bump celery from 4.1.1 to 5.2.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cherrypy==17.3.0
-celery==5.2.2
+celery==4.1.1
 python-dateutil==2.6.0
 psycopg2
 py3k-bcrypt==0.3


### PR DESCRIPTION
Reverts magfest/ubersystem#3917

Right now our distro can't find this package. We'll want this fixed but I need to run at least one deploy now and not later.