### PR TITLE
Support None as quantity

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -418,7 +418,7 @@ class MagModel:
                 return sum(item[0] * item[1] for item in cost_calc[1].items()) / 100
             except AttributeError:
                 if len(cost_calc) > 2:
-                    return cost_calc[1] * cost_calc[2] / 100
+                    return cost_calc[1] * (cost_calc[2] or 1) / 100
                 else:
                     return cost_calc[1] / 100
         except Exception:


### PR DESCRIPTION
The badge_cost receiptItem is returning `return (label, cost, None)`

This breaks the default_badge_cost logic as it tries multiplying the cost with None:
```python
if len(cost_calc) > 2:
    return cost_calc[1] * cost_calc[2] / 100
```

I think in the case that the quantity is None we can just assume the price is multiplied by 1?