### PR TITLE
Add child badges to base system

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -315,6 +315,8 @@ class Config(_Overridable):
     @property
     def PREREG_BADGE_TYPES(self):
         types = [self.ATTENDEE_BADGE, self.PSEUDO_DEALER_BADGE]
+        if c.AGE_GROUP_CONFIGS[c.UNDER_13]['can_register']:
+            types.append(self.CHILD_BADGE)
         for reg_open, badge_type in [(self.BEFORE_GROUP_PREREG_TAKEDOWN, self.PSEUDO_GROUP_BADGE)]:
             if reg_open:
                 types.append(badge_type)

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -289,7 +289,7 @@ numbered_badges = boolean(default=True)
 barcode_prefix_char = string(default="~")
 
 # Certain badge types are eligible for discounts, like age based discounts.
-discountable_badge_types = string_list(default=list('attendee_badge'))
+discountable_badge_types = string_list(default=list('attendee_badge', 'child_badge'))
 
 # MAGFest has customized badges for Staff and Supporters.  This means that badge
 # numbers have to be assigned in advance for those badge types, and new ones
@@ -1225,6 +1225,15 @@ staff_badge     = string(default="Staff")
 contractor_badge = string(default="Contractor")
 guest_badge     = string(default="Guest")
 one_day_badge   = string(default="One Day")
+# Child badges are automatically given to anyone under 18.
+# Anyone under 13 also gets a half-price discount,
+# with a corresponding badge selection on the prereg page.
+#
+# To remove the button and auto-assigning for this badge and the corresponding
+# under 13 ribbon, override PREREG_BADGE_TYPES in config.py.
+#
+# To remove the age-related discount, redefine discountable_badge_types without child_badge.
+child_badge = string(default="Minor")
 __many__ = string
 
 [[badge_status]]
@@ -1242,6 +1251,7 @@ volunteer_ribbon = string(default="Volunteer")
 dept_head_ribbon = string(default="Department Head")
 dealer_ribbon    = string(default="Shopkeep")
 panelist_ribbon  = string(default="Panelist")
+under_13 = string(default="12 & Under")
 __many__ = string
 
 [[payment]]

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -211,6 +211,29 @@ def group_leader_under_13(attendee):
 
 
 @prereg_validation.Attendee
+def child_badge_over_13(attendee):
+    if c.CHILD_BADGE in c.PREREG_BADGE_TYPES and attendee.is_new and attendee.badge_type == c.CHILD_BADGE \
+            and attendee.age_now_or_at_con and attendee.age_now_or_at_con >= 13:
+        return "If you will be 13 or older at the start of {}, " \
+            "please select an Attendee badge instead of a 12 and Under badge.".format(c.EVENT_NAME)
+
+
+@prereg_validation.Attendee
+def attendee_badge_under_13(attendee):
+    if c.CHILD_BADGE in c.PREREG_BADGE_TYPES and attendee.is_new and attendee.badge_type == c.ATTENDEE_BADGE \
+            and attendee.age_now_or_at_con and attendee.age_now_or_at_con < 13:
+        return "If you will be 12 or younger at the start of {}, " \
+            "please select the 12 and Under badge instead of an Attendee badge.".format(c.EVENT_NAME)
+
+           
+@validation.Attendee
+def no_more_child_badges(attendee):
+    if c.CHILD_BADGE in c.PREREG_BADGE_TYPES and attendee.is_new and attendee.age_now_or_at_con and attendee.age_now_or_at_con < 18 \
+            and not c.CHILD_BADGE_AVAILABLE:
+        return "Unfortunately, we are sold out of badges for attendees under 18."
+
+
+@prereg_validation.Attendee
 def upgrade_sold_out(attendee):
     currently_available_upgrades = [tier['price'] for tier in c.PREREG_DONATION_DESCRIPTIONS]
     if (attendee.is_new or attendee.orig_value_of('amount_extra') != attendee.amount_extra) \

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -134,6 +134,24 @@
             }
         });
     {% endif %}
+    {% if attendee.is_new and not group_id and c.CHILD_BADGE in c.PREREG_BADGE_TYPES %}
+        if (window.REG_TYPES) {
+            REG_TYPES.options.push({
+                title: '12 and Under: $' + Math.floor({{ c.BADGE_PRICE }} / 2),
+                description: '<p class="list-group-item-text">Attendees 12 and younger must be accompanied by an adult with a valid Attendee badge.</p>' +
+            '<span class="prereg-price-notice">Price is always half that of the Single Attendee badge price.</span>',
+                onClick: function () {
+                    $('.group_fields').addClass('hide');
+                    $('.non_group_fields').removeClass('hide');
+                    if ($.field('first_name')) {
+                        $('#bold-field-message').insertBefore($.field('first_name').parents('.form-group'));
+                    }
+                    $('input[name="badge_type"]').val('{{ c.CHILD_BADGE }}');
+                    togglePrices();
+                }
+            });
+        }
+    {% endif %}
     var BADGE_TYPES = {
         row: '#badge-types',
         selector: '.badge-type-selector',
@@ -466,6 +484,15 @@
                   });
               }
           });
+      {% endif %}
+      // This auto-selects the Child badge when the user is, e.g., editing their registration before paying
+      {% if attendee.badge_type == c.CHILD_BADGE %}
+      $(window).on("runJavaScript", function () {
+          if (window.REG_TYPES && $(REG_TYPES.row).size()) {
+              {% set child_badge_index = 2 if c.GROUPS_ENABLED else 1 %}
+              setBadge(REG_TYPES, {{ child_badge_index }});  // default to child badge when appropriate
+          }
+        });
       {% endif %}
   </script>
   {% if not attendee.is_new %}
@@ -1633,6 +1660,19 @@ $(window).on("runJavaScript", function(){
     </div>
   {% endcall %}
   </div>
+  {% if c.CHILD_BADGE in c.PREREG_BADGE_TYPES %}
+  <div class="form-group">
+      <p class="help-block col-sm-9 col-sm-offset-3">
+      {% if c.CHILD_BADGE_AVAILABLE %}
+        Badges for attendees under 13 are half-price. <br/>
+        Attendees under 6 enter free. <br/>
+        All attendees under 13 must be accompanied by an adult with a valid Attendee badge.
+    {% else %}
+    <span class="text-danger">Unfortunately, we are sold out of badges for attendees under 18.</span>
+    {% endif %}
+      </p>
+    </div>
+  {% endif %}
 {% elif not admin_area and c.AT_THE_CON %}
   <script type="text/javascript">
       var maybeBold = function() {


### PR DESCRIPTION
Both West and Super use child badges with a discount, so this moves the code from the magprime plugin to the base plugin. Fixes https://jira.magfest.net/browse/MAGDEV-1105.