### PR TITLE
Use unavailability instead of availability for guests

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -1022,14 +1022,8 @@ def pa_phone(pa):
 
 @validation.PanelApplication
 def unavailability(app):
-    if not app.unavailable and not app.poc_id:
+    if not app.unavailable:
         return 'Your unavailability is required.'
-
-
-@validation.PanelApplication
-def availability(app):
-    if not app.available and app.poc and app.poc.guest_group:
-        return 'Please list the times you are available to hold this panel!'
 
 
 @validation.PanelApplication

--- a/uber/templates/panel_app_form.html
+++ b/uber/templates/panel_app_form.html
@@ -55,7 +55,7 @@
     </div>
     <div class="clearfix"></div>
     <p class="help-block col-sm-9 col-sm-offset-3">
-        For regular panels, leave {{ c.PANEL_DEPT_OPTS[c.PANELS] }} selected.
+        For regular panels, leave "{{ c.PANEL_DEPTS[c.PANELS] }}" selected.
     </p>
 </div>
 <script type="text/javascript">

--- a/uber/templates/panels/guest.html
+++ b/uber/templates/panels/guest.html
@@ -30,18 +30,18 @@
 
       <h3>Additional Information</h3>
       <div class="form-group">
-        <label class="col-sm-3 control-label">When are your preferred panel times?</label>
+        <label class="col-sm-3 control-label">When are you NOT available?</label>
         <div class="col-sm-6">
-          <textarea class="form-control" name="available" rows="4" required="required">{{ app.available }}</textarea>
+          <textarea class="form-control" name="unavailable" rows="4" required="required">{{ app.unavailable }}</textarea>
         </div>
         <div class="clearfix"></div>
         <p class="help-block col-sm-9 col-sm-offset-3">
-          Please let us know the time slot you would prefer for this panel. Panel times can’t be guaranteed, but we’ll
-          do our best to accommodate preferences.
+          Please let us know of any schedule conflicts due to prior obligations, travel times, or other needs.
+          (e.g. you made a deal with a fairy godmother to get here and have to be back in your room by midnight.)
         </p>
       </div>
       <div class="form-group">
-        <label class="col-sm-3 control-label">Is there anything else you would like to provide regarding your submission?</label>
+        <label class="col-sm-3 control-label optional-field">Is there anything else you would like to provide regarding your submission?</label>
         <div class="col-sm-6">
           <textarea class="form-control" name="extra_info" rows="4">{{ app.extra_info }}</textarea>
         </div>

--- a/uber/templates/panels/index.html
+++ b/uber/templates/panels/index.html
@@ -120,7 +120,7 @@
             </div>
           </div>
           <div class="form-group">
-            <label class="col-sm-3 control-label">Is there anything else you would like to provide regarding your submission?</label>
+            <label class="col-sm-3 control-label optional-field">Is there anything else you would like to provide regarding your submission?</label>
             <div class="col-sm-6">
               <textarea class="form-control" name="extra_info" rows="4">{{ app.extra_info }}</textarea>
             </div>


### PR DESCRIPTION
Instead of "When are you available" we now ask guests to list when they're unavailable, just like we do with attendees.