### PR TITLE
Fix encoding issue with emails sent from tasks

### DIFF
--- a/uber/site_sections/marketplace.py
+++ b/uber/site_sections/marketplace.py
@@ -49,7 +49,7 @@ class Root:
                     c.MARKETPLACE_APP_EMAIL,
                     'Marketplace Application Received',
                     render('emails/marketplace/reg_notification.txt',
-                           {'app': app}), model=app)
+                           {'app': app}), model=app, encoding=None)
                 session.commit()
                 raise HTTPRedirect('confirmation?id={}', app.id)
 

--- a/uber/tasks/attractions.py
+++ b/uber/tasks/attractions.py
@@ -169,7 +169,7 @@ def attractions_send_notifications():
                         body = render(template, {
                             'signup': signup,
                             'checkin': checkin,
-                            'c': c}).decode('utf-8')
+                            'c': c}, encoding=None)
                         sid = ident
                         send_email.delay(from_, to_, subject=subject, body=body, format='html', model=attendee.to_dict(), ident=ident)
                 except Exception:

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -53,7 +53,7 @@ def check_duplicate_registrations():
                         a.badge_status = c.NEW_STATUS
 
                 if dupes:
-                    body = render('emails/daily_checks/duplicates.html', {'dupes': sorted(dupes.items())})
+                    body = render('emails/daily_checks/duplicates.html', {'dupes': sorted(dupes.items())}, encoding=None)
                     send_email.delay(c.ADMIN_EMAIL, c.REGDESK_EMAIL, subject, body, format='html', model='n/a')
 
 
@@ -92,7 +92,7 @@ def check_placeholder_registrations():
                                            .options(joinedload(Attendee.group))
                                            .order_by(Attendee.registered, Attendee.full_name).all())  # noqa: E712
                     if placeholders:
-                        body = render('emails/daily_checks/placeholders.html', {'placeholders': placeholders})
+                        body = render('emails/daily_checks/placeholders.html', {'placeholders': placeholders}, encoding=None)
                         send_email.delay(c.ADMIN_EMAIL, to, subject, body, format='html', model='n/a')
 
 
@@ -115,8 +115,8 @@ def check_pending_badges():
             for badge_type, to, per_email_filter, site_section in emails:
                 pending = session.query(Attendee).filter_by(badge_status=c.PENDING_STATUS).filter(per_email_filter).all()
                 if pending and session.no_email(subject.format(badge_type)):
-                        body = render('emails/daily_checks/pending.html', {'pending': pending, 'site_section': site_section})
-                        send_email.delay(c.ADMIN_EMAIL, to, subject.format(badge_type), body, format='html', model='n/a')
+                    body = render('emails/daily_checks/pending.html', {'pending': pending, 'site_section': site_section}, encoding=None)
+                    send_email.delay(c.ADMIN_EMAIL, to, subject.format(badge_type), body, format='html', model='n/a')
 
 
 @celery.schedule(crontab(minute=0, hour='*/6'))
@@ -128,7 +128,7 @@ def check_unassigned_volunteers():
                 not_(Attendee.dept_memberships.any())).order_by(Attendee.full_name).all()  # noqa: E712
             subject = c.EVENT_NAME + ' Unassigned Volunteer Report for ' + localized_now().strftime('%Y-%m-%d')
             if unassigned and session.no_email(subject):
-                body = render('emails/daily_checks/unassigned.html', {'unassigned': unassigned})
+                body = render('emails/daily_checks/unassigned.html', {'unassigned': unassigned}, encoding=None)
                 send_email.delay(c.STAFF_EMAIL, c.STAFF_EMAIL, subject, body, format='html', model='n/a')
 
 
@@ -139,7 +139,7 @@ def check_near_cap():
         subject = "BADGES SOLD ALERT: {} BADGES LEFT!".format(badges_left)
         with Session() as session:
             if not session.query(Email).filter_by(subject=subject).first() and actual_badges_left <= badges_left:
-                body = render('emails/badges_sold_alert.txt', {'badges_left': actual_badges_left})
+                body = render('emails/badges_sold_alert.txt', {'badges_left': actual_badges_left}, encoding=None)
                 send_email.delay(c.ADMIN_EMAIL, [c.REGDESK_EMAIL, c.ADMIN_EMAIL], subject, body, model='n/a')
 
 


### PR DESCRIPTION
Emails sent from tasks were failing because they were being encoded in UTF-8, then JSONized. This fixes the encoding issue.