### PR TITLE
Fix 500 error when claiming group badge

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -293,7 +293,7 @@ def promo_code_is_useful(attendee):
             return "You can't apply a promo code to a one day badge."
         elif attendee.overridden_price:
             return "You already have a special badge price, you can't use a promo code on top of that."
-        elif attendee.badge_cost >= attendee.badge_cost_without_promo_code:
+        elif attendee.default_badge_cost >= attendee.badge_cost_without_promo_code:
             return "That promo code doesn't make your badge any cheaper. You may already have other discounts."
 
 

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -410,6 +410,9 @@ class MagModel:
         receipt_items = uber.receipt_items.cost_calculation.items
         try:
             cost_calc = receipt_items[self.__class__.__name__][name[8:]](self)
+            if not cost_calc:
+                return 0
+
             try:
                 return sum(item[0] * item[1] for item in cost_calc[1].items()) / 100
             except AttributeError:


### PR DESCRIPTION
A default_xyz_cost property will no longer throw an error just because there's no cost returned. Also, we use the new default_badge_cost property to check promo codes.