### PR TITLE
Add CSV of dept head checklist items

### DIFF
--- a/uber/templates/dept_checklist/item.html
+++ b/uber/templates/dept_checklist/item.html
@@ -2,7 +2,9 @@
 {% block title %}Department Checklist - {{ conf.name }}{% endblock %}
 {% block content %}
 
-<h2>Department Checklist: {{ conf.name }}</h2>
+<h2>Department Checklist: {{ conf.name }}
+  <a class="btn btn-info" href="item_csv?slug={{ conf.slug }}"><span class="glyphicon glyphicon-download"></span> Download CSV</a>
+</h2>
 
 {{ conf.description }}
 

--- a/uber/templates/dept_checklist/overview.html
+++ b/uber/templates/dept_checklist/overview.html
@@ -177,6 +177,7 @@ th.checklist-item div {
 </h2>
 
 <div class="legend">
+  <strong>Click the title of a checklist item to view responses from all departments for that item.</strong><br/><br/>
   <div>
     <span class="glyphicon glyphicon-remove-circle"></span>
     Checklist admins have missed the deadline for this step


### PR DESCRIPTION
Also adds a note to the overview page reminding you to click the item title, since I constantly forget how to get to the item overview page myself. Fixes https://jira.magfest.net/browse/MAGDEV-1017.