### PR TITLE
Lock down new customized badges more

### DIFF
--- a/uber/templates/guests_macros.html
+++ b/uber/templates/guests_macros.html
@@ -92,7 +92,7 @@
   suffix=suffix,
   type="textarea",
   label="Arrival Details",
-  placeholder="For example, the airport or station you're arriving at and the flight/train/bus #s.",
+  placeholder="For example, the airport or station you're arriving at, the airline, and the flight/train/bus #s.",
   is_required=True,
   is_readonly=is_readonly,
   is_admin=is_admin) }}
@@ -121,7 +121,7 @@
   suffix=suffix,
   type="textarea",
   label="Departure Details",
-  placeholder="For example, the airport or station you're departing from and the flight/train/bus #s.",
+  placeholder="For example, the airport or station you're departing from, the airline, and the flight/train/bus #s.",
   is_required=True,
   is_readonly=is_readonly,
   is_admin=is_admin) }}


### PR DESCRIPTION
Now only full admins can add customized badges. Also allows contractors to not have to put in a MAGBuddy