### PR TITLE
Added health check endpoint

### DIFF
--- a/uber/site_sections/devtools.py
+++ b/uber/site_sections/devtools.py
@@ -1,10 +1,13 @@
 import os
 import json
 import shlex
+import time
 import subprocess
 import csv
 import urllib
+import random
 import six
+import cherrypy
 from datetime import datetime
 
 from sideboard.debugging import register_diagnostics_status_function, gather_diagnostics_status_information
@@ -12,11 +15,13 @@ from sqlalchemy.dialects.postgresql.json import JSONB
 from pockets.autolog import log
 from pytz import UTC
 from sqlalchemy.types import Date, Boolean, Integer
+from sqlalchemy import text
 
 from uber.badge_funcs import badge_consistency_check
 from uber.config import c, _config
-from uber.decorators import all_renderable, csv_file, set_csv_filename, site_mappable
+from uber.decorators import all_renderable, csv_file, public, set_csv_filename, site_mappable
 from uber.models import Choice, MultiChoice, Session, UTCDateTime
+from uber.tasks.health import ping
 
 
 # admin utilities.  should not be used during normal ubersystem operations except by developers / sysadmins
@@ -201,6 +206,38 @@ class Root:
         for row in rows:
             out.writerow(row)
 
+    @public
+    def health(self, session):
+        cherrypy.response.headers["Access-Control-Allow-Origin"] = "*"
+        cherrypy.session.load()
+
+        read_count = cherrypy.session.get("read_count", default=0)
+        read_count += 1
+        cherrypy.session["read_count"] = read_count
+        session_commit_time = -time.perf_counter()
+        cherrypy.session.save()
+        session_commit_time += time.perf_counter()
+
+        db_read_time = -time.perf_counter()
+        session.execute(text('SELECT 1'))
+        db_read_time += time.perf_counter()
+
+        payload = random.randrange(1024)
+        task_run_time = -time.perf_counter()
+        response = ping.delay(payload).wait()
+        task_run_time += time.perf_counter()
+
+        return json.dumps({
+            'server_current_timestamp': int(datetime.utcnow().timestamp()),
+            'session_read_count': read_count,
+            'session_commit_time': session_commit_time,
+            'db_read_time': db_read_time,
+            'db_status': Session.engine.pool.status(),
+            'task_run_time': task_run_time,
+            'task_response_correct': payload == response,
+            'task_payload': payload,
+            'task_response': response,
+        })
 
 @register_diagnostics_status_function
 def database_pool_information():

--- a/uber/tasks/__init__.py
+++ b/uber/tasks/__init__.py
@@ -13,7 +13,7 @@ celery.conf.beat_schedule = {}
 celery.conf.beat_startup_tasks = []
 celery.conf.update(config_dict['celery'])
 celery.conf.update(broker_url=config_dict['secret']['broker_url'])
-
+celery.conf.update(result_backend="rpc")
 
 def celery_on_startup(fn, *args, **kwargs):
     celery.conf.beat_startup_tasks.append((celery.task(fn), args, kwargs))
@@ -60,6 +60,7 @@ def configure_celery_logger(loglevel, logfile, format, colorize, **kwargs):
 
 from uber.tasks import attractions  # noqa: F401
 from uber.tasks import email  # noqa: F401
+from uber.tasks import health  # noqa: F401
 from uber.tasks import panels  # noqa: F401
 from uber.tasks import mivs  # noqa: F401
 from uber.tasks import registration  # noqa: F401

--- a/uber/tasks/health.py
+++ b/uber/tasks/health.py
@@ -1,0 +1,9 @@
+from uber.tasks import celery
+from uber.models import Session
+from sqlalchemy import text
+
+@celery.task
+def ping(response):
+    with Session() as session:
+        session.execute(text('SELECT 1'))
+    return response


### PR DESCRIPTION
This adds a public endpoint at `/uber/devtools/health` that quickly tests the session store, database, and task broker. It returns 200 if they all work, and times out or gives a 500 error otherwise. It returns a json object that gives some stats:
```json
{
  "server_current_timestamp": 1684306723,
  "session_read_count": 1,
  "session_commit_time": 0.0003650000003290188,
  "db_read_time": 0.001840582999648177,
  "db_status": "Pool size: 5  Connections in pool: 0 Current Overflow: -4 Current Checked out connections: 1",
  "task_run_time": 6.971455335999963,
  "task_response_correct": true,
  "task_payload": 392,
  "task_response": 392
}
```

Adding this endpoint will allow us to make the load balancer in front of uber a lot more graceful, as at the moment it has a bad habit of sending traffic to dead ubers.