### PR TITLE
Show emergency contact info if it is not set

### DIFF
--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1220,7 +1220,7 @@ If you're interested in kicking in an extra donation, you can{% if c.COLLECT_EXT
 
 
 {% set emergency_contact %}
-{% if full_read or c.SECURITY_ADMIN_ACCESS %}
+{% if full_read or c.SECURITY_ADMIN_ACCESS or not attendee.ec_name or not attendee.ec_phone %}
 {% if attendee.is_new or not admin_area or c.HAS_REG_ADMIN_ACCESS %}
 {% set read_only = emergency_contact_ro or page_ro %}
 <div class="form-group">
@@ -1245,7 +1245,7 @@ If you're interested in kicking in an extra donation, you can{% if c.COLLECT_EXT
 
 
 {% set onsite_contact %}
-{% if full_read or c.SECURITY_ADMIN_ACCESS %}
+{% if full_read or c.SECURITY_ADMIN_ACCESS or not attendee.onsite_contact %}
 {% if attendee.is_new or not admin_area or c.HAS_REG_ADMIN_ACCESS %}
 {% set read_only = onsite_contact_ro or page_ro %}
 <div class="form-group">


### PR DESCRIPTION
If an attendee doesn't have emergency contact info or an onsite contact, we now show these fields so that admins can set them and thus save the form without validation errors.