### PR TITLE
Remove circular joins on has_badge

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1329,6 +1329,8 @@ refunded_status = string(default="Refunded")
 deferred_status = string(default="Deferred")
 watched_status = string(default="On Hold")
 not_attending = string(default="Not Attending")
+invalid_group_status = string(default="Group Invalid")
+unapproved_dealer_status = string(default="Unapproved Dealer")
 
 [[ribbon]]
 volunteer_ribbon = string(default="Volunteer")

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -80,7 +80,7 @@ class Group(MagModel, TakesPaymentMixin):
             self.approved = datetime.now(UTC)
         if self.leader and self.is_dealer:
             self.leader.ribbon = add_opt(self.leader.ribbon_ints, c.DEALER_RIBBON)
-        if not self.is_unpaid:
+        if not self.is_unpaid or self.orig_value_of('status') != self.status:
             for a in self.attendees:
                 a.presave_adjustments()
 

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -119,7 +119,7 @@ def group_discount(attendee):
 @credit_calculation.Attendee
 def promo_code_discount(attendee):
     if attendee.promo_code:
-        discount = attendee.calculate_badge_cost() - attendee.badge_cost_with_promo_code()
+        discount = attendee.calculate_badge_cost() - attendee.badge_cost_with_promo_code
         return ("Promo Code", discount * 100 * -1, None)
 
 


### PR DESCRIPTION
The SQL I wrote to check if group attendees were valid/had badges was causing too much trouble, so instead we now directly update attendees' badge status based on their group status.

Also fixes an error in the badge cost summary report.