### PR TITLE
Update Guest autograph reports

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -745,6 +745,8 @@ tabletop_tournament_slack = integer(default=5)
 # guests
 # =============================
 
+rock_island_email = string(default="MAGFest Rock Island <rockisland-heads@magfest.org>")
+
 band_email = string(default="MAGFest Music Department <music@magfest.org>")
 band_email_signature = string(default="- MAGFest Music Department")
 

--- a/uber/site_sections/guest_reports.py
+++ b/uber/site_sections/guest_reports.py
@@ -29,6 +29,8 @@ class Root:
             'Twitter', 'Instagram', 'Twitch', 'Bandcamp', 'Discord', 'Other Social Media', 'Bio Pic', 'Bio Pic Link',
             'Wants Panel', 'Panel Name',
             'Panel Length', 'Panel Description', 'Panel Tech Needs',
+            '# of Autograph Sessions', 'Autograph Session Length (Minutes)',
+            'Wants RI Meet & Greet', 'Meet & Greet Length (Minutes)',
             'Completed W9', 'Stage Plot',
             'Selling Merchandise',
             'Charity Answer', 'Charity Donation',
@@ -53,6 +55,8 @@ class Root:
                 getattr(guest.panel, 'wants_panel', ''), getattr(guest.panel, 'name', ''),
                 getattr(guest.panel, 'length', ''), getattr(guest.panel, 'desc', ''),
                 ' / '.join(getattr(guest.panel, 'panel_tech_needs_labels', '')),
+                getattr(guest.autograph, 'num', ''), getattr(guest.autograph, 'length', ''),
+                getattr(guest.autograph, 'rock_island_autographs', ''), getattr(guest.autograph, 'rock_island_length', ''),
                 getattr(guest.taxes, 'w9_sent', ''), absolute_stageplot_url,
                 getattr(guest.merch, 'selling_merch_label', ''),
                 getattr(guest.charity, 'donating_label', ''), getattr(guest.charity, 'desc', ''),
@@ -147,9 +151,14 @@ class Root:
     @csv_file
     def autograph_requests(self, out, session):
         out.writerow([
-            'Group Name', '# of Sessions', 'Session Length (Minutes)',
+            'Group Name', '# of Sessions', 'Session Length (Minutes)', 'Wants RI Meet & Greet', 'Meet & Greet Length (Minutes)'
         ])
 
-        autograph_sessions = session.query(GuestAutograph).filter(GuestAutograph.num > 0)
+        autograph_sessions = session.query(GuestAutograph).filter(or_(GuestAutograph.num > 0,
+                                                                      GuestAutograph.rock_island_autographs == True))
         for request in autograph_sessions:
-            out.writerow([request.guest.group.name, request.num, request.length])
+            out.writerow([request.guest.group.name,
+                          request.num,
+                          request.length,
+                          request.rock_island_autographs,
+                          request.rock_island_length])

--- a/uber/templates/emails/guests/charity_notification.txt
+++ b/uber/templates/emails/guests/charity_notification.txt
@@ -5,4 +5,4 @@ They have said they can donate the following:
 {{ guest.charity.desc }}{% endif %}
 
 
-Their group leader is {{ guest.group.leader.full_name }} and their email address is {{ guest.group.leader.email }}
+Their group leader is {{ guest.group.leader.full_name }} and their email address is {{ guest.group.leader.email }}.

--- a/uber/templates/emails/guests/meetgreet_notification.txt
+++ b/uber/templates/emails/guests/meetgreet_notification.txt
@@ -1,0 +1,7 @@
+"{{ guest.group.name }}" has just updated their meet and greet preferences. They {% if guest.autograph.rock_island_autographs %}DO{% else %}DO NOT{% endif %} want to run a meet and greet.{% if guest.autograph.rock_island_autographs %}
+
+
+They want a {{ guest.autograph.rock_island_length // 60 }}-hour session.{% endif %}
+
+
+Their group leader is {{ guest.group.leader.full_name }} and their email address is {{ guest.group.leader.email }}.

--- a/uber/templates/group_admin/guests.html
+++ b/uber/templates/group_admin/guests.html
@@ -51,4 +51,6 @@
   {% if c.HAS_GUEST_REPORTS_ACCESS %}
   <p><a href="../guest_reports/rock_island">View all Rock Island merch</a></p>
   <p><a href="../guest_reports/checklist_info_csv">Export all checklist data as a CSV file</a></p>
+  <p><a href="../guest_reports/autograph_requests">Autographs CSV</a></p>
+  <p><a href="../guest_reports/detailed_travel_info_csv">Detailed Travel Info CSV</a></p>
   {% endif %}


### PR DESCRIPTION
Emails Rock Island heads about RI meet and greets every time a guest updates their autograph step (unless they say they want no meet and greets and they didn't earlier say they wanted meet and greets). Also adds autograph information to the main checklist info CSV and adds links to all Guest reports on the groups page.