### PR TITLE
Improve printable schedule

### DIFF
--- a/uber/templates/staffing/printable_schedule.html
+++ b/uber/templates/staffing/printable_schedule.html
@@ -32,8 +32,8 @@
         <tr>
             <td>{{ shift.job.name }}</td>
             <td>{{ shift.job.department_name }}</td>
-            <td>{{ hour_day_local(shift.job.start_time) }}</td>
-            <td>{% if shift.job.is_setup or shift.job.is_teardown %}__________
+            <td>{{ shift.job.start_time|datetime_local("%-I:%M %p") }}</td>
+            <td>{% if shift.job.is_setup or shift.job.is_teardown %}__________ (up to {{ (shift.job.duration / 60)|int }} hours)
                 {% else %}{{ (shift.job.duration / 60)|int }}{% endif %}</td>
             <td>(x{{ shift.job.weight }})</td>
             <td>__________</td>


### PR DESCRIPTION
Adds minutes to the start time displayed on the printable schedule. Also prints the hours for setup/teardown shifts.