### PR TITLE
Improve receipt auto-updater and fix receipt items

### DIFF
--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -274,7 +274,7 @@ class Root:
         receipt = session.get_receipt_by_model(app, create_if_none="DEFAULT")
         
         charge_desc = "{}'s Art Show Application: {}".format(app.attendee.full_name, receipt.charge_description_list)
-        charge = TransactionRequest(receipt, app.attendee.email, charge_desc)
+        charge = TransactionRequest(receipt, app.attendee.email, charge_desc, create_receipt_item=True)
         
         message = charge.process_payment()
 

--- a/uber/site_sections/marketplace.py
+++ b/uber/site_sections/marketplace.py
@@ -107,7 +107,7 @@ class Root:
         receipt = session.get_receipt_by_model(app, create_if_none="DEFAULT")
         
         charge_desc = "{}'s Marketplace Application: {}".format(app.attendee.full_name, receipt.charge_description_list)
-        charge = TransactionRequest(receipt, app.attendee.email, charge_desc)
+        charge = TransactionRequest(receipt, app.attendee.email, charge_desc, create_receipt_item=True)
         
         message = charge.process_payment()
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -948,7 +948,8 @@ class Root:
         receipt = session.get_receipt_by_model(group.buyer, create_if_none="DEFAULT")
         count = int(count)
         charge_desc = '{} extra badge{} for {}'.format(count, 's' if count > 1 else '', group.name)
-        charge = TransactionRequest(receipt, receipt_email=group.email, description=charge_desc, amount=c.get_group_price() * 100 * count)
+        charge = TransactionRequest(receipt, receipt_email=group.email, description=charge_desc,
+                                    amount=c.get_group_price() * 100 * count, create_receipt_item=True)
         if charge.dollar_amount % c.GROUP_PRICE:
             session.rollback()
             return {'error': 'Our preregistration price has gone up since you tried to add more codes; please try again'}
@@ -1205,11 +1206,12 @@ class Root:
                                 who='non-admin',
                             ))
         charge_desc = '{} extra badge{} for {}'.format(count, 's' if count > 1 else '', group.name)
-        charge = TransactionRequest(receipt, group.email, charge_desc, group.new_badge_cost * count * 100)
+        charge = TransactionRequest(receipt, group.email, charge_desc,
+                                    group.new_badge_cost * count * 100, create_receipt_item=True)
         if charge.dollar_amount % group.new_badge_cost:
             session.rollback()
             return {'error': 'Our preregistration price has gone up since you tried to add the badges; please try again'}
-        
+
         message = charge.process_payment()
         if message:
             return {'error': message}


### PR DESCRIPTION
The auto_update_receipt function now only looks at parameters that have changed, which should fix several bugs (most importantly, the current bug where PC group owners get asked for $10 every time they save their badge). Also actually creates receipt items in several places where those were missing, including promo code groups and dealer groups.