### PR TITLE
Fix daily badges sold statistic for PC groups

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -309,7 +309,7 @@ class Config(_Overridable):
                     Attendee.paid == self.PAID_BY_GROUP,
                     Group.amount_paid > 0).count()
 
-                promo_code_badges = session.query(PromoCode).join(PromoCodeGroup).count()
+                promo_code_badges = session.query(PromoCode).join(PromoCodeGroup).filter(PromoCode.cost > 0).count()
 
                 return individuals + group_badges + promo_code_badges
 

--- a/uber/models/promo_code.py
+++ b/uber/models/promo_code.py
@@ -170,9 +170,15 @@ class PromoCodeGroup(MagModel):
     def email(self):
         return self.buyer.email if self.buyer else None
 
-    @property
+    @hybrid_property
     def total_cost(self):
         return sum(code.cost for code in self.promo_codes if code.cost)
+    
+    @total_cost.expression
+    def total_cost(cls):
+        return select([func.sum(PromoCode.cost)]
+                     ).where(PromoCode.group_id == cls.id
+                     ).label('total_cost')
 
     @property
     def valid_codes(self):
@@ -360,6 +366,15 @@ class PromoCode(MagModel):
     @is_expired.expression
     def is_expired(cls):
         return cls.expiration_date < localized_now()
+
+    @hybrid_property
+    def group_registered(self):
+        if self.group_id:
+            return self.group.registered
+        
+    @group_registered.expression
+    def group_registered(cls):
+        return select([PromoCodeGroup.registered]).where(PromoCodeGroup.id == cls.group_id).label('group_registered')
 
     @property
     def is_free(self):

--- a/uber/site_sections/statistics.py
+++ b/uber/site_sections/statistics.py
@@ -61,7 +61,7 @@ class RegistrationDataOneYear:
                 date_trunc_day(Attendee.registered),
                 func.count(date_trunc_day(Attendee.registered))
             ) \
-            .outerjoin(Attendee.group).outerjoin(Attendee.promo_code) \
+            .outerjoin(Attendee.group) \
             .filter(
                 (
                     (Attendee.group_id != None) &
@@ -70,15 +70,20 @@ class RegistrationDataOneYear:
                     (Group.amount_paid > 0)               # make sure they've paid something
                 ) | (                                     # OR
                     (Attendee.paid == c.HAS_PAID)         # if they're an attendee, make sure they're fully paid
-                ) | (
-                    (Attendee.promo_code != None) &
-                    (PromoCode.group_id != None) &
-                    (PromoCode.cost > 0)
                 )
             ) \
             .group_by(date_trunc_day(Attendee.registered)) \
             .order_by(date_trunc_day(Attendee.registered)) \
             .all()  # noqa: E711
+        
+        group_reg_per_day = session.query(
+            date_trunc_day(PromoCode.group_registered),
+            func.count(date_trunc_day(PromoCode.group_registered))
+            ) \
+        .filter(PromoCode.cost > 0) \
+        .group_by(date_trunc_day(PromoCode.group_registered)) \
+        .order_by(date_trunc_day(PromoCode.group_registered)) \
+        .all()
 
         # now, convert the query's data into the format we need.
         # SQL will skip days without registrations
@@ -87,7 +92,11 @@ class RegistrationDataOneYear:
         # create 365 elements in the final array
         self.registrations_per_day = self.num_days_to_report * [0]
 
-        for reg_data in reg_per_day:
+        # merge attendee and promo code group reg
+        dict_reg_per_day = dict(reg_per_day)
+        total_reg_per_day = [(k, dict_reg_per_day[k] + dict(group_reg_per_day)[k]) for k in sorted(dict_reg_per_day)]
+
+        for reg_data in total_reg_per_day:
             day = reg_data[0]
             reg_count = reg_data[1]
 


### PR DESCRIPTION
We were only counting group codes that had been claimed because they had attendees associated with them, but the badges_sold graph is about sales, not registrations. We now count promo code groups when they're bought and don't count people with claimed pc group badges. Also fixes BADGES_SOLD to filter out unpaid promo codes.