### PR TITLE
Improve UX for attractions requiring badge number

### DIFF
--- a/uber/templates/attractions/events.html
+++ b/uber/templates/attractions/events.html
@@ -79,7 +79,15 @@
       $('.signup-event-label').html($('#' + eventId + ' .event-label').html());
       $('.signup-event-location').html($('#' + eventId + ' .event-location').html());
 
+      {% if c.AT_THE_CON %}
       $signupModal.modal('show');
+      {% else %}
+      if($event.hasClass('badge-num-required')) {
+        $signupModal.modal('show');
+      } else {
+        $altSignupModal.modal('show');
+      }
+      {% endif %}
     });
 
     var signupForEvent = function(eventId, extraParams, callback) {
@@ -244,7 +252,14 @@
           You {% if feature.attraction.advance_checkin < 0 %}may{% else %}must{% endif %}
           check in {{ feature.attraction.advance_checkin_label }}.
         </p>
-        {{ attractions_macros.badge_num_form('All we need is your badge number!') }}
+        {% if not c.AT_THE_CON %}
+        {% if feature.badge_num_required %}
+        <br/>
+        <h4 class="text-center">This event requires a badge number to sign up. You'll be able to sign up after you pick up your badge at registration!</h3>
+        {% endif %}
+        {% else %}
+        {{ attractions_macros.badge_num_form('Type your badge # here after picking up your badge!') }}
+        {% endif %}
       </div>
       <div class="modal-footer">
         {% if not feature.badge_num_required %}
@@ -398,7 +413,7 @@
           {% for event in events %}
             {%- set is_soldout = event.is_sold_out -%}
             {%- set is_unavailable = not event.signups_open -%}
-            <div class="event hover-btn{% if is_soldout %} soldout{% endif %}{% if is_unavailable %} unavailable{% endif %}"
+            <div class="event hover-btn{% if is_soldout %} soldout{% endif %}{% if is_unavailable %} unavailable{% endif %}{% if feature.badge_num_required %} badge-num-required{% endif %}"
                 id="{{ event.id }}"
                 data-event-id="{{ event.id }}"
                 data-event-name="{{ event.name }}"

--- a/uber/templates/attractions_macros.html
+++ b/uber/templates/attractions_macros.html
@@ -24,7 +24,7 @@
   <form class="form-horizontal badge-num-form" method="post" action="verify_badge_num" role="form">
     <div class="form-group">
       <label class="col-sm-offset-2 col-sm-8">
-        <span class="badge-num-label">{{label }}</span>
+        <span class="badge-num-label">{{ label }}</span>
         <span class="confirm-label" style="display: none;">{{ confirm_label }}</span>
         <span>&nbsp;</span>
       </label>


### PR DESCRIPTION
Discussed in Slack -- attendees were getting confused because we have public attractions that require a badge number before the event, so they've been emailing us asking what their badge number is. This will hopefully make things a little clearer.