### PR TITLE
Allow pulling covid_ready status via API

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -324,6 +324,7 @@ class AttendeeLookup:
         'is_dept_head': True,
         'ribbon_labels': True,
         'public_id': True,
+        'covid_ready': True,
     }
 
     fields_full = dict(fields, **{


### PR DESCRIPTION
It would be nice for the covid verification system to be able to pull the current covid_ready status out of uber.