### PR TITLE
Fixing cash payments

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -757,7 +757,7 @@ class Root:
         else:
             desc = "At-door marked as paid"
 
-        session.add(Charge.create_receipt_transaction(receipt, desc, method=payment_method))
+        session.add(Charge.create_receipt_transaction(receipt, desc, method=payment_method, amount=receipt.current_amount_owed))
         
         attendee.reg_station = cherrypy.session.get('reg_station')
         session.commit()


### PR DESCRIPTION
It appears that `create_receipt_transaction` is returning a string, likely due to the `amount` being 0. This change passes the amount owed from the ModelReceipt to `create_receipt_transaction`.