### PR TITLE
Use the correct Stripe property to check for refund availability

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1022,7 +1022,7 @@ class Session(SessionManager):
             refund_amount = amount or txn.amount_left
 
             balance = stripe.Balance.retrieve()
-            if balance['available'][0]['amount'] < refund_amount:
+            if balance['instant_available'][0]['amount'] < refund_amount:
                 return "We cannot currently refund this transaction. Please try again in a few days or contact an administrator."
 
             log.debug('REFUND: attempting to refund Stripe transaction with ID {} {} cents for {}',


### PR DESCRIPTION
The "available" property on our Stripe account is how much money Stripe is ready to deposit into our bank account, which will often be $0 (like, say, after Stripe has deposited money in our bank account). Refunds are actually levied against both current and future funds, which seem to be captured in the "instant_available" property.