### PR TITLE
Remove setup/teardown approval options

### DIFF
--- a/uber/models/department.py
+++ b/uber/models/department.py
@@ -11,6 +11,7 @@ from sqlalchemy.schema import ForeignKey, Table, UniqueConstraint, Index
 from sqlalchemy.types import Boolean, Float, Integer
 
 from uber.config import c
+from uber.decorators import presave_adjustment
 from uber.models import MagModel
 from uber.models.attendee import Attendee
 from uber.models.types import default_relationship as relationship, Choice, DefaultColumn as Column
@@ -159,8 +160,8 @@ class Department(MagModel):
     solicits_volunteers = Column(Boolean, default=True)
     is_shiftless = Column(Boolean, default=False)
     parent_id = Column(UUID, ForeignKey('department.id'), nullable=True)
-    is_setup_approval_exempt = Column(Boolean, default=False)
-    is_teardown_approval_exempt = Column(Boolean, default=False)
+    is_setup_approval_exempt = Column(Boolean, default=True)
+    is_teardown_approval_exempt = Column(Boolean, default=True)
     max_consecutive_minutes = Column(Integer, default=0)
 
     jobs = relationship('Job', backref='department')
@@ -272,6 +273,14 @@ class Department(MagModel):
         cascade='save-update,merge,refresh-expire,expunge',
         remote_side='Department.id',
         single_parent=True)
+    
+    @presave_adjustment
+    def force_approval_exempt(self):
+        # We used to have a system where departments would approve staffers for
+        # setup and teardown shifts -- we're getting rid of this option, which
+        # is most easily accomplished by making all departments always exempt
+        self.is_setup_approval_exempt = True
+        self.is_teardown_approval_exempt = True
 
     @hybrid_property
     def member_count(self):

--- a/uber/templates/dept_admin/form.html
+++ b/uber/templates/dept_admin/form.html
@@ -219,24 +219,6 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="col-sm-3 control-label">Setup/Teardown Approval?</label>
-              <div class="col-sm-9">
-                <div class="form-control-static checkbox">
-                  {{ macros.checkbox(department, 'is_setup_approval_exempt', label='Setup approval exempt') }}
-                  &nbsp;
-                  {{ macros.checkbox(department, 'is_teardown_approval_exempt', label='Teardown approval exempt') }}
-                </div>
-                <div class="help-block">
-                  These settings determine whether members of this department require
-                  approval to work setup/teardown shifts for this department.
-                  <br><br>
-                  Unless most of the department's work is done during setup/teardown,
-                  these should remain unchecked (members of the department should
-                  probably require approval to work setup/teardown).
-                </div>
-              </div>
-            </div>
-            <div class="form-group">
               <label class="col-sm-3 control-label optional-field">Max Consecutive Hours</label>
               <div class="col-sm-6">
                   <input
@@ -298,13 +280,6 @@
 {%- endif %}
 {%- endif %}
 <p>This department {% if department.solicits_volunteers %}solicits{% else %}<b>does not</b> solicit{% endif %} volunteers.</p>
-{% if department.is_setup_approval_exempt or department.is_teardown_approval_exempt %}
-  <p>
-    Members of this department <b>do not need approval</b> to work
-    {%- if department.is_setup_approval_exempt %} setup{%- endif -%}
-    {%- if department.is_teardown_approval_exempt %}{% if department.is_setup_approval_exempt %} or{% endif %} teardown{% endif %} shifts.
-  </p>
-{% endif %}
 {% if is_admin_checklist_admin or can_admin_dept -%}
   <p>
     <a href="../dept_checklist/index?department_id={{ department.id }}">

--- a/uber/templates/dept_admin/index.html
+++ b/uber/templates/dept_admin/index.html
@@ -30,8 +30,6 @@
             <th>Description</th>
             <th>Shiftless</th>
             <th>Solicits Volunteers</th>
-            <th>Setup Approval Exempt</th>
-            <th>Teardown Approval Exempt</th>
             <th>Max Consecutive Hours</th>
             <th>Members</th>
           </tr>
@@ -43,8 +41,6 @@
               <td>{{ department.description }}</td>
               <td>{{ department.is_shiftless|yesno("Yes,No") }}</td>
               <td>{{ department.solicits_volunteers|yesno("Yes,No") }}</td>
-              <td>{{ department.is_setup_approval_exempt|yesno("Yes,No") }}</td>
-              <td>{{ department.is_teardown_approval_exempt|yesno("Yes,No") }}</td>
               <td>{{ department.max_consecutive_minutes / 60 }}</td>
               <td>{{ department.member_count }}</td>
             </tr>

--- a/uber/templates/dept_admin/new.html
+++ b/uber/templates/dept_admin/new.html
@@ -42,24 +42,6 @@
       </div>
     </div>
   </div>
