### PR TITLE
Fixes for shifts views

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -1108,7 +1108,7 @@ c.START_TIME_OPTS = [
 
 c.SETUP_JOB_START = c.EPOCH - timedelta(days=c.SETUP_SHIFT_DAYS)
 c.TEARDOWN_JOB_END = c.ESCHATON + timedelta(days=1, hours=23) # Allow two full days for teardown shifts
-c.CON_TOTAL_LENGTH = int((c.TEARDOWN_JOB_END - c.SETUP_JOB_START).seconds / 3600)
+c.CON_TOTAL_DAYS = -(-(int((c.TEARDOWN_JOB_END - c.SETUP_JOB_START).total_seconds() // 3600)) // 24)
 c.PANEL_STRICT_LENGTH_OPTS = [opt for opt in c.PANEL_LENGTH_OPTS if opt != c.OTHER]
 
 c.EVENT_YEAR = c.EPOCH.strftime('%Y')

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -540,7 +540,7 @@ class MagModel:
 
     def timespan(self, minute_increment=1):
         def minutestr(dt):
-            return ':30' if dt.minute == 30 else ''
+            return '' if dt.minute == 0 else dt.strftime(':%M')
 
         timespan = timedelta(minutes=minute_increment * self.duration)
         endtime = self.start_time_local + timespan

--- a/uber/site_sections/staffing.py
+++ b/uber/site_sections/staffing.py
@@ -210,7 +210,7 @@ class Root:
             d.is_teardown_approval_exempt for d in volunteer.assigned_depts)
 
         if has_setup and has_teardown:
-            cal_length = c.CON_TOTAL_LENGTH
+            cal_length = c.CON_TOTAL_DAYS
         elif has_setup:
             cal_length = con_days + c.SETUP_SHIFT_DAYS
         elif has_teardown:

--- a/uber/templates/shifts_admin/index.html
+++ b/uber/templates/shifts_admin/index.html
@@ -147,7 +147,7 @@ $(document).ready(function() {
             },
             listConDuration: {
                 type: 'list',
-                duration: { days: {{ c.CON_TOTAL_LENGTH }} },
+                duration: { days: {{ c.CON_TOTAL_DAYS }} },
                 buttonText: 'List'
             }
         },


### PR DESCRIPTION
Fixes the following issues, reported via Slack:
- Certain admin views were displaying only the hour start time and not the minute for shifts, e.g., an 11:15am shift was shown as starting at 11am
- If you had access to setup and teardown shifts, your shift signup view started on the first shift setup day but would not show you the full length of the event