### PR TITLE
Fix panels app links

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -490,6 +490,9 @@ guest_email = string(default="MAGFest Guests <guests@magfest.org>")
 # Emails relating to banned attendees are sent to and from this address.
 security_email = string(default="MAGFest Security <security@magfest.org>")
 
+# Emails relating to technical needs are sent to and from this address.
+techops_email = string(default="MAGFest TechOps <techops@magfest.org>")
+
 # Emails for Marketplace applications are sent from this address.
 marketplace_app_email = string(default="")
 

--- a/uber/templates/panel_app_form.html
+++ b/uber/templates/panel_app_form.html
@@ -180,7 +180,7 @@
     power for a laptop, and connections for 1/8" audio and HDMI video. VGA support
     will <strong>not</strong> be available. If you need anything beyond this
     please describe it above. Our techops department
-    ({{ "techops@magfest.org"|email_to_link }}) will reach out to you directly
+    ({{ c.TECHOPS_EMAIL|email_only|email_to_link }}) will reach out to you directly
     for details.
   </p>
 </div>

--- a/uber/templates/panels/index.html
+++ b/uber/templates/panels/index.html
@@ -152,7 +152,7 @@
             <div class="col-sm-9 col-sm-offset-3">
               <label class="checkbox-label" style="font-weight: normal;">
                 <input type="checkbox" name="covid_agreement"{% if covid_agreement %} checked{% endif %} />
-                I understand and agree with the {{ macros.popup_link("{{ c.COVID_POLICIES_URL }}", "{{ c.EVENT_NAME_AND_YEAR }} COVID Policy") }}.
+                I understand and agree with the {{ macros.popup_link(c.COVID_POLICIES_URL, c.EVENT_NAME_AND_YEAR ~ " COVID Policy") }}.
               </label>
             </div>
           </div>


### PR DESCRIPTION
Part of fixing https://jira.magfest.net/browse/MAGDEV-1092. Fixes the covid policy link and adds an overrideable email for techops.