### PR TITLE
Dealer and payment fixes

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -26,7 +26,7 @@ from uber.jinja import JinjaEnv
 from uber.models import AdminAccount, Attendee, AttendeeAccount, ArtShowApplication, AutomatedEmail, Department, Group, \
     GuestGroup, IndieGame, IndieJudge, IndieStudio, MarketplaceApplication, MITSTeam, MITSApplicant, PanelApplication, \
     PanelApplicant, PromoCodeGroup, Room, RoomAssignment, Shift
-from uber.utils import after, before, days_after, days_before, localized_now, DeptChecklistConf
+from uber.utils import after, before, days_after, days_before, days_between, localized_now, DeptChecklistConf
 
 
 class AutomatedEmailFixture:
@@ -169,7 +169,7 @@ if c.ATTENDEE_ACCOUNTS_ENABLED:
         AttendeeAccount,
         '{EVENT_NAME} account creation confirmed',
         'reg_workflow/account_confirmation.html',
-        lambda a: not a.imported and a.hashed and not a.password_reset,
+        lambda a: not a.imported and a.hashed and not a.password_reset and not a.is_sso_account,
         needs_approval=False,
         allow_at_the_con=True,
         ident='attendee_account_confirmed')
@@ -313,7 +313,7 @@ if c.ART_SHOW_ENABLED:
         'Reminder to pay for your {EVENT_NAME} Art Show application',
         'art_show/payment_reminder.txt',
         lambda a: a.status == c.APPROVED and a.is_unpaid,
-        when=days_before(14, c.ART_SHOW_PAYMENT_DUE),
+        when=days_between((14, c.ART_SHOW_PAYMENT_DUE), (1, c.EPOCH)),
         ident='art_show_payment_reminder')
 
     ArtShowAppEmailFixture(
@@ -334,7 +334,7 @@ if c.ART_SHOW_ENABLED:
         '{EVENT_NAME} Art Show MAIL IN Instructions',
         'art_show/mailing_in.html',
         lambda a: a.status == c.APPROVED and not a.is_unpaid and a.delivery_method == c.BY_MAIL,
-        when=days_before(40, c.ART_SHOW_DEADLINE),
+        when=days_between((c.ART_SHOW_REG_START, 13), (16, c.ART_SHOW_WAITLIST)),
         ident='art_show_mail_in')
 
 

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -535,6 +535,7 @@ marketplace_app_email = string(default="")
 
 # Emails for Art Show applications are sent from this address.
 art_show_email = string(default="")
+art_show_notifications_email = string(default='%(art_show_email)s')
 
 # These signatures are used at the bottom of many of our automated emails.
 regdesk_email_signature = string(default='')

