### PR TITLE
Only mark payment intents as paid if they were successful

### DIFF
--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -359,7 +359,7 @@ class ReceiptTransaction(MagModel):
             return
 
         intent = self.get_stripe_intent()
-        if intent and intent.charges:
+        if intent and intent.status == "succeeded":
             new_charge_id = intent.charges.data[0].id
             ReceiptManager.mark_paid_from_intent_id(self.intent_id, new_charge_id)
             return new_charge_id

--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -120,7 +120,7 @@ class Root:
 
         stripe_intent = txn.get_stripe_intent()
 
-        if stripe_intent.charges:
+        if stripe_intent.status == "succeeded":
             return {'error': "This payment has already been finalized!"}
 
         return {'stripe_intent': stripe_intent,

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1649,7 +1649,7 @@ class Root:
         if not stripe_intent:
             return {'error': "Something went wrong. Please contact us at {}.".format(email_only(c.REGDESK_EMAIL))}
 
-        if stripe_intent.charges:
+        if stripe_intent.status == "succeeded":
             return {'error': "This payment has already been finalized!"}
 
         return {'stripe_intent': stripe_intent,


### PR DESCRIPTION
Fixes a bug where declined payments were marked as paid since they technically had a charge on them.