### PR TITLE
Handle long zipcodes in hotel audit report

### DIFF
--- a/uber/site_sections/hotel_reports.py
+++ b/uber/site_sections/hotel_reports.py
@@ -415,8 +415,8 @@ class Root:
         for attendee in session.valid_attendees().filter(Attendee.is_unassigned == False):
             city = ''
             state = ''
-            if engine and not attendee.international:
-                simple_zip = engine.by_zipcode(attendee.zip_code)
+            if engine and attendee.zip_code and not attendee.international:
+                simple_zip = engine.by_zipcode(attendee.zip_code[:5])
                 city = simple_zip.city
                 state = simple_zip.state
             out.writerow([


### PR DESCRIPTION
Hopefully the last fix needed for this. I really would've expected the uszipcode library to just handle these.