### PR TITLE
Fix requested_depts_ids

### DIFF
--- a/tests/locust/dealerreg/locustfile.py
+++ b/tests/locust/dealerreg/locustfile.py
@@ -212,7 +212,7 @@ class DealerReg(HttpUser):
             "form_list": "PreregOtherInfo"
         }
         if is_staffing:
-            additional_info["requested_dept_ids"] = random.sample(departments, random.randrange(len(departments)+1))
+            additional_info["requested_depts_ids"] = random.sample(departments, random.randrange(len(departments)+1))
         additional_info["interests"] = random.sample(interests, random.randrange(len(interests)+1))
         if random.randrange(2):
             additional_info["requested_accessibility_services"] = "1"

--- a/tests/locust/prereg/locustfile.py
+++ b/tests/locust/prereg/locustfile.py
@@ -102,7 +102,7 @@ class Preregister(HttpUser):
                 "csrf_token": csrf_token,
                 "staffing": "1",
                 "cellphone": cellphone,
-                "requested_dept_ids": "252431566",
+                "requested_depts_ids": "252431566",
                 "requested_accessibility_services": "1",
                 "form_list": "PreregOtherInfo"
             }

--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -239,14 +239,14 @@ class BadgeExtras(MagForm):
 
 
 class OtherInfo(MagForm):
-    dynamic_choices_fields = {'requested_dept_ids': lambda: [(v[0], v[1]) for v in c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC] if len(c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC) > 1 else c.JOB_INTEREST_OPTS}
+    dynamic_choices_fields = {'requested_depts_ids': lambda: [(v[0], v[1]) for v in c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC] if len(c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC) > 1 else c.JOB_INTEREST_OPTS}
 
     placeholder = BooleanField(widget=HiddenInput())
     staffing = BooleanField('I am interested in volunteering!', widget=SwitchInput(), description=popup_link(c.VOLUNTEER_PERKS_URL, "What do I get for volunteering?"))
-    requested_dept_ids = SelectMultipleField('Where do you want to help?', widget=MultiCheckbox()) # TODO: Show attendees department descriptions
+    requested_depts_ids = SelectMultipleField('Where do you want to help?', widget=MultiCheckbox()) # TODO: Show attendees department descriptions
     requested_accessibility_services = BooleanField(f'I would like to be contacted by the {c.EVENT_NAME} Accessibility Services department prior to the event and I understand my contact information will be shared with Accessibility Services for this purpose.', widget=SwitchInput())
     interests = SelectMultipleField('What interests you?', choices=c.INTEREST_OPTS, coerce=int, validators=[validators.Optional()], widget=MultiCheckbox())
-        
+
     def get_non_admin_locked_fields(self, attendee):
         locked_fields = [] 
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1467,6 +1467,7 @@ class Root:
 
             session.add(attendee)
             session.commit()
+
             if placeholder:
                 attendee.confirmed = localized_now()
                 message = 'Your registration has been confirmed'

--- a/uber/templates/forms/attendee/other_info.html
+++ b/uber/templates/forms/attendee/other_info.html
@@ -30,7 +30,7 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
 {% endif %}
 <div class="row g-sm-3">
     <div class="col-12">{{ form_macros.toggle_checkbox(other_info.staffing, 
-        [other_info.requested_dept_ids, other_info.cellphone] if include_cellphone else [other_info.requested_dept_ids], toggle_required=True, help_text=staffing_message) }}</div>
+        [other_info.requested_depts_ids, other_info.cellphone] if include_cellphone else [other_info.requested_depts_ids], toggle_required=True, help_text=staffing_message) }}</div>
 </div>
 
 {% if include_cellphone %}
@@ -44,7 +44,7 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
 
 {% if c.JOB_INTEREST_OPTS or c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC|length > 1 %}
 <div class="row g-sm-3">
-    <div class="col-12">{{ form_macros.form_input(other_info.requested_dept_ids) }}</div>
+    <div class="col-12">{{ form_macros.form_input(other_info.requested_depts_ids) }}</div>
 </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
There were two issues with this field:
1. It was spelled as requested_dept_ids (dept vs depts)
2. It's a special property on the Attendee class, which means it's not included in all_checkgroups, which means it wasn't being preprocessed correctly.

This fixes both of those. It also slightly refactors how we preprocess data by moving it into the process function rather than the init function. This does mean the form gets processed twice -- once on init and again after initializing the dynamic chocies -- but I think we don't have much choice there.