### PR TITLE
Post Prereg Fixes

### DIFF
--- a/tests/uber/models/test_promo_code.py
+++ b/tests/uber/models/test_promo_code.py
@@ -235,7 +235,7 @@ class TestAttendeePromoCodeModelChecks:
         Charge.unpaid_preregs[sess.id] = Charge.to_sessionized(sess)
         sess.promo_code = None
         sess.promo_code_id = None
-        assert len(promo_code.used_by) == 0
+        assert len(promo_code.valid_used_by) == 0
 
         attendee = Attendee(
             promo_code=promo_code,

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1441,6 +1441,7 @@ class Root:
         if message:
             session.rollback()
             return {'error': message}
+        session.add(attendee)
         session.commit()
 
         return {'success': True}

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1431,9 +1431,13 @@ class Root:
 
         for param in params:
             if param in Attendee.cost_changes:
-                receipt_item = Charge.process_receipt_upgrade_item(attendee, param, receipt=receipt, new_val=params[param])
-                if receipt_item.amount != 0:
-                    session.add(receipt_item)
+                try:
+                    receipt_item = Charge.process_receipt_upgrade_item(attendee, param, receipt=receipt, new_val=params[param])
+                    if receipt_item.amount != 0 and not receipt.open_receipt_items:
+                        session.add(receipt_item)
+                except Exception as e:
+                    session.rollback()
+                    return {'error': str(e)}
 
         attendee.apply(params, ignore_csrf=True, restricted=False)
         message = check(attendee)
@@ -1441,7 +1445,7 @@ class Root:
         if message:
             session.rollback()
             return {'error': message}
-        session.add(attendee)
+
         session.commit()
 
         return {'success': True}

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1439,7 +1439,7 @@ $(window).on("runJavaScript", function () {
 
 {% if c.BADGE_PROMO_CODES_ENABLED and not group_id and (attendee.is_unpaid or attendee.promo_code_code or admin_area) %}
   <div class="non_group_fields form-group">
-    <label for="promo_code" class="col-sm-3 control-label optional-field">Promo Code</label>
+    <label for="promo_code" class="col-sm-3 control-label optional-field">Promo {% if c.GROUPS_ENABLED %}or Group {% endif %}Code</label>
     <div class="col-sm-6">
       {% if attendee.is_unpaid and not read_only %}
         <input type="textarea" name="promo_code" value="{{ attendee.promo_code_code or promo_code_code }}" class="form-control" placeholder="Promo Code">

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -103,6 +103,7 @@ $(document).ready(function() {
     {{ group_fields.address }}
     {{ group_fields.invite_code_field }}
   {% endif %}
+  {% if not is_prereg_dealer and c.GROUPS_ENABLED %}{{ attendee_fields.promo_code }}{% endif %}
   {{ group_fields.explanation }}
   {{ attendee_fields.group_fields }}
   {{ attendee_fields.badge_buttons }}
@@ -120,7 +121,7 @@ $(document).ready(function() {
   {{ attendee_fields.emergency_contact }}
   {{ attendee_fields.onsite_contact }}
   {{ attendee_fields.cellphone }}
-  {{ attendee_fields.promo_code }}
+  {% if (not is_prereg_dealer or c.ART_SHOW_ENABLED) and not c.GROUPS_ENABLED %}{{ attendee_fields.promo_code }}{% endif %}
   {{ attendee_fields.interests }}
   {{ attendee_fields.found_how }}
   {{ attendee_fields.comments }}

--- a/uber/templates/preregistration/group_promo_codes.html
+++ b/uber/templates/preregistration/group_promo_codes.html
@@ -24,8 +24,8 @@
         <tr>
           <td><ul style="margin: 5px 0; padding-right: 0"><li></li></ul></td>
           <td>{{ code.code }}</td>
-          {% if code.used_by %}
-            {% set attendee = code.used_by[0] %}
+          {% if code.valid_used_by %}
+            {% set attendee = code.valid_used_by[0] %}
             <td style="padding-right: 10px">
               {{ attendee.full_name }}
             </td>

--- a/uber/templates/promo_codes/index.html
+++ b/uber/templates/promo_codes/index.html
@@ -121,7 +121,7 @@ $(document).ready(function() {
         <td data-order="{{ promo_code.uses_count }}">
           {{ promo_code.uses_count_str }}, {{ promo_code.uses_remaining_str }}
           <br>
-          {% for attendee in promo_code.used_by %}
+          {% for attendee in promo_code.valid_used_by %}
           <a href="#attendee_form?id={{ attendee.id }}">{{ attendee.full_name }}</a>{% if not loop.last %}, {% endif %}
           {% endfor %}
         </td>

--- a/uber/templates/registration/promo_code_group_form.html
+++ b/uber/templates/registration/promo_code_group_form.html
@@ -98,8 +98,8 @@
           <td>
             {{ code.code }}
           </td>
-          <td data-order="{{ code.used_by[0].full_name if code.used_by else '' }}">
-            {{ code.used_by[0]|form_link if code.used_by else 'N/A' }}
+          <td data-order="{{ code.valid_used_by[0].full_name if code.valid_used_by else '' }}">
+            {{ code.valid_used_by[0]|form_link if code.valid_used_by else 'N/A' }}
           </td>
           <td>{{ code.created.when|datetime_local }}</td>
           <td>{{ code.cost|format_currency }}</td>

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1125,6 +1125,9 @@ class Charge:
         if model_dict.get(col_name) == None:
             return None, None
         
+        if not new_val:
+            new_val = 0
+        
         return (model_dict[col_name] * 100, (int(new_val) - model_dict[col_name]) * 100)
 
     @classmethod


### PR DESCRIPTION
Fixes several issues that are generating support tickets post-launch:
- An empty Superstar donation no longer breaks the upgrade process
- Fixed issue where attendees weren't receiving badge upgrades if the upgrade process did not fully complete, including loading the page after payment
- Receipt items are now only added to the attendee if the upgrade process is not interrupted by, for example, an empty Superstar donation breaking the upgrade process
- Pending badges (and imported and invalid badges) no longer 'use up' group promo codes
- Transaction amounts for multiple badges no longer apply the full payment amount to both attendees' receipts