### PR TITLE
Fix several form and validation bugs for prereg launch

### DIFF
--- a/alembic/versions/29b1b9a4e601_moves_departments_into_database.py
+++ b/alembic/versions/29b1b9a4e601_moves_departments_into_database.py
@@ -103,9 +103,10 @@ def all_dept_ids_from_existing_locations(locations):
                 dept_ids.append(department_id)
     return dept_ids
 
-
-job_location_to_department_id = {i: _dept_id_from_location(i) for i in c.JOB_LOCATIONS.keys()}
-job_interests_to_department_id = {i: job_location_to_department_id[i] for i in c.JOB_INTERESTS.keys() if i in job_location_to_department_id}
+job_locations = getattr(c, 'JOB_LOCATIONS', {})
+job_interests = getattr(c, 'JOB_INTERESTS', {})
+job_location_to_department_id = {i: _dept_id_from_location(i) for i in job_locations.keys()}
+job_interests_to_department_id = {i: job_location_to_department_id[i] for i in job_interests.keys() if i in job_location_to_department_id}
 
 
 job_table = table(
@@ -192,7 +193,8 @@ dept_membership_dept_role_table = table(
 
 def _upgrade_job_departments():
     connection = op.get_bind()
-    for value, name in c.JOB_LOCATIONS.items():
+    job_locations = getattr(c, 'JOB_LOCATIONS', {})
+    for value, name in job_locations.items():
         department_id = job_location_to_department_id[value]
         op.execute(
             department_table.insert().values({

--- a/alembic/versions/41c34c63d54c_remove_panels_interest_column_from_.py
+++ b/alembic/versions/41c34c63d54c_remove_panels_interest_column_from_.py
@@ -1,0 +1,60 @@
+"""Remove panels_interest column from attendees
+
+Revision ID: 41c34c63d54c
+Revises: 9122d9b6f62c
+Create Date: 2023-09-13 22:08:44.699427
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '41c34c63d54c'
+down_revision = '9122d9b6f62c'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    with op.batch_alter_table("attendee") as batch_op:
+        batch_op.drop_column('panel_interest')
+
+
+def downgrade():
+    op.add_column('attendee', sa.Column('panel_interest', sa.BOOLEAN(), server_default=sa.text('false'), autoincrement=False, nullable=False))

--- a/test-defaults.ini
+++ b/test-defaults.ini
@@ -272,15 +272,6 @@ con_ops = "Fest Ops"
 console = "Consoles"
 arcade = "Arcade"
 
-[[job_location]]
-# ensure that "arcade" and "consoles" exist in any model columns using "job_location"
-console = "Console"
-arcade = "Arcade"
-con_ops = "Fest Ops"
-food_prep = "Staff Suite"
-regdesk = "Registration"
-stops = "Staffing Ops"
-
 [[badge]]
 attendee_badge = "Attendee"
 child_badge = "Minor"

--- a/tests/data/import_test_data.py
+++ b/tests/data/import_test_data.py
@@ -57,10 +57,11 @@ def all_dept_ids_from_existing_locations(locations):
                 dept_ids.append(department_id)
     return dept_ids
 
-
-job_location_to_department_id = {i: _dept_id_from_location(i) for i in c.JOB_LOCATIONS.keys()}
+job_locations = getattr(c, 'JOB_LOCATIONS', {})
+job_interests = getattr(c, 'JOB_INTERESTS', {})
+job_location_to_department_id = {i: _dept_id_from_location(i) for i in job_locations.keys()}
 job_interests_to_department_id = {
-    i: job_location_to_department_id[i] for i in c.JOB_INTERESTS.keys() if i in job_location_to_department_id}
+    i: job_location_to_department_id[i] for i in job_interests.keys() if i in job_location_to_department_id}
 
 
 TEST_DATA_FILE = join(os.path.dirname(__file__), 'test_data.json')
@@ -134,7 +135,8 @@ def import_events(session):
 
 
 def import_jobs(session):
-    job_locs, _ = zip(*c.JOB_LOCATION_OPTS)
+    job_location_opts = getattr(c, 'JOB_LOCATION_OPTS', [])
+    job_locs, _ = zip(*job_location_opts)
     depts_known = []
     for j in dump['jobs']:
         if j['location'] in job_locs:
@@ -156,11 +158,6 @@ def import_jobs(session):
 
 @entry_point
 def import_uber_test_data(test_data_file):
-    if not c.JOB_LOCATION_OPTS:
-        print("JOB_LOCATION_OPTS is empty! "
-        "Try copying the [[job_location]] section from test-defaults.ini to your development.ini.")
-        exit(1)
-
     with open(test_data_file) as f:
         global dump
         dump = json.load(f)

--- a/tests/uber/models/test_config.py
+++ b/tests/uber/models/test_config.py
@@ -204,17 +204,6 @@ class TestBadgeOpts:
         assert dict(c.AT_THE_DOOR_BADGE_OPTS).keys() == {c.ATTENDEE_BADGE, c.ONE_DAY_BADGE, c.CONTRACTOR_BADGE}
 
 
-class TestStaffGetFood:
-    def test_job_locations_with_food_prep(self):
-        assert c.STAFF_GET_FOOD
-
-    def test_job_locations_without_food_prep(self, monkeypatch):
-        job_locations = dict(c.JOB_LOCATIONS)
-        del job_locations[c.FOOD_PREP]
-        monkeypatch.setattr(c, 'JOB_LOCATIONS', job_locations)
-        assert not c.STAFF_GET_FOOD
-
-
 class TestDealerConfig:
     def test_dealer_reg_open(self, monkeypatch):
         monkeypatch.setattr(c, 'DEALER_REG_START', localized_now() - timedelta(days=1))

--- a/uber/api.py
+++ b/uber/api.py
@@ -414,7 +414,6 @@ class AttendeeLookup:
         'is_dept_head': True,
         'ribbon_labels': True,
         'public_id': True,
-        'covid_ready': True,
     }
 
     fields_full = dict(fields, **{

--- a/uber/config.py
+++ b/uber/config.py
@@ -495,7 +495,7 @@ class Config(_Overridable):
         if c.CHILD_BADGE in c.PREREG_BADGE_TYPES:
             reg_type_opts.append({
                 'name': "12 and Under",
-                'desc': Markup("Attendees 12 and younger must be accompanied by an adult with a valid Attendee badge. \
+                'desc': Markup(f"Attendees 12 and younger at the start of {c.EVENT_NAME} must be accompanied by an adult with a valid Attendee badge. \
                                <br/><br/><span class='form-text text-danger'>Price is always half that of the Single Attendee badge price.</span>"),
                 'value': c.CHILD_BADGE,
                 'price': str(c.BADGE_PRICE - math.ceil(c.BADGE_PRICE / 2)),

--- a/uber/config.py
+++ b/uber/config.py
@@ -1280,8 +1280,6 @@ c.REGION_OPTS_CANADA = [('', 'Select a province')] + sorted([(region.name, regio
 
 c.MAX_BADGE = max(xs[1] for xs in c.BADGE_RANGES.values())
 
-c.JOB_LOCATION_OPTS.sort(key=lambda tup: tup[1])
-
 c.JOB_PAGE_OPTS = (
     ('index',    'Calendar View'),
     ('signups',  'Signups View'),

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1816,8 +1816,6 @@ __many__ = string
 [[new_reg_payment_method]]
 [[door_payment_method]]
 [[interest]]
-[[job_interest]]
-[[job_location]]
 [[dept_head_overrides]]
 [[event_location]]
 

--- a/uber/forms/__init__.py
+++ b/uber/forms/__init__.py
@@ -70,7 +70,7 @@ def load_forms(params, model, form_list, prefix_dict={}, get_optional=True, trun
 
         for name, field in loaded_form._fields.items():
             if name in optional_fields:
-                field.validators = [validators.Optional()]
+                field.validators = [validators.Optional()] + [validator for validator in field.validators if not isinstance(validator, (validators.DataRequired, validators.InputRequired))]
                 field.flags.required = False
             else:
                 override_validators = get_override_attr(loaded_form, name, '_validators', field)

--- a/uber/forms/__init__.py
+++ b/uber/forms/__init__.py
@@ -368,9 +368,8 @@ class AddressForm():
         return optional_list
     
     def validate_zip_code(form, field):
-        if field.data and (form.country.data == 'United States' or (
-            not c.COLLECT_FULL_ADDRESS and not form.country.data and field.flags.required)) \
-            and invalid_zip_code(field.data):
+        if field.data and invalid_zip_code(field.data) and (
+            not form.international.data or c.COLLECT_FULL_ADDRESS and form.country.data == 'United States'):
             raise ValidationError('Please enter a valid 5 or 9-digit zip code.')
 
 

--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -25,8 +25,8 @@ __all__ = ['AdminInfo', 'BadgeExtras', 'PersonalInfo', 'PreregOtherInfo', 'Other
 # TODO: turn this into a proper validation class
 def valid_cellphone(form, field):
     if field.data and invalid_phone_number(field.data):
-        raise ValidationError('The provided phone number was not a valid 10-digit US phone number. ' \
-                                'Please include a country code (e.g. +44) for international numbers.')
+        raise ValidationError('Please provide a valid 10-digit US phone number or ' \
+                                'include a country code (e.g. +44) for international numbers.')
 
 class PersonalInfo(AddressForm, MagForm):
     field_validation, new_or_changed_validation = CustomValidation(), CustomValidation()
@@ -55,7 +55,8 @@ class PersonalInfo(AddressForm, MagForm):
         ],
         render_kw={'placeholder': 'test@example.com'})
     cellphone = TelField('Phone Number', validators=[
-        validators.DataRequired("Please provide a phone number.")
+        validators.DataRequired("Please provide a phone number."),
+        valid_cellphone
         ], render_kw={'placeholder': 'A phone number we can use to contact you during the event'})
     birthdate = DateField('Date of Birth', validators=[
         validators.DataRequired("Please enter your date of birth.") if c.COLLECT_EXACT_BIRTHDATE else validators.Optional(),
@@ -67,7 +68,8 @@ class PersonalInfo(AddressForm, MagForm):
         validators.DataRequired("Please tell us the name of your emergency contact.")
         ], render_kw={'placeholder': 'Who we should contact if something happens to you'})
     ec_phone = TelField('Emergency Contact Phone', validators=[
-        validators.DataRequired("Please give us an emergency contact phone number.")
+        validators.DataRequired("Please give us an emergency contact phone number."),
+        valid_cellphone
         ], render_kw={'placeholder': 'A valid phone number for your emergency contact'})
     onsite_contact = TextAreaField('Onsite Contact', validators=[
         validators.DataRequired("Please enter contact information for at least one trusted friend onsite, \
@@ -160,15 +162,6 @@ class PersonalInfo(AddressForm, MagForm):
     def not_same_cellphone_ec(form, field):
         if field.data and field.data == form.ec_phone.data:
             raise ValidationError("Your phone number cannot be the same as your emergency contact number.")
-
-    @field_validation.ec_phone
-    def valid_ec_phone(form, field):
-        if not form.international.data and invalid_phone_number(field.data):
-            if c.COLLECT_FULL_ADDRESS:
-                raise ValidationError('Please enter a 10-digit US phone number or include a ' \
-                                        'country code (e.g. +44) for your emergency contact number.')
-            else:
-                raise ValidationError('Please enter a 10-digit emergency contact number.')
 
 
 class BadgeExtras(MagForm):

--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -239,7 +239,7 @@ class BadgeExtras(MagForm):
 
 class OtherInfo(MagForm):
     field_validation = CustomValidation()
-    dynamic_choices_fields = {'requested_depts_ids': lambda: [(v[0], v[1]) for v in c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC] if len(c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC) > 1 else c.JOB_INTEREST_OPTS}
+    dynamic_choices_fields = {'requested_depts_ids': lambda: [(v[0], v[1]) for v in c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC]}
 
     placeholder = BooleanField(widget=HiddenInput())
     staffing = BooleanField('I am interested in volunteering!', widget=SwitchInput(), description=popup_link(c.VOLUNTEER_PERKS_URL, "What do I get for volunteering?"))
@@ -267,7 +267,7 @@ class OtherInfo(MagForm):
 
     @field_validation.requested_depts_ids
     def select_requested_depts(form, field):
-        if form.staffing.data and not field.data:
+        if form.staffing.data and not field.data and len(c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC) > 1:
             raise ValidationError('Please select the department(s) you would like to work for, or "Anything".')
 
 

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -818,7 +818,6 @@ class Session(SessionManager):
                 
             return_dict['panels_admin'] = self.query(Attendee).filter(
                                                  or_(Attendee.ribbon.contains(c.PANELIST_RIBBON),
-                                                     Attendee.panel_interest == True,
                                                      Attendee.panel_applications != None,
                                                      Attendee.assigned_panelists != None,
                                                      Attendee.panel_applicants != None,

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -406,7 +406,6 @@ class Attendee(MagModel, TakesPaymentMixin):
     panel_applicants = relationship('PanelApplicant', backref='attendee')
     panel_applications = relationship('PanelApplication', backref='poc')
     panel_feedback = relationship('EventFeedback', backref='attendee')
-    panel_interest = Column(Boolean, default=False)
 
     # =========================
     # attractions

--- a/uber/models/department.py
+++ b/uber/models/department.py
@@ -300,12 +300,6 @@ class Department(MagModel):
             except ValueError:
                 return department
 
-        if isinstance(department, int):
-            # This is the same algorithm used by the migration script to
-            # convert c.JOB_LOCATIONS into department ids in the database.
-            prefix = '{:07x}'.format(department)
-            return prefix + str(uuid.uuid5(cls.NAMESPACE, str(department)))[7:]
-
         return department.id
 
     def checklist_item_for_slug(self, slug):

--- a/uber/site_sections/landing.py
+++ b/uber/site_sections/landing.py
@@ -4,6 +4,7 @@ from uber.decorators import all_renderable, requires_account
 from uber.errors import HTTPRedirect
 from uber.forms import attendee as attendee_forms, load_forms
 from uber.models import Attendee
+from uber.payments import PreregCart
 
 
 @all_renderable(public=True)
@@ -11,6 +12,10 @@ class Root:
     def index(self, session, **params):
         if 'exit_kiosk' in params:
             cherrypy.session['kiosk_mode'] = False
+
+        if 'clear_cookies' in params:
+            for key in PreregCart.session_keys:
+                cherrypy.session.pop(key)
 
         forms = load_forms({}, Attendee(), ['BadgeExtras'])
 

--- a/uber/site_sections/mivs.py
+++ b/uber/site_sections/mivs.py
@@ -55,8 +55,6 @@ class Root:
             message = check(studio)
             if not message and studio.is_new:
                 message = check(developer)
-                if not message and 'covid_agreement' not in params:
-                    message = 'You must check the box acknowledging the {} COVID Policy'.format(c.EVENT_NAME_AND_YEAR)
             if not message:
                 session.add(studio)
                 if studio.is_new:
@@ -68,7 +66,6 @@ class Root:
             'message': message,
             'studio': studio,
             'developer': developer,
-            'covid_agreement': params.get('covid_agreement'),
         }
 
     def game(self, session, message='', **params):

--- a/uber/site_sections/panels.py
+++ b/uber/site_sections/panels.py
@@ -95,7 +95,6 @@ class Root:
             'other_panelists': other_panelists,
             'coc_agreement': params.get('coc_agreement'),
             'data_agreement': params.get('data_agreement'),
-            'covid_agreement': params.get('covid_agreement'),
             'verify_tos': params.get('verify_tos'),
             'verify_poc': params.get('verify_poc'),
             'verify_waiting': params.get('verify_waiting'),

--- a/uber/templates/emails/placeholders/deferred.html
+++ b/uber/templates/emails/placeholders/deferred.html
@@ -4,7 +4,7 @@
 You ({{ attendee.full_name }}) deferred your attendee badge last year, so we have created a placeholder badge for you for 
 {{ c.EVENT_NAME_AND_YEAR }} this coming {{ event_dates() }}. 
 Please <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">click here to claim your badge</a>, 
-make sure your information is up-to-date, and review and agree to this year's <a href="{{ c.COVID_POLICIES_URL }}" target="_blank">COVID policy</a>.
+make sure your information is up-to-date.
 
 <br/><br/>Badges are not mailed out before the event, so your badge will be available for pickup at the registration desk when 
 you arrive at {{ c.EVENT_NAME }}. Bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }}

--- a/uber/templates/forms/attendee.html
+++ b/uber/templates/forms/attendee.html
@@ -940,7 +940,7 @@ If you're interested in kicking in an extra donation, you can{% if c.COLLECT_EXT
 
 {% set job_interests %}
 {% set read_only = job_interests_ro or page_ro %}
-{% if c.JOB_INTEREST_OPTS or c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC|length > 1 %}
+{% if c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC|length > 1 %}
   <div class="form-group staffing" id="departments">
     <label for="requested_depts_ids" class="col-sm-3 control-label">Where do you want to help?</label>
     {% call macros.read_only_if(read_only, attendee.requested_depts_labels) %}

--- a/uber/templates/forms/attendee.html
+++ b/uber/templates/forms/attendee.html
@@ -1400,20 +1400,6 @@ $(window).on("runJavaScript", function () {
 {% endset %}
 
 
-{% set panel_interest %}
-{% set read_only = panel_interest_ro or page_ro %}
-{% if c.BEFORE_PANELS_DEADLINE %}
-<div class="form-group">
-  <label for="panel_interest" class="col-sm-3 control-label optional-field">Panel Interest</label>
-  <div class="checkbox col-sm-9">
-    {{ macros.checkbox(attendee, 'panel_interest', label='I plan to apply for a panel this year.', is_readonly=read_only, clientside_bool=clientside_bool) }}<br/>
-    {% if not admin_area and c.AFTER_PANELS_START %}<a href="../panels/" target="_blank">Apply for a panel here</a>!{% endif %}
-  </div>
-</div>
-{% endif %}
-{% endset %}
-
-
 {% set pii_consent_checkbox %}
 {% set read_only = pii_consent_ro or page_ro %}
 <div class="form-group">

--- a/uber/templates/forms/attendee/badge_extras.html
+++ b/uber/templates/forms/attendee/badge_extras.html
@@ -58,7 +58,7 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
 {% endblock %}
 
 {% block perk_info %}
-{% if c.DONATIONS_ENABLED or attendee.gets_any_kind_of_shirt %}
+{% if (c.DONATIONS_ENABLED and (not receipt or upgrade_modal)) or attendee.gets_any_kind_of_shirt %}
 <div class="row g-sm-3">
     {% if attendee.gets_staff_shirt and c.SHIRT_OPTS != c.STAFF_SHIRT_OPTS %}
         <div class="col-12 col-sm-6">{{ form_macros.form_input(badge_extras.staff_shirt, required=True) }}</div>

--- a/uber/templates/forms/attendee/other_info.html
+++ b/uber/templates/forms/attendee/other_info.html
@@ -51,7 +51,7 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
 <input type="hidden" name="cellphone" value="{{ other_info.cellphone.data }}" />
 {% endif %}
 
-{% if c.JOB_INTEREST_OPTS or c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC|length > 1 %}
+{% if c.PUBLIC_DEPARTMENT_OPTS_WITH_DESC|length > 1 %}
 <div class="row g-sm-3">
     <div class="col-12">{{ form_macros.form_input(other_info.requested_depts_ids) }}</div>
 </div>

--- a/uber/templates/forms/attendee/personal_info.html
+++ b/uber/templates/forms/attendee/personal_info.html
@@ -126,7 +126,7 @@
 {% else %}
 <div class="row g-sm-3">
   <div class="col-12 col-sm-6">
-    {{ form_macros.form_input(personal_info.zip_code, extra_field=form_macros.toggle_checkbox(personal_info.international, [personal_info.zip_code], hide_on_checked=True, toggle_required=True, prop='disabled')) }}
+    {{ form_macros.form_input(personal_info.zip_code, extra_field=form_macros.toggle_checkbox(personal_info.international, [personal_info.zip_code], hide_on_checked=True, toggle_required=True, prop='')) }}
   </div>
 
   <div class="col-12 col-sm-6">

--- a/uber/templates/forms/group/admin_group_info.html
+++ b/uber/templates/forms/group/admin_group_info.html
@@ -11,12 +11,11 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
 #}
 
 {% block badges_tables %}
-{% set max_badges = c.MAX_GROUP_SIZE %}
 
 <div class="row g-sm-3">
     <div class="col-12 col-sm-6">{{ form_macros.form_input(group_info.tables, choices=c.ADMIN_TABLE_OPTS) }}</div>
     <div class="col-12 col-sm-6">{{ form_macros.form_input(group_info.badges,
-                                        choices=int_choices(1, max_badges),
+                                        choices=int_choices(1, c.MAX_GROUP_SIZE),
                                         extra_field=form_macros.form_input(group_info.can_add),
                                         admin_text="[" ~ group.badges_purchased ~ " badge" ~ group.badges_purchased|pluralize ~ " purchased]" if not group.is_new else "",
                                         required=True) }}

--- a/uber/templates/forms/group/group_info.html
+++ b/uber/templates/forms/group/group_info.html
@@ -9,10 +9,14 @@
 Use these to add or rearrange fields. Remember to use {{ super() }} to print the original fields as-is.
 #}
 
+{# Takes the Stripe transaction max and divides it by the group price,
+    then rounds down to the nearest multiple of 5 so that people don't ask us why we're selling 86 badges #}
+{% set max_badges = ((9999 / c.GROUP_PRICE / 5)|int * 5)|int if is_prereg_attendee else c.MAX_GROUP_SIZE %}
+
 {% block name_badges %}
 <div class="row g-sm-3">
     <div class="col-12 col-sm-6">{{ form_macros.form_input(group_info.name) }}</div>
-    {% if is_prereg_attendee %}<div class="col-12 col-sm-6">{{ form_macros.form_input(group_info.badges, choices=int_choices(0 if admin_area else c.MIN_GROUP_SIZE, c.MAX_GROUP_SIZE)) }}</div>
+    {% if is_prereg_attendee %}<div class="col-12 col-sm-6">{{ form_macros.form_input(group_info.badges, choices=int_choices(0 if admin_area else c.MIN_GROUP_SIZE, max_badges)) }}</div>
     {% elif admin_area and not group.is_dealer %}<div class="col-12 col-sm-6">{{ form_macros.form_input(group_info.guest_group_type) }}</div>{% endif %}
 </div>
 {% endblock %}

--- a/uber/templates/forms/macros.html
+++ b/uber/templates/forms/macros.html
@@ -153,7 +153,7 @@
 #}
 
 {% set is_preview = 'landing' in c.PAGE_PATH %}
-{% set label_required = kwargs['required'] if 'required' in kwargs else None %}
+{% set label_required = kwargs['required'] if 'required' in kwargs else target_field.flags.required %}
 {% set field_id = target_field_id or target_field.id %}
 {% set show_desc = not admin_area and not is_preview and (help_text or target_field.description) %}
 
@@ -162,7 +162,7 @@
 {% else %}
 <fieldset>
   <legend class="mt-3 mb-0 form-text">
-    {{ target_field.label.text }}{% if target_field.flags.required %}<span class="required-indicator text-danger"> *</span>{% endif %}
+    {{ kwargs['label'] if 'label' in kwargs else target_field.label.text }}{% if label_required %}<span class="required-indicator text-danger"> *</span>{% endif %}
   </legend>
 {% endif %}
 <div class="card-group mt-0{% if not show_desc %} mb-3{% endif %}">

--- a/uber/templates/forms/prereg_fields.html
+++ b/uber/templates/forms/prereg_fields.html
@@ -7,7 +7,7 @@
 <div class="row g-sm-3">
     {{ form_macros.card_select(badge_extras.badge_type,
         c.FORMATTED_REG_TYPES, disabled_opts=c.UNAVAILABLE_REG_TYPES,
-        target_field_id="badge_type", disabled_card_text="Unavailable") }}
+        target_field_id="badge_type", disabled_card_text="Unavailable", label="Registration Type") }}
 </div>
 {% if c.GROUPS_ENABLED %}
 {{ form_macros.toggle_fields_js(badge_extras.badge_type, [group_info.name, group_info.badges],

--- a/uber/templates/mivs/developer_agreements.html
+++ b/uber/templates/mivs/developer_agreements.html
@@ -15,8 +15,6 @@ determining showcase selections for {{ c.EVENT_NAME_AND_YEAR }}. My information 
   </div>
 </div>
 
-{% include "preregistration/covid_checkbox.html" ignore missing %}
-
 <div class="form-group">
   <div class="col-sm-9 col-sm-offset-3">
     <div class="form-control-static checkbox">

--- a/uber/templates/preregistration/additional_info.html
+++ b/uber/templates/preregistration/additional_info.html
@@ -44,7 +44,7 @@
 {% if is_prereg_dealer %}
 {{ "js/warn-before-logout-dealer.js"|serve_static_content }}
 {% else %}
-<em class="form-text">Please note: your badge and any upgrades are not reserved until you complete the registration process, including payment.</em>
+<div class="text-center"><em class="badge bg-dark fw-normal">Please note: your badge and any upgrades are not reserved until you complete the registration process, including payment.</em></div>
 {{ "js/warn-before-logout.js"|serve_static_content }}
 {% endif %}
 {% endblock %}

--- a/uber/templates/preregistration/disclaimer_popup.html
+++ b/uber/templates/preregistration/disclaimer_popup.html
@@ -7,6 +7,9 @@
     var openDisclaimersModal = function() {
       var modal = bootstrap.Modal.getOrCreateInstance($('#disclaimers_modal'))
       modal.show();
+      $('#disclaimers_modal').on('hidden.bs.modal', function (event) {
+        if(serverValidationPassed != undefined) { serverValidationPassed = false; }
+      })
     }
     
   </script>

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -106,7 +106,7 @@
 {% if is_prereg_dealer %}
 {{ "js/warn-before-logout-dealer.js"|serve_static_content }}
 {% else %}
-<em class="form-text">Please note: your badge and any upgrades are not reserved until you complete the registration process, including payment.</em>
+<div class="text-center"><em class="badge bg-dark fw-normal">Please note: your badge and any upgrades are not reserved until you complete the registration process, including payment.</em></div>
 {% if cart_not_empty %}{{ "js/warn-before-logout.js"|serve_static_content }}{% endif %}
 {% endif %}
 {% endblock %}

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -81,7 +81,6 @@
   {{ attendee_fields.comments }}
   {{ attendee_fields.requested_accessibility_services }}
   {{ attendee_fields.can_spam }}
-  {{ attendee_fields.panel_interest }}
   {{ attendee_fields.pii_consent_checkbox }} #}
 
   {# Deprecated forms included for backwards compatibility with old plugins #}

--- a/uber/templates/preregistration/group_promo_codes.html
+++ b/uber/templates/preregistration/group_promo_codes.html
@@ -9,7 +9,6 @@
           return false;
       };
   </script>
-  {% include 'prereg_masthead.html' %}
   <div class="card">
   <div class="card-body">
     {% include 'confirm_tabs.html' with context %}

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -138,6 +138,6 @@
     {% include "preregistration/disclaimers.html" %}
   </div>
 </div>
-<em class="form-text">Please note: your badge and any upgrades are not reserved until you complete the registration process, including payment.</em>
+<div class="text-center"><em class="badge bg-dark fw-normal">Please note: your badge and any upgrades are not reserved until you complete the registration process, including payment.</em></div>
 {{ "js/warn-before-logout.js"|serve_static_content }}
 {% endblock %}

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -36,8 +36,7 @@
 
       {% if cart.attendees or cart.groups %}
         {% include 'preregistration/index_payment_form.html' %}
-  </div>
-
+  <br/>
   <table class="charge table table-striped">
     <caption class="visually-hidden">A table listing the preregistrations currently in your cart. 
       Column one shows the name associated with the preregistration along with a list of purchased items and discounts,
@@ -45,10 +44,10 @@
       and column three gives options to modify or delete the preregistration.</caption>
     <thead>
       <tr>
-        <th>Preregistration</th>
-        <th data-hide="phone" data-sort-ignore="true">Details</th>
-        <th data-type="numeric">Price</th>
-        <th data-sort-ignore="true"></th>
+        <th scope="col">Preregistration</th>
+        <th scope="col" data-hide="phone" data-sort-ignore="true">Details</th>
+        <th scope="col" data-type="numeric">Price</th>
+        <th scope="col" data-sort-ignore="true"></th>
       </tr>
     </thead>
     <tbody>
@@ -87,7 +86,7 @@
           <td>
               {{ attendee.default_cost|format_currency }}
           </td>
-          <td>
+          <td class="text-nowrap">
             <span id="edit-{{ attendee.first_name }}-{{ attendee.last_name }}">
               <a href="form?edit_id={{ attendee.id }}" aria-describedby="edit-{{ attendee.first_name }}-{{ attendee.last_name }}">Edit</a>
             </span> / 

--- a/uber/templates/preregistration/paid_preregistrations.html
+++ b/uber/templates/preregistration/paid_preregistrations.html
@@ -41,7 +41,7 @@
         {% else %}
           <tr>
             <td>{{ prereg.name }}</td>
-            <td colspan="3">(<a href="group_promo_codes?id={{ prereg.id }}" target="_blank">Click Here</a> to assign your group's badges)</td>
+            <td colspan="3">(<a href="group_members?id={{ prereg.id }}" target="_blank">Click Here</a> to assign your group's badges)</td>
           </tr>
         {% endif %}
       {% endfor %}

--- a/uber/templates/preregistration/paid_preregistrations.html
+++ b/uber/templates/preregistration/paid_preregistrations.html
@@ -6,60 +6,55 @@
   <div class="card-body">
     {{ macros.prereg_wizard(c.PAGE_PATH, is_prereg_dealer) }}
 
-    <div class="row">
-      <div class="well col-md-offset-1 col-md-10">
-        <h2>Registration Complete</h2>
+    <h2>Registration Complete</h2>
+    <p>
+        Congratulations! Your registration was successful.
+    </p>
+    {% if total_cost|int > 0 %}
         <p>
-            Congratulations! Your registration was successful.
+            Your credit card was successfully charged for
+            <strong>{{ total_cost|format_currency }}</strong>, and you will receive a confirmation
+            email sent to you shortly. If you paid for other registrations, those
+            attendees will get their own confirmation email.
         </p>
-        {% if total_cost|int > 0 %}
-            <p>
-                Your credit card was successfully charged for
-                <strong>{{ total_cost|format_currency }}</strong>, and you will receive a confirmation
-                email sent to you shortly. If you paid for other registrations, those
-                attendees will get their own confirmation email.
-            </p>
-        {% else %}
-            <p>
-                You will receive a confirmation email sent to you shortly.
-                {% if preregs|length > 1 %}All attendees will get their own confirmation email.{% endif %}
-            </p>
-        {% endif %}
-      </div>
-    </div>
+    {% else %}
+        <p>
+            You will receive a confirmation email sent to you shortly.
+            {% if preregs|length > 1 %}All attendees will get their own confirmation email.{% endif %}
+        </p>
+    {% endif %}
 
-    <div class="row">
-      <div class="col-md-offset-1 col-md-10">
-
-        <p>The following preregistrations have been made from this computer:</p>
-
-        <table class="table table-striped">
+    <p>You can view your registrations below:</p>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Name</th>
+          <th scope="col">Confirmation Link</th>
+        </tr>
+      </thead>
+      {% for prereg in preregs %}
+        {% if prereg.first_name %}
           <tr>
-            <td>Name</td>
-            <td>Confirmation Link</td>
+            <td>{{ prereg.full_name }}</td>
+            <td><a href="../preregistration/confirm?id={{ prereg.id }}" target="_blank">Click Here</a></td>
           </tr>
-          {% for prereg in preregs %}
-            {% if prereg.first_name %}
-              <tr>
-                <td>{{ prereg.full_name }}</td>
-                <td><a href="../preregistration/confirm?id={{ prereg.id }}" target="_blank">Click Here</a></td>
-              </tr>
-            {% else %}
-              <tr>
-                <td>{{ prereg.name }}</td>
-                <td colspan="3">(<a href="group_members?id={{ prereg.id }}" target="_blank">Click Here</a> to assign your group's badges)</td>
-              </tr>
-            {% endif %}
-          {% endfor %}
-        </table>
-      </div>
-    </div>
+        {% else %}
+          <tr>
+            <td>{{ prereg.name }}</td>
+            <td colspan="3">(<a href="group_promo_codes?id={{ prereg.id }}" target="_blank">Click Here</a> to assign your group's badges)</td>
+          </tr>
+        {% endif %}
+      {% endfor %}
+    </table>
 
-    <div class="row">
-      <div class="col-md-offset-1 col-md-10">
-        <a href="index" class="btn btn-primary">Add Another Registration</a>
-      </div>
-    </div>
+    <p>
+      <strong>If you are on a shared computer, we strongly recommend logging out using the button below.</strong>
+      This will remove the record (browser cookie) that stores the above registrations, protecting your personal 
+      information. All other cookie(s), which are purely functional, have already been cleared.
+    </p>
+
+    <a href="../preregistration/form" class="btn btn-primary">Add Another Registration</a>
+    <a href="../landing/index?clear_cookies=true" class="btn btn-danger">Log Out</a>
   </div>
 </div>
 

--- a/uber/templates/preregistration/transfer_badge.html
+++ b/uber/templates/preregistration/transfer_badge.html
@@ -33,7 +33,6 @@
       {{ attendee_fields.found_how }}
       {{ attendee_fields.comments }}
       {{ attendee_fields.can_spam }}
-      {{ attendee_fields.panel_interest }}
       {{ attendee_fields.pii_consent_checkbox }}
       {# Deprecated form included for backwards compatibility with old plugins #}
       {% include "regform.html" %}

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -99,7 +99,6 @@
 {{ attendee_fields.found_how }}
 {{ attendee_fields.comments }}
 {{ attendee_fields.can_spam }}
-{{ attendee_fields.panel_interest }}
 {{ attendee_fields.attractions_opt_out }}
 
 {% block post_regform %}{% endblock %}

--- a/uber/templates/registration/register.html
+++ b/uber/templates/registration/register.html
@@ -40,7 +40,6 @@
         {{ attendee_fields.comments }}
         {{ attendee_fields.requested_accessibility_services }}
         {{ attendee_fields.can_spam }}
-        {{ attendee_fields.panel_interest }}
         {{ attendee_fields.pii_consent_checkbox }}
 
         {# Deprecated forms included for backwards compatibility with old plugins #}

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -563,7 +563,7 @@ def validate_model(forms, model, preview_model=None, is_admin=False):
         for field_name in form.get_optional_fields(preview_model, is_admin):
             field = getattr(form, field_name)
             if field:
-                field.validators = [validators.Optional()]
+                field.validators = [validators.Optional()] + [validator for validator in field.validators if not isinstance(validator, (validators.DataRequired, validators.InputRequired))]
 
         # TODO: Do we need to check for custom validations or is this code performant enough to skip that?
         for key, field in form.field_list:


### PR DESCRIPTION
- Removes almost all references to COVID
- Sets the max group size to fit in the Stripe transaction limit
- Fixes some broken validations by changing how we handle optional fields
- Updates wording on the registration type display cards
- Stops disabling the zipcode field when the "international" field is checked
- Fixes several issues with the "interested in working in" field, including getting rid of the old job_interests and job_locations config values because they do literally nothing useful
- Removes the second masthead from the promo code group management page