### PR TITLE
Fix admin group validations

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -162,6 +162,7 @@ AutomatedEmailFixture(
     'placeholders/deferred.html',
     lambda a: a.placeholder and a.registered_local <= c.PREREG_OPEN and \
               a.badge_type == c.ATTENDEE_BADGE and a.paid == c.NEED_NOT_PAY and not a.admin_account,
+    when=after(c.PREREG_OPEN),
     ident='claim_deferred_badge')
 
 if c.ATTENDEE_ACCOUNTS_ENABLED:
@@ -552,6 +553,7 @@ AutomatedEmailFixture(
     'Last Chance to Accept Your {EVENT_NAME} ({EVENT_DATE}) Badge',
     'placeholders/reminder.txt',
     lambda a: a.placeholder and not a.is_dealer,
+    needs_approval=False,
     when=days_before(7, c.PLACEHOLDER_DEADLINE if c.PLACEHOLDER_DEADLINE else c.UBER_TAKEDOWN),
     ident='badge_confirmation_reminder_last_chance')
 

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -1026,7 +1026,7 @@ def require_staff_shirt_size(attendee):
 
 @validation.Attendee
 def volunteers_cellphone_or_checkbox(attendee):
-    if not attendee.no_cellphone and attendee.staffing_or_will_be and not attendee.cellphone:
+    if not attendee.placeholder and not attendee.no_cellphone and attendee.staffing_or_will_be and not attendee.cellphone:
         return ('cellphone', "Volunteers and staffers must provide a cellphone number or indicate they do not have a cellphone.")
 
 

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -147,13 +147,14 @@ class Root:
                 leader.badge_type = group.new_badge_type
                 leader.ribbon_ints = group.new_ribbons
                 leader_params = {key[7:]: val for key, val in params.items() if key.startswith('leader_')}
-                forms = load_forms(leader_params, leader, ['PersonalInfo'])
-                all_errors = validate_model(forms, leader, Attendee(**leader.to_dict()), is_admin=True)
+                leader_forms = load_forms(leader_params, leader, ['PersonalInfo'])
+                all_errors = validate_model(leader_forms, leader, Attendee(**leader.to_dict()), is_admin=True)
                 if all_errors:
                     session.delete(group)
                     session.commit()
-                    message = " ".join(list(zip(*[all_errors]))[1])
+                    message = ' '.join([item for sublist in all_errors.values() for item in sublist])
                 else:
+                    forms['personal_info'] = leader_forms['personal_info']
                     forms['personal_info'].populate_obj(leader)
 
             if not message:

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -645,7 +645,6 @@ def validate_model(forms, model, preview_model=None, is_admin=False):
                 extra_validators[key].extend(form.new_or_changed_validation.get_validations_by_field(key))
         valid = form.validate(extra_validators=extra_validators)
         if not valid:
-            log.debug(form.errors)
             for key, val in form.errors.items():
                 all_errors[key].extend(map(str, val))
 


### PR DESCRIPTION
Fixes several bugs where running into a validation error with the group leader's info while creating a group would crash the page. Also stops requiring a phone number for staff who are placeholder badges (whoops).