### PR TITLE
Revert "Bump pillow from 8.3.2 to 9.0.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ twilio==6.10.0
 cherrys==0.4
 redis==2.10.6
 ics==0.4
-Pillow==9.0.1
+Pillow==8.3.2
 fpdf==1.7.2
 boto3==1.14.45
 SQLAlchemy==1.3.0


### PR DESCRIPTION
Reverts magfest/ubersystem#3928.

Pillow dropped support for Python 3.8 so we can't use the new version unless/until we upgrade our Python install.