### PR TITLE
Remove erroneous sanity check

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -969,10 +969,6 @@ class Session(SessionManager):
                 self.rollback()
                 return receipt_txn
 
-            if stripe_intent.amount != receipt.current_amount_owed:
-                self.rollback()
-                return "There was an error calculating the amount. Please contact the system admin."
-
             # Later we will want code to assign receipt items to this transaction
 
             self.add(receipt_txn)


### PR DESCRIPTION
We can't check the stripe intent amount against the receipt's current amount owed because we don't want to save anything to the session until after everything is done. Oh well.