### PR TITLE
Fix group badge claiming via generic link

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1070,7 +1070,7 @@ class Root:
     def register_group_member(self, session, group_id, message='', **params):
         group = session.group(group_id, ignore_csrf=True)
         if params.get('id') in [None, '', 'None']:
-            attendee = Attendee()
+            attendee = group.unassigned[0] if group.unassigned else None
         else:
             attendee = session.attendee(params.get('id'), ignore_csrf=True)
 
@@ -1577,7 +1577,7 @@ class Root:
         }
     
     @ajax
-    def validate_dealer(self, session, form_list=[], **params):
+    def validate_dealer(self, session, form_list=[], is_prereg=False, **params):
         id = params.get('id', params.get('edit_id'))
         if id in [None, '', 'None']:
             group = Group(tables=1)
@@ -1585,10 +1585,13 @@ class Root:
             try:
                 group = session.group(id)
             except NoResultFound:
-                group = self._get_unsaved(
-                    id,
-                    PreregCart.pending_dealers,
-                    if_not_found=HTTPRedirect('dealer_registration?message={}', 'That application expired or has already been finalized.'))
+                if is_prereg:
+                    group = self._get_unsaved(
+                        id,
+                        PreregCart.pending_dealers,
+                        if_not_found=HTTPRedirect('dealer_registration?message={}', 'That application expired or has already been finalized.'))
+                else:
+                    return {"error": {'': ["We could not find the group you're trying to update."]}}
 
         if not form_list:
             form_list = ['ContactInfo', 'TableInfo']
@@ -1603,7 +1606,7 @@ class Root:
         return {"success": True}
 
     @ajax
-    def validate_attendee(self, session, form_list=[], **params):
+    def validate_attendee(self, session, form_list=[], is_prereg=False, **params):
         id = params.get('id', params.get('edit_id', params.get('attendee_id')))
         if id in [None, '', 'None']:
             attendee = Attendee()
@@ -1611,9 +1614,12 @@ class Root:
             try:
                 attendee = session.attendee(id)
             except NoResultFound:
-                attendee = self._get_unsaved(
-                    id,
-                    if_not_found=HTTPRedirect('form?message={}', 'That preregistration expired or has already been finalized.'))
+                if is_prereg:
+                    attendee = self._get_unsaved(
+                        id,
+                        if_not_found=HTTPRedirect('form?message={}', 'That preregistration expired or has already been finalized.'))
+                else:
+                    return {"error": {'': ["We could not find the badge you're trying to update."]}}
 
         if not form_list:
             form_list = ['PersonalInfo', 'BadgeExtras', 'BadgeFlags', 'OtherInfo', 'Consents']

--- a/uber/templates/preregistration/additional_info.html
+++ b/uber/templates/preregistration/additional_info.html
@@ -23,6 +23,7 @@
     {% endif %}
 
     <form novalidate method="post" id="prereg-form" action="additional_info" class="form-horizontal" role="form">
+      <input type="hidden" name="is_prereg" value="True" />
       {% if is_prereg_dealer %}
       <input type="hidden" name="group_id" value="{{ attendee.group_id }}" />
       {% else %}

--- a/uber/templates/preregistration/dealer_registration.html
+++ b/uber/templates/preregistration/dealer_registration.html
@@ -16,6 +16,7 @@
     <input type="hidden" name="edit_id" value="{{ edit_id }}" />
 {% endif %}
 {{ csrf_token() }}
+<input type="hidden" name="is_prereg" value="True" />
 
 <h2 class="h3 text-center mt-3">{{ c.DEALER_APP_TERM|title }} Info</h2>
 

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -24,6 +24,7 @@
 {% if edit_id %}
     <input type="hidden" name="edit_id" value="{{ edit_id }}" />
 {% endif %}
+<input type="hidden" name="is_prereg" value="True" />
 {{ csrf_token() }}
 
 {% include "forms/prereg_fields.html" %}


### PR DESCRIPTION
When I updated group badge claiming I accidentally made it so that if you accessed the page without the attendee ID, it would generate a new registration for you and then refuse to save it. It also wanted to direct you to prereg -- this fixes both issues.