### PR TITLE
Refresh receipts before sending emails

### DIFF
--- a/uber/tasks/email.py
+++ b/uber/tasks/email.py
@@ -172,6 +172,8 @@ def send_automated_emails():
                     if model_instance.id not in automated_email.emails_by_fk_id:
                         if automated_email.would_send_if_approved(model_instance):
                             if automated_email.approved or not automated_email.needs_approval:
+                                if model_instance.active_receipt:
+                                    session.refresh_receipt_and_model(model_instance)
                                 automated_email.send_to(model_instance, delay=False)
                             else:
                                 automated_email.unapproved_count += 1


### PR DESCRIPTION
This should hopefully fix the intermittent bug people were seeing where their "amount paid" was listed as $0.