### PR TITLE
Fix groups list performance and remove row limit

### DIFF
--- a/uber/templates/group_admin/dealers.html
+++ b/uber/templates/group_admin/dealers.html
@@ -9,7 +9,7 @@
 </script>
 
   <div class="card-body">
-    {{ dealer_groups }} {{ c.DEALER_TERM }} groups ({{ dealer_badges }} badges, {{ tables }} tables)
+    {{ num_dealer_groups }} {{ c.DEALER_TERM }} groups ({{ dealer_badges }} badges, {{ tables }} tables)
     <span class="pull-right"><a href="index?show_all=true#dealers" class="btn btn-info">Show All {{ c.DEALER_TERM|title }}s</a>
     <a href="../dealer_admin/waitlist" class="btn btn-warning">Manage Waitlisted {{ c.DEALER_TERM|title }}s</a></span>
     <br/> <br/>
@@ -35,7 +35,7 @@
     </tr>
   </thead>
   <tbody>
-{% for group in groups if group.is_dealer and (show_all or (group.status not in [c.DECLINED, c.IMPORTED, c.CANCELLED])) %}
+{% for group in dealer_groups %}
     <tr{% if c.SIGNNOW_DEALER_TEMPLATE_ID and not group.signnow_document_signed or group.status in [c.DECLINED, c.CANCELLED] %} class="danger"{% endif %}>
         <td style="text-align:left" data-order="{{ group.name }}" data-search="{{ group.name }}"> 
           <a href="form?id={{ group.id }}">{{ group.name|default('?????', boolean=True) }}</a></td>


### PR DESCRIPTION
We need to see more than 1000 groups (ahhh), so this uses joinedloads to fix the page load time so we can also remove the row limit.