### PR TITLE
Don't log email locking changes

### DIFF
--- a/uber/models/tracking.py
+++ b/uber/models/tracking.py
@@ -144,6 +144,8 @@ class Tracking(MagModel):
             data = cls.format(diff)
             if len(diff) == 1 and 'badge_num' in diff and c.SHIFT_CUSTOM_BADGES:
                 action = c.AUTO_BADGE_SHIFT
+            if len(diff) == 1 and 'currently_sending' in diff:
+                return
             elif not data:
                 return
         else:


### PR DESCRIPTION
Our tracking DB tracks every change to every model, but locking emails via the DB means generating approximately 8 bajillion DB entries. This should stop that.