### PR TITLE
Add a way for admins to manually create receipts

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1174,7 +1174,7 @@ class Session(SessionManager):
             if existing_account:
                 self.add_attendee_to_account(attendee, existing_account)
 
-        def get_receipt_by_model(self, model, include_closed=False, create_if_none=False):
+        def get_receipt_by_model(self, model, include_closed=False, create_if_none=""):
             receipt_select = self.query(ModelReceipt).filter_by(owner_id=model.id, owner_model=model.__class__.__name__)
             if not include_closed:
                 receipt_select = receipt_select.filter(ModelReceipt.closed == None)
@@ -1183,11 +1183,11 @@ class Session(SessionManager):
             if not receipt and create_if_none:
                 receipt, receipt_items = Charge.create_new_receipt(model, create_model=True)
 
-                if receipt_items:
-                    self.add(receipt)
+                self.add(receipt)
+                if create_if_none != "BLANK":
                     for item in receipt_items:
                         self.add(item)
-                    self.commit()
+                self.commit()
             return receipt
 
         def get_model_by_receipt(self, receipt):

--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -265,7 +265,7 @@ class Root:
     def process_art_show_payment(self, session, id):
         app = session.art_show_application(id)
 
-        receipt = session.get_receipt_by_model(app, create_if_none=True)
+        receipt = session.get_receipt_by_model(app, create_if_none="DEFAULT")
         
         charge_desc = "{}'s Art Show Application: {}".format(app.attendee.full_name, receipt.charge_description_list)
         charge = Charge(app, amount=receipt.current_amount_owed, description=charge_desc)

--- a/uber/site_sections/badge_printing.py
+++ b/uber/site_sections/badge_printing.py
@@ -148,7 +148,7 @@ class Root:
         if success:
             reprint_fee = int(params.get('fee_amount', 0))
             if reprint_fee:
-                receipt = session.get_receipt_by_model(attendee, create_if_none=True)
+                receipt = session.get_receipt_by_model(attendee, create_if_none="DEFAULT")
                 session.add(ReceiptItem(receipt_id=receipt.id,
                                         desc="Badge reprint fee (${})".format(reprint_fee),
                                         amount=reprint_fee * 100,

--- a/uber/site_sections/marketplace.py
+++ b/uber/site_sections/marketplace.py
@@ -103,7 +103,7 @@ class Root:
     def process_marketplace_payment(self, session, id):
         app = session.marketplace_application(id)
         
-        receipt = session.get_receipt_by_model(app, create_if_none=True)
+        receipt = session.get_receipt_by_model(app, create_if_none="DEFAULT")
         
         charge_desc = "{}'s Marketplace Application: {}".format(app.attendee.full_name, receipt.charge_description_list)
         charge = Charge(app, amount=receipt.current_amount_owed, description=charge_desc)

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1028,7 +1028,7 @@ class Root:
     @credit_card
     def process_group_payment(self, session, id):
         group = session.group(id)
-        receipt = session.get_receipt_by_model(group, create_if_none=True)
+        receipt = session.get_receipt_by_model(group, create_if_none="DEFAULT")
         charge_desc = "{}: {}".format(group.name, receipt.charge_description_list)
         charge = Charge(group, amount=receipt.current_amount_owed, description=charge_desc)
 
@@ -1088,7 +1088,7 @@ class Root:
     def pay_for_extra_members(self, session, id, count):
         from uber.models import ReceiptItem
         group = session.group(id)
-        receipt = session.get_receipt_by_model(group, create_if_none=True)
+        receipt = session.get_receipt_by_model(group, create_if_none="DEFAULT")
         session.add(receipt)
         session.commit()
         count = int(count)
@@ -1363,7 +1363,7 @@ class Root:
 
                 page = ('badge_updated?id=' + attendee.id + '&') if return_to == 'confirm' else (return_to + '?')
                 if not receipt:
-                    new_receipt = session.get_receipt_by_model(attendee, create_if_none=True)
+                    new_receipt = session.get_receipt_by_model(attendee, create_if_none="DEFAULT")
                     if new_receipt.current_amount_owed and not new_receipt.pending_total:
                         raise HTTPRedirect('new_badge_payment?id=' + attendee.id + '&return_to=' + return_to)
                 raise HTTPRedirect(page + 'message=' + message)
@@ -1496,7 +1496,7 @@ class Root:
         attendee = session.attendee(id)
         return {
             'attendee': attendee,
-            'receipt': session.get_receipt_by_model(attendee, create_if_none=True),
+            'receipt': session.get_receipt_by_model(attendee, create_if_none="DEFAULT"),
             'return_to': return_to,
             'message': message,
         }
@@ -1512,7 +1512,7 @@ class Root:
 
         message = attendee.undo_extras()
         if not message:
-            new_receipt = session.get_receipt_by_model(attendee, create_if_none=True)
+            new_receipt = session.get_receipt_by_model(attendee, create_if_none="DEFAULT")
             page = ('badge_updated?id=' + attendee.id + '&') if return_to == 'confirm' else (return_to + '?')
             if new_receipt.current_amount_owed:
                 raise HTTPRedirect('new_badge_payment?id=' + attendee.id + '&return_to=' + return_to)

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -100,6 +100,19 @@ class Root:
             'message': message,
         }
 
+    def create_receipt(self, session, id='', blank=False):
+        try:
+            model = session.attendee(id)
+        except NoResultFound:
+            try:
+                model = session.group(id)
+            except NoResultFound:
+                model = session.art_show_application(id)
+        receipt = session.get_receipt_by_model(model, create_if_none="BLANK" if blank else "DEFAULT")
+
+        raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}', model.id, "{} receipt created.".format("Blank" if blank else "Default"))
+
+
     @ajax
     def add_receipt_item(self, session, id='', **params):
         receipt = session.model_receipt(id)

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -628,7 +628,7 @@ class Root:
                         cherrypy.session['attendee_account_id'] = new_or_existing_account.id
 
                 session.add(attendee)
