### PR TITLE
Add ability to resume payment

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1355,6 +1355,7 @@ class Root:
             raise HTTPRedirect('repurchase?id={}', attendee.id)
 
         placeholder = attendee.placeholder
+        receipt = session.get_receipt_by_model(attendee)
         if 'email' in params and not message:
             attendee.placeholder = False
             message = check(attendee, prereg=True)
@@ -1366,7 +1367,6 @@ class Root:
                     message = 'Your information has been updated'
 
                 page = ('badge_updated?id=' + attendee.id + '&') if return_to == 'confirm' else (return_to + '?')
-                receipt = session.get_receipt_by_model(attendee)
                 if not receipt:
                     new_receipt = session.get_receipt_by_model(attendee, create_if_none=True)
                     if new_receipt.current_amount_owed and not new_receipt.pending_total:
@@ -1381,6 +1381,15 @@ class Root:
 
         group_credit = receipt_items.credit_calculation.items['Attendee']['group_discount'](attendee)
 
+        last_incomplete_txn = None
+        if receipt:
+            for txn in receipt.pending_txns:
+                txns_marked_paid = txn.check_paid_from_stripe()
+                if not txns_marked_paid:
+                    last_incomplete_txn = txn
+
+            session.commit()
+
         return {
             'undoing_extra': undoing_extra,
             'return_to':     return_to,
@@ -1391,6 +1400,7 @@ class Root:
             'attractions':   session.query(Attraction).filter_by(is_public=True).all(),
             'badge_cost':    attendee.badge_cost if attendee.paid != c.PAID_BY_GROUP else 0,
             'receipt':       session.get_receipt_by_model(attendee),
+            'incomplete_txn':  last_incomplete_txn,
             'attendee_group_discount': (group_credit[1] / 100) if group_credit else 0,
         }
         
@@ -1433,6 +1443,24 @@ class Root:
         session.commit()
 
         return {'success': True}
+
+    @ajax
+    @credit_card
+    @requires_account(Attendee)
+    def finish_pending_payment(self, session, id, txn_id, **params):
+        attendee = session.attendee(id)
+        txn = session.receipt_transaction(txn_id)
+
+        stripe_intent = txn.get_stripe_intent()
+
+        if stripe_intent.charges:
+            return {'error': "This payment has already been finalized!"}
+
+        return {'stripe_intent': stripe_intent,
+                'success_url': 'confirm?id={}&message={}'.format(
+                    attendee.id,
+                    'Your payment has been accepted!'),
+                'cancel_url': 'cancel_payment'}
 
     @ajax
     @credit_card

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -54,11 +54,11 @@
       </div>
       {% else %}
         {% if not attendee.placeholder and receipt and receipt.current_amount_owed %}
-            {% if receipt.pending_total %}
+            {% if incomplete_txn %}
             <div class="alert alert-warning">
               You currently have an outstanding balance of <strong>{{ (receipt.current_amount_owed / 100)|format_currency }}</strong>
-              with pending payments of {{ (receipt.pending_total / 100)|format_currency }}.
-              Please contact us at {{ c.REGDESK_EMAIL|email_only|email_to_link }} if this issue persists or if you have any questions.
+              with an incomplete payment of {{ (incomplete_txn.amount / 100)|format_currency }}.
+              <br/><br/>Click here to complete your payment: {{ stripe_form('finish_pending_payment', attendee, txn_id=incomplete_txn.id, stripe_button_id="complete_txn") }}
             </div>
             {% else %}
             <div class="alert alert-danger">
@@ -110,7 +110,7 @@
         {% endif %}
       {% endif %}
 
-      {% if money_fields_ro %}
+      {% if money_fields_ro and not incomplete_txn %}
         {% include 'preregistration/upgrade_modal.html' %}
       {% endif %}
       {{ attendee_fields.receipt_modal }}

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1324,7 +1324,6 @@ class Charge:
     def create_receipt_transaction(self, receipt, desc='', intent_id='', amount=0):
         if not amount and intent_id:
             intent = stripe.PaymentIntent.retrieve(intent_id)
-            log.debug(intent)
             amount = intent.amount
         
         if not amount:


### PR DESCRIPTION
Our experience both with staff reg launch and at MFF have shown us that the current admin intervention required for 'dangling' payments is going to end with one of the reg heads driving down to my house to murder me in my sleep. Luckily I accidentally read some documentation for once and now attendees can resume their own payments!