### PR TITLE
Fix required checks for dropdown fields

### DIFF
--- a/uber/utils.py
+++ b/uber/utils.py
@@ -455,7 +455,7 @@ def check(model, *, prereg=False):
     """
     errors = []
     for field, name in model.required:
-        if not str(getattr(model, field)).strip():
+        if not getattr(model, field) or not str(getattr(model, field)).strip():
             errors.append(name + ' is a required field')
 
     validations = [uber.model_checks.validation.validations]


### PR DESCRIPTION
While updating the panel application I ran into a bug where the required field check was letting through a null value because it was interpreting it as the literal string "None."