### PR TITLE
Adding links to email templates from Pending Emails page

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -13,6 +13,7 @@ ALREADY SENT FOR THAT CATEGORY TO RE-SEND.
 
 import os
 from datetime import datetime, timedelta
+import pathlib
 
 from pockets import listify
 from pytz import UTC
@@ -20,6 +21,7 @@ from sqlalchemy.orm import joinedload, subqueryload
 
 from uber.config import c
 from uber import decorators
+from uber.jinja import JinjaEnv
 from uber.models import AdminAccount, Attendee, AttendeeAccount, ArtShowApplication, AutomatedEmail, Department, Group, \
     GuestGroup, IndieGame, IndieJudge, IndieStudio, MarketplaceApplication, MITSTeam, MITSApplicant, PanelApplication, \
     PanelApplicant, PromoCodeGroup, Room, RoomAssignment, Shift
@@ -122,6 +124,11 @@ class AutomatedEmailFixture:
 
         before = [d.active_before for d in when if d.active_before]
         self.active_before = max(before) if before else None
+
+        env = JinjaEnv.env()
+        template_path = pathlib.Path(env.get_template(os.path.join('emails', self.template)).name)
+        self.template_plugin = template_path.parts[3]
+        self.template_url = f"https://github.com/magfest/{self.template_plugin}/tree/main/{self.template_plugin}/{pathlib.Path(*template_path.parts[5:]).as_posix()}"
 
     @property
     def body(self):

--- a/uber/templates/email_admin/pending.html
+++ b/uber/templates/email_admin/pending.html
@@ -29,6 +29,7 @@
     <thead>
     <tr class="header">
       <th>Subject</th>
+      <th>Template</th>
       <th>Sender</th>
       <th>Emails Sent</th>
       <th>Emails waiting to send but need approval</th>
@@ -50,6 +51,7 @@
               require{{ email.unapproved_count|pluralize('s', '') }} approval
             {% endif %}
           </td>
+          <td><a href="{{ email.fixture.template_url }}" target="_blank">{{ email.fixture.template_plugin }}</a></td>
           <td>{{ email.sender }}</td>
           <td>{{ email.sent_email_count }}</td>
           <td>{{ email.unapproved_count }}</td>


### PR DESCRIPTION
This adds a column to the Pending Emails page with links directly to the templates used to generate each email.

<img width="1511" alt="Screenshot 2023-02-22 at 20 27 00" src="https://user-images.githubusercontent.com/1031406/220801821-7d603742-740f-456d-8f6d-61969d73efc0.png">
