### PR TITLE
Only record emails if there are no errors

### DIFF
--- a/uber/amazon_ses.py
+++ b/uber/amazon_ses.py
@@ -52,7 +52,7 @@ class AmazonSES:
                 },
                 ReturnPath=returnPath or source,
             )
-            log.error("Sent email. Response: " + str(response))
+            log.info("Sent email. Response: " + str(response))
         except ClientError as e:
             return e.response['Error']['Message']
         except Exception as e:


### PR DESCRIPTION
We were getting confused about email sending because the system records the email as sent even if there was a problem sending it. We still record emails if email sending is turned off in development environments, but otherwise emails now don't get recorded unless they actually get sent.

Also sets email-related logs to INFO level since we don't need the extra data anymore.