### PR TITLE
Make placeholder deadline optional

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -561,7 +561,7 @@ AutomatedEmailFixture(
     'Last Chance to Accept Your {EVENT_NAME} ({EVENT_DATE}) Badge',
     'placeholders/reminder.txt',
     lambda a: a.placeholder and not a.is_dealer,
-    when=days_before(7, c.PLACEHOLDER_DEADLINE),
+    when=days_before(7, c.PLACEHOLDER_DEADLINE if c.PLACEHOLDER_DEADLINE else c.UBER_TAKEDOWN),
     ident='badge_confirmation_reminder_last_chance')
 
 

--- a/uber/templates/emails/placeholders/reminder.txt
+++ b/uber/templates/emails/placeholders/reminder.txt
@@ -2,6 +2,6 @@
 
 {% endif %}You still haven't accepted the {{ attendee.badge_type_label }} badge{% if attendee.ribbon %} with a {{ attendee.ribbon_labels|join(" / ") }} ribbon{% endif %} for this year's {{ c.EVENT_NAME }}.  We need to know whether you're coming, so please let us know by filling out the form at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
 
-We're going to delete all un-accepted preregistrations at {{ c.PLACEHOLDER_DEADLINE|datetime_local }}, so please make sure to fill out the form before then.
+{% if c.PLACEHOLDER_DEADLINE %}We're going to delete all un-accepted preregistrations at {{ c.PLACEHOLDER_DEADLINE|datetime_local }}, so please make sure to fill out the form before then.{% endif %}
 
 {{ c.REGDESK_EMAIL_SIGNATURE }}


### PR DESCRIPTION
We don't actually delete placeholder badges, so now if the deadline isn't set we don't talk about deleting them. This fixes the last bit of https://jira.magfest.net/browse/MAGDEV-867.