### PR TITLE
Fix 500 error on dealer admin form

### DIFF
--- a/uber/templates/forms/group/admin_table_info.html
+++ b/uber/templates/forms/group/admin_table_info.html
@@ -2,7 +2,39 @@
 
 {% block badges_tables %}
 <div class="row g-sm-3">
-    <div class="col-12 col-sm-6">{{ form_macros.form_input(table_info.tables, choices=c.PREREG_TABLE_OPTS, required=True) }}</div>
+    <div class="col-12 col-sm-6">{{ form_macros.form_input(table_info.tables, choices=c.ADMIN_TABLE_OPTS) }}</div>
+    <div class="col-12 col-sm-6">{{ form_macros.form_input(table_info.badges,
+                                        choices=int_choices(1, c.MAX_GROUP_SIZE),
+                                        extra_field=form_macros.form_input(table_info.can_add),
+                                        admin_text="[" ~ group.badges_purchased ~ " badge" ~ group.badges_purchased|pluralize ~ " purchased]" if not group.is_new else "",
+                                        required=True) }}
+    </div>
+</div>
+<div class="row g-sm-3 bg-light">
+    <div class="col-12 form-text">New Badges Settings</div>
+    <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(table_info.new_badge_type) }}
+    </div>
+    <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(table_info.new_ribbons) }}
+    </div>
+    {{ form_macros.toggle_fields_js(table_info.badges, [table_info.new_badge_type, table_info.new_ribbons], off_values=range(table_info.badges.data + 1)|list, closest_hide_selector='.row') }}
+</div>
+{% endblock %}
+
+{% block cost %}
+<div class="row g-sm-3">
+    <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(table_info.cost, extra_field=form_macros.form_input(table_info.auto_recalc), no_margin=True) }}
+    </div>
+    {% if group.cost %}
+    <div class="col-12 col-sm-3">
+        {{ form_macros.form_input(table_info.amount_paid_repr) }}
+    </div>
+    <div class="col-12 col-sm-3">
+        {{ form_macros.form_input(table_info.amount_refunded_repr) }}
+    </div>
+    {% endif %}
 </div>
 {% endblock %}
 

--- a/uber/templates/forms/group/table_info.html
+++ b/uber/templates/forms/group/table_info.html
@@ -6,6 +6,7 @@
     name_desc
     badges_js
     badges_tables
+    cost (admin-only)
     group_status (admin-only)
     website
     categories
@@ -65,10 +66,7 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
 {% endif %}
 {% endblock %}
 
-{% if admin_area %}
-{% include '/forms/group/admin_group_info.html' %}
-{% endif %}
-
+{% block cost %}{% endblock %}
 {% block group_status %}{% endblock %}
 
 {% if admin_area %}


### PR DESCRIPTION
I'd rearranged the way we build admin forms but my changes broke the admin form for dealers. This fixes that somewhat clumsily by copying the logic I need from admin_group_info into admin_table_info.