### PR TITLE
Only show homepage to real admins

### DIFF
--- a/uber/templates/accounts/homepage.html
+++ b/uber/templates/accounts/homepage.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Homepage{% endblock %}
 {% block content %}
+{% if c.ADMIN_ACCESS_SET %}
 <div class="panel panel-body">
 <a href="#attendee_form?id=None" class="btn btn-primary">Add new attendee</a>
 {% if c.HAS_SHIFTS_ADMIN_ACCESS %}
@@ -34,4 +35,5 @@ var loadViewableAttendees = function(query) {
       });
     }
 </script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
MIVS judges could access the attendee form and make badges. This is a quick fix to stop that.