### PR TITLE
Allow guest admins to see ALL guests

### DIFF
--- a/uber/models/admin.py
+++ b/uber/models/admin.py
@@ -134,6 +134,8 @@ class AdminAccount(MagModel):
     
     @property
     def viewable_guest_group_types(self):
+        if 'guest_admin' in self.read_or_write_access_set:
+            [opt for opt in c.GROUP_TYPE_VARS if opt.lower() + "_admin" in self.read_or_write_access_set or opt.lower() + "_admin" not in c.ADMIN_PAGES]
         return [opt for opt in c.GROUP_TYPE_VARS if opt.lower() + "_admin" in self.read_or_write_access_set]
 
     @property


### PR DESCRIPTION
This is a quick workaround for a somewhat odd problem in how we calculate our guest group accesses -- we made a checklist type that doesn't really fit into our admin accesses, so now we give people with guest_admin access to any checklists without corresponding site sections.