-  <div class="form-group">
-    <label class="col-sm-3 control-label">Setup/Teardown Exempt?</label>
-    <div class="col-sm-9">
-      <div class="form-control-static checkbox">
-        {{ macros.checkbox(department, 'is_setup_approval_exempt', label='Setup approval exempt') }}
-        &nbsp;
-        {{ macros.checkbox(department, 'is_teardown_approval_exempt', label='Teardown approval exempt') }}
-      </div>
-      <div class="help-block">
-        These settings determine whether members of this department require
-        approval to work setup/teardown shifts for this department.
-        <br><br>
-        Unless most of the department's work is done during setup/teardown,
-        these should remain unchecked (members of the department should
-        probably require approval to work setup/teardown).
-      </div>
-    </div>
-  </div>
   {{ macros.form_group(
       Department,
       'max_consecutive_hours',

--- a/uber/templates/dept_checklist/index.html
+++ b/uber/templates/dept_checklist/index.html
@@ -39,7 +39,7 @@
   {% for item, completed_item in checklist %}
     <tr>
         <td width="25">
-          <i class="fa fa-{% if completed_item %}check{% else %}unchecked{% endif %}"></i>
+          <i class="fa fa-{% if completed_item %}check-{% endif %}square-o"></i>
         </td>
         <td>
           <b>{{ item.name }}</b>{% if completed_item %} – Completed by {{ completed_item.attendee|form_link }}{% endif %}

--- a/uber/templates/forms/attendee.html
+++ b/uber/templates/forms/attendee.html
@@ -986,13 +986,6 @@ If you're interested in kicking in an extra donation, you can{% if c.COLLECT_EXT
 
 {% set setup_teardown %}
 {% set read_only = setup_teardown_ro or page_ro %}
-<div class="form-group staffing staffing-checked">
-  <label class="col-sm-3 control-label">Approved for Setup/Teardown</label>
-  <div class="checkbox col-sm-9">
-    {{ macros.checkbox(attendee, 'can_work_setup', label='Approved for setup', is_readonly=read_only, clientside_bool=clientside_bool) }} <br/>
-    {{ macros.checkbox(attendee, 'can_work_teardown', label='Approved for teardown', is_readonly=read_only, clientside_bool=clientside_bool) }}
-  </div>
-</div>
 {% endset %}
 
 

--- a/uber/templates/shifts_admin/index.html
+++ b/uber/templates/shifts_admin/index.html
@@ -31,12 +31,14 @@
         {% if department.is_shiftless %}
             This department is on record as not needing any shifts.  Please click the following link to confirm this so we know we don't need to make any shifts.  If this is in error and you'd like shifts for your people, please email {{ 'stops@magfest.org'|email_to_link }}.
         {% else %}
-            <p>We are able to import shifts from last year. If you want us to import last year’s shifts, please email {{ 'stops@magfest.org'|email_to_link }}. You will still be able to edit those shifts, add slots for additional volunteers, and create new shifts. 
-            If you choose to import last year’s shifts, please take the time to look them over and make any needed changes. After the import, you will need to return to this page and approve that they are correct by clicking "I Don’t Need To Do Anything Else Here."</p>
+            <p>We are able to import shifts from last year. If you want us to import last year's shifts, please email {{ 'stops@magfest.org'|email_to_link }}.
+                You will still be able to edit those shifts, add slots for additional volunteers, and create new shifts. If you choose to import last year’s shifts, please take the time to look them over and make any needed changes. After the import, you will need to return to this page and approve that they are correct by clicking "I Don’t Need To Do Anything Else Here."</p>
+
+            <p>If you want any shifts to be restricted to certain staffers, <strong>including setup or teardown shifts</strong>, please use the "roles" function when creating shifts. Shifts with specific roles will only be visible to staff that you have assigned to ALL of those roles.</p>
 
             <p>Otherwise, you can create shifts, and when you are done, click "I Don’t Need To Do Anything Else Here."</p>
         {% endif %}
-        <br/> <a href="#" onClick="$('#checkoff').show(); return false;">I Don't Need To Do Anything Else Here</a>
+        <p><a href="#" onClick="$('#checkoff').show(); return false;">I Don't Need To Do Anything Else Here</a></p>
         <form id="checkoff" style="display:none" method="post" action="../dept_checklist/mark_item_complete">
         {{ csrf_token() }}
         <input type="hidden" name="department_id" value="{{ department.id }}" />

--- a/uber/templates/shifts_admin/main_menu.html
+++ b/uber/templates/shifts_admin/main_menu.html
@@ -35,7 +35,7 @@
 <div class="jobs-menu form-inline">
   <div class="department-group form-group">
     <label for="department_id">Department</label>
-    <select id="department_id" onChange="mainMenuDropdownChanged()" class="form-control">
+    <select id="department_id" onChange="mainMenuDropdownChanged()" class="form-select">
       {% if c.ADMIN_DEPARTMENTS|length > 1 %}<option>All</option>{% endif %}
       {{ options(c.ADMIN_DEPARTMENT_OPTS, department_id) }}
     </select>
@@ -45,7 +45,7 @@
   {% else %}
   <div class="page-group form-group">
     <label for="page">View</label>
-    <select id="page" onChange="mainMenuDropdownChanged()" class="form-control">
+    <select id="page" onChange="mainMenuDropdownChanged()" class="form-select">
       {{ options(c.JOB_PAGE_OPTS, c.PAGE) }}
     </select>
   </div>

--- a/uber/templates/staffing/hotel_item.html
+++ b/uber/templates/staffing/hotel_item.html
@@ -1,4 +1,5 @@
 {% import 'macros.html' as macros %}
+{{ c.HOTELS_ENABLED }}
 {% if c.HOTELS_ENABLED and c.PRE_CON %}
 {% if attendee.hotel_eligible and c.AFTER_ROOM_DEADLINE and c.HAS_HOTEL_ADMIN_ACCESS %}
     <li>


### PR DESCRIPTION
We're making all setup and teardown shifts available by default without needing approval. Also updates the "creating shifts" step to explain roles a bit better, and updates the department head checklist page to correctly display checkboxes.