### PR TITLE
Stop with_badge filtering before joins

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -309,13 +309,14 @@ class Config(_Overridable):
                 return max(0, attendee_count - staff_count)
         else:
             with Session() as session:
-                attendees = session.attendees_with_badges()
-                individuals = attendees.filter(or_(
+                attendees = session.query(Attendee)
+                individuals = attendees.filter(Attendee.has_badge == True, or_(
                     Attendee.paid == self.HAS_PAID,
                     Attendee.paid == self.REFUNDED)
                 ).filter(Attendee.badge_status == self.COMPLETED_STATUS).count()
 
-                group_badges = attendees.filter(
+                group_badges = attendees.join(Attendee.group).filter(
+                    Attendee.has_badge == True,
                     Attendee.paid == self.PAID_BY_GROUP,
                     Group.amount_paid > 0).count()
 

--- a/uber/site_sections/budget.py
+++ b/uber/site_sections/budget.py
@@ -39,7 +39,7 @@ class Root:
         }
 
     def badge_cost_summary(self, session):
-        attendees = session.attendees_with_badges()
+        attendees = session.query(Attendee)
 
         base_filter = [Attendee.has_or_will_have_badge]
 

--- a/uber/site_sections/hotel_reports.py
+++ b/uber/site_sections/hotel_reports.py
@@ -528,7 +528,8 @@ class Root:
 
     @csv_file
     def attendee_hotel_pins(self, out, session):
-        hotel_query = session.attendees_with_badges().filter(Attendee.email != '')
+        hotel_query = session.filter(Attendee.email != '', Attendee.is_valid == True,
+                                     ~Attendee.badge_status.in_([c.REFUNDED_STATUS, c.NOT_ATTENDING, c.DEFERRED_STATUS]))
 
         attendees_without_hotel_pin = hotel_query.filter(or_(
             Attendee.hotel_pin == None,

--- a/uber/site_sections/reg_reports.py
+++ b/uber/site_sections/reg_reports.py
@@ -10,11 +10,12 @@ class Root:
     def comped_badges(self, session, message='', show='all'):
         regular_comped = session.attendees_with_badges().filter(Attendee.paid == c.NEED_NOT_PAY, 
                                                                 Attendee.promo_code == None)
-        promo_comped = session.attendees_with_badges().join(PromoCode).filter(Attendee.paid == c.NEED_NOT_PAY,
-                                                                              or_(PromoCode.cost == None, 
-                                                                                  PromoCode.cost == 0))
-        group_comped = session.attendees_with_badges().join(Group, Attendee.group_id == Group.id)\
-                .filter(Attendee.paid == c.PAID_BY_GROUP, Group.cost == 0)
+        promo_comped = session.query(Attendee).join(PromoCode).filter(Attendee.has_badge == True,
+                                                                      Attendee.paid == c.NEED_NOT_PAY,
+                                                                      or_(PromoCode.cost == None, 
+                                                                          PromoCode.cost == 0))
+        group_comped = session.query(Attendee).join(Group, Attendee.group_id == Group.id)\
+                .filter(Attendee.has_badge == True, Attendee.paid == c.PAID_BY_GROUP, Group.cost == 0)
         all_comped = regular_comped.union(promo_comped, group_comped)
         claimed_comped = all_comped.filter(Attendee.placeholder == False)
         unclaimed_comped = all_comped.filter(Attendee.placeholder == True)


### PR DESCRIPTION
I _think_ the use of the attendees_with_badges() shortcut prior to any join is the root of the issues we've been having. Also fixes an issue where the hotel export excluded unapproved dealers but included deferred badges, both of which were incorrect.