### PR TITLE
Adding option to pull config into dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       - DB_CONNECTION_STRING=postgresql://uber_db:uber_db@db:5432/uber_db
       - PORT=80
+      - UBERSYSTEM_GIT_CONFIG=https://github.com/magfest/terraform-aws-magfest.git
+      - UBERSYSTEM_GIT_CONFIG_PATHS=uber_config/environments/dev uber_config/events/super/2024
   db:
     image: postgres
     environment:
@@ -29,8 +31,12 @@ services:
     command: ['celery-beat']
     environment:
       - DB_CONNECTION_STRING=postgresql://uber_db:uber_db@db:5432/uber_db
+      - UBERSYSTEM_GIT_CONFIG=https://github.com/magfest/terraform-aws-magfest.git
+      - UBERSYSTEM_GIT_CONFIG_PATHS=uber_config/environments/dev uber_config/events/super/2024
   celery-worker:
     build: .
     command: ['celery-worker']
     environment:
       - DB_CONNECTION_STRING=postgresql://uber_db:uber_db@db:5432/uber_db
+      - UBERSYSTEM_GIT_CONFIG=https://github.com/magfest/terraform-aws-magfest.git
+      - UBERSYSTEM_GIT_CONFIG_PATHS=uber_config/environments/dev uber_config/events/super/2024

--- a/make_config.py
+++ b/make_config.py
@@ -1,5 +1,8 @@
 #!/app/env/bin/python3
 from configobj import ConfigObj
+import tempfile
+import argparse
+import pathlib
 import base64
 import gzip
 import yaml
@@ -9,6 +12,34 @@ root = os.environ.get("UBERSYSTEM_ROOT", "/app")
 config = os.environ.get("UBERSYSTEM_CONFIG", "[]")
 secrets = yaml.load(os.environ.get("UBERSYSTEM_SECRETS", "{}"), Loader=yaml.Loader)
 
+parser = argparse.ArgumentParser(
+    prog='make_config',
+    description='Generates ubersystem config files from compressed environment variables'
+)
+parser.add_argument("--repo", required=False, help="Optional git repo to pull config from, used for development")
+parser.add_argument("--paths", nargs="*", help="Configuration paths to use when loading from git repo")
+args = parser.parse_args()
+
+if args.repo:
+    repo_config = []
+    with tempfile.TemporaryDirectory() as temp:
+        print(f"Cloning config repo {args.repo} into {temp}")
+        os.system(f"git clone --depth=1 {args.repo} {temp}")
+        files = []
+        for path in args.paths:
+            print(f"Loading files from {path}")
+            parts = pathlib.PurePath(path).parts
+            for idx, part in enumerate(parts):
+                full_path = os.path.join(temp, *parts[:idx+1])
+                files.extend([os.path.join(full_path, x) for x in os.listdir(full_path) if x.endswith(".yaml")])
+        for filename in files:
+            print(f"Loading config from {filename}")
+            with open(filename, "rb") as FILE:
+                config_data = FILE.read()
+            zipped = gzip.compress(config_data)
+            encoded = base64.b64encode(zipped)
+            repo_config.append(encoded)
+    config = yaml.dump(repo_config, Dumper=yaml.Dumper, encoding="utf8")
 
 plugins = os.listdir(os.path.join(root, "plugins"))
 plugin_configs = {x: [] for x in plugins}

--- a/uber-wrapper.sh
+++ b/uber-wrapper.sh
@@ -7,6 +7,11 @@ set -e
 envsubst < "uber-development.ini.template" > /app/plugins/uber/development.ini
 envsubst < "sideboard-development.ini.template" > /app/development.ini
 
+if [ -n "${UBERSYSTEM_GIT_CONFIG}" ]; then
+    echo "Loading UBERSYSTEM_CONFIG from git repo ${UBERSYSTEM_GIT_CONFIG}"
+    /app/env/bin/python /app/plugins/uber/make_config.py --repo "${UBERSYSTEM_GIT_CONFIG}" --paths ${UBERSYSTEM_GIT_CONFIG_PATHS}
+fi
+
 if [ -n "${UBERSYSTEM_CONFIG}" ]; then
     echo "Parsing config from environment"
     /app/env/bin/python /app/plugins/uber/make_config.py


### PR DESCRIPTION
This adds `UBERSYSTEM_GIT_CONFIG` and `UBERSYSTEM_GIT_CONFIG_PATHS` environment variables that allow pulling configuration from a git repo in the same format used by the MAGFest terraform scripts. 