### PR TITLE
Narrow down targets for deferred attendee email

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -157,7 +157,8 @@ AutomatedEmailFixture(
     Attendee,
     'Claim your Deferred Badge for {EVENT_NAME} {EVENT_YEAR}!',
     'placeholders/deferred.html',
-    lambda a: a.placeholder and a.registered_local <= c.PREREG_OPEN and a.badge_type != c.STAFF_BADGE,
+    lambda a: a.placeholder and a.registered_local <= c.PREREG_OPEN and \
+              a.badge_type == c.ATTENDEE_BADGE and a.paid == c.NEED_NOT_PAY and not a.admin_account,
     ident='claim_deferred_badge')
 
 AutomatedEmailFixture(


### PR DESCRIPTION
We actually don't have a reliable way to specify deferred attendees only, which is something we should fix later before we import them. For now, we'll add more conditions to the email so we don't email every dealer and MIVS judge.