### PR TITLE
Fix group discount calculation

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -767,6 +767,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         if self.badge_type in c.BADGE_TYPE_PRICES:
             self.badge_type = c.ATTENDEE_BADGE
 
+    @property
     def qualifies_for_discounts(self):
         return self.paid != c.NEED_NOT_PAY and self.overridden_price is None and not self.is_dealer and self.badge_type not in c.BADGE_TYPE_PRICES
 

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -102,7 +102,7 @@ def age_discount(attendee):
 @credit_calculation.Attendee
 def group_discount(attendee):
     if c.GROUP_DISCOUNT and attendee.qualifies_for_discounts and not attendee.age_discount and (
-                attendee.promo_code_groups or attendee.group and attendee.paid == c.PAID_BY_GROUP):
+                attendee.promo_code_groups or attendee.group):
         return ("Group Discount", c.GROUP_DISCOUNT * 100 * -1)
 
 


### PR DESCRIPTION
This is for dealers, not attendee groups. We were giving someone a badge discount even if they were being covered by their group, so e.g. if they preordered merch they'd get $10 off that merch.