### PR TITLE
Convert active_receipt to a relationship

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -188,23 +188,6 @@ class MagModel:
         from uber.models.commerce import ReceiptTransaction
         return self.session.query(ReceiptTransaction).filter_by(fk_id=self.id).all()
 
-    @property
-    def active_receipt(self):
-        """
-        Returns a dictionary of this object's current active receipt, if there is one.
-        This lets us access various properties of the receipt as if they were directly
-        tied to the model without having to have an extra active Session().
-        """
-        from uber.models import Session, ModelReceipt
-        receipt_dict = {}
-        with Session() as session:
-            receipt = session.get_receipt_by_model(self)
-            if receipt:
-                receipt_dict = receipt.to_dict()
-                for property in ['item_total', 'txn_total', 'current_amount_owed', 'pending_total', 'payment_total', 'refund_total']:
-                    receipt_dict[property] = getattr(receipt, property)
-        return receipt_dict
-
     @cached_classproperty
     def unrestricted(cls):
         """

--- a/uber/models/art_show.py
+++ b/uber/models/art_show.py
@@ -59,6 +59,12 @@ class ArtShowApplication(MagModel):
     us_only = Column(Boolean, default=False)
     admin_notes = Column(UnicodeText, admin_only=True)
     overridden_price = Column(Integer, nullable=True, admin_only=True)
+    active_receipt = relationship(
+        'ModelReceipt',
+        cascade='save-update,merge,refresh-expire,expunge',
+        primaryjoin='and_(remote(ModelReceipt.owner_id) == foreign(ArtShowApplication.id),'
+                        'ModelReceipt.owner_model == "ArtShowApplication",'
+                        'ModelReceipt.closed == None)')
 
     email_model_name = 'app'
 
@@ -133,7 +139,7 @@ class ArtShowApplication(MagModel):
             return 0
         else:
             if self.active_receipt:
-                return self.active_receipt['item_total'] / 100
+                return self.active_receipt.item_total / 100
             return self.potential_cost
 
     @property
@@ -177,15 +183,15 @@ class ArtShowApplication(MagModel):
 
     @property
     def amount_pending(self):
-        return self.active_receipt.get('pending_total', 0)
+        return self.active_receipt.pending_total if self.active_receipt else 0
 
     @property
     def amount_paid(self):
-        return self.active_receipt.get('payment_total', 0)
+        return self.active_receipt.payment_total if self.active_receipt else 0
 
     @property
     def amount_refunded(self):
-        return self.active_receipt.get('refund_total', 0)
+        return self.active_receipt.refund_total if self.active_receipt else 0
 
     @property
     def has_general_space(self):

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -254,6 +254,13 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     badge_printed_name = Column(UnicodeText)
 
+    active_receipt = relationship(
+        'ModelReceipt',
+        cascade='save-update,merge,refresh-expire,expunge',
+        primaryjoin='and_(remote(ModelReceipt.owner_id) == foreign(Attendee.id),'
+                        'ModelReceipt.owner_model == "Attendee",'
+                        'ModelReceipt.closed == None)')
+
     dept_memberships = relationship('DeptMembership', backref='attendee')
     dept_membership_requests = relationship('DeptMembershipRequest', backref='attendee')
     anywhere_dept_membership_request = relationship(
@@ -597,7 +604,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @presave_adjustment
     def refunded_if_receipt_has_refund(self):
-        if self.paid == c.HAS_PAID and self.active_receipt and self.active_receipt.get('refund_total'):
+        if self.paid == c.HAS_PAID and self.active_receipt and self.active_receipt.refund_total:
             self.paid = c.REFUNDED
 
     @presave_adjustment
@@ -865,7 +872,7 @@ class Attendee(MagModel, TakesPaymentMixin):
             return 0
 
         if self.active_receipt:
-            return self.active_receipt['item_total'] / 100
+            return self.active_receipt.item_total / 100
         return self.default_cost
 
     @property
@@ -883,23 +890,11 @@ class Attendee(MagModel, TakesPaymentMixin):
     
     @property
     def amount_pending(self):
-        return self.active_receipt.get('pending_total', 0)
-    
-    @hybrid_property
-    def has_receipt(self):
-        return self.active_receipt
-    
-    @has_receipt.expression
-    def has_receipt(cls):
-        from uber.models import ModelReceipt
-        return exists().select_from(ModelReceipt).where(
-            and_(ModelReceipt.owner_id == cls.id,
-                 ModelReceipt.owner_model == "Attendee",
-                 ModelReceipt.closed == None))
+        return self.active_receipt.pending_total if self.active_receipt else 0
 
     @hybrid_property
     def is_paid(self):
-        return self.active_receipt.get('current_amount_owed', None) == 0
+        return self.active_receipt and self.active_receipt.current_amount_owed == 0
     
     @is_paid.expression
     def is_paid(cls):
@@ -915,7 +910,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @hybrid_property
     def amount_paid(self):
-        return self.active_receipt.get('payment_total', 0)
+        return self.active_receipt.payment_total if self.active_receipt else 0
     
     @amount_paid.expression
     def amount_paid(cls):
@@ -929,7 +924,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     
     @hybrid_property
     def amount_refunded(self):
-        return self.active_receipt.get('refund_total', 0)
+        return self.active_receipt.refund_total if self.active_receipt else 0
     
     @amount_refunded.expression
     def amount_refunded(cls):

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -65,6 +65,12 @@ class Group(MagModel, TakesPaymentMixin):
     leader = relationship('Attendee', foreign_keys=leader_id, post_update=True, cascade='all')
     studio = relationship('IndieStudio', uselist=False, backref='group')
     guest = relationship('GuestGroup', backref='group', uselist=False)
+    active_receipt = relationship(
+        'ModelReceipt',
+        cascade='save-update,merge,refresh-expire,expunge',
+        primaryjoin='and_(remote(ModelReceipt.owner_id) == foreign(Group.id),'
+                        'ModelReceipt.owner_model == "Group",'
+                        'ModelReceipt.closed == None)',)
 
     _repr_attr_names = ['name']
 
@@ -297,24 +303,12 @@ class Group(MagModel, TakesPaymentMixin):
             return 0
 
         if self.active_receipt:
-            return self.active_receipt['item_total'] / 100
+            return self.active_receipt.item_total / 100
         return self.default_cost + self.amount_extra
-    
-    @hybrid_property
-    def has_receipt(self):
-        return self.active_receipt
-    
-    @has_receipt.expression
-    def has_receipt(cls):
-        from uber.models import ModelReceipt
-        return exists().select_from(ModelReceipt).where(
-            and_(ModelReceipt.owner_id == cls.id,
-                 ModelReceipt.owner_model == "Group",
-                 ModelReceipt.closed == None))
 
     @hybrid_property
     def is_paid(self):
-        return self.active_receipt.get('current_amount_owed', None) == 0
+        return self.active_receipt and self.active_receipt.current_amount_owed == 0
     
     @is_paid.expression
     def is_paid(cls):
@@ -335,7 +329,7 @@ class Group(MagModel, TakesPaymentMixin):
 
     @property
     def amount_pending(self):
-        return self.active_receipt.get('pending_total', 0)
+        return self.active_receipt.pending_total if self.active_receipt else 0
 
     @property
     def amount_paid_repr(self):
@@ -347,7 +341,7 @@ class Group(MagModel, TakesPaymentMixin):
 
     @hybrid_property
     def amount_paid(self):
-        return self.active_receipt.get('payment_total', 0)
+        return self.active_receipt.payment_total if self.active_receipt else 0
     
     @amount_paid.expression
     def amount_paid(cls):
@@ -361,7 +355,7 @@ class Group(MagModel, TakesPaymentMixin):
     
     @hybrid_property
     def amount_refunded(self):
-        return self.active_receipt.get('refund_total', 0)
+        return self.active_receipt.refund_total if self.active_receipt else 0
     
     @amount_refunded.expression
     def amount_refunded(cls):

--- a/uber/site_sections/budget.py
+++ b/uber/site_sections/budget.py
@@ -55,7 +55,7 @@ class Root:
         
         paid_group_badges = get_grouped_costs(session, badge_cost_matters_filter + [Group.is_paid == True], [Attendee.group])
         unpaid_group_badges = get_grouped_costs(session, 
-                                                badge_cost_matters_filter + [Group.has_receipt == True, Group.is_paid == False], 
+                                                badge_cost_matters_filter + [Group.active_receipt != None, Group.is_paid == False], 
                                                 [Attendee.group])
 
         group_total = session.query(Attendee).filter(*group_filter).count()
@@ -82,15 +82,15 @@ class Root:
                                            Attendee.promo_code_group_name == None,
                                            Attendee.badge_cost > 0]
         paid_ind_filter = individual_filter + [Attendee.is_paid == True]
-        unpaid_ind_filter = individual_filter + [Attendee.has_receipt == True, Attendee.is_paid == False]
+        unpaid_ind_filter = individual_filter + [Attendee.active_receipt != None, Attendee.is_paid == False]
 
         not_unpaid_badges = 0
 
         individual_badges = get_grouped_costs(session, paid_ind_filter)
         unpaid_badges = get_grouped_costs(session, unpaid_ind_filter)
 
-        receiptless_ind_filter = individual_filter + [Attendee.has_receipt == False]
-        receiptless_group_filter = badge_cost_matters_filter + [Group.has_receipt == False]
+        receiptless_ind_filter = individual_filter + [Attendee.active_receipt == None]
+        receiptless_group_filter = badge_cost_matters_filter + [Group.active_receipt == None]
 
         for attendee in session.query(Attendee).outerjoin(Attendee.group).filter(*receiptless_group_filter):
             if attendee.group.amount_unpaid == 0:
@@ -211,7 +211,7 @@ class Root:
                                                   preordered_merch_filter + [Attendee.is_paid == True],
                                                   selector=Attendee.amount_extra)
         unpaid_preordered_merch = get_grouped_costs(session,
-                                                  preordered_merch_filter + [Attendee.has_receipt == True,
+                                                  preordered_merch_filter + [Attendee.active_receipt != None,
                                                                              Attendee.is_paid == False],
                                                   selector=Attendee.amount_extra)
         
@@ -219,13 +219,13 @@ class Root:
                                                   extra_donation_filter + [Attendee.is_paid == True],
                                                   selector=Attendee.extra_donation)
         unpaid_extra_donations = get_grouped_costs(session,
-                                                  extra_donation_filter + [Attendee.has_receipt == True,
+                                                  extra_donation_filter + [Attendee.active_receipt != None,
                                                                              Attendee.is_paid == False],
                                                   selector=Attendee.extra_donation)
         not_unpaid_preordered_merch = 0
         not_unpaid_extra_donations = 0
 
-        for attendee in session.query(Attendee).filter(*base_filter).filter(Attendee.has_receipt == False).filter(
+        for attendee in session.query(Attendee).filter(*base_filter).filter(Attendee.active_receipt == None).filter(
                                                                         or_(Attendee.amount_extra > 0,
                                                                             Attendee.extra_donation > 0)):
             if attendee.amount_unpaid == 0:

--- a/uber/tasks/email.py
+++ b/uber/tasks/email.py
@@ -193,7 +193,7 @@ def send_automated_emails():
                         if model_instance.id not in automated_email.emails_by_fk_id:
                             if automated_email.would_send_if_approved(model_instance):
                                 if automated_email.approved or not automated_email.needs_approval:
-                                    if model_instance.active_receipt:
+                                    if getattr(model_instance, 'active_receipt', None):
                                         session.refresh_receipt_and_model(model_instance)
                                     automated_email.send_to(model_instance, delay=False)
                                     quantity_sent += 1


### PR DESCRIPTION
We want to do a joinedload to optimize accessing models' receipt properties, so we now explicitly define a relationship instead of creating a dictionary on property access.