### PR TITLE
Updates to receipt refunds plus adding refunding of group badges

### DIFF
--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -392,7 +392,7 @@ class ReceiptTransaction(MagModel):
         intent = intent or self.get_stripe_intent()
         if intent and intent.status == "succeeded":
             new_charge_id = intent.charges.data[0].id
-            ReceiptManager.mark_paid_from_intent_id(self.intent_id, new_charge_id)
+            ReceiptManager.mark_paid_from_stripe_intent(intent)
             return new_charge_id
 
     def update_amount_refunded(self):

--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -318,7 +318,7 @@ class ReceiptTransaction(MagModel):
         # Return the most relevant Stripe ID for admins
         return self.refund_id or self.charge_id or self.intent_id
     
-    @request_cached_property
+    @property
     def total_processing_fee(self):
         if self.processing_fee and self.amount == self.txn_total:
             return self.processing_fee

--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -342,7 +342,7 @@ class ReceiptTransaction(MagModel):
             amount = self.amount
         
         refund_pct = Decimal(amount) / Decimal(self.txn_total)
-        return refund_pct * Decimal(self.total_processing_fee)
+        return int(refund_pct * Decimal(self.total_processing_fee))
     
     def check_stripe_id(self):
         # Check all possible Stripe IDs for invalid request errors

--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -104,11 +104,11 @@ class ModelReceipt(MagModel):
     
     @property
     def total_processing_fees(self):
-        return sum([txn.calc_partial_processing_fee(txn.amount) for txn in self.refundable_txns])
+        return sum([txn.calc_processing_fee(txn.amount) for txn in self.refundable_txns])
     
     @property
     def remaining_processing_fees(self):
-        return sum([txn.calc_partial_processing_fee(txn.amount_left) for txn in self.refundable_txns])
+        return sum([txn.calc_processing_fee(txn.amount_left) for txn in self.refundable_txns])
 
     @property
     def open_receipt_items(self):
@@ -189,6 +189,10 @@ class ModelReceipt(MagModel):
 
     @property
     def total_str(self):
