### PR TITLE
Remove "proof of vaccination" from emails

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -204,6 +204,9 @@ check_in_time = string(default='4pm')
 # What time in the morning people need to check out of their hotel rooms.
 check_out_time = string(default='12pm/Noon')
 
+# A string appended to any place that reminds people to bring their Photo ID to check into the event.
+extra_checkin_docs = string(default='')
+
 # The path used to mount the app in cherrypy's mount tree. This may be
 # different from the "path" setting if the server is running behind a
 # reverse proxy with rewrite rules that change the URL path.

--- a/uber/templates/emails/mivs/judge_badge_info.txt
+++ b/uber/templates/emails/mivs/judge_badge_info.txt
@@ -8,7 +8,7 @@ First, please fill out this short survey about your experience being a judge: ht
 
 *** Badge Information ***
 
-{% if judge.attendee.paid == c.NEED_NOT_PAY %}Your complementary badge will be waiting for you at our registration desk under your name ({{ judge.attendee.full_name }}). Simply bring a photo ID and proof of vaccination ({{ c.COVID_POLICIES_URL }}) to pick it up. Due to limitations in our system, we can not transfer complementary judge badges to other people right now.{% else %}We provide complementary badges to our judges that completed their assigned games, but if you already paid for a badge, please reply to this email to let us know to issue you a refund.{% endif %}
+{% if judge.attendee.paid == c.NEED_NOT_PAY %}Your complementary badge will be waiting for you at our registration desk under your name ({{ judge.attendee.full_name }}). Simply bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to pick it up. Due to limitations in our system, we can not transfer complementary judge badges to other people right now.{% else %}We provide complementary badges to our judges that completed their assigned games, but if you already paid for a badge, please reply to this email to let us know to issue you a refund.{% endif %}
 
 If you're not attending {{ c.EVENT_NAME }} this year, everything is taken care of and you don't need to do anything. If you are attending, then please stop by the MIVS area and talk with the indie devs showcasing their games. You can also say hi to the MIVS staff at the MIVS Ops booth.
 

--- a/uber/templates/emails/placeholders/guest.txt
+++ b/uber/templates/emails/placeholders/guest.txt
@@ -1,6 +1,6 @@
 {% if attendee.first_name %}{{ attendee.first_name }},
 
-{% endif %}Thanks for coming out to {{ c.EVENT_NAME }} as a Guest! We've added you to our registration database for your complimentary badge, but we don't have all of your personal information. To ensure that you can pick up your badge with no hassles, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID and proof of vaccination ({{ c.COVID_POLICIES_URL }}) to {{ c.EVENT_NAME }}.
+{% endif %}Thanks for coming out to {{ c.EVENT_NAME }} as a Guest! We've added you to our registration database for your complimentary badge, but we don't have all of your personal information. To ensure that you can pick up your badge with no hassles, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to {{ c.EVENT_NAME }}.
 
 Please let us know if you have any questions by reaching out to us at {{ c.GUEST_EMAIL|email_only }}.
 

--- a/uber/templates/emails/placeholders/panelist.txt
+++ b/uber/templates/emails/placeholders/panelist.txt
@@ -1,6 +1,6 @@
 {% if attendee.first_name %}{{ attendee.first_name }},
 
-{% endif %}Thanks for coming out to {{ c.EVENT_NAME }} as a Panelist!  We've added you to our registration database for your complementary badge, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID and proof of vaccination ({{ c.COVID_POLICIES_URL }}) to {{ c.EVENT_NAME }}.
+{% endif %}Thanks for coming out to {{ c.EVENT_NAME }} as a Panelist!  We've added you to our registration database for your complementary badge, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to {{ c.EVENT_NAME }}.
 
 Please let us know if you have any questions.
 

--- a/uber/templates/emails/placeholders/regular.txt
+++ b/uber/templates/emails/placeholders/regular.txt
@@ -1,6 +1,6 @@
 {% if attendee.first_name %}{{ attendee.first_name }},
 
-{% endif %}You've been added to the {{ c.EVENT_NAME }} registration database, but we don't have all of your personal information{% if attendee.amount_unpaid %} and you have not yet paid your outstanding balance of {{ attendee.amount_unpaid|format_currency }}{% endif %}.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info{% if attendee.amount_unpaid %} and pay{% endif %} at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID and proof of vaccination ({{ c.COVID_POLICIES_URL }}) to {{ c.EVENT_NAME }}.
+{% endif %}You've been added to the {{ c.EVENT_NAME }} registration database, but we don't have all of your personal information{% if attendee.amount_unpaid %} and you have not yet paid your outstanding balance of {{ attendee.amount_unpaid|format_currency }}{% endif %}.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info{% if attendee.amount_unpaid %} and pay{% endif %} at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to {{ c.EVENT_NAME }}.
 
 Please let us know if you have any questions.
 

--- a/uber/templates/emails/placeholders/volunteer.txt
+++ b/uber/templates/emails/placeholders/volunteer.txt
@@ -1,6 +1,6 @@
 {% if attendee.first_name %}{{ attendee.first_name }},
 
-{% endif %}Thanks for volunteering to help run {{ c.EVENT_NAME }}!  You've been added to our registration database, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID and proof of vaccination ({{ c.COVID_POLICIES_URL }}) to {{ c.EVENT_NAME }}.
+{% endif %}Thanks for volunteering to help run {{ c.EVENT_NAME }}!  You've been added to our registration database, but we don't have all of your personal information.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to {{ c.EVENT_NAME }}.
 
 After entering the rest of your information, we'll assign you to the appropriate department and you'll be able to sign up for shifts.
 


### PR DESCRIPTION
Replaces it with a configurable string, since that seems useful anyway.