### PR TITLE
Implement various fixes/requests post-MFF

### DIFF
--- a/alembic/versions/fa2deb095760_add_column_to_track_email_sending.py
+++ b/alembic/versions/fa2deb095760_add_column_to_track_email_sending.py
@@ -1,7 +1,7 @@
 """Add column to track email sending
 
 Revision ID: fa2deb095760
-Revises: c7a439f29c1c
+Revises: cd2578936cb0
 Create Date: 2022-11-28 21:45:45.496955
 
 """
@@ -9,7 +9,7 @@ Create Date: 2022-11-28 21:45:45.496955
 
 # revision identifiers, used by Alembic.
 revision = 'fa2deb095760'
-down_revision = 'c7a439f29c1c'
+down_revision = 'cd2578936cb0'
 branch_labels = None
 depends_on = None
 

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -525,6 +525,9 @@ security_email = string(default="MAGFest Security <security@magfest.org>")
 # Emails relating to technical needs are sent to and from this address.
 techops_email = string(default="MAGFest TechOps <techops@magfest.org>")
 
+# Notifications about the charity step on guest checklists are sent here
+charity_email = string(default="MAGFest Charity <charity@magfest.org>")
+
 # Emails for Marketplace applications are sent from this address.
 marketplace_app_email = string(default="")
 

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -285,9 +285,15 @@ def reasonable_total_cost(attendee):
 
 @prereg_validation.Attendee
 def promo_code_is_useful(attendee):
-    with Session() as session:
-        if attendee.promo_code and session.lookup_agent_code(attendee.promo_code.code):
-            return
+    if attendee.promo_code:
+        with Session() as session:
+            if session.lookup_agent_code(attendee.promo_code.code):
+                return
+            code = session.lookup_promo_or_group_code(attendee.promo_code.code, PromoCode)
+            if code and code.group:
+                return
+            if session.lookup_promo_or_group_code(attendee.promo_code.code, PromoCodeGroup):
+                return
 
     if attendee.is_new and attendee.promo_code:
         if not attendee.is_unpaid:

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -692,12 +692,13 @@ class Attendee(MagModel, TakesPaymentMixin):
         We use this list to determine which admins can create, edit, and view the attendee.
         """
         section_list = []
-        if self.badge_type in [c.STAFF_BADGE, c.CONTRACTOR_BADGE, c.ATTENDEE_BADGE] and self.staffing_or_will_be:
+        if self.staffing_or_will_be:
             section_list.append('shifts_admin')
         if (self.group and self.group.guest and self.group.guest.group_type == c.BAND
-            ) or (self.badge_type == c.GUEST and c.BAND in self.ribbon_ints):
+            ) or (self.badge_type == c.GUEST_BADGE and c.BAND in self.ribbon_ints):
             section_list.append('band_admin')
-        if self.group and self.group.guest and self.group.guest.group_type == c.GUEST:
+        if (self.group and self.group.guest and self.group.guest.group_type == c.GUEST
+            ) or (self.badge_type == c.GUEST_BADGE and c.BAND not in self.ribbon_ints):
             section_list.append('guest_admin')
         if c.PANELIST_RIBBON in self.ribbon_ints:
             section_list.append('panels_admin')

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1344,6 +1344,10 @@ class Root:
             if message:
                 log.error("Error while auto-updating attendee receipt: {}".format(message))
 
+            # Stop unsetting these every time someone updates their info
+            params['agreed_to_volunteer_agreement'] = session.attendee(params.get('id')).agreed_to_volunteer_agreement
+            params['reviewed_emergency_procedures'] = session.attendee(params.get('id')).reviewed_emergency_procedures
+
         # Safe to ignore csrf tokens here, because an attacker would need to know the attendee id a priori
         attendee = session.attendee(params, restricted=True, ignore_csrf=True)
 

--- a/uber/templates/emails/guests/charity_notification.txt
+++ b/uber/templates/emails/guests/charity_notification.txt
@@ -3,3 +3,6 @@
 
 They have said they can donate the following:
 {{ guest.charity.desc }}{% endif %}
+
+
+Their group leader is {{ guest.group.leader.full_name }} and their email address is {{ guest.group.leader.email }}

--- a/uber/templates/emails/guests/charity_notification.txt
+++ b/uber/templates/emails/guests/charity_notification.txt
@@ -1,0 +1,5 @@
+"{{ guest.group.name }}" has just updated their charity intent to "{{ guest.charity.donating_label }}"{% if guest.charity.donating != c.NOT_DONATING %}
+
+
+They have said they can donate the following:
+{{ guest.charity.desc }}{% endif %}

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1443,13 +1443,13 @@ $(window).on("runJavaScript", function () {
   <div class="non_group_fields form-group">
     <label for="promo_code" class="col-sm-3 control-label optional-field">Promo {% if c.GROUPS_ENABLED %}or Group {% endif %}Code</label>
     <div class="col-sm-6">
-      {% if attendee.is_unpaid and not read_only %}
+      {% if not attendee.active_receipt and not read_only %}
         <input type="textarea" name="promo_code" value="{{ attendee.promo_code_code or promo_code_code }}" class="form-control" placeholder="Promo Code">
       {% else %}
         <input type="hidden" name="promo_code" value="{{ attendee.promo_code_code }}">
         <p class="form-control-static">
-          {{ attendee.promo_code_code }}
-          {% if not read_only and c.HAS_REG_ADMIN_ACCESS %}
+          {{ attendee.promo_code_code|default("N/A") }}
+          {% if not read_only and c.HAS_REG_ADMIN_ACCESS and attendee.promo_code_code %}
             [<a href="" id="remove_promo_code" onClick="removePromoCode(event)">Remove</a>]
           {% endif %}
         </p>


### PR DESCRIPTION
Catching up on various issues raised on Slack the past couple weeks, including:

- An issue with permissions seeing volunteers
- A problem where people would unset their own volunteer agreement and emergency procedures agreement when updating their own info
- A request to add an email notification when a guest indicates they have something to donate to charity
- An issue where minors could not ever join promo code groups