### PR TITLE
Add panels start date

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1006,8 +1006,8 @@ mits_submission_deadline = string(default="2017-11-07")
 # MITS Teams can edit their applications even after submitting it until this deadline.
 mits_editing_deadline = string(default="2017-11-30")
 
-
-# Deadline for panel applications
+# Open date and deadline for panel applications
+panels_start = string(default="")
 panels_deadline = string(default="")
 
 # The start and end time for the panels schedule

--- a/uber/templates/panels/index.html
+++ b/uber/templates/panels/index.html
@@ -23,10 +23,18 @@
 
       {% if c.AFTER_PANELS_DEADLINE and not c.HAS_PANELS_ADMIN_ACCESS %}
         Unfortunately, the deadline for panel applications has passed and we are no longer accepting panel submissions.
+      {% elif c.BEFORE_PANELS_START and not c.HAS_PANELS_ADMIN_ACCESS %}
+        Panel applications will open {{ c.PANELS_START|datetime_local }}.
       {% else %}
         {% if c.AFTER_PANELS_DEADLINE and c.HAS_PANELS_ADMIN_ACCESS %}
           <span style="color:red">
             Panel applications have closed, but because you are a logged in
+            administrator you can submit a new application using this form.
+          </span>
+          <br/> <br/>
+        {% elif c.BEFORE_PANELS_START and c.HAS_PANELS_ADMIN_ACCESS %}
+          <span style="color:red">
+            Panel applications open {{ c.PANELS_START|datetime_local }}, but because you are a logged in
             administrator you can submit a new application using this form.
           </span>
           <br/> <br/>


### PR DESCRIPTION
Panels wants changes before they open applications this year, but there's actually no way to prevent applications from being open when the server is online except by setting a deadline. This fixes that.