+        if self.closed:
+            return "{} in {}".format(format_currency(abs(self.txn_total / 100)),
+                                                        "Payments" if self.txn_total >= 0 else "Refunds")
+
         return "{} in {} and {} in {} = {} owe {}".format(format_currency(abs(self.item_total / 100)),
                                                         "Purchases" if self.item_total >= 0 else "Credit",
                                                         format_currency(abs(self.txn_total / 100)),
@@ -283,7 +287,8 @@ class ReceiptTransaction(MagModel):
 
     @property
     def refundable(self):
-        return self.charge_id and self.amount_left and self.amount > 0
+        return not self.receipt.closed and self.charge_id and self.amount > 0 and \
+            self.amount_left and self.amount_left != self.calc_processing_fee()
 
     @property
     def stripe_url(self):
@@ -313,8 +318,9 @@ class ReceiptTransaction(MagModel):
         # Return the most relevant Stripe ID for admins
         return self.refund_id or self.charge_id or self.intent_id
     
-    def get_processing_fee(self):
-        if self.processing_fee:
+    @request_cached_property
+    def total_processing_fee(self):
+        if self.processing_fee and self.amount == self.txn_total:
             return self.processing_fee
 
         if c.AUTHORIZENET_LOGIN_ID:
@@ -326,14 +332,17 @@ class ReceiptTransaction(MagModel):
         
         return intent.charges.data[0].balance_transaction.fee_details[0].amount
     
-    def calc_partial_processing_fee(self, refund_amount):
+    def calc_processing_fee(self, amount=0):
         from decimal import Decimal
 
-        if not refund_amount:
-            return 0
+        if not amount:
+            if self.processing_fee:
+                return self.processing_fee
+
+            amount = self.amount
         
-        refund_pct = Decimal(refund_amount) / Decimal(self.txn_total)
-        return refund_pct * Decimal(self.get_processing_fee())
+        refund_pct = Decimal(amount) / Decimal(self.txn_total)
+        return refund_pct * Decimal(self.total_processing_fee)
     
     def check_stripe_id(self):
         # Check all possible Stripe IDs for invalid request errors

--- a/uber/models/promo_code.py
+++ b/uber/models/promo_code.py
@@ -9,7 +9,7 @@ import six
 from pytz import UTC
 from dateutil import parser as dateparser
 from residue import CoerceUTF8 as UnicodeText, UTCDateTime, UUID
-from sqlalchemy import func, select, CheckConstraint
+from sqlalchemy import exists, func, select, CheckConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.schema import Index, ForeignKey
 from sqlalchemy.types import Integer
@@ -172,13 +172,17 @@ class PromoCodeGroup(MagModel):
 
     @hybrid_property
     def total_cost(self):
-        return sum(code.cost for code in self.promo_codes if code.cost)
+        return sum(code.cost for code in self.paid_codes if code.cost)
     
     @total_cost.expression
     def total_cost(cls):
         return select([func.sum(PromoCode.cost)]
-                     ).where(PromoCode.group_id == cls.id
+                     ).where(PromoCode.group_id == cls.id).where(PromoCode.refunded == False
                      ).label('total_cost')
+    
+    @property
+    def paid_codes(self):
+        return [code for code in self.promo_codes if not code.refunded]
 
     @property
     def valid_codes(self):
@@ -456,6 +460,16 @@ class PromoCode(MagModel):
     def uses_remaining_str(self):
         uses = self.uses_remaining
         return 'Unlimited uses' if uses is None else '{} use{} remaining'.format(uses, '' if uses == 1 else 's')
+    
+    @hybrid_property
+    def refunded(self):
+        return self.used_by and self.used_by[0].badge_status == c.REFUNDED_STATUS
+    
+    @refunded.expression
+    def refunded(cls):
+        from uber.models import Attendee
+        return exists().select_from(Attendee).where(cls.id == Attendee.promo_code_id
+                                            ).where(Attendee.badge_status == c.REFUNDED_STATUS)
 
     @presave_adjustment
     def _attribute_adjustments(self):

--- a/uber/site_sections/api.py
+++ b/uber/site_sections/api.py
@@ -173,7 +173,7 @@ class Root:
 
         if event and event['type'] == 'payment_intent.succeeded':
             payment_intent = event['data']['object']
-            matching_txns = ReceiptManager.mark_paid_from_intent_id(payment_intent['id'], payment_intent.charges.data[0].id)
+            matching_txns = ReceiptManager.mark_paid_from_stripe_intent(payment_intent)
             if not matching_txns:
                 cherrypy.response.status = 400
                 return "No matching Stripe transactions"

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1350,9 +1350,6 @@ class Root:
             if attendee.paid == c.HAS_PAID:
                 attendee.paid = c.REFUNDED
 
-        if attendee.in_promo_code_group:
-            attendee.promo_code = None
-
         # if attendee is part of a group, we must delete attendee and remove them from the group
         if attendee.group:
             session.assign_badges(

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -745,7 +745,7 @@ class Root:
             pending_attendee = session.query(Attendee).filter_by(id=attendee.id).first()
             if pending_attendee:
                 pending_attendee.apply(attendee.to_dict(), restricted=True)
-                if attendee.badges:
+                if attendee.badges and pending_attendee.promo_code_groups:
                     pc_group = pending_attendee.promo_code_groups[0]
                     pc_group.name = attendee.name
 
@@ -755,6 +755,9 @@ class Root:
                         session.add_codes_to_pc_group(pc_group, pc_codes - pending_codes)
                     elif pc_codes < pending_codes:
                         session.remove_codes_from_pc_group(pc_group, pending_codes - pc_codes)
+                elif attendee.badges:
+                    pc_group = session.create_promo_code_group(pending_attendee, attendee.name, int(attendee.badges) - 1)
+                    session.add(pc_group)
                 elif pending_attendee.promo_code_groups:
                     pc_group = pending_attendee.promo_code_groups[0]
                     session.delete(pc_group)

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -21,11 +21,12 @@ from uber.utils import check, get_api_service_from_server, normalize_email, norm
 from uber.payments import ReceiptManager, TransactionRequest
 
 def check_custom_receipt_item_txn(params, is_txn=False):
+    from decimal import Decimal
     if not params.get('amount'):
         return "You must enter a positive or negative amount."
     
     try:
-        amount = int(params['amount'])
+        amount = Decimal(params['amount'])
     except Exception:
         return "The amount must be a number."
 
@@ -37,7 +38,7 @@ def check_custom_receipt_item_txn(params, is_txn=False):
     if is_txn:
         if not params.get('method'):
             return "You must choose a payment method."
-        if int(params['amount']) < 0 and not params.get('desc'):
+        if Decimal(params['amount']) < 0 and not params.get('desc'):
             return "You must enter a description when adding a refund."
     elif not params.get('desc'):
         return "You must describe the item you are adding or crediting."
@@ -89,8 +90,16 @@ def assign_account_by_email(session, attendee, account_email):
 @all_renderable()
 class Root:
     def receipt_items(self, session, id, message=''):
+        group_leader_receipt = None
+        group_processing_fee = 0
         try:
             model = session.attendee(id)
+            if model.in_promo_code_group and model.promo_code.group.buyer:
+                group_leader_receipt = session.get_receipt_by_model(model.promo_code.group.buyer)
+                potential_refund_amount = model.promo_code.cost * 100
+                txn = sorted([txn for txn in group_leader_receipt.refundable_txns if txn.amount_left >= potential_refund_amount],
+                                key=lambda x: x.added)[0]
+                group_processing_fee = txn.calc_processing_fee(potential_refund_amount)
         except NoResultFound:
             try:
                 model = session.group(id)
@@ -121,6 +130,8 @@ class Root:
             'attendee': model if isinstance(model, Attendee) else None,
             'group': model if isinstance(model, Group) else None,
             'art_show_app': model if isinstance(model, ArtShowApplication) else None,
+            'group_leader_receipt': group_leader_receipt,
+            'group_processing_fee': group_processing_fee,
             'receipt': receipt,
             'other_receipts': other_receipts,
             'closed_receipts': session.query(ModelReceipt).filter(ModelReceipt.owner_id == id,
@@ -144,13 +155,15 @@ class Root:
 
     @ajax
     def add_receipt_item(self, session, id='', **params):
+        from decimal import Decimal
+
         receipt = session.model_receipt(id)
 
         message = check_custom_receipt_item_txn(params)
         if message:
             return {'error': message}
 
-        amount = int(params.get('amount', 0))
+        amount = Decimal(params.get('amount', 0))
 
         if params.get('item_type', '') == 'credit':
             amount = amount * -1
@@ -266,7 +279,7 @@ class Root:
         if item.receipt_txn and item.receipt_txn.amount_left:
             refund_amount = min(item.amount, item.receipt_txn.amount_left)
             if params.get('exclude_fees'):
-                processing_fees = item.receipt_txn.calc_partial_processing_fee(refund_amount)
+                processing_fees = item.receipt_txn.calc_processing_fee(refund_amount)
                 session.add(ReceiptItem(
                     receipt_id=item.receipt.id,
                     desc=f"Processing Fees for Refunding {item.desc}",
@@ -297,6 +310,8 @@ class Root:
 
     @ajax
     def add_receipt_txn(self, session, id='', **params):
+        from decimal import Decimal
+
         receipt = session.model_receipt(id)
         model = session.get_model_by_receipt(receipt)
 
@@ -304,7 +319,7 @@ class Root:
         if message:
             return {'error': message}
 
-        amount = int(params.get('amount', 0))
+        amount = Decimal(params.get('amount', 0))
 
         if params.get('txn_type', '') == 'refund':
             amount = amount * -1
@@ -425,44 +440,102 @@ class Root:
     def process_full_refund(self, session, id='', attendee_id='', group_id='', exclude_fees=False):
         receipt = session.model_receipt(id)
         refund_total = 0
-        for txn in receipt.refundable_txns:
-            refund_amount = txn.amount_left
-            if exclude_fees:
-                processing_fees = txn.calc_partial_processing_fee(txn.amount_left)
-                session.add(ReceiptItem(
-                    receipt_id=txn.receipt.id,
-                    desc=f"Processing Fees for Full Refund of {txn.desc}",
-                    amount=processing_fees,
-                    who=AdminAccount.admin_name() or 'non-admin',
-                ))
-                refund_amount -= processing_fees
-
-            refund = TransactionRequest(receipt, amount=refund_amount)
-            error = refund.refund_or_skip(txn)
-            if error:
-                raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}', attendee_id or group_id, error)
-            session.add_all(refund.get_receipt_items_to_add())
-            refund_total += refund.amount
-
-        receipt.closed = datetime.now()
-        session.add(receipt)
+        processing_fee_total = 0
+        group_leader_receipt = None
+        group_refund_amount = 0
 
         if attendee_id:
             model = session.attendee(attendee_id)
+            if model.in_promo_code_group and model.promo_code.group.buyer:
+                group_leader_receipt = session.get_receipt_by_model(model.promo_code.group.buyer)
+                group_refund_amount = model.promo_code.cost * 100
+        elif group_id:
+            model = session.group(group_id)
+
+        if session.get_receipt_by_model(model) == receipt:
+            for txn in receipt.refundable_txns:
+                refund_amount = txn.amount_left
+                if exclude_fees:
+                    processing_fees = txn.calc_processing_fee(txn.amount_left)
+                    session.add(ReceiptItem(
+                        receipt_id=txn.receipt.id,
+                        desc=f"Processing Fees for Full Refund of {txn.desc}",
+                        amount=processing_fees,
+                        who=AdminAccount.admin_name() or 'non-admin',
+                    ))
+                    refund_amount -= processing_fees
+                    processing_fee_total += processing_fees
+
+                refund = TransactionRequest(receipt, amount=refund_amount)
+                error = refund.refund_or_skip(txn)
+                if error:
+                    raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}', attendee_id or group_id, error)
+                session.add_all(refund.get_receipt_items_to_add())
+                refund_total += refund.amount
+
+            session.add(ReceiptItem(
+                receipt_id=receipt.id,
+                desc=f"Refunding and Cancelling {model.full_name}'s Badge",
+                amount=-(refund_total + processing_fee_total),
+                who=AdminAccount.admin_name() or 'non-admin',
+            ))
+
+            receipt.closed = datetime.now()
+            session.add(receipt)
+
+        if attendee_id:
             model.badge_status = c.REFUNDED_STATUS
             model.paid = c.REFUNDED
 
         if group_id:
-            model = session.group(group_id)
             model.status = c.CANCELLED
         
         session.add(model)
-        
         session.commit()
+
+        if group_refund_amount:
+            if refund_total:
+                error_start = f"This attendee was refunded {format_currency(refund_total / 100)}, but their"
+            else:
+                error_start = "This attendee's"
+
+            txn = sorted([txn for txn in group_leader_receipt.refundable_txns if txn.amount_left >= group_refund_amount],
+                                key=lambda x: x.added)[0]
+            if not txn:
+                message = f"{error_start} group leader could not be refunded \
+                            because there wasn't a transaction with enough money left on it for {model.full_name}'s badge."
+                raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}', attendee_id or group_id, message)
+            
+            session.add(ReceiptItem(
+                receipt_id=txn.receipt.id,
+                desc=f"Refunding {model.full_name}'s Promo Code",
+                amount=-group_refund_amount,
+                who=AdminAccount.admin_name() or 'non-admin',
+            ))
+
+            if exclude_fees:
+                processing_fees = txn.calc_processing_fee(group_refund_amount)
+                session.add(ReceiptItem(
+                    receipt_id=txn.receipt.id,
+                    desc=f"Processing Fees for Refund of {model.full_name}'s Promo Code",
+                    amount=processing_fees,
+                    who=AdminAccount.admin_name() or 'non-admin',
+                ))
+                group_refund_amount -= processing_fees
+            
+            refund = TransactionRequest(txn.receipt, amount=group_refund_amount)
+            error = refund.refund_or_cancel(txn)
+            if error:
+                message = f"{error_start} group leader could not be refunded: {error}"
+                raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}', attendee_id or group_id, message)
+            session.add_all(refund.get_receipt_items_to_add())
+            session.commit()
+
+        message_end = f" Their group leader was refunded {format_currency(group_refund_amount / 100)}." if group_refund_amount else ""
         raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}',
                            attendee_id or group_id,
