### PR TITLE
Return only valid attendees in API calls

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -51,7 +51,10 @@ def _format_opts(opts):
     return ''.join(html)
 
 
-def _attendee_fields_and_query(full, query):
+def _attendee_fields_and_query(full, query, only_valid=True):
+    if only_valid:
+        query = query.filter(Attendee.is_valid == True)
+
     if full:
         fields = AttendeeLookup.fields_full
         query = query.options(


### PR DESCRIPTION
You wouldn't really expect or wanting pending, invalid, and "imported" (note: not MAGFest-staff-imported, it's another thing) badges to come back through the API, and it's tripping up some people doing vax pre-check, so let's filter them out.