--- a/uber/forms/__init__.py
+++ b/uber/forms/__init__.py
@@ -36,9 +36,9 @@ def load_forms(params, model, form_list, prefix_dict={}, get_optional=True, trun
         conflicting field names on the same page, e.g., passing {'GroupInfo': 'group_'} will add group_ to all GroupInfo fields.
     `get_optional` is a flag that controls whether or not the forms' get_optional_fields() function is called. Set this to false
         when loading forms for validation, as the validate_model function in utils.py handles optional fields.
-    `truncate_prefix` allows you to remove a single word from the form, so e.g. a truncate_prefix of "admin" will make
-        "AdminTableInfo" saved as "table_info." This allows loading admin and prereg versions of forms while using
-        the same form template.
+    `truncate_prefix` allows you to remove a single word from the form, so e.g. a truncate_prefix of "admin" will save
+        "AdminTableInfo" as "table_info." This allows loading admin and prereg versions of forms while using the 
+        same form template.
 
     Returns a dictionary of form objects with the snake-case version of the form as the ID, e.g.,
     the PersonalInfo class will be returned as form_dict['personal_info'].

--- a/uber/models/art_show.py
+++ b/uber/models/art_show.py
@@ -132,6 +132,10 @@ class ArtShowApplication(MagModel):
             return "Mailing address required"
         if self.attendee.placeholder and self.attendee.badge_status != c.NOT_ATTENDING:
             return "Missing registration info"
+        
+    @hybrid_property
+    def is_valid(self):
+        return self.status != c.DECLINED
 
     @property
     def total_cost(self):
@@ -140,14 +144,11 @@ class ArtShowApplication(MagModel):
         else:
             if self.active_receipt:
                 return self.active_receipt.item_total / 100
-            return self.potential_cost
+            return self.default_cost
 
     @property
     def potential_cost(self):
-        if self.overridden_price is not None:
-            return self.overridden_price
-        else:
-            return self.default_cost or 0
+        return self.default_cost or 0
 
     def calc_app_price_change(self, **kwargs):
         preview_app = ArtShowApplication(**self.to_dict())
@@ -179,7 +180,7 @@ class ArtShowApplication(MagModel):
 
     @property
     def amount_unpaid(self):
-        return max(0, self.total_cost - (self.amount_paid / 100))
+        return max(0, ((self.total_cost * 100) - self.amount_paid) / 100)
 
     @property
     def amount_pending(self):

--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -213,9 +213,11 @@ class ModelReceipt(MagModel):
                     txn.cancelled = datetime.now() # TODO: Add logs to txns/items and log the automatic cancellation reason?
 
                 if txn.amount != self.current_amount_owed and self.current_amount_owed:
-                    txn.amount = self.current_amount_owed
                     if not c.AUTHORIZENET_LOGIN_ID:
+                        txn.amount = self.current_amount_owed
                         stripe.PaymentIntent.modify(txn.intent_id, amount = txn.amount)
+                    else:
+                        txn.cancelled = datetime.now()
 
                 if self.session:
                     self.session.add(txn)

--- a/uber/payments.py
+++ b/uber/payments.py
@@ -1083,6 +1083,9 @@ class ReceiptManager:
             session.add(txn)
             txn_receipt = txn.receipt
 
+            if txn.cancelled != None:
+                txn.cancelled == None
+
             for item in txn.receipt_items:
                 item.closed = datetime.now()
                 session.add(item)

--- a/uber/payments.py
+++ b/uber/payments.py
@@ -1059,7 +1059,7 @@ class ReceiptManager:
             log.error(f"Tried to mark payments with intent ID {payment_intent.id} as paid but the charge on this intent wasn't successful!")
             return []
         
-        ReceiptManager.mark_paid_from_ids(payment_intent.id, payment_intent.charges.data[0].id)
+        return ReceiptManager.mark_paid_from_ids(payment_intent.id, payment_intent.charges.data[0].id)
         
     @staticmethod
     def mark_paid_from_ids(intent_id, charge_id):

--- a/uber/payments.py
+++ b/uber/payments.py
@@ -1,35 +1,18 @@
-import importlib
-import math
-import os
-import random
-import re
-import string
-import traceback
-import json
 import pytz
 from typing import Iterable
-import urllib
-from collections import defaultdict, OrderedDict
-from datetime import date, datetime, timedelta
+from collections import OrderedDict
+from datetime import datetime, timedelta
 from dateutil.parser import parse
-from glob import glob
-from os.path import basename
-from random import randrange
-from rpctools.jsonrpc import ServerProxy
-from urllib.parse import urlparse, urljoin
 from uuid import uuid4
 
 import cherrypy
-import phonenumbers
 import stripe
 from authorizenet import apicontractsv1, apicontrollers
-from phonenumbers import PhoneNumberFormat
-from pockets import cached_property, classproperty, floor_datetime, is_listy, listify
+from pockets import cached_property, classproperty, is_listy, listify
 from pockets.autolog import log
-from sideboard.lib import threadlocal
 
 import uber
-from uber.config import c, _config, signnow_sdk
+from uber.config import c
 from uber.custom_tags import format_currency, email_only
 from uber.errors import CSRFException, HTTPRedirect
 from uber.utils import report_critical_exception
@@ -821,7 +804,6 @@ class ReceiptManager:
             for calculation in i[model.__class__.__name__].values():
                 item = calculation(model)
                 if item:
-                    log.debug(item)
                     try:
                         desc, cost, col_name, count = item
                     except ValueError:
@@ -1039,6 +1021,12 @@ class ReceiptManager:
                 if coerced_val != getattr(model, key, None):
                     changed_params[key] = coerced_val
         
+        if isinstance(model, Group):
+            # "badges" is a property and not a column, so we have to include it explicitly
+            maybe_badges_update = params.get('badges', None)
+            if maybe_badges_update != None and maybe_badges_update != model.badges:
+                changed_params['badges'] = maybe_badges_update
+        
         cost_changes = getattr(model.__class__, 'cost_changes', [])
         credit_changes = getattr(model.__class__, 'credit_changes', [])
         for param in changed_params:
@@ -1127,7 +1115,7 @@ class ReceiptManager:
                 try:
                     send_email.delay(
                         c.ART_SHOW_EMAIL,
-                        c.ART_SHOW_EMAIL,
+                        c.ART_SHOW_NOTIFICATIONS_EMAIL,
                         'Art Show Payment Received',
                         render('emails/art_show/payment_notification.txt',
                             {'app': model}, encoding=None),

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -27,7 +27,7 @@ ArtShowApplication.cost_changes = {
 
 @cost_calculation.ArtShowApplication
 def overridden_app_cost(app):
-    if app.status == c.APPROVED and app.overridden_price != None:
+    if app.overridden_price != None:
         return ("Art Show Application (Custom Price)", app.overridden_price * 100, 'overridden_price')
 
 @cost_calculation.ArtShowApplication
@@ -66,12 +66,13 @@ def mailing_fee_cost(app):
 Attendee.cost_changes = {
     'overridden_price': ('Custom Badge Price', "calc_badge_cost_change"),
     'badge_type': ('Badge ({})', "calc_badge_cost_change", c.BADGES),
+    'ribbon': ('Ribbon ({})', "calc_badge_cost_change", c.RIBBONS),
     'amount_extra': ('Preordered Merch ({})', None, c.DONATION_TIERS),
     'extra_donation': ('Extra Donation', None),
 }
 
 Attendee.credit_changes = {
-    'paid': ('Badge Comp', "calc_badge_comp_change"),
+    'paid': ('Badge Comped or Paid By Group', "calc_badge_comp_change"),
     'birthdate': ('Age Discount', "calc_age_discount_change"),
     'promo_code': ('Promo Code', "calc_promo_discount_change"),
 }

--- a/uber/sep_commands.py
+++ b/uber/sep_commands.py
@@ -180,7 +180,7 @@ def reset_uber_db():
 
 @entry_point
 def decline_and_convert_dealer_groups():
-    from uber.site_sections.groups import _decline_and_convert_dealer_group
+    from uber.site_sections.groups import decline_and_convert_dealer_group
     Session.initialize_db(initialize=True)
     with Session() as session:
         groups = session.query(Group) \
@@ -193,7 +193,7 @@ def decline_and_convert_dealer_groups():
         for group in groups:
             print('{}: {}'.format(
                 group.name,
-                _decline_and_convert_dealer_group(session, group)))
+                decline_and_convert_dealer_group(session, group)))
 
 
 @entry_point

--- a/uber/site_sections/art_show_admin.py
+++ b/uber/site_sections/art_show_admin.py
@@ -7,6 +7,7 @@ import math
 from decimal import Decimal
 from six import string_types
 from sqlalchemy import or_, and_
+from sqlalchemy.orm import joinedload
 from io import BytesIO
 
 from uber.config import c
@@ -23,7 +24,7 @@ class Root:
     def index(self, session, message=''):
         return {
             'message': message,
-            'applications': session.art_show_apps()
+            'applications': session.query(ArtShowApplication).options(joinedload(ArtShowApplication.attendee))
         }
 
     def form(self, session, new_app='', message='', **params):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -25,7 +25,7 @@ from uber.models import Attendee, AttendeeAccount, Attraction, Email, Group, Mod
                         ReceiptTransaction, SignedDocument, Tracking
 from uber.tasks.email import send_email
 from uber.utils import add_opt, check, check_pii_consent, localized_now, normalize_email, normalize_email_legacy, genpasswd, valid_email, \
-    valid_password, SignNowDocument, validate_model
+    valid_password, SignNowDocument, validate_model, remove_opt
 from uber.payments import PreregCart, TransactionRequest, ReceiptManager
 
 
@@ -116,7 +116,7 @@ def check_account(session, email, password, confirm_password, skip_if_logged_in=
     if existing_account and (old_email and normalize_email_legacy(normalize_email(existing_account.email)) != super_normalized_old_email
             or not old_email and not logged_in_account):
         return "There's already an account with that email address."
-    elif logged_in_account and logged_in_account.normalized_email != existing_account.normalized_email:
+    elif existing_account and logged_in_account and logged_in_account.normalized_email != existing_account.normalized_email:
         return "You cannot reset someone's password while logged in as someone else."
     
     if update_password:
@@ -136,17 +136,19 @@ def set_up_new_account(session, attendee, email=None):
     else:
         account = session.create_attendee_account(email)
         session.add_attendee_to_account(attendee, account)
-    session.add(PasswordReset(attendee_account=account, hashed=bcrypt.hashpw(token, bcrypt.gensalt())))
 
-    body = render('emails/accounts/new_account.html', {
-            'attendee': attendee, 'account_email': email, 'token': token}, encoding=None)
-    send_email.delay(
-        c.ADMIN_EMAIL,
-        email,
-        c.EVENT_NAME + ' Account Setup',
-        body,
-        format='html',
-        model=account.to_dict('id'))
+    if not account.is_sso_account:
+        session.add(PasswordReset(attendee_account=account, hashed=bcrypt.hashpw(token, bcrypt.gensalt())))
+
+        body = render('emails/accounts/new_account.html', {
+                'attendee': attendee, 'account_email': email, 'token': token}, encoding=None)
+        send_email.delay(
+            c.ADMIN_EMAIL,
+            email,
+            c.EVENT_NAME + ' Account Setup',
+            body,
+            format='html',
+            model=account.to_dict('id'))
 
 @all_renderable(public=True)
 @check_post_con
@@ -980,9 +982,9 @@ class Root:
         group = session.group(id)
 
         if group.is_dealer:
-            form_list = ['AdminTableInfo', 'ContactInfo']
+            form_list = ['TableInfo', 'ContactInfo']
         else:
-            form_list = ['AdminGroupInfo']
+            form_list = ['GroupInfo']
 
         forms = load_forms(params, group, form_list)
         for form in forms.values():
@@ -1051,7 +1053,6 @@ class Root:
             'locked_fields': [item for sublist in [form.get_non_admin_locked_fields(group) for form in forms.values()] for item in sublist],
             'homepage_account': session.get_attendee_account_by_attendee(group.leader),
             'logged_in_account': session.current_attendee_account(),
-            'upgraded_badges': len([a for a in group.attendees if a.badge_type in c.BADGE_TYPE_PRICES]),
             'signnow_document': signnow_document,
             'signnow_link': signnow_link,
             'receipt': receipt,
@@ -1228,6 +1229,38 @@ class Root:
         return {'stripe_intent': charge.intent,
                 'success_url': 'group_members?id={}&message={}'.format(
                     group.id, 'Your payment has been accepted and the badges have been added to your group')}
+    
+    def cancel_dealer(self, session, id):
+        from uber.site_sections.dealer_admin import decline_and_convert_dealer_group
+        group = session.group(id)
+        has_assistants = group.badges_purchased - len(group.floating) > 1
+        decline_and_convert_dealer_group(session,
+                                         group,
+                                         c.CANCELLED,
+                                         f'Converted badge from {c.DEALER_REG_TERM} "{group.name}" cancelling their application.',
+                                         email_leader=False)
+
+        message = "Dealer application cancelled.{} You may purchase your own badge using the form below.".format(
+                    " Assistants have been emailed a link to purchase their badges." if has_assistants else "")
+
+        raise HTTPRedirect('../preregistration/new_badge_payment?id={}&message={}&return_to=confirm', group.leader.id, message)
+    
+    def purchase_dealer_badge(self, session, id):
+        from uber.site_sections.dealer_admin import convert_dealer_badge
+        from uber.custom_tags import datetime_local_filter
+        attendee = session.attendee(id)
+        convert_dealer_badge(session, attendee, f"Self-purchased dealer badge {datetime_local_filter(datetime.now())}.")
+        session.add(attendee)
+        session.commit()
+        
+        raise HTTPRedirect(f'new_badge_payment?id={attendee.id}&return_to=confirm')
+    
+    def dealer_signed_document(self, session, id):
+        message = 'Thanks for signing!'
+        group = session.group(id)
+        if group.amount_unpaid:
+            message += ' Please pay your application fee below.'
+        raise HTTPRedirect(f'group_members?id={id}&message={message}')
 
     @id_required(Attendee)
     @requires_account(Attendee)
@@ -1354,7 +1387,7 @@ class Root:
                 attendee.paid = c.REFUNDED
 
         # if attendee is part of a group, we must delete attendee and remove them from the group
-        if attendee.group:
+        if attendee.group and attendee.group.is_valid:
             session.assign_badges(
                 attendee.group,
                 attendee.group.badges + 1,
@@ -1370,7 +1403,9 @@ class Root:
             attendee.badge_status = new_status
             for shift in attendee.shifts:
                 session.delete(shift)
-            raise HTTPRedirect('{}?id={}&message={}', page_redirect, attendee.id, success_message)
+            raise HTTPRedirect('{}?id={}&message={}', 
+                               'homepage' if c.ATTENDEE_ACCOUNTS_ENABLED else page_redirect, 
+                               attendee.id, success_message)
 
     def badge_updated(self, session, id, message=''):
         return {
@@ -1836,15 +1871,25 @@ class Root:
             account = session.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(account_email)).first()
             if 'admin_url' in params:
                 success_url = "../{}message=Password reset email sent.".format(params['admin_url'])
+                sso_url = "../{}message=SSO accounts do not have passwords.".format(params['admin_url'])
             else:
                 success_url = "../landing/index?message=Check your email for a password reset link."
+                sso_url = "../landing/index?message=Please log in via the staff login link!"
             if not account:
                 # Avoid letting attendees de facto search for other attendees by email
+                if c.SSO_EMAIL_DOMAINS:
+                    local, domain = normalize_email(account_email, split_address=True)
+                    if domain in c.SSO_EMAIL_DOMAINS:
+                        raise HTTPRedirect(sso_url)
                 raise HTTPRedirect(success_url)
+
             if account.password_reset:
                 session.delete(account.password_reset)
                 session.commit()
-
+            
+            if account.is_sso_account:
+                raise HTTPRedirect(sso_url)
+            
             token = genpasswd(short=True)
             session.add(PasswordReset(attendee_account=account, hashed=bcrypt.hashpw(token, bcrypt.gensalt())))
 

--- a/uber/templates/art_show_admin/index.html
+++ b/uber/templates/art_show_admin/index.html
@@ -3,9 +3,9 @@
 {% block content %}
 
 <ol class="breadcrumb">
-  <li><a href="../accounts/homepage">Home</a></li>
-  <li>Art Show</li>
-  <li class="active">Admin</li>
+  <li class="breadcrumb-item"><a href="../accounts/homepage">Home</a></li>
+  <li class="breadcrumb-item">Art Show</li>
+  <li class="breadcrumb-item active">Admin</li>
 </ol>
 
 <div class="card">
@@ -13,13 +13,15 @@
     <h3 class="card-title">Art Show Applications</h3>
   </div>
   <div class="card-body">
-    <a class="btn btn-outline-secondary" href="form?new_app=True">Add an application</a>
-    <div class="pull-right form-inline">
-      <div class="form-group">
-        <div class="control-label">Status</div> <div class="input-group" id="status_filter"></div>
+    <div class="row g-sm-3 mb-3">
+      <div class="col-6"><a class="btn btn-outline-secondary" href="form?new_app=True">Add an application</a></div>
+      <div class="col-6">
+        <div class="row g-sm-3">
+          <div class="col-8 text-end col-form-label-sm">Status:</div><div class="col-4" id="status_filter"></div>
+        </div>
       </div>
     </div>
-  </div>
+  
 <table class="table table-striped datatable">
 <thead><tr>
     <th>Name</th>
@@ -30,7 +32,8 @@
     <th>General Tables</th>
     <th>Mature Panels</th>
     <th>Mature Tables</th>
-    <th>Art Show Cost</th>
+    <th>Cost</th>
+    <th>Owed</th>
     <th>Admin Notes</th>
 </tr></thead>
 {% for app in applications %}
@@ -46,7 +49,8 @@
         <td>{{ app.tables }}</td>
         <td>{{ app.panels_ad }}</td>
         <td>{{ app.tables_ad }}</td>
-        <td>{{ app.total_cost|default(app.potential_cost)|format_currency }}{% if app.amount_unpaid %} ({{ (app.amount_unpaid)|format_currency }} unpaid){% endif %}</td>
+        <td>{{ app.total_cost|format_currency }}</td>
+        <td>{{ app.amount_unpaid|format_currency }}</td>
         <td>{{ app.admin_notes }}</td>
     </tr>
 {% endfor %}
@@ -54,4 +58,5 @@
 		<ul class="pagination"></ul>
 	</caption>
 </table>
+</div>
 {% endblock %}

--- a/uber/templates/art_show_applications/index.html
+++ b/uber/templates/art_show_applications/index.html
@@ -16,26 +16,32 @@
 <h2>{{ c.EVENT_NAME }} Art Show Application</h2>
 <div class="card">
   <div class="card-body">
+    {% if c.DEV_BOX %}
+      <div class="alert alert-info">
+        <strong> You are on a development box.
+          {% if c.BEFORE_ART_SHOW_REG_START %}
+            Otherwise, you would be automatically redirected to <a href="../static_views/art_show_not_open.html">the "art show reg not yet open" page</a>.
+          {% elif c.AFTER_ART_SHOW_DEADLINE and not c.AT_THE_CON %}
+            Otherwise, you would be automatically redirected to <a href="../static_views/art_show_closed.html">the "art show reg closed" page</a>.
+          {% endif %}
+        </strong>
+      </div>
+    {% endif %}
     {% if c.AFTER_ART_SHOW_DEADLINE and not c.HAS_ART_SHOW_ACCESS %}
       <p>Unfortunately, the deadline for art show applications has passed and we are no longer accepting applications.</p>
     {% else %}
-      {% if c.AFTER_ART_SHOW_DEADLINE and c.HAS_ART_SHOW_ACCESS %}
-        <p style="color:red">
-          Art show applications have closed, but because you are a logged in
-          administrator you can submit a new application using this form.
-        </p>
-      {% endif %}
       {% if c.AFTER_ART_SHOW_WAITLIST %}
         <p style="color:orange">
           The deadline for art show applications has passed. You may still submit an application to be put on our waiting
           list. Applications will close completely on {{ c.ART_SHOW_DEADLINE|datetime_local }}.
+          Space is limited and may be filled prior to the application window closing.
         </p>
       {% endif %}
 
     <p>Art show applications are due by {{ c.ART_SHOW_WAITLIST|datetime_local }}. Any applications submitted after this
     date will be automatically waitlisted. Applications will close completely on
     {{ c.ART_SHOW_DEADLINE|datetime_local }}. Please review the {{ c.EVENT_NAME }} Art Show rules
-    <a href="{{ c.ART_SHOW_RULES_URL }}" target="_blank">here</a>.</p>
+    <a href="{{ c.ART_SHOW_RULES_URL }}" target="_blank">here</a>. Space is limited and may be filled prior to the application window closing.</p>
 
     <form method="post" action="index" role="form">
       <h3>Your Information</h3>

--- a/uber/templates/art_show_common/art_show_agent.html
+++ b/uber/templates/art_show_common/art_show_agent.html
@@ -1,8 +1,8 @@
-<form method="post" id="new_agent_app" class="form-horizontal" action="../art_show_applications/new_agent_app">
-<div class="form-group" id="art-show-agent">
-  <label for="art_show_agent" class="col-sm-3 control-label optional-field">Art Show Agent</label>
-  <div class="col-sm-6">
-    <span class="form-control-static">
+<form method="post" id="new_agent_app" action="../art_show_applications/new_agent_app">
+<div class="row g-sm-3" id="art-show-agent">
+  <div class="col-12 col-sm-6">
+  <label for="art_show_agent" class="form-text">Art Show Agent</label>
+    <p>
     {% if attendee.art_agent_applications %}
       You are currently an agent for the following artists:
       <ul>{% for app in attendee.art_agent_applications %}
@@ -11,9 +11,12 @@
     {% else %}
       You are not an agent for any artists in the {{ c.EVENT_NAME }} Art Show.
     {% endif %}
-    </span>
+    </p>
+  </div>
+  <div class="col-12 col-sm-6">
+      <input type="hidden" name="id" form="new_agent_app" value="{{ attendee.id }}" />
+      <label for="agent_code" class="form-text invisible">Agent Code</label>
       <div class="input-group">
-        <input type="hidden" name="id" form="new_agent_app" value="{{ attendee.id }}" />
         <input type="text" class="form-control" name="agent_code" />
         <button type="submit" form="new_agent_app" class="btn btn-primary">Submit Agent Code</button>
       </div>

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -295,7 +295,7 @@
 
                         if($(filter_span).length) {
                         // Create the select list and search operation
-                        var select = $('<select><option label="(No Filter)"></option> </select>')
+                        var select = $('<select class="form-select form-select-sm"><option label="(No Filter)"></option> </select>')
                             .appendTo(
                                 filter_span
                             )
@@ -339,7 +339,7 @@
 
                         if($(filter_span).length) {
                         // Create the select list and search operation
-                        var select = $('<select><option label="(No Filter)"></option> </select>')
+                        var select = $('<select class="form-control"><option label="(No Filter)"></option> </select>')
                             .appendTo(
                                 filter_span
                             )

--- a/uber/templates/email_admin/pending.html
+++ b/uber/templates/email_admin/pending.html
@@ -2,25 +2,6 @@
 {% block title %}Automated Emails Pending Approval{% endblock %}
 {% block content %}
 
-<style>
-  h2 {
-    margin-bottom: 0;
-  }
-
-  table.table > tbody > tr.danger > td {
-    border-top: 1px solid #f28e8e;
-  }
-
-  .pending .subject {
-    color: #e00000;
-  }
-
-  .pending .subject span {
-    font-weight: bold;
-  }
-</style>
-
-
 {% macro email_table(emails) %}
   <table class="table table-striped datatable"
       data-paging="false"
@@ -32,10 +13,10 @@
       <th>Template</th>
       <th>Sender</th>
       <th>Emails Sent</th>
-      <th>Emails waiting to send but need approval</th>
-      <th>Show Examples</th>
+      <th>Emails Waiting to Send</th>
+      <th>Examples</th>
       <th>Approval Status</th>
-      <th>Date emails generated</th>
+      <th>Date Restrictions</th>
     </tr>
     </thead>
     <tbody>
@@ -87,18 +68,44 @@
 </table>
 {% endmacro %}
 
-<h2>Automated Emails</h2>
-<br>
+<h2>Pending Automated Emails</h2>
+<div class="card">
+  <div class="card-body">
 {% if not automated_emails %}
   <p class="text-info">
     There are currently no automated emails. The system is probably updating,
-    and should be finished in at most 5 minutes.
+    and should be finished in at most {{ "5" if c.DEV_BOX else "15" }} minutes.
   </p>
 {% else %}
+  <p>
+    The emails below will be sent to any qualifying attendee or group as long as that email is active and approved.
+    Attendees or groups who qualify for an email before it is approved will receive the email when it is approved.
+  </p>
+  <p>
+    If there are date restrictions for an email, that email will not be sent outside of those dates.
+    Emails may be "unapproved" after approval to stop them being sent to newly qualifying attendees or groups.
+  </p>
+  <p>
+    Please note that the emails below represent most, <em>but not all</em>, of the automated emails the system sends.
+    Any emails that don't appear here are sent in response to an action (e.g., a dealer changing their application) and cannot be approved or unapproved.
+  </p>
+  <ul class="nav nav-pills">
+  {% for sender in automated_emails.keys() %}
+    <li class="nav-item border border-primary rounded">
+      <a class="nav-link" href="#{{ sender|email_only }}">{{ sender|email_only }}</a>
+    </li>&nbsp;
+  {% endfor %}
+  </ul>
+  <hr/>
   {% for sender, emails in automated_emails.items() %}
-    <h3>{{ sender }}</h3>
+  <a id="{{ sender|email_only }}"></a>
+    <h3 class="mb-0 mt-4">{{ sender }}</h3>
     {{ email_table(emails) }}
+    {% if not loop.last %}<hr/>{% endif %}
   {% endfor %}
 {% endif %}
+  </div>
+</div>
+
 
 {% endblock %}

--- a/uber/templates/email_admin/sent.html
+++ b/uber/templates/email_admin/sent.html
@@ -5,6 +5,7 @@
 
 {% for email in emails  %}
 <div class="card">
+  <div class="card-body">
     <h3>{{ email.subject }} ({{ email.when|full_datetime_local }})</h3>
     <h4>To:
       {% if email.fk_id %}
@@ -19,7 +20,8 @@
         <input type="hidden" name="id" value="{{ email.id }}" />
         <button class="btn btn-primary" type="submit">Resend Email</button>
     </form>
-    </div>
+  </div>
+</div>
     <br/>
 {% endfor %}
 {{ "js/resend-email-form.js"|serve_static_content }}

--- a/uber/templates/emails/art_show/agent_code.html
+++ b/uber/templates/emails/art_show/agent_code.html
@@ -9,8 +9,8 @@ an email confirming their unassignment.
 
 
 <br/><br/>To assign an agent to your art application, send them the above code.
-They must then add the code to their registration, either while signing up or
-afterwards by {% if c.ATTENDEE_ACCOUNTS_ENABLED %}logging in{% else %}using the confirmation link they received by email when they
+They must then add the code to their registration by 
+{% if c.ATTENDEE_ACCOUNTS_ENABLED %}<a href="{{ c.URL_BASE }}/preregistration/homepage" target="_blank">logging in</a> and updating their badge details after registering{% else %}using the confirmation link they received by email when they
 registered{% endif %}. You can check your
 <a href="{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}">Art Show
 application </a> at any time to see your agent's status or assign a new agent.

--- a/uber/templates/emails/art_show/approved.html
+++ b/uber/templates/emails/art_show/approved.html
@@ -15,8 +15,8 @@ filled by another applicant.{% endif %}
 
 {% if app.attendee.badge_status == c.NOT_ATTENDING %}
     <br/> <br/>
-    As a reminder, you have indicated that you are not attending {{ c.EVENT_NAME }}. As such, you will need to contact
-    the art show staff at {{ c.ART_SHOW_EMAIL }} to coordinate sending your art.
+    As a reminder, you have indicated that you are not attending {{ c.EVENT_NAME }}.
+    You will receive an email with Mail in Instructions closer to the convention.
 {% endif %}
 
 {% if app.agent_code %}

--- a/uber/templates/emails/art_show/mailing_in.html
+++ b/uber/templates/emails/art_show/mailing_in.html
@@ -22,13 +22,13 @@ art.</li>
 <li>PREPAID Return label to:
 <blockquote>
 Midwest Art Show
-<br/>c/o Carol Gobeyn
-<br/>607 Lilac Way
+<br/>c/o Jacob Dawson
+<br/>46 N Elizabeth St
 <br/>Lombard, IL 60148
 </blockquote>
 All art must be shipped via trackable means both ways. DO NOT SEND
 SIGNATURE REQUIRED.
-<br/>Deadline to receive mail-in packages is Wednesday, November 23rd.
+<br/>Deadline to receive mail-in packages is Wednesday, November 22nd.
 </li>
 </ul>
 </li>
@@ -36,7 +36,7 @@ SIGNATURE REQUIRED.
 Name, Tracking Number and shipper name.</li>
 </ol>
 <p>I will send back any unsold Art via your prepaid label on Monday,
-December 5th. If all of your art sells we will send back your prepaid
+December 4th. If all of your art sells we will send back your prepaid
 label, receipt and the check for your sales during the week after the
 convention.</p>
 <p>Thank you,

--- a/uber/templates/emails/art_show/payment_reminder.txt
+++ b/uber/templates/emails/art_show/payment_reminder.txt
@@ -1,10 +1,9 @@
 {{ app.attendee.first_name }},
 
-Thanks again for applying to present in the Art Show for this year's {{ c.EVENT_NAME }}.  Our records indicate that your
-Art Show application is still unpaid, and if we do not receive payment by {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }} then it will be
-deleted.
+Thanks again for applying to present in the Art Show for this year's {{ c.EVENT_NAME }}. Our records indicate that your Art Show application is still unpaid, and if we do not receive payment by {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }} then it will be deleted.
 
-You can use the credit card button on your application's page to {% if group.amount_pending %}finish your payment of {{ (group.amount_pending / 100)|format_currency }}{% else %}pay the {{ group.amount_unpaid|format_currency }} that you owe{% endif %}:
-{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}
+You can use the credit card button on your application's page to {% if app.attendee.amount_pending %}finish your payment of {{ (app.attendee.amount_pending / 100)|format_currency }}{% else %}pay the {{ app.attendee.amount_unpaid|format_currency }} that you owe{% endif %}: {{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}
+
+If you are having issues with payment or need an extension please contact us at {{ c.ART_SHOW_EMAIL|email_only }}.
 
 {{ c.ART_SHOW_EMAIL_SIGNATURE }}

--- a/uber/templates/emails/dealers/approved.html
+++ b/uber/templates/emails/dealers/approved.html
@@ -6,7 +6,7 @@ You can pay the {{ group.cost|format_currency }} you owe using the credit card b
 <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">on this page</a>.
 Payment is expected by: {{ c.DEALER_PAYMENT_DUE|datetime_local }} or your application will be removed and your tables filled by another applicant.
 
-{% if group.unassigned_badges %}
+{% if group.unassigned %}
     <br/> <br/>
     Some of your badges are not yet assigned to a specific person. If you assign these badges
     now then it will take much less time for their owners to pick them up at the festival.

--- a/uber/templates/emails/dealers/payment_confirmation.html
+++ b/uber/templates/emails/dealers/payment_confirmation.html
@@ -2,7 +2,7 @@
 
 Your group ({{ group.name }}) has been preregistered for {{ c.EVENT_NAME }} this coming {{ event_dates() }} and your payment of {{ (attendee.amount_paid / 100)|format_currency }} has been received. Your group will have {{ group.tables }} Marketplace table{{ group.table|pluralize }}. The Marketplace coordinator will continue to be in touch with you to keep you informed of Marketplace rules and procedures.
 
-{% if group.unassigned_badges %}
+{% if group.unassigned %}
     <br/> <br/>
     Some of your badges are not yet assigned to a specific person. If you assign these badges 
     now then it will take much less time for their owners to pick them up at the festival. 

--- a/uber/templates/forms/group.html
+++ b/uber/templates/forms/group.html
@@ -22,7 +22,7 @@
     <p><a href="{{ signnow_link }}" class="btn btn-primary" target="_blank">
       {% if group.signnow_document %}Finish Signing{% else %}Review and Sign{% endif %}
     </a></p>
-    <p>Make sure to click "DONE" in the top right to confirm your signature.</p>
+    <p>Make sure to click "Finish" in the top right to confirm your signature.</p>
   </div>
   {% endif %}
 {% endif %}
@@ -53,69 +53,77 @@
       </div>
     {% endcall %}
   </div>
+  <script type="text/javascript">
+    var unapprove = function(action, convert) {
+      if (!$.val("email_text")) {
+        $("#setstatus").prepend('<div style="color:red">You must enter an email message.</div>');
+      } else {
+        $("button").attr("disabled", true);
+        $.post("../dealer_admin/unapprove", {
+          id: "{{ group.id }}",
+          action: action,
+          convert: convert,
+          csrf_token: csrf_token,
+          email_text: $.val("email_text")
+        }, function(json) {
+          if (json.message) {
+            window.location = "index?message="+ json.message + "#dealers";
+          } else {
+            $("#status").text("Waitlisted");
+          }
+        }, 'json');
+      }
+    }
+  </script>
 {% else %}
   {# Always read-only for attendees #}
   {% if group.status == c.APPROVED %}
     <div class="alert alert-success pb-0" role="alert">
-    Congratulations, your {{ c.DEALER_APP_TERM }} has been <strong>approved</strong>!
+    <p>Congratulations, your {{ c.DEALER_APP_TERM }} has been <strong>approved</strong>!</p>
     {% if group.cost %}
-      <br/><br/>Here is your group's cost breakdown:
+      <p>Here is your group's cost breakdown:</p>
       <ul>
         {% if group.auto_recalc %}
           <li>{{ group.default_table_cost|format_currency }} for {% if group.tables_repr %}a {{ group.tables_repr }}{% else %}{{ group.tables }} table{{ group.tables|pluralize }}{% endif %}</li>
-          <li>{{ group.default_badge_cost|format_currency }} for {{ group.badges_purchased }} badge{{ group.badges_purchased|pluralize }}
-            {% if upgraded_badges %}(including {{ upgraded_badges }} upgraded badge{{ upgraded_badges|pluralize }}){% endif %}</li>
+          {% if group.badges_purchased %}
+            <li>{{ group.default_badge_cost|format_currency }} for {{ group.badges_purchased }} badge{{ group.badges_purchased|pluralize }}</li>
+          {% endif %}
         {% else %}
           <li>{{ group.cost|format_currency }} total cost</li>
         {% endif %}
-        <li>{{ (group.amount_paid / 100)|format_currency or '$0' }} paid{% if group.amount_unpaid %} so far</li>
-          <li>{{ group.amount_unpaid|format_currency }} unpaid</li>
+        <li>{{ (group.amount_paid / 100)|format_currency or '$0' }} paid{% if group.amount_unpaid %} so far{% endif %}</li>
+        {% if group.amount_unpaid %}
+            <li>{{ group.amount_unpaid|format_currency }} unpaid</li>
           </ul>
-          <br/>{{ stripe_form('process_group_payment', group) }}
+          <p>{{ stripe_form('process_group_payment', group) }}</p>
         {% else %}
-        {% if receipt and receipt.current_amount_owed and incomplete_txn %}
-        <br/><br/>
-        You currently have an incomplete payment of {{ (incomplete_txn.amount / 100)|format_currency }}.
-              <br/><br/>Click here to complete your payment: {{ stripe_form('finish_pending_group_payment', group, txn_id=incomplete_txn.id, stripe_button_id="complete_txn") }}
-        {% endif %}
-          </li></ul>
+          </ul>
+          {% if receipt and receipt.current_amount_owed and incomplete_txn %}
+            <p>You currently have an incomplete payment of {{ (incomplete_txn.amount / 100)|format_currency }}.</p>
+            <p>Click here to complete your payment: {{ stripe_form('finish_pending_group_payment', group, txn_id=incomplete_txn.id, stripe_button_id="complete_txn") }}</p>
+          {% endif %}
         {% endif %}
     {% endif %}
+    </div>
   {% elif group.status == c.CANCELLED %}
-    <div class="alert alert-info" role="alert">
-    You have <strong>cancelled</strong> your {{ c.DEALER_APP_TERM }}. If this was a mistake, please contact us at
-    <a href="mailto:{{ c.MARKETPLACE_EMAIL }}">{{ c.MARKETPLACE_EMAIL }}</a>.
+    <div class="alert alert-info pb-0" role="alert">
+      <p>You have <strong>cancelled</strong> your {{ c.DEALER_APP_TERM }}. If this was a mistake, please contact us at
+      <a href="mailto:{{ c.MARKETPLACE_EMAIL }}">{{ c.MARKETPLACE_EMAIL }}</a>.</p>
+    </div>
   {% else %}
-    <div class="alert alert-{{ 'danger' if group.status == c.DECLINED else 'warning' }}" role="alert">
-    Your {{ c.DEALER_APP_TERM }} {{ 'is' if group.status == c.UNAPPROVED else 'has been' }} <strong>{{ group.status_label }}</strong>.
+    <div class="alert alert-{{ 'danger' if group.status == c.DECLINED else 'warning' }} pb-0" role="alert">
+      <p>Your {{ c.DEALER_APP_TERM }} {{ 'is' if group.status == c.UNAPPROVED else 'has been' }} <strong>{{ group.status_label }}</strong>.</p>
+      {% if group.status != c.UNAPPROVED and group.leader and group.leader.paid == c.PAID_BY_GROUP and c.DEALER_BADGE_PRICE == c.INITIAL_ATTENDEE %}
+        <p>If you'd like to attend the event regardless of your application status, you can purchase your badge now by clicking the button below. Your {{ c.DEALER_APP_TERM }} will remain {{ group.status_label }}.</p>
+        <p><a class="btn btn-success" href="../preregistration/purchase_dealer_badge?id={{ group.leader.id }}">Purchase Badge Now</a></p>
+      {% endif %}
       {% if c.AFTER_MARKETPLACE_REG_START and c.BEFORE_MARKETPLACE_DEADLINE and group.leader %}
-      <br/><br/>If you would like, you may instead
-      <a href="../marketplace/index?attendee_id={{ group.leader.id }}" target="_blank">apply for a table in the Marketplace.</a>{% endif %}
+        <p>If you would like, you may instead
+        <a href="../marketplace/index?attendee_id={{ group.leader.id }}" target="_blank">apply for a table in the Marketplace.</a></p>
+      {% endif %}
+    </div>
   {% endif %}
-  </div>
 {% endif %}
-<script type="text/javascript">
-  var unapprove = function(action, convert) {
-    if (!$.val("email_text")) {
-      $("#setstatus").prepend('<div style="color:red">You must enter an email message.</div>');
-    } else {
-      $("button").attr("disabled", true);
-      $.post("../dealer_admin/unapprove", {
-        id: "{{ group.id }}",
-        action: action,
-        convert: convert,
-        csrf_token: csrf_token,
-        email_text: $.val("email_text")
-      }, function(json) {
-        if (json.message) {
-          window.location = "index?message="+ json.message + "#dealers";
-        } else {
-          $("#status").text("Waitlisted");
-        }
-      }, 'json');
-    }
-  }
-</script>
 {% endset %}
 
 

--- a/uber/templates/group_admin/form.html
+++ b/uber/templates/group_admin/form.html
@@ -7,7 +7,7 @@
 
   {% include "check_in.html" %}
   <div class="card">
-
+    <div class="card-body">
     {% if not group.is_new %} 
     <div class="row mb-3">
       <div class="col text-start">

--- a/uber/templates/group_admin/index.html
+++ b/uber/templates/group_admin/index.html
@@ -6,6 +6,7 @@
     {{ options(c.GROUP_TYPE_OPTS) }}
   </div>
 <div class="card">
+  <div class="card-body">
   <h1>
   <a class="btn btn-primary" href="form">Add a Group</a>
   {% if c.HAS_DEALER_ADMIN_ACCESS %}<a class="btn btn-success" href="form?id=None&new_dealer=true">Add a {{ c.DEALER_TERM|title }}</a>{% endif %}
@@ -91,6 +92,7 @@
   {% if c.HAS_DEALER_ADMIN_ACCESS %}
   <div role="tabpanel" class="tab-pane" id="dealers" aria-labelledby="dealers-tab">{% include '/group_admin/dealers.html' %}</div>
   {% endif %}
+  </div>
   </div>
   </div>
 </div>

--- a/uber/templates/preregistration/attendee_card.html
+++ b/uber/templates/preregistration/attendee_card.html
@@ -64,7 +64,7 @@
 
 {% include 'attendee_card_extra.html' %}
 
-    {% if attendee.group %}
+    {% if attendee.group and attendee.group.is_valid %}
         <div class="col-sm-12 text-center mb-2">
             <span class="h4">
                 {% if attendee == attendee.group.leader %}Leader{% else %}Member{% endif %} of "{{ attendee.group.name }}"

--- a/uber/templates/preregistration/badge_refund.html
+++ b/uber/templates/preregistration/badge_refund.html
@@ -9,7 +9,7 @@
             Refunds are no longer available.
         {% elif attendee.amount_paid and c.BEFORE_REFUND_START %}
             Refunds will open at {{ c.REFUND_START|datetime_local }}.
-        {% elif attendee.is_group_leader %}
+        {% elif attendee.is_group_leader and attendee.group.is_valid %}
             As a leader of a group, you cannot abandon your badge.
         {% elif attendee.amount_paid %}
             We cannot automatically refund your badge at the moment due to technical difficulties.
@@ -24,6 +24,14 @@
         {% endif %}contact us at {{ c.REGDESK_EMAIL|email_only }}{% if c.SELF_SERVICE_REFUNDS_OPEN %} to make sure your refund gets processed.{% endif %}
         {% endif %}
     {% endset %}
+
+    {# Problems that attendees should not contact registration over: #}
+    {% if attendee.art_show_applications %}
+        {% set abandon_hover_text %}Please contact {{ c.ART_SHOW_EMAIL|email_only }} to cancel your art show application first.{% endset %}
+    {% elif attendee.art_agent_applications %}
+        {% set abandon_hover_text %}Please ask the artist you're agenting for to assign a new agent first.{% endset %}
+    {% endif %}
+
     <span class="tooltip-wrapper" tabindex="0" data-bs-toggle="tooltip" data-placement="top"{% if must_keep %} title="{{ abandon_hover_text }}"{% endif %}>
     {% endif %}
 <button type="submit" form="abandon_badge" alt="{{ abandon_hover_text }}" id="abandon_button" class="btn btn-danger"

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -30,10 +30,6 @@
       {% include 'confirm_tabs.html' with context %}
     {% endif %}
 
-    {% if c.ART_SHOW_ENABLED and c.AFTER_ART_SHOW_REG_START and not attendee.is_new %}
-      {% include 'art_show_common/art_show_agent.html' %}
-    {% endif %}
-
       {% if not attendee.is_valid %}
       <div class="alert alert-danger" role="alert">
         Your registration is currently marked as <strong>{{ attendee.badge_status_label }}</strong>
@@ -94,6 +90,10 @@
           </div> 
         {% endif %}
       {% endif %}
+
+    {% if c.AFTER_ART_SHOW_REG_START and not attendee.is_new %}
+      {% include 'art_show_common/art_show_agent.html' %}
+    {% endif %}
 
       {% if receipt %}
         {% include 'forms/receipt_modal.html' %}

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -5,9 +5,8 @@
 {% set title_text = "Group Members" %}
 {% block content %}
 <script type="text/javascript">
-    $().ready(function() {
-        $("form[action='unset_group_member']").submit(function(event){
-            var formToSubmit = this;
+  var unsetMemberConfirm = function(event) {
+    var formToSubmit = this;
             event.preventDefault();
             bootbox.confirm({
                 message: "This will permanently unassign this person's badge. They will receive an email about this. Are you sure?",
@@ -27,16 +26,17 @@
                     }
                 }
             });
-        })
+  }
 
-        $("form[action='../dealer_admin/cancel_dealer']").submit(function(event){
+  var cancelConfirm = function(event) {
             var formToSubmit = this;
             event.preventDefault();
             bootbox.confirm({
-                message: "This will permanently cancel this application. All registered badges in the group will be converted to individual badges. Are you sure?",
+                title: "Cancel Dealer Application?",
+                message: "This will permanently cancel your application. All registered badges in the group will be converted to individual badges. Are you sure?",
                 buttons: {
                     confirm: {
-                        label: 'Cancel Application',
+                        label: 'Yes, Cancel My Application',
                         className: 'btn-danger'
                     },
                     cancel: {
@@ -50,7 +50,11 @@
                     }
                 }
             });
-        })
+        }
+    $().ready(function() {
+        $("form[action='unset_group_member']").submit(unsetMemberConfirm);
+
+        $("form[action='../preregistration/cancel_dealer']").submit(cancelConfirm);
     });
 </script>
 
@@ -65,7 +69,7 @@
       {{ group_fields.signed_document }}
       <h2 class="h5">"{{ group.name }}" Information</h2>
       {{ form_macros.form_validation('group-form', 'validate_dealer' if group.is_dealer else 'validate_group') }}
-      <form method="post" action="group_members" class="form-horizontal" role="form">
+      <form method="post" action="group_members" role="form">
         <input type="hidden" name="id" value="{{ group.id }}" />
         {% if forms and 'group_info' in forms %}
           {% include "forms/group/group_info.html" %}
@@ -74,12 +78,12 @@
           {% include "forms/group/contact_info.html" %}
         {% endif %}
         {% include "groupextra.html" %}
-        {% if not page_ro %}
+        {% if group.status in c.DEALER_EDITABLE_STATUSES %}
         <button type="submit" class="btn btn-primary" value="Update Application">Update Application</button>
         <button type="submit" class="btn btn-danger" value="Cancel {{ c.DEALER_APP_TERM|title }}" form="cancel_dealer">Cancel Application</button>
         {% endif %}
       </form>
-        <form method="post" id="cancel_dealer" action="../dealer_admin/cancel_dealer" class="form-horizontal" role="form">
+        <form method="post" id="cancel_dealer" action="../preregistration/cancel_dealer" class="form-horizontal" role="form">
           <input type="hidden" name="id" value="{{ group.id }}" />
         </form>
     {% endif%}

--- a/uber/templates/preregistration/update_account.html
+++ b/uber/templates/preregistration/update_account.html
@@ -1,52 +1,63 @@
 {% import "forms/account.html" as account_fields with context %}
-<button class="btn btn-info pull-left" type="button" data-bs-toggle="collapse" data-bs-target="#update-account" aria-expanded="false" aria-controls="update-account">
-    <i class="fa fa-cog"></i> Account Settings
-</button>
-{% if c.PAGE_PATH != '/preregistration/homepage' %}
-<a href="../preregistration/homepage" class="btn btn-primary">Go to Homepage</a>
-{% endif %}
-<a href="../preregistration/logout" class="btn btn-danger pull-right">
-    <i class="fa fa-log-out"></i> Log Out
-</a>
+<div class="row g-sm-3">
+    <div class="col-4">
+        {% if not homepage_account.is_sso_account %}
+        <button class="btn btn-info pull-left" type="button" data-bs-toggle="collapse" data-bs-target="#update-account" aria-expanded="false" aria-controls="update-account">
+            <i class="fa fa-cog"></i> Account Settings
+        </button>
+        {% endif %}
+    </div>
+    <div class="col-4">
+        {% if c.PAGE_PATH != '/preregistration/homepage' %}
+        <a href="../preregistration/homepage" class="btn btn-primary">Go to Homepage</a>
+        {% endif %}
+    </div>
+    <div class="col-4">
+        <a href="../preregistration/logout" class="btn btn-danger pull-right">
+            <i class="fa fa-log-out"></i> Log Out
+        </a>
+    </div>
+</div>
 <div class="clearfix"></div>
-<div class="collapse" id="update-account">
+{% if not homepage_account.is_sso_account %}
+&nbsp;
+<div class="collapse text-start" id="update-account">
+    <div class="card">
     <div class="card-body">
-        <form method="post" action="update_account" class="form-horizontal">
+        <form method="post" action="update_account">
             {{ csrf_token() }}
             <input type="hidden" name="id" value="{{ homepage_account.id }}" />
-            <div class="form-group">
-                <label for="current_password" class="col-sm-3 control-label">Current Password</label>
-                <div class="col-sm-6">
-                    <input type="password" name="current_password" id="current_password" value="" class="form-control" placeholder="Enter account password to make changes" required>
+            <div class="row g-sm-3">
+                <div class="col-12 col-sm-6">
+                    <label for="current_password" class="form-text">Current Password</label>
+                <input type="password" name="current_password" id="current_password" value="" class="form-control" placeholder="Enter account password to make changes" required>
                 </div>
             </div>
             <hr>
-            <div class="form-group">
-                <label for="email" class="col-sm-3 control-label">Account Email</label>
-                <div class="col-sm-6">
+            <div class="row g-sm-3">
+                <div class="col-12 col-sm-6">
+                    <label for="email" class="form-text">Account Email</label>
                     <input type="email" name="account_email" id="account_email" value="{{ homepage_account.email }}" class="form-control" placeholder="Account email address" required>
                 </div>
             </div>
-            <div class="form-group">
-                <label for="new-password" class="col-sm-3 control-label">New Password</label>
-                <div class="col-sm-6">
+            <div class="row g-sm-3">
+                <div class="col-12 col-sm-6">
+                    <label for="new-password" class="form-text">New Password</label>
                     <input type="password" name="new_password" id="new-password" value="" class="form-control" placeholder="Leave blank to keep current password">
+                    {{ account_fields.password_help }}
                 </div>
-                {{ account_fields.password_help }}
-            </div>
-            <div class="form-group">
-                <label for="confirm-password" class="col-sm-3 control-label">Confirm New Password</label>
-                <div class="col-sm-6">
+                <div class="col-12 col-sm-6">
+                    <label for="confirm-password" class="form-text">Confirm New Password</label>
                     <input type="password" name="confirm_password" id="confirm-password" value="" class="form-control" placeholder="Leave blank to keep current password">
                 </div>
             </div>
-            <div class="col-sm-9 col-sm-offset-3">
-                <button type="submit" class="btn btn-primary" id="accountUpdateButton">
-                Update Account Info
-                </button>
-            </div>
+            <button type="submit" class="btn btn-primary" id="accountUpdateButton">
+            Update Account Info
+            </button>
         </form>
+    </div>
     </div>
 </div>
 
 {{ account_fields.new_password_validation }}
+{% endif %}

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -568,7 +568,7 @@
                   Refund
                   {% else %}
                   refundItem('{{ item.id }}', '{{ (item.amount / 100)|format_currency }}', '{{ item.count }}', '{{ item.revert_change|yesno }}')">
-                  Refund Item
+                  Refund Options
                   {% endif %}
           </button>
           {% endif %}


### PR DESCRIPTION
Includes several fixes from MFF:
- Fixes a bug where dealers would unset their own "auto recalc" box because their page was treated the same as an admin page
- Fixes receipt costs for people who are set to 'paid by group' or vice versa
- Fixes a bug I introduced earlier where changing dealer groups' badge count wouldn't update their receipt
- Fixes a bug in dealer emails where it would never tell them to assign their unassigned badges
- Correctly updates people's badge statuses when they're no longer paid by group
- Fixes a very old bug with the badges_purchased property for groups

Also:
- Uncancels payments that went through on Stripe's end
- Fixes a bug that made Stripe disable our webhook because we were erroneously throwing errors