### PR TITLE
Open most volunteer checklist steps at once

### DIFF
--- a/uber/templates/staffing/emergency_procedures_item.html
+++ b/uber/templates/staffing/emergency_procedures_item.html
@@ -7,7 +7,7 @@
     {% else %}
         You have acknowledged that you reviewed our
     {% endif %}
-    {% if attendee.shirt_info_marked or (not attendee.gets_any_kind_of_shirt and attendee.food_restrictions_filled_out) %}<a href="emergency_procedures">Emergency Procedures</a>{% else %}Emergency Procedures{% endif %}
+    {% if not attendee.placeholder and (attendee.agreed_to_volunteer_agreement or not c.VOLUNTEER_AGREEMENT_ENABLED) %}<a href="emergency_procedures">Emergency Procedures</a>{% else %}Emergency Procedures{% endif %}
     {% if not attendee.reviewed_emergency_procedures %} and acknowledge that you have done so{% endif %}. 
     (Deadline: {{ c.EMERGENCY_PROCEDURES_DEADLINE }})
 </li>

--- a/uber/templates/staffing/food_item.html
+++ b/uber/templates/staffing/food_item.html
@@ -2,7 +2,7 @@
 {% if c.HOURS_FOR_FOOD %}
 <li>
     {{ macros.checklist_image(attendee.food_restrictions) }}
-    {% if (not c.VOLUNTEER_AGREEMENT_ENABLED or attendee.agreed_to_volunteer_agreement) and not attendee.placeholder %}
+    {% if not attendee.placeholder %}
         <a href="food_restrictions">Let us know</a>
     {% else %}
         Let us know

--- a/uber/templates/staffing/hotel_item.html
+++ b/uber/templates/staffing/hotel_item.html
@@ -24,7 +24,7 @@
 {% elif c.ROOM_DEADLINE and attendee.hotel_eligible and attendee.registered < c.ROOM_DEADLINE %}
     {% if c.BEFORE_ROOM_DEADLINE %}
         <li>
-            {% if not attendee.placeholder and (attendee.agreed_to_volunteer_agreement or not c.VOLUNTEER_AGREEMENT_ENABLED) and not attendee.hotel_requests %}
+            {% if not attendee.placeholder and not attendee.hotel_requests %}
                 {% if c.HOTEL_REQUESTS_URL %}
                     <img src="{{ c.HOTEL_REQUESTS_URL }}/hotels/request_complete.png?id={{ attendee.id }}&seed={{ range(65536) | random }}" style="vertical-align:top ; margin-right:5px" height="20" width="20" />
                     <a href="{{ c.HOTEL_REQUESTS_URL }}/hotels/request?id={{ attendee.id }}" target="_blank">Tell us</a>


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1089. Every year we reorder the volunteer checklist, and every year that creates bugs where you can't fill out the checklist in order. Now the majority of steps are available once you fill out your information. The exceptions are the emergency procedures step, which requires the volunteer agreement to be signed, and the shifts step, which requires everything else to be completed.