### PR TITLE
Stop job creation with negative hours

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -615,6 +615,12 @@ def time_conflicts(job):
                     shift.attendee.full_name)
 
 
+@validation.Job
+def no_negative_hours(job):
+    if job.duration < 0:
+        return 'You cannot create a job with negative hours.'
+
+
 Department.required = [('name', 'Name'), ('description', 'Description')]
 DeptRole.required = [('name', 'Name')]
 


### PR DESCRIPTION
Pointed out via Slack. Boy, our validations for job creation are really lacking.