### PR TITLE
Fix issues with auto-updating receipts

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -918,6 +918,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     def calc_badge_cost_change(self, **kwargs):
         preview_attendee = Attendee(**self.to_dict())
+        promo_code_discount = self.calculate_badge_cost(use_promo_code=False) - self.calculate_badge_cost()
         new_cost = None
         if 'overridden_price' in kwargs:
             try:
@@ -936,7 +937,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         if not new_cost:
             new_cost = (preview_attendee.calculate_badge_cost() * 100) - current_cost
 
-        return current_cost, new_cost
+        return current_cost, new_cost - (promo_code_discount * 100)
 
     def calc_age_discount_change(self, birthdate):
         preview_attendee = Attendee(**self.to_dict())

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -132,7 +132,7 @@ class Group(MagModel, TakesPaymentMixin):
             preview_group.tables = int(kwargs['tables'])
             return self.default_table_cost * 100, (preview_group.default_table_cost * 100) - (self.default_table_cost * 100)
         if 'badges' in kwargs:
-            num_new_badges = int(kwargs['badges']) - self.badges_purchased
+            num_new_badges = int(kwargs['badges']) - self.badges
             return self.current_badge_cost * 100, self.new_badge_cost * num_new_badges * 100
 
         if not new_cost:


### PR DESCRIPTION
We now account for promo codes when calculating attendee badge cost changes. Also fixes a bug where dealers with non-purchased badges (i.e., attendees that weren't paid by group) would be charged for the non-purchased badges whenever they were saved.