### PR TITLE
Render an overridable template for post-con

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -30,13 +30,8 @@ def check_post_con(klass):
     def wrapper(func):
         @wraps(func)
         def wrapped(self, *args, **kwargs):
-            if c.POST_CON:  # TODO: replace this with a template and make that suitably generic
-                return """
-                <html><head></head><body style='text-align:center'>
-                    <h2 style='color:red'>We hope you enjoyed {event} {current_year}!</h2>
-                    We look forward to seeing you in {next_year}! Watch our website (<a href="https://www.magfest.org">https://www.magfest.org</a>) and our Twitter (<a href="https://twitter.com/MAGFest">@MAGFest</a>) for announcements.
-                </body></html>
-                """.format(event=c.EVENT_NAME, current_year=c.EVENT_YEAR, next_year=(1 + int(c.EVENT_YEAR)) if c.EVENT_YEAR else '')
+            if c.POST_CON:
+                return render('static_views/post_con.html')
             else:
                 return func(self, *args, **kwargs)
         return wrapped

--- a/uber/templates/static_views/post_con.html
+++ b/uber/templates/static_views/post_con.html
@@ -1,0 +1,4 @@
+<html><head></head><body style='text-align:center'>
+    <h2 style='color:red'>We hope you enjoyed {{ c.EVENT_NAME_AND_YEAR }}!</h2>
+    We look forward to seeing you in {{ c.EVENT_YEAR|int + 1 }}! Watch our website (<a href="https://www.magfest.org">https://www.magfest.org</a>) and our Twitter (<a href="https://twitter.com/MAGFest">@MAGFest</a>) for announcements.
+</body></html>


### PR DESCRIPTION
Weird that we weren't already doing this. Other events can now override the template as normal instead of changing the code. Fixes https://jira.magfest.net/browse/MAGDEV-1118.

We don't need this right now so I'll just include it in the next update to the super2023 branch.