### PR TITLE
Reorder Alembic migrations

### DIFF
--- a/alembic/versions/4acd51ac5462_add_signed_documents.py
+++ b/alembic/versions/4acd51ac5462_add_signed_documents.py
@@ -1,7 +1,7 @@
 """Add signed documents
 
 Revision ID: 4acd51ac5462
-Revises: 81b45e3d967c
+Revises: ed2acba6f8bd
 Create Date: 2022-06-28 03:19:40.614556
 
 """
@@ -9,7 +9,7 @@ Create Date: 2022-06-28 03:19:40.614556
 
 # revision identifiers, used by Alembic.
 revision = '4acd51ac5462'
-down_revision = '81b45e3d967c'
+down_revision = 'ed2acba6f8bd'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/551b8ff65d33_add_last_email_send_time_for_signed_.py
+++ b/alembic/versions/551b8ff65d33_add_last_email_send_time_for_signed_.py
@@ -1,7 +1,7 @@
 """Add last email send time for signed documents.
 
 Revision ID: 551b8ff65d33
-Revises: ed2acba6f8bd
+Revises: 517103c57a08
 Create Date: 2023-07-23 01:50:10.008953
 
 """
@@ -9,7 +9,7 @@ Create Date: 2023-07-23 01:50:10.008953
 
 # revision identifiers, used by Alembic.
 revision = '551b8ff65d33'
-down_revision = 'ed2acba6f8bd'
+down_revision = '517103c57a08'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/a4a79802ba51_allow_api_and_print_jobs_to_not_have_.py
+++ b/alembic/versions/a4a79802ba51_allow_api_and_print_jobs_to_not_have_.py
@@ -11,7 +11,7 @@ Create Date: 2022-08-18 23:48:31.985975
 revision = 'a4a79802ba51'
 down_revision = 'a5d2a3700b1a'
 branch_labels = None
-depends_on = 'c7a439f29c1c'
+depends_on = None
 
 from alembic import op
 import sqlalchemy as sa

--- a/alembic/versions/a5d2a3700b1a_overhaul_payments_and_payment_tracking.py
+++ b/alembic/versions/a5d2a3700b1a_overhaul_payments_and_payment_tracking.py
@@ -98,7 +98,6 @@ def upgrade():
     op.drop_column('group', 'amount_paid_override')
     op.drop_column('group', 'refunded_items')
     op.drop_column('group', 'amount_refunded_override')
-    op.drop_index('ix_marketplace_application_amount_paid', table_name='marketplace_application')
     op.drop_column('marketplace_application', 'base_price')
     op.drop_column('marketplace_application', 'amount_paid')
     op.drop_table('receipt_item')
@@ -120,7 +119,6 @@ def upgrade():
 def downgrade():
     op.add_column('marketplace_application', sa.Column('amount_paid', sa.INTEGER(), server_default=sa.text('0'), autoincrement=False, nullable=False))
     op.add_column('marketplace_application', sa.Column('base_price', sa.INTEGER(), server_default=sa.text('0'), autoincrement=False, nullable=False))
-    op.create_index('ix_marketplace_application_amount_paid', 'marketplace_application', ['amount_paid'], unique=False)
     op.add_column('group', sa.Column('amount_refunded_override', sa.INTEGER(), server_default=sa.text('0'), autoincrement=False, nullable=False))
     op.add_column('group', sa.Column('refunded_items', postgresql.JSONB(astext_type=sa.Text()), server_default=sa.text("'{}'::jsonb"), autoincrement=False, nullable=False))
     op.add_column('group', sa.Column('amount_paid_override', sa.INTEGER(), server_default=sa.text('0'), autoincrement=False, nullable=False))

--- a/alembic/versions/af64b33e950a_initial_migration.py
+++ b/alembic/versions/af64b33e950a_initial_migration.py
@@ -1,7 +1,9 @@
 """Initial migration
+
 Revision ID: af64b33e950a
 Revises: 0b4ad67a27be
 Create Date: 2018-05-08 23:18:35.150928
+
 """
 
 


### PR DESCRIPTION
The use of the `alembic history` command made this slightly less painful.

Protocol is to manually remove all revisions from the database except the event plugin revision (1368bafd0eb2 for magprime, e86fcf34f217 for MFF), stamp to the latest revisions for the main plugin (c31a2e5b6fbd), and hope nothing breaks