### PR TITLE
Allow MIVS admins to disqualify judges

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1468,6 +1468,7 @@ unconfirmed = string(default="Unconfirmed")
 confirmed = string(default="Yes")
 next_year = string(default="Maybe Next Year")
 cancelled = string(default="Asked for Removal")
+disqualified = string(default="Disqualified")
 
 [[mivs_video_review_status]]
 pending = string(default="not reviewed yet")

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -395,7 +395,8 @@ class Root:
                         session.add(account)
                         body = render('emails/accounts/new_account.txt', {
                             'account': account,
-                            'password': password if not c.AUTH_DOMAIN else ''
+                            'password': password if not c.AUTH_DOMAIN else '',
+                            'creator': AdminAccount.admin_name()
                         }, encoding=None)
                         send_email.delay(
                             c.ADMIN_EMAIL,

--- a/uber/templates/emails/mivs/judge_disqualified.txt
+++ b/uber/templates/emails/mivs/judge_disqualified.txt
@@ -1,0 +1,11 @@
+Hello {{ judge.attendee.first_name }}!
+
+Our records indicate that you completed judging on {{ judge.game_reviews|length }} of the {{ judge.reviews|length }} assigned games before the {{ c.MIVS_JUDGING_DEADLINE|datetime_local }}.
+
+Unfortunately, since you did not complete reviewing your assigned games before the deadline, we are unable to provide a complementary MAGFest badge for this year.
+
+{% if prior_payment_status == c.NEED_NOT_PAY and judge.attendee.paid == c.NOT_PAID %}However, if you are still interested in attending MAGFest, you may complete your badge purchase{% else %}You can still view your existing badge{% endif %} here: {{ c.URL_BASE }}/preregistration/confirm?id={{ judge.attendee.id }}
+
+Thanks again for offering to help this year.  We appreciate your time in helping support indie developers.
+
+MIVS

--- a/uber/templates/mivs_admin/edit_judge.html
+++ b/uber/templates/mivs_admin/edit_judge.html
@@ -56,8 +56,26 @@
     <div class="form-group">
         <div class="col-sm-6 col-sm-offset-2">
             <button type="submit" class="btn btn-primary">Upload Changes</button>
+            <a href="#" class="btn btn-danger" onClick="confirmDisqualify()">Disqualify for {{ c.EVENT_YEAR }}</a>
         </div>
     </div>
 </form>
-
+<script type="text/javascript">
+    var confirmDisqualify = function() {
+        bootbox.confirm({
+        backdrop: true,
+        title: 'Disqualify {{ judge.full_name }}?',
+        message: 'Are you sure you want to disqualify this judge for this year? This will trigger an email letting them know they are disqualified.',
+        buttons: {
+            confirm: { label: 'Disqualify Judge', className: 'btn-danger' },
+            cancel: { label: 'Nevermind', className: 'btn-default' }
+        },
+        callback: function (result) {
+            if (result) {
+            window.location = "disqualify_judge?id={{ judge.id }}"
+            }
+        }
+    });
+}
+</script>
 {% endblock %}

--- a/uber/templates/mivs_judging/index.html
+++ b/uber/templates/mivs_judging/index.html
@@ -41,7 +41,9 @@
 {% elif judge.status == c.NEXT_YEAR %}
   Sorry you won't be able to judge this year. We'll be in touch next year and hope you can join us then.
 {% elif judge.status == c.CANCELLED %}
-  Thank you for updating your preference, we'll be removing you from the judging list going forward. Thanks for all the work you've put into judging for MIVS in the past. If you change your mind, email {{ '{{ c.MIVS_EMAIL|email_only }}'|email_to_link }}.
+  Thank you for updating your preference, we'll be removing you from the judging list going forward. Thanks for all the work you've put into judging for MIVS in the past. If you change your mind, email {{ c.MIVS_EMAIL|email_only|email_to_link }}.
+{% elif judge.status == c.DISQUALIFIED %}
+  Unfortunately, since you did not complete reviewing your assigned games before the deadline, you have been disqualified as a judge for this year. If this doesn't sound right, email {{ c.MIVS_EMAIL|email_only|email_to_link }}.
 {% else %}
 <h2>Your Preferences</h2>
   In order to help us match you with the right kinds of games, please tell us what genres you prefer to play and what


### PR DESCRIPTION
There was no way to mark a judge as not qualifying for a comped badge if they didn't complete all their reviews in time. Now there is!

Marking a judge as disqualified with the new "Disqualify for (year)" button will also set their badge as needing to pay (if it was comped beforehand) and sends them an email informing them of the disqualification.