### PR TITLE
Fixing case of missing days

### DIFF
--- a/uber/site_sections/statistics.py
+++ b/uber/site_sections/statistics.py
@@ -94,7 +94,7 @@ class RegistrationDataOneYear:
 
         # merge attendee and promo code group reg
         dict_reg_per_day = dict(reg_per_day)
-        total_reg_per_day = [(k, dict_reg_per_day[k] + dict(group_reg_per_day)[k]) for k in sorted(dict_reg_per_day)]
+        total_reg_per_day = [(k, dict_reg_per_day.get(k, 0) + dict(group_reg_per_day).get(k, 0)) for k in sorted(dict_reg_per_day)]
 
         for reg_data in total_reg_per_day:
             day = reg_data[0]


### PR DESCRIPTION
I think this is what's causing a KeyError in the stock instance:
```
Traceback (most recent call last):
  File "/app/env/lib/python3.6/site-packages/cherrypy/_cprequest.py", line 630, in respond
    self._do_respond(path_info)
  File "/app/env/lib/python3.6/site-packages/cherrypy/_cprequest.py", line 689, in _do_respond
    response.body = self.handler()
  File "/app/env/lib/python3.6/site-packages/cherrypy/lib/encoding.py", line 221, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/app/env/lib/python3.6/site-packages/cherrypy/_cpdispatch.py", line 54, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/app/plugins/uber/uber/decorators.py", line 526, in with_timed
    return func(*args, **kwargs)
  File "/app/plugins/uber/uber/decorators.py", line 552, in with_session
    retval = func(*args, session=session, **kwargs)
  File "/app/plugins/uber/uber/decorators.py", line 701, in with_restrictions
    return func(*args, **kwargs)
  File "/app/plugins/uber/uber/decorators.py", line 607, in with_rendering
    result = func(*args, **kwargs)
  File "/app/plugins/uber/uber/site_sections/statistics.py", line 263, in badges_sold
    graph_data_current_year.query_current_year(session)
  File "/app/plugins/uber/uber/site_sections/statistics.py", line 97, in query_current_year
    total_reg_per_day = [(k, dict_reg_per_day[k] + dict(group_reg_per_day)[k]) for k in sorted(dict_reg_per_day)]
  File "/app/plugins/uber/uber/site_sections/statistics.py", line 97, in <listcomp>
    total_reg_per_day = [(k, dict_reg_per_day[k] + dict(group_reg_per_day)[k]) for k in sorted(dict_reg_per_day)]
KeyError: datetime.datetime(2023, 4, 21, 0, 0)
```

This PR adds a default value of 0 for days that aren't in the dict.