### PR TITLE
Don't update the last_send_time as often

### DIFF
--- a/uber/tasks/email.py
+++ b/uber/tasks/email.py
@@ -159,6 +159,7 @@ def send_automated_emails():
     if not (c.DEV_BOX or c.SEND_EMAILS):
         return None
 
+    expiration = timedelta(hours=1)
     quantity_sent = 0
     start_time = time()
     with Session() as session:
@@ -176,7 +177,7 @@ def send_automated_emails():
                 if automated_email.currently_sending:
                     log.info(automated_email.ident + " is marked as currently sending")
                     if automated_email.last_send_time:
-                        if (datetime.now() - automated_email.last_send_time) < timedelta(hours=1):
+                        if (datetime.now() - automated_email.last_send_time) < expiration:
                             # Looks like another thread is still running and hasn't timed out.
                             continue
                 automated_email.currently_sending = True
@@ -199,9 +200,10 @@ def send_automated_emails():
                                 quantity_sent += 1
                             else:
                                 unapproved_count += 1
-                            automated_email.last_send_time = datetime.now()
-                            session.add(automated_email)
-                            session.commit()
+                            if datetime.now() - automated_email.last_send_time > (expiration / 2):
+                                automated_email.last_send_time = datetime.now()
+                                session.add(automated_email)
+                                session.commit()
 
                     automated_email.unapproved_count = unapproved_count
                     automated_email.currently_sending = False


### PR DESCRIPTION
Only update the last_send_time if we are in danger of approaching the expiration time, rather than on every potential send.