### PR TITLE
Improve display of list of departments for dept heads

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1329,6 +1329,8 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def cannot_transfer_reason(self):
+        from uber.custom_tags import readable_join
+
         reasons = []
         if self.admin_account:
             reasons.append("they have an admin account")
@@ -1336,7 +1338,7 @@ class Attendee(MagModel, TakesPaymentMixin):
             reasons.append("their badge type ({}) is not transferable".format(self.badge_type_label))
         if self.has_role_somewhere:
             reasons.append("they are a department head, checklist admin, or point of contact for the following departments: {}".format(
-                                ", ".join([membership.department.name for membership in self.dept_memberships_with_role])))
+                                readable_join(self.get_labels_for_memberships('dept_memberships_with_role'))))
         return reasons
     
     @presave_adjustment
@@ -1653,6 +1655,11 @@ class Attendee(MagModel, TakesPaymentMixin):
     @property
     def requested_depts_labels(self):
         return [d.name for d in self.requested_depts]
+    
+    def get_labels_for_memberships(self, prop_name):
+        # Takes a string for one of the 'depts_memberships' properties on the Attendee model
+        # (e.g., dept_memberships_where_can_admin_checklist) and returns a list of department names
+        return [membership.department.name for membership in getattr(self, prop_name, [])]
 
     @property
     def assigned_depts_ids(self):

--- a/uber/templates/emails/shifts/dept_checklist.txt
+++ b/uber/templates/emails/shifts/dept_checklist.txt
@@ -1,6 +1,6 @@
 {{ attendee.first_name }},
 
-As a department head for {{ attendee.assigned_depts_labels|readable_join }} we need some information from you about: {{ conf.name|safe }}
+As a department head or checklist admin for {{ attendee.get_labels_for_memberships('dept_memberships_where_can_admin_checklist')|readable_join }} we need some information from you about: {{ conf.name|safe }}
 {% if conf.full_description %}
 {{ conf.full_description|safe }}{% endif %}{% if conf.slug == 'approve_setup_teardown' %}
 

--- a/uber/templates/forms/attendee.html
+++ b/uber/templates/forms/attendee.html
@@ -1552,11 +1552,7 @@ $(window).on("runJavaScript", function(){
     {% if attendee.is_inherently_transferable %}
     This attendee can currently transfer their badge.
     {% elif attendee.cannot_transfer_reason %}
-    This attendee cannot transfer their badge under any circumstances because
-    {% for reason in attendee.cannot_transfer_reason %}
-    {% if loop.last and attendee.cannot_transfer_reason|length > 1 %} and {% endif %}
-    {{ reason }}{% if attendee.cannot_transfer_reason|length > 2 %}, {% endif %}
-    {% endfor %}.
+    This attendee cannot transfer their badge under any circumstances because {{ attendee.cannot_transfer_reason|readable_join }}.
     {% else %}
     <label for='can_transfer' class="checkbox-label">
       {{ macros.checkbox(attendee, 'can_transfer', is_readonly=read_only, clientside_bool=clientside_bool) }} Make this attendee's badge always transferable


### PR DESCRIPTION
Our emails for the department head checklist were listing ASSIGNED departments, not departments you actually needed to fill out the checklist for. This adds a property that lets you easily generate a list of department names for any property (in this case, "can admin checklist") so that we can display that in our emails.

Also uses the readable_join custom tag, which I didn't know existed, to fix minor issues with displaying the "can't transfer their badge" message on the attendee admin form.