### PR TITLE
Allow hotel_eligible to stay False for staffers

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1923,7 +1923,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @presave_adjustment
     def staffer_hotel_eligibility(self):
-        if self.badge_type == c.STAFF_BADGE:
+        if self.badge_type == c.STAFF_BADGE and (self.is_new or self.orig_value_of('badge_type') != c.STAFF_BADGE):
             self.hotel_eligible = True
 
     @presave_adjustment

--- a/uber/site_sections/hotel_reports.py
+++ b/uber/site_sections/hotel_reports.py
@@ -529,7 +529,8 @@ class Root:
     @csv_file
     def attendee_hotel_pins(self, out, session):
         hotel_query = session.filter(Attendee.email != '', Attendee.is_valid == True,
-                                     ~Attendee.badge_status.in_([c.REFUNDED_STATUS, c.NOT_ATTENDING, c.DEFERRED_STATUS]))
+                                     ~Attendee.badge_status.in_([c.REFUNDED_STATUS, c.NOT_ATTENDING, c.DEFERRED_STATUS]),
+                                     or_(Attendee.badge_type != c.STAFF_BADGE, Attendee.hotel_eligible == True))
 
         attendees_without_hotel_pin = hotel_query.filter(or_(
             Attendee.hotel_pin == None,


### PR DESCRIPTION
We need a way to mark some staff as not eligible for both staff rooming and the attendee lottery. This makes it so that if we set hotel_eligible to False, it doesn't then reset to True just because someone has a staff badge. This also checks for hotel_eligible for staffers during the attendee hotel export.