### PR TITLE
Adding ical download for shift schedule

### DIFF
--- a/uber/site_sections/staffing.py
+++ b/uber/site_sections/staffing.py
@@ -247,11 +247,12 @@ class Root:
         attendee = session.logged_in_volunteer()
         icalendar = ics.Calendar()
 
-        calname = "".join(filter(str.isalnum, f"{attendee.full_name}_shifts"))
+        calname = "".join(filter(str.isalnum, attendee.full_name)) + "_Shifts"
 
         for shift in attendee.shifts:
             icalendar.events.add(ics.Event(
-                name=f"{shift.job.department_name}: {shift.job.name}",
+                name=shift.job.name,
+                location=shift.job.department_name,
                 begin=shift.job.start_time,
                 end=(shift.job.start_time + timedelta(minutes=shift.job.duration)),
                 description=shift.job.description))

--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -111,7 +111,8 @@
     Shifts will be available starting {{ c.SHIFTS_CREATED.astimezone(c.EVENT_TIMEZONE).strftime('%B %-e') }}.
     <br/><br/>
     {% endif %}
-    <a href="index">Click Here</a> to return to the main page of the Volunteer Checklist.
+    <a href="index">Click Here</a> to return to the main page of the Volunteer Checklist.<br/>
+    <a href="shifts_ical">Click Here</a> to download your shifts in ical format
   </div>
 </div>
 {% if c.AFTER_SHIFTS_CREATED %}


### PR DESCRIPTION
This was a request from Nova at MFF. It adds a button for volunteers to download their shift schedule in a convenient ical format.

Not sure if that's the best place for a download button, but the ical download seems to work correctly in staging2023.