### PR TITLE
Customize Rock Island groups' checklist

### DIFF
--- a/uber/templates/guest_checklist/merch_deadline.html
+++ b/uber/templates/guest_checklist/merch_deadline.html
@@ -19,6 +19,7 @@
       <br/></br>
     </td>
   </tr>
+  {% block deadline_extra %}
   {% if HAS_ROCK_ISLAND and guest.merch.selling_merch == c.ROCK_ISLAND %}
     <tr>
       <td></td>
@@ -38,6 +39,7 @@
       </td>
     </tr>
   {% endif %}
+  {% endblock %}
 {% else %}
 
   {% import 'guests_macros.html' as guests_macros with context %}

--- a/uber/templates/guest_checklist/rock_island_merch_deadline.html
+++ b/uber/templates/guest_checklist/rock_island_merch_deadline.html
@@ -1,0 +1,29 @@
+{% extends "guest_checklist/merch_deadline.html" %}
+
+{% block deadline_headline %}Rock Island Inventory{% endblock %}
+{% block deadline_text %}
+{% if guest.merch_status %}
+    You have submitted information for Rock Island, but you can edit it using the link above.
+{% else %}
+    Fill out your information for Rock Island!
+{% endif %}
+{% endblock %}
+{% block deadline_extra %}{% endblock %}
+
+{% block form_header %}
+{{ super() }}
+<script type="text/javascript">
+    $(function () {
+        $.field('selling_merch').val('{{ c.ROCK_ISLAND }}').parents('.form-group').hide();
+    });
+</script>
+{% endblock %}
+
+{% block form_desc %}
+<p>Please fill in your information for Rock Island below.</p>
+<p>
+    <a href="../static/RockIsland.pdf">
+      Click here for more info about our Rock Island service!
+    </a>
+</p>
+{% endblock %}


### PR DESCRIPTION
Requested via Slack. This removes references to having a merch table and auto-selects Rock Island from the merch preferences.