### PR TITLE
Fix email template URLs

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -126,6 +126,12 @@ class AutomatedEmailFixture:
         before = [d.active_before for d in when if d.active_before]
         self.active_before = max(before) if before else None
 
+    @property
+    def body(self):
+        return decorators.render_empty(os.path.join('emails', self.template))
+    
+    @property
+    def template_url(self):
         env = JinjaEnv.env()
         try:
             template_path = pathlib.Path(env.get_template(os.path.join('emails', self.template)).name)
@@ -133,11 +139,6 @@ class AutomatedEmailFixture:
             self.template_url = f"https://github.com/magfest/{self.template_plugin}/tree/main/{self.template_plugin}/{pathlib.Path(*template_path.parts[5:]).as_posix()}"
         except jinja2.exceptions.TemplateNotFound:
             self.template_url = ""
-        
-
-    @property
-    def body(self):
-        return decorators.render_empty(os.path.join('emails', self.template))
 
 
 # Payment reminder emails, including ones for groups, which are always safe to be here, since they just


### PR DESCRIPTION
Since the URLs for emails were only being set on initialization, they didn't always match the email body, which is re-calculated on access. It might be worth figuring out later why the email body sometimes changes after init, but for now this Probably™ won't cause issues.