-                           "{}'s registration has been cancelled and they have been refunded {}.".format(
-                            getattr(model, 'full_name', None) or model.name, format_currency(refund_total / 100)
+                           "{}'s registration has been cancelled and they have been refunded {}.{}".format(
+                            getattr(model, 'full_name', None) or model.name, format_currency(refund_total / 100), message_end
                            ))
 
     @not_site_mappable

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -514,7 +514,7 @@ class Root:
             ))
 
             if exclude_fees:
-                processing_fees = int(txn.calc_processing_fee(group_refund_amount))
+                processing_fees = txn.calc_processing_fee(group_refund_amount)
                 session.add(ReceiptItem(
                     receipt_id=txn.receipt.id,
                     desc=f"Processing Fees for Refund of {model.full_name}'s Promo Code",

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -514,7 +514,7 @@ class Root:
             ))
 
             if exclude_fees:
-                processing_fees = txn.calc_processing_fee(group_refund_amount)
+                processing_fees = int(txn.calc_processing_fee(group_refund_amount))
                 session.add(ReceiptItem(
                     receipt_id=txn.receipt.id,
                     desc=f"Processing Fees for Refund of {model.full_name}'s Promo Code",

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -217,7 +217,7 @@ def check_missed_stripe_payments():
         payment_intent = event.data.object
         if payment_intent.id in pending_ids:
             paid_ids.append(payment_intent.id)
-            ReceiptManager.mark_paid_from_intent_id(payment_intent.id, payment_intent.charges.data[0].id)
+            ReceiptManager.mark_paid_from_stripe_intent(payment_intent)
     return paid_ids
 
 

--- a/uber/templates/art_show_admin/history.html
+++ b/uber/templates/art_show_admin/history.html
@@ -13,7 +13,7 @@ app, c.PAGE_PATH,
 
 <h2>Changelog for {{ app.attendee.full_name }}'s Art Show Application</h2>
 
-<table class="table-striped table-bordered table-condensed">
+<table class="table table-striped table-bordered table-sm">
 <thead><tr>
     <th>Which</th>
     <th>What</th>

--- a/uber/templates/email_admin/index.html
+++ b/uber/templates/email_admin/index.html
@@ -16,7 +16,7 @@
     </div>
 <div class="card-body">
     {{ pages(page, count) }}
-<table class="table table-striped table-bordered table-condensed">
+<table class="table table-striped table-bordered table-sm">
 <thead><tr>
     <th>Sent</th>
     <th>Subject</th>

--- a/uber/templates/guests_macros.html
+++ b/uber/templates/guests_macros.html
@@ -283,7 +283,7 @@
         </div>
         <div class="clearfix"></div>
         <div class="card card-sizes">
-          <table class="table table-condensed">
+          <table class="table table-striped table-sm">
             <tbody>
               {% for cut_value, cut_label in cuts_opts %}
                 {% for size_value, size_label in sizes_opts %}

--- a/uber/templates/marketplace_admin/history.html
+++ b/uber/templates/marketplace_admin/history.html
@@ -11,7 +11,7 @@ app, c.PAGE_PATH,
 
 <h2>Changelog for {{ app.attendee.full_name }}'s Marketplace Application</h2>
 
-<table class="table-striped table-bordered table-condensed">
+<table class="table table-striped table-bordered table-sm">
 <thead><tr>
     <th>Which</th>
     <th>What</th>

--- a/uber/templates/model_history_base.html
+++ b/uber/templates/model_history_base.html
@@ -3,7 +3,7 @@
 {% set admin_area=True %}
   <h2>Changelog for {{ model.full_name|default(model.name) }} {% if c.AT_THE_CON and model.badge_num %}({{ model.badge_num }}){% endif %}</h2>
 
-  <table class="table-striped table-bordered table-condensed">
+  <table class="table table-striped table-bordered table-sm">
     <thead><tr>
       <th>Which</th>
       <th>What</th>
@@ -24,7 +24,7 @@
 
   <h2>Page View History for {{ model.full_name|default(model.name) }} {% if c.AT_THE_CON and model.badge_num %}({{ model.badge_num }}){% endif %}</h2>
 
-  <table class="table-striped table-bordered table-condensed">
+  <table class="table table-striped table-bordered table-sm">
     <thead><tr>
       <th>When</th>
       <th>Who</th>

--- a/uber/templates/preregistration/group_promo_codes.html
+++ b/uber/templates/preregistration/group_promo_codes.html
@@ -17,7 +17,7 @@
     {% include 'confirm_tabs.html' with context %}
 
     <h2> Members of "{{ group.name }}" </h2>
-    <p>You have bought {{ group.promo_codes|length }} promo codes for a total of {{ group.total_cost|format_currency }} (not including your badge).</p>
+    <p>You have bought {{ group.paid_codes|length }} promo codes for a total of {{ group.total_cost|format_currency }} (not including your badge).</p>
 
     <p>{% if group.valid_codes %}Anyone can claim one of the {{ group.valid_codes|length }} remaining badges in this group using either an unclaimed promo code below or this group's universal code, <strong>{{ group.code }}</strong>.
     {% else %}All promo codes have been claimed. Please email us at {{ c.REGDESK_EMAIL|email_to_link }} if a promo code was claimed in error.{% endif %}</p>
@@ -28,6 +28,7 @@
           <th>Promo Code</th>
           <th>Used By</th>
           <th>Last Sent To</th>
+          <th></th>
         </tr>
       </thead>
     {% for code in group.sorted_promo_codes %}
@@ -55,6 +56,7 @@
         </td>
       {% endif %}
       <td>{% if emailed_codes[code.code] %}{{ emailed_codes[code.code] }}{% endif %}</td>
+      <td>{% if code.refunded %}<em>Refunded</em>{% endif %}</td>
       </tr>
     {% endfor %}
   </table>

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -489,19 +489,19 @@
   {% endmacro %}
 
 {% macro receipt_table(receipt, items) %}
-<ul class="nav nav-tabs" role="tablist">
-  <li class="nav-item" role="presentation" class="active">
-    <button class="nav-link" id="{{ receipt.id }}-home-tab" data-bs-toggle="tab" data-bs-target="#{{ receipt.id }}-home" type="button" role="tab" aria-controls="{{ receipt.id }}-home">
+<ul class="nav nav-tabs" role="tablist" id="tabs-{{ receipt.id }}">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="receipt-tab-{{ receipt.id }}" data-bs-toggle="tab" data-bs-target="#receipt-{{ receipt.id }}" type="button" role="tab" aria-controls="receipt-{{ receipt.id }}">
       Receipt
     </button>
   </li>
   <li class="nav-item" role="presentation">
-    <button class="nav-link" id="{{ receipt.id }}-history-tab" data-bs-toggle="tab" data-bs-target="#{{ receipt.id }}-history" type="button" role="tab" aria-controls="{{ receipt.id }}-history">
+    <button class="nav-link" id="history-tab-{{ receipt.id }}" data-bs-toggle="tab" data-bs-target="#history-{{ receipt.id }}" type="button" role="tab" aria-controls="history-{{ receipt.id }}">
       History
     </button>
 </ul>
 <div class="tab-content">
-  <div role="tabpanel" class="tab-pane active" id="{{ receipt.id }}-home">
+  <div role="tabpanel" class="tab-pane active" id="receipt-{{ receipt.id }}">
   <table class="table table-striped">
     <thead><tr>
       <th>Added</th>
@@ -605,8 +605,8 @@
     {% endif %}
   </table>
 </div>
-<div role="tabpanel" class="tab-pane" id="{{ receipt.id }}-history" aria-labelledby="{{ receipt.id }}-history-tab">
-  <table class="table-striped table-bordered table-condensed">
+<div role="tabpanel" class="tab-pane" id="history-{{ receipt.id }}">
+  <table class="table table-striped table-bordered table-sm">
     <thead><tr>
       <th>Which</th>
       <th>What</th>

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -279,10 +279,20 @@
   };
 
   var fullRefund = function (receiptId) {
+    let message = '';
+    {% if group_leader_receipt and not receipt %}
+      message = "This will refund this attendee's group leader the cost of one badge.";
+    {% else %}
+      let extra_message = '';
+      {% if group_leader_receipt %}
+        extra_message = " for this attendee, plus the cost of one badge for their group leader";
+      {% endif %}
+      message = "This will refund ALL existing {{ processor_str }} transactions that have not already been refunded" + 
+                extra_message + ".";
+    {% endif %}
     bootbox.confirm({
       title: "Refund and Cancel Registration?",
-      message: "This will refund ALL existing {{ processor_str }} transactions that have not already been refunded. " +
-               "It will also cancel this {{ model_str }}'s registration. Are you sure?",
+      message: message + " It will also cancel this {{ model_str }}'s registration. Are you sure?",
       buttons: {
           confirm: {
               label: 'Fully Refund and Cancel',
@@ -306,11 +316,24 @@
     });
   };
 
-  var mostlyFullRefund = function (receiptId, fee_str) {
+  var mostlyFullRefund = function (receiptId, fee_str, group_leader_fee_str = '') {
+    let message = '';
+    {% if group_leader_receipt and not receipt %}
+      message = "This will refund this attendee's group leader the cost of one badge minus " + fee_str + " in processing fees. It will also";
+    {% else %}
+      let extra_message = '';
+      {% if group_leader_receipt %}
+        extra_message = " It will also refund their group leader the cost of one badge minus " + group_leader_fee_str + " in processing fees, and it will";
+      {% else %}
+        extra_message = " It will also"
+      {% endif %}
+      message = "This will refund ALL existing {{ processor_str }} transactions that have not already been refunded, " + 
+                "minus " + fee_str + " in processing fees." + extra_message
+    {% endif %}
+
     bootbox.confirm({
       title: "Refund and Cancel Registration?",
-      message: "This will refund ALL existing {{ processor_str }} transactions that have not already been refunded, "+
-               "minus " + fee_str + " in processing fees. It will also cancel this {{ model_str }}'s registration. Are you sure?",
+      message: message + " cancel this {{ model_str }}'s registration. Are you sure?",
       buttons: {
           confirm: {
               label: 'Fully Refund and Cancel',
@@ -439,8 +462,7 @@
         <div class="col-auto">
           <div class="input-group">
             <span class="input-group-text">$</span>
-            <input type="number" name="amount" class="form-control" placeholder="0" required>
-            <span class="input-group-text">.00</span>
+            <input type="number" name="amount" class="form-control" placeholder="0" required step=".01">
           </div>
         </div>
         <label for="count" class="col-auto col-form-label">Quantity</label>
@@ -638,11 +660,15 @@
   <button class="btn btn-danger" onClick="fullRefund('{{ receipt.id }}')">Refund and Cancel This {{ model_str|title }}</button>
   {% if not c.AUTHORIZENET_LOGIN_ID %}
   OR
-  <button class="btn btn-danger" onClick="mostlyFullRefund('{{ receipt.id }}', '{{ (receipt.remaining_processing_fees / 100)|format_currency }}')">Refund and Cancel This {{ model_str|title }} Excluding Processing Fees</button>
+  <button class="btn btn-danger" onClick="mostlyFullRefund('{{ receipt.id }}', '{{ (receipt.remaining_processing_fees / 100)|format_currency }}', '{{ (group_processing_fee / 100)|format_currency if group_leader_receipt else '' }}')">Refund and Cancel This {{ model_str|title }} Excluding Processing Fees</button>
   {% endif %}
 {% else %}
-There are no active receipts for this {{ model_str }}.
-<br/><a href="create_receipt?id={{ model.id }}" class="btn btn-success">Create Default Receipt</a> <a href="create_receipt?id={{ model.id }}&blank=true" class="btn btn-info">Create Blank Receipt</a>
+  There are no active receipts for this {{ model_str }}.
+  <br/><a href="create_receipt?id={{ model.id }}" class="btn btn-success">Create Default Receipt</a> <a href="create_receipt?id={{ model.id }}&blank=true" class="btn btn-info">Create Blank Receipt</a>
+  {% if group_leader_receipt and attendee and attendee.badge_status != c.REFUNDED_STATUS %}
+  <button class="btn btn-danger" onClick="fullRefund('{{ group_leader_receipt.id }}')">Refund Badge Cost To Group Leader</button>
+  <button class="btn btn-danger" onClick="mostlyFullRefund('{{ group_leader_receipt.id }}', '{{ (group_processing_fee / 100)|format_currency }}')">Refund Badge Cost To Group Leader Excluding Processing Fees</a>
+  {% endif %}
 {% endif %}
 </div>
 </div>

--- a/uber/templates/registration/feed.html
+++ b/uber/templates/registration/feed.html
@@ -33,7 +33,7 @@
 
 {{ pages(page,count) }}
 
-<table class="table-striped table-bordered table-condensed">
+<table class="table table-striped table-bordered table-sm">
 <thead><tr>
     <th>When</th>
     <th>Who</th>

--- a/uber/templates/registration/promo_code_group_form.html
+++ b/uber/templates/registration/promo_code_group_form.html
@@ -155,7 +155,13 @@
           
           <td>{{ code.created.when|datetime_local }}</td>
           <td>{{ code.cost|format_currency }}</td>
-          <td>{% if not code.valid_used_by %}<button class="btn btn-sm btn-danger" onClick="deleteCode('{{ code.id }}')"><i class="fa fa-remove"></i></button>{% endif %}</td>
+          <td>
+            {% if not code.valid_used_by %}
+              <button class="btn btn-sm btn-danger" onClick="deleteCode('{{ code.id }}')"><i class="fa fa-remove"></i></button>
+            {% elif code.refunded %}
+              <em>Refunded</em>
+            {% endif %}
+          </td>
         </tr>
       {% endfor -%}
       </tbody>


### PR DESCRIPTION
Allows you to fully refund badges that are in promo code groups, including with and without processing fees. Also fixes history tab styling and accounts for refunded promo codes.

The rules for promo code usage are:
- Badges that pending, invalid, imported, and "invalid group" don’t count against promo code usage -- they are effectively the same as that badge not having the promo code attached.
- If a badge status is Refunded, the promo code is still used and shows up with a “Refunded” tag on group leader’s page and also the admin page.
- All other badge statuses are counted as a valid use and have no special display logic.