### PR TITLE
Allow super admins to manually set staff crash space

### DIFF
--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -329,7 +329,7 @@ class AdminStaffingInfo(StaffingInfo):
     got_staff_merch = BooleanField('This staffer has picked up their merch.')
     agreed_to_volunteer_agreement = HiddenBoolField('Agreed to Volunteer Agreement')
     reviewed_emergency_procedures = HiddenBoolField('Reviewed Emergency Procedures')
-    hotel_eligible = HiddenBoolField('Eligible for Staff Crash Space')
+    hotel_eligible = BooleanField('This staffer is eligible for staff crash space.')
 
     def staffing_label(self):
         return "This attendee is volunteering or staffing."

--- a/uber/templates/forms/attendee/admin_staffing_info.html
+++ b/uber/templates/forms/attendee/admin_staffing_info.html
@@ -96,10 +96,9 @@
     </div>
     {% endif %}
     <div class="col">
-        <div class="form-text">{{ staffing_info.hotel_eligible.label.text }}</div>
+        <div class="form-text">Staff Crash Space</div>
         <div class="mb-3">
-            {{ staffing_info.hotel_eligible }}
-            {{ staffing_info.hotel_eligible.data|yesno("Yes,No") }}
+            {{ form_macros.form_input(staffing_info.hotel_eligible, readonly=not c.HAS_DEVTOOLS_ACCESS) }}
         </div>
     </div>
 </div>

--- a/uber/templates/forms/macros.html
+++ b/uber/templates/forms/macros.html
@@ -30,7 +30,7 @@
 
 {% set type = field.meta.get_field_type(field) %}
 {% set label_required = kwargs['required'] if 'required' in kwargs else field.flags.required %}
-{% set disable_checkboxes = 'readonly' in kwargs or 'readonly' in field.render_kw %}
+{% set disable_checkboxes = ('readonly' in kwargs and kwargs['readonly'] == True) or 'readonly' in field.render_kw %}
 {% if type in ['checkbox','switch'] %}
 <div class="form-check{% if type == 'switch' %} form-switch{% endif %}{% if not no_margin %} mb-3{% endif %}">
   {% if disable_checkboxes %}


### PR DESCRIPTION
Also fixes a bug where if you passed `readonly` to a checkbox form macro, it would always disable the checkbox.