### PR TITLE
Unset currently_sending when reconciling email fixtures

### DIFF
--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -214,6 +214,7 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
         self.active_before = fixture.active_before
         self.approved = False if self.is_new else self.approved
         self.unapproved_count = 0 if self.is_new else self.unapproved_count
+        self.currently_sending = False
         return self
 
     def renderable_data(self, model_instance):


### PR DESCRIPTION
If you restarted the server while the email task was running, some emails would get stuck in the "currently sending" state -- this should knock them back out of it whenever the email task starts.