### PR TITLE
Stop waitlisting panels with confirmed POC

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -1172,8 +1172,7 @@ if c.PANELS_ENABLED:
         'panels/panel_accept_reminder.txt',
         lambda app: (
             c.PANELS_CONFIRM_DEADLINE
-            and app.status == c.ACCEPTED
-            and not app.confirmed
+            and app.confirm_deadline
             and (localized_now() + timedelta(days=2)) > app.confirm_deadline),
         ident='panel_accept_reminder')
 

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -676,7 +676,7 @@ expected_response = string(default='')
 
 # Panelists have a certain number of days after their acceptance to confirm they will run their panel.
 # Their custom confirmation deadline is calculated using this config option.
-panels_confirm_deadline = integer(default=14)
+panels_confirm_deadline = integer(default=0)
 
 # While true, the schedule is not visible to non-admins.  This is a bool and not
 # a date because we've never really been able to predict when the schedule will

--- a/uber/models/panels.py
+++ b/uber/models/panels.py
@@ -160,7 +160,7 @@ class PanelApplication(MagModel):
     
     @property
     def confirm_deadline(self):
-        if self.accepted and c.PANELS_CONFIRM_DEADLINE:
+        if c.PANELS_CONFIRM_DEADLINE and self.has_been_accepted and not self.confirmed and not self.poc_id:
             confirm_deadline = timedelta(days=c.PANELS_CONFIRM_DEADLINE)
             return self.accepted + confirm_deadline
 


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1244, although it is a little weird that the guest submitter is made the POC... in any case, we can (probably) safely assume that applications with a POC assigned should not be waitlisted. Also sets panels_confirm_deadline to be off by default to avoid confusing behavior.