### PR TITLE
Send all emails to the email task

### DIFF
--- a/uber/site_sections/marketplace.py
+++ b/uber/site_sections/marketplace.py
@@ -44,7 +44,7 @@ class Root:
                 app.attendee = attendee
 
                 session.add(app)
-                send_email(
+                send_email.delay(
                     c.MARKETPLACE_APP_EMAIL,
                     c.MARKETPLACE_APP_EMAIL,
                     'Marketplace Application Received',

--- a/uber/tasks/attractions.py
+++ b/uber/tasks/attractions.py
@@ -171,7 +171,7 @@ def attractions_send_notifications():
                             'checkin': checkin,
                             'c': c}).decode('utf-8')
                         sid = ident
-                        send_email(from_, to_, subject=subject, body=body, format='html', model=attendee, ident=ident)
+                        send_email.delay(from_, to_, subject=subject, body=body, format='html', model=attendee.to_dict(), ident=ident)
                 except Exception:
                     log.error(
                         'Error sending notification\n'

--- a/uber/tasks/panels.py
+++ b/uber/tasks/panels.py
@@ -26,7 +26,7 @@ def panels_waitlist_unaccepted_panels():
                 body = render('emails/panels/panel_app_waitlisted.txt', {
                     'app': app,
                 }, encoding=None)
-                send_email(c.PANELS_EMAIL, app.email,
+                send_email.delay(c.PANELS_EMAIL, app.email,
                            "Your {EVENT_NAME} Panel Application Has Been Automatically Waitlisted: {{ app.name }}",
                            body, ident="panel_waitlisted"
                            )

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -54,7 +54,7 @@ def check_duplicate_registrations():
 
                 if dupes:
                     body = render('emails/daily_checks/duplicates.html', {'dupes': sorted(dupes.items())})
-                    send_email(c.ADMIN_EMAIL, c.REGDESK_EMAIL, subject, body, format='html', model='n/a')
+                    send_email.delay(c.ADMIN_EMAIL, c.REGDESK_EMAIL, subject, body, format='html', model='n/a')
 
 
 @celery.schedule(crontab(minute=0, hour='*/6'))
@@ -93,7 +93,7 @@ def check_placeholder_registrations():
                                            .order_by(Attendee.registered, Attendee.full_name).all())  # noqa: E712
                     if placeholders:
                         body = render('emails/daily_checks/placeholders.html', {'placeholders': placeholders})
-                        send_email(c.ADMIN_EMAIL, to, subject, body, format='html', model='n/a')
+                        send_email.delay(c.ADMIN_EMAIL, to, subject, body, format='html', model='n/a')
 
 
 @celery.schedule(crontab(minute=0, hour='*/6'))
@@ -116,7 +116,7 @@ def check_pending_badges():
                 pending = session.query(Attendee).filter_by(badge_status=c.PENDING_STATUS).filter(per_email_filter).all()
                 if pending and session.no_email(subject.format(badge_type)):
                         body = render('emails/daily_checks/pending.html', {'pending': pending, 'site_section': site_section})
-                        send_email(c.ADMIN_EMAIL, to, subject.format(badge_type), body, format='html', model='n/a')
+                        send_email.delay(c.ADMIN_EMAIL, to, subject.format(badge_type), body, format='html', model='n/a')
 
 
 @celery.schedule(crontab(minute=0, hour='*/6'))
@@ -129,7 +129,7 @@ def check_unassigned_volunteers():
             subject = c.EVENT_NAME + ' Unassigned Volunteer Report for ' + localized_now().strftime('%Y-%m-%d')
             if unassigned and session.no_email(subject):
                 body = render('emails/daily_checks/unassigned.html', {'unassigned': unassigned})
-                send_email(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
+                send_email.delay(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
 
 
 @celery.schedule(timedelta(minutes=5))
@@ -140,7 +140,7 @@ def check_near_cap():
         with Session() as session:
             if not session.query(Email).filter_by(subject=subject).first() and actual_badges_left <= badges_left:
                 body = render('emails/badges_sold_alert.txt', {'badges_left': actual_badges_left})
-                send_email(c.ADMIN_EMAIL, [c.REGDESK_EMAIL, c.ADMIN_EMAIL], subject, body, model='n/a')
+                send_email.delay(c.ADMIN_EMAIL, [c.REGDESK_EMAIL, c.ADMIN_EMAIL], subject, body, model='n/a')
 
 
 @celery.schedule(timedelta(minutes=30))


### PR DESCRIPTION
Apparently, when you call a celery task function with no other modifiers, you attempt to run that function inside the current process. We basically never want this, and I am like 14% sure this is what's breaking some of our automated emails, so this switches everything to use send_email.delay() -- "delay" makes it send a message to the actual email task.