### PR TITLE
Returning errors generated by check_if_can_reg

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -188,7 +188,9 @@ class Root:
         return {'message': message}
 
     def index(self, session, message='', account_email='', account_password='', **params):
-        check_if_can_reg()
+        errors = check_if_can_reg()
+        if errors:
+            return errors
 
         pending_preregs = PreregCart.pending_preregs.copy()
         for id in pending_preregs:
@@ -223,7 +225,9 @@ class Root:
             }
 
     def reapply(self, session, id, **params):
-        check_if_can_reg(is_dealer_reg=True)
+        errors = check_if_can_reg(is_dealer_reg=True)
+        if errors:
+            return errors
 
         old_attendee = session.attendee(id)
         old_attendee_dict = old_attendee.to_dict(c.UNTRANSFERABLE_ATTRS)
@@ -242,7 +246,10 @@ class Root:
         
 
     def repurchase(self, session, id, skip_confirm=False, **params):
-        check_if_can_reg()
+        errors = check_if_can_reg()
+        if errors:
+            return errors
+        
         if skip_confirm or 'csrf_token' in params:
             old_attendee = session.attendee(id)
             old_attendee_dict = old_attendee.to_dict(c.UNTRANSFERABLE_ATTRS)
@@ -262,7 +269,9 @@ class Root:
     @cherrypy.expose('post_dealer')
     @requires_account()
     def dealer_registration(self, session, message='', edit_id=None, **params):
-        check_if_can_reg(is_dealer_reg=True)
+        errors = check_if_can_reg(is_dealer_reg=True)
+        if errors:
+            return errors
 
         if c.DEALER_INVITE_CODE and not edit_id:
             if not params.get('invite_code'):
@@ -317,7 +326,9 @@ class Root:
             }
     
     def finish_dealer_reg(self, session, id, **params):
-        check_if_can_reg(is_dealer_reg=True)
+        errors = check_if_can_reg(is_dealer_reg=True)
+        if errors:
+            return errors
 
         group = self._get_unsaved(id, PreregCart.pending_dealers)
         attendee = group.attendees[0]
@@ -365,7 +376,9 @@ class Root:
     @requires_account()
     def form(self, session, message='', edit_id=None, **params):
         is_dealer_reg = 'dealer_id' in params
-        check_if_can_reg(is_dealer_reg)
+        errors = check_if_can_reg(is_dealer_reg)
+        if errors:
+            return errors
         """
         Our production NGINX config caches the page at /preregistration/form.
         Since it's cached, we CAN'T return a session cookie with the page. We
@@ -510,7 +523,9 @@ class Root:
     
     def additional_info(self, session, message='', editing=None, **params):
         is_dealer_reg = 'group_id' in params
-        check_if_can_reg(is_dealer_reg)
+        errors = check_if_can_reg(is_dealer_reg)
+        if errors:
+            return errors
 
         attendee, group = self._get_attendee_or_group(params)
 
@@ -538,7 +553,9 @@ class Root:
         }
 
     def duplicate(self, session, **params):
-        check_if_can_reg(is_dealer_reg='group_id' in params)
+        errors = check_if_can_reg(is_dealer_reg='group_id' in params)
+        if errors:
+            return errors
 
         attendee, group = self._get_attendee_or_group(params)
         orig = session.query(Attendee).filter_by(
@@ -554,7 +571,9 @@ class Root:
         }
 
     def banned(self, **params):
-        check_if_can_reg(is_dealer_reg='group_id' in params)
+        errors = check_if_can_reg(is_dealer_reg='group_id' in params)
+        if errors:
+            return errors
 
         attendee, group = self._get_attendee_or_group(params)
         return {

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -566,7 +566,9 @@ class Root:
     @check_atd
     @requires_account()
     def register(self, session, message='', error_message='', **params):
-        check_if_can_reg()
+        errors = check_if_can_reg()
+        if errors:
+            return errors
 
         params['id'] = 'None'
         login_email = None


### PR DESCRIPTION
This should fix returning "reg is closed" errors based on time.

<img width="1127" alt="Screenshot 2023-08-11 at 17 34 04" src="https://github.com/magfest/ubersystem/assets/1031406/35b4ff6c-f223-43e7-b770-e19df12c2a9e">
