### PR TITLE
Fixes for hotel audit

### DIFF
--- a/uber/site_sections/hotel_reports.py
+++ b/uber/site_sections/hotel_reports.py
@@ -404,6 +404,7 @@ class Root:
             'Zip Code',
             'Non-US?'
         ])
+        engine = None
         if c.MAPS_ENABLED:
             from uszipcode import SearchEngine
             try:
@@ -411,7 +412,7 @@ class Root:
             except Exception as e:
                 log.error("Error calling SearchEngine: " + e)
 
-        for attendee in session.valid_attendees():
+        for attendee in session.valid_attendees().filter(Attendee.is_unassigned == False):
             city = ''
             state = ''
             if engine and not attendee.international:


### PR DESCRIPTION
Prevents a 500 error when maps aren't enabled, and excludes unassigned badges from the report.