### PR TITLE
Revert "Bump pillow from 8.3.2 to 9.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ twilio==6.10.0
 cherrys==0.4
 redis==2.10.6
 ics==0.4
-Pillow==9.0.0
+Pillow==8.3.2
 fpdf==1.7.2
 boto3==1.14.45
 SQLAlchemy==1.3.0


### PR DESCRIPTION
Reverts magfest/ubersystem#3922

Pip can't find this version of Pillow, so we need to roll back for now.