### PR TITLE
Remove extra MIVS checklist notifications

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -315,21 +315,21 @@ if c.ART_SHOW_ENABLED:
     ArtShowAppEmailFixture(
         '{EVENT_NAME} Art Show piece entry needed',
         'art_show/pieces_reminder.txt',
-        lambda a: not a.is_unpaid and not a.art_show_pieces,
+        lambda a: a.status == c.APPROVED and not a.is_unpaid and not a.art_show_pieces,
         when=days_before(15, c.EPOCH),
         ident='art_show_pieces_reminder')
 
     ArtShowAppEmailFixture(
         'Reminder to assign an agent for your {EVENT_NAME} Art Show application',
         'art_show/agent_reminder.html',
-        lambda a: not a.is_unpaid and a.delivery_method == c.AGENT and not a.agent,
+        lambda a: a.status == c.APPROVED and not a.is_unpaid and a.delivery_method == c.AGENT and not a.agent,
         when=after(c.EVENT_TIMEZONE.localize(datetime(int(c.EVENT_YEAR), 11, 1))),
         ident='art_show_agent_reminder')
 
     ArtShowAppEmailFixture(
         '{EVENT_NAME} Art Show MAIL IN Instructions',
         'art_show/mailing_in.html',
-        lambda a: not a.is_unpaid and a.delivery_method == c.BY_MAIL,
+        lambda a: a.status == c.APPROVED and not a.is_unpaid and a.delivery_method == c.BY_MAIL,
         when=days_before(40, c.ART_SHOW_DEADLINE),
         ident='art_show_mail_in')
 
@@ -962,23 +962,12 @@ if c.MIVS_ENABLED:
         ident='mivs_checklist_update_hotel_information'
     )
 
-
     MIVSGuestEmailFixture(
         'New {EVENT_NAME} MIVS Checklist Item: MIVS Training',
         'mivs/checklist/new_update_training_information.txt',
         lambda mg: True,
         ident='mivs_checklist_update_training_information'
     )
-
-    for key, val in c.MIVS_CHECKLIST.items():
-        if val['start']:
-            MIVSGuestEmailFixture(
-                'New MIVS Checklist Item Available: {}'.format(val['name']),
-                'mivs/checklist_new_item.txt',
-                lambda mg: val['start'] > mg.created.when,
-                when=after(val['start']),
-                ident='mivs_checklist_new_item_{}'.format(key),
-            )
 
     # At-Con MIVS Emails
     MIVSEmailFixture(

--- a/uber/templates/emails/mivs/checklist_new_item.txt
+++ b/uber/templates/emails/mivs/checklist_new_item.txt
@@ -1,1 +1,0 @@
-This space intentionally left blank.


### PR DESCRIPTION
I had built in a way to generate emails for every checklist item, but it's better if the MIVS folks have more control so we don't need those automatically generated ones anymore.