### PR TITLE
Reset email approval counts when sending automated emails

### DIFF
--- a/uber/tasks/email.py
+++ b/uber/tasks/email.py
@@ -155,12 +155,12 @@ def send_automated_emails():
             .filter(*AutomatedEmail.filters_for_active) \
             .options(joinedload(AutomatedEmail.emails)).all()
 
-        """ This appears to be breaking our email-sending process and I do not have the time or tools to figure it out
         for automated_email in active_automated_emails:
+            """ This appears to be breaking our email-sending process and I do not have the time or tools to figure it out
             automated_email.currently_sending = True
             session.add(automated_email)
-            session.commit()
-            automated_email.unapproved_count = 0"""
+            session.commit()"""
+            automated_email.unapproved_count = 0
 
         automated_emails_by_model = groupify(active_automated_emails, 'model')
 


### PR DESCRIPTION
I accidentally commented out too much code in an earlier change. This will make the system stop listing some emails as 1 million+ waiting to send.