### PR TITLE
Send automated emails a little less often

### DIFF
--- a/uber/tasks/email.py
+++ b/uber/tasks/email.py
@@ -139,8 +139,7 @@ def notify_admins_of_pending_emails():
 
         return groupify(pending_emails, 'sender', 'ident')
 
-
-@celery.schedule(timedelta(minutes=5))
+@celery.schedule(timedelta(minutes=5 if c.DEV_BOX else 15))
 def send_automated_emails():
     """
     Send any automated emails that are currently active, and have been approved


### PR DESCRIPTION
I suspect that people are getting double-emailed because the automated email task isn't actually finishing before it's kicked off again, causing race conditions or whatever. Hopefully this helps. I created an exception for dev boxes to ease development.