### PR TITLE
Let groups without receipts buy badges

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1085,7 +1085,7 @@ class Root:
     def pay_for_extra_members(self, session, id, count):
         from uber.models import ReceiptItem
         group = session.group(id)
-        receipt = session.get_receipt_by_model(group)
+        receipt = session.get_receipt_by_model(group, create_if_none=True)
         count = int(count)
         session.add(ReceiptItem(receipt_id=receipt.id,
                                 desc='Extra badge for {}'.format(group.name),


### PR DESCRIPTION
Fixes a bug where a comped group (i.e. one without a receipt) couldn't actually buy extra badges.