### PR TITLE
Stop silent error when resuming payment intent

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1440,6 +1440,9 @@ class Root:
 
         stripe_intent = txn.get_stripe_intent()
 
+        if not stripe_intent:
+            return {'error': "Something went wrong. Please contact us at {}.".format(c.REGDESK_EMAIL)}
+
         if stripe_intent.charges:
             return {'error': "This payment has already been finalized!"}
 


### PR DESCRIPTION
Although this should technically never happen, we managed to glitch our way into having a pending payment without a stripe intent and it failed silently for the user. This will at least make it fail less silently.