### PR TITLE
Include currently_sending emails in active emails

### DIFF
--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -106,8 +106,7 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
         now = utils.localized_now()
         return cls.filters_for_allowed + [
             or_(cls.active_after == None, cls.active_after <= now),
-            or_(cls.active_before == None, cls.active_before >= now),
-            cls.currently_sending == False]  # noqa: E711
+            or_(cls.active_before == None, cls.active_before >= now)]  # noqa: E711
 
     @classproperty
     def filters_for_approvable(cls):


### PR DESCRIPTION
We have a way to ignore currently_sending if it's been stuck for too long, but it wasn't working because any currently_sending email category was fully excluded from the list. This should fix that and prevent emails from getting indefinitely blocked.