### PR TITLE
Account for mismatching keys in group and attendee queries

### DIFF
--- a/uber/site_sections/statistics.py
+++ b/uber/site_sections/statistics.py
@@ -93,8 +93,11 @@ class RegistrationDataOneYear:
         self.registrations_per_day = self.num_days_to_report * [0]
 
         # merge attendee and promo code group reg
-        dict_reg_per_day = dict(reg_per_day)
-        total_reg_per_day = [(k, dict_reg_per_day[k] + dict(group_reg_per_day)[k]) for k in sorted(dict_reg_per_day)]
+        total_reg_per_day = defaultdict(int)
+        for k, v in dict(reg_per_day).items():
+            total_reg_per_day[k] += v
+        for k, v in dict(group_reg_per_day).items():
+            total_reg_per_day[k] += v
 
         for reg_data in total_reg_per_day:
             day = reg_data[0]


### PR DESCRIPTION
This Should™ fix the 500 error on Stock while preserving the correct dates for attendee registrations and promo code group registrations.