-                receipt = session.get_receipt_by_model(attendee, create_if_none=True)
+                receipt = session.get_receipt_by_model(attendee, create_if_none="DEFAULT")
                 session.commit()
                 if c.AFTER_BADGE_PRICE_WAIVED:
                     message = c.AT_DOOR_WAIVED_MSG
@@ -687,7 +687,7 @@ class Root:
     @credit_card
     def take_payment(self, session, id):
         attendee = session.attendee(id)
-        receipt = session.get_receipt_by_model(attendee, create_if_none=True)
+        receipt = session.get_receipt_by_model(attendee, create_if_none="DEFAULT")
         charge_desc = "{}: {}".format(attendee.full_name, receipt.charge_description_list)
         charge = Charge(attendee, amount=receipt.current_amount_owed, description=charge_desc)
         stripe_intent = session.process_receipt_charge(receipt, charge)
@@ -752,7 +752,7 @@ class Root:
             return {'success': False, 'message': 'Payments can only be taken by at-door stations.'}
         
         attendee = session.attendee(id)
-        receipt = session.get_receipt_by_model(attendee, create_if_none=True)
+        receipt = session.get_receipt_by_model(attendee, create_if_none="DEFAULT")
         attendee.paid = c.HAS_PAID
         if int(payment_method) == c.STRIPE_ERROR:
             desc = "Automated message: Stripe payment manually verified by admin."
@@ -769,7 +769,7 @@ class Root:
     @credit_card
     def manual_reg_charge(self, session, id):
         attendee = session.attendee(id)
-        receipt = session.get_receipt_by_model(attendee, create_if_none=True)
+        receipt = session.get_receipt_by_model(attendee, create_if_none="DEFAULT")
         charge_desc = "{}: {}".format(attendee.full_name, receipt.charge_description_list)
         charge = Charge(attendee, amount=receipt.current_amount_owed, description=charge_desc)
 

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -472,6 +472,7 @@
   <button class="btn btn-danger" onClick="fullRefund('{{ receipt.id }}')">Refund and Cancel This {{ model_str|title }}</button>
 {% else %}
 There are no active receipts for this {{ model_str }}.
+<br/><a href="create_receipt?id={{ model.id }}" class="btn btn-success">Create Default Receipt</a> <a href="create_receipt?id={{ model.id }}&blank=true" class="btn btn-info">Create Blank Receipt</a>
 {% endif %}
 </div>
 </div>


### PR DESCRIPTION
We're having issues with some workflows because the system will only create a model receipt when an attendee saves their info. This adds a button to create either a "Default" receipt (one with all the default costs calculated) or a blank receipt.