### PR TITLE
FIX. EMAILS.

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -126,14 +126,16 @@ class AutomatedEmailFixture:
         before = [d.active_before for d in when if d.active_before]
         self.active_before = max(before) if before else None
 
+    def update_template_plugin_info(self):
         env = JinjaEnv.env()
         try:
             template_path = pathlib.Path(env.get_or_select_template(os.path.join('emails', self.template)).filename)
-            self.template_plugin = template_path.parts[3]
-            self.template_url = f"https://github.com/magfest/{self.template_plugin}/tree/main/{self.template_plugin}/{pathlib.Path(*template_path.parts[5:]).as_posix()}"
+            self.template_plugin_name = template_path.parts[3]
+            self.template_url = f"https://github.com/magfest/{self.template_plugin_name}/tree/main/{self.template_plugin_name}/{pathlib.Path(*template_path.parts[5:]).as_posix()}"
         except jinja2.exceptions.TemplateNotFound:
+            self.template_plugin_name = "ERROR: TEMPLATE NOT FOUND"
             self.template_url = ""
-        
+        return self.template_plugin_name, self.template_url
 
     @property
     def body(self):

--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -130,6 +130,7 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
             for ident, fixture in AutomatedEmail._fixtures.items():
                 automated_email = session.query(AutomatedEmail).filter_by(ident=ident).first() or AutomatedEmail()
                 session.add(automated_email.reconcile(fixture))
+                fixture.update_template_plugin_info()
             session.flush()
             for automated_email in session.query(AutomatedEmail).all():
                 if automated_email.ident in AutomatedEmail._fixtures:

--- a/uber/site_sections/email_admin.py
+++ b/uber/site_sections/email_admin.py
@@ -31,6 +31,7 @@ class Root:
         return {'emails': session.query(Email).filter_by(**params).order_by(Email.when).all()}
 
     def pending(self, session, message=''):
+        AutomatedEmail.reconcile_fixtures()
         emails_with_count = session.query(AutomatedEmail, AutomatedEmail.email_count).filter(
             AutomatedEmail.subject != '', AutomatedEmail.sender != '',).all()
         emails = []

--- a/uber/templates/email_admin/pending.html
+++ b/uber/templates/email_admin/pending.html
@@ -51,7 +51,11 @@
               require{{ email.unapproved_count|pluralize('s', '') }} approval
             {% endif %}
           </td>
-          <td><a href="{{ email.fixture.template_url }}" target="_blank">{{ email.fixture.template_plugin }}</a></td>
+          <td>
+            {% if email.fixture.template_url %}
+            <a href="{{ email.fixture.template_url }}" target="_blank">{{ email.fixture.template_plugin_name }}</a>
+            {% else %}{{ email.fixture.template_plugin_name }}{% endif %}
+          </td>
           <td>{{ email.sender }}</td>
           <td>{{ email.sent_email_count }}</td>
           <td>{{ email.unapproved_count }}</td>

--- a/uber/templates/emails/placeholders/imported_volunteer.txt
+++ b/uber/templates/emails/placeholders/imported_volunteer.txt
@@ -2,8 +2,6 @@
 
 {% endif %}Hey all! We’re so excited to see you at {{ c.EVENT_NAME }}! You're eligible for a complimentary badge for the next event, which will be {{ c.EPOCH|datetime_local }}. You can accept your badge by visiting {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
 
-All attendees at {{ c.EVENT_NAME }} (including minors, volunteers, staff, guests, contractors, and vendors) are required to be fully vaccinated against COVID-19. When you register, you will be asked to acknowledge that you will abide by the event’s COVID-19 precautions. You can find more information at {{ c.COVID_POLICIES_URL }}.
-
 At this stage, you can apply to volunteer again this year. By default, the checkbox labeled "Yes, I want to staff {{ c.EVENT_NAME }}." is toggled ON, which means that you'll automatically be enrolled. If you are not interested in applying to volunteer again, you can uncheck that box (toggle it OFF), and your badge will be set to a complimentary Attendee Badge (instead of Volunteer Badge).
 
 If accepted, you'll be emailed when your Volunteer Checklist launches. The Checklist will need to be completed before the event starts, and will have a link to our volunteering guidelines and agreement. 

--- a/uber/templates/emails/shifts/reminder.txt
+++ b/uber/templates/emails/shifts/reminder.txt
@@ -4,7 +4,7 @@ Thanks again for signing up to volunteer at {{ c.EVENT_NAME }}!  You are not cur
 
 Please sign up for shifts at {{ c.URL_BASE }}/staffing/login?first_name={{ attendee.first_name|urlencode }}&last_name={{ attendee.last_name|urlencode }}&email={{ attendee.email|urlencode }}&zip_code={{ attendee.zip_code|urlencode }} -- if you need to, you can verify/update your personal information at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
 
-After July 6, you cannot drop shifts, but you can continue to sign up for shifts through the event.
+After {{ c.DROP_SHIFTS_DEADLINE.astimezone(c.EVENT_TIMEZONE).strftime('%B %-e') }}, you cannot drop shifts, but you can continue to sign up for shifts through the event.
 
 Please let us know if you have any questions.
 


### PR DESCRIPTION
We now reconcile email fixtures whenever someone loads the pending email page. Also makes sure that fixtures' template paths get updated during the reconciliation process.