### PR TITLE
Fix timezone conversion issue with datetimepicker

### DIFF
--- a/uber/templates/attractions_macros.html
+++ b/uber/templates/attractions_macros.html
@@ -84,9 +84,9 @@
     $('#{{ html_id }} input[name="{{ field_name }}"]').datetimepicker({
       sideBySide: true,
       useCurrent: false,
-      defaultDate: '{{ value.isoformat() }}',
-      minDate: '{{ c.EPOCH.isoformat() }}',
-      maxDate: '{{ c.ESCHATON.isoformat() }}',
+      defaultDate: '{{ value.isoformat()[:-6] }}',
+      minDate: '{{ c.EPOCH.isoformat()[:-6] }}',
+      maxDate: '{{ c.ESCHATON.isoformat()[:-6] }}',
       format: 'M/D/Y h:mm A'
     });
   </script>

--- a/uber/templates/detailed_travel_plans_form.html
+++ b/uber/templates/detailed_travel_plans_form.html
@@ -38,17 +38,17 @@
                 $('#arrival-time' + suffix).datetimepicker({
                   sideBySide: true,
                   useCurrent: false,
-                  defaultDate: '{{ c.EPOCH.isoformat() }}',
-                  minDate: '{{ min_arrival_time.isoformat() }}',
-                  maxDate: '{{ max_arrival_time.isoformat() }}',
+                  defaultDate: '{{ c.EPOCH.isoformat()[:-6] }}',
+                  minDate: '{{ min_arrival_time.isoformat()[:-6] }}',
+                  maxDate: '{{ max_arrival_time.isoformat()[:-6] }}',
                   format: 'M/D/Y h:mm A'
                 });
                 $('#departure-time' + suffix).datetimepicker({
                   sideBySide: true,
                   useCurrent: false,
-                  defaultDate: '{{ c.ESCHATON.isoformat() }}',
-                  minDate: '{{ min_departure_time.isoformat() }}',
-                  maxDate: '{{ max_departure_time.isoformat() }}',
+                  defaultDate: '{{ c.ESCHATON.isoformat()[:-6] }}',
+                  minDate: '{{ min_departure_time.isoformat()[:-6] }}',
+                  maxDate: '{{ max_departure_time.isoformat()[:-6] }}',
                   format: 'M/D/Y h:mm A'
                 });
             }

--- a/uber/templates/shifts_admin/form.html
+++ b/uber/templates/shifts_admin/form.html
@@ -143,9 +143,9 @@
     $('#start-time').datetimepicker({
       sideBySide: true,
       useCurrent: false,
-      defaultDate: '{{ min_date.isoformat() }}',
-      minDate: '{{ min_date.isoformat() }}',
-      maxDate: '{{ max_date.isoformat() }}',
+      defaultDate: '{{ min_date.isoformat()[:-6] }}',
+      minDate: '{{ min_date.isoformat()[:-6] }}',
+      maxDate: '{{ max_date.isoformat()[:-6] }}',
       format: 'M/D/Y h:mm A'
     });
   </script>


### PR DESCRIPTION
Our datetimepicker plugin was converting all times to the browser's local timezone, but we always want times to be in the event's timezone. This forces all times passed to datetimepicker to be timezone-naive so it stops converting them to the browser's timezone.

This specifically fixes an issue where a department head could not create a West loadout shift before 7pm (the minimum should be 4pm).