### PR TITLE
Stop guest groups from buying badges

### DIFF
--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -350,7 +350,7 @@ class Group(MagModel, TakesPaymentMixin):
             return 0
         if self.can_add:
             return 1
-        elif self.is_dealer:
+        elif self.guest and self.guest.group_type != c.MIVS:
             return 0
         else:
             return c.MIN_GROUP_ADDITION


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1166. Makes an exception for MIVS groups because there's no reason to keep them from adding badges. Also lets dealer groups buy more badges.