### PR TITLE
Fixes for dealer badge conversion, email reports, and admin shift schedule

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -989,7 +989,8 @@ def no_more_child_badges(attendee):
 
 @prereg_validation.Attendee
 def child_badge_over_13(attendee):
-    if not attendee.is_new and not attendee.badge_status == c.PENDING_STATUS:
+    if not attendee.is_new and not attendee.badge_status == c.PENDING_STATUS \
+        or attendee.unassigned_group_reg or attendee.valid_placeholder:
         return
 
     if c.CHILD_BADGE in c.PREREG_BADGE_TYPES and attendee.birthdate and attendee.badge_type == c.CHILD_BADGE \
@@ -1000,7 +1001,8 @@ def child_badge_over_13(attendee):
 
 @prereg_validation.Attendee
 def attendee_badge_under_13(attendee):
-    if not attendee.is_new and not attendee.badge_status == c.PENDING_STATUS:
+    if not attendee.is_new and not attendee.badge_status == c.PENDING_STATUS \
+        or attendee.unassigned_group_reg or attendee.valid_placeholder:
         return
 
     if c.CHILD_BADGE in c.PREREG_BADGE_TYPES and attendee.birthdate and attendee.badge_type == c.ATTENDEE_BADGE \

--- a/uber/site_sections/dealer_admin.py
+++ b/uber/site_sections/dealer_admin.py
@@ -62,10 +62,9 @@ def decline_and_convert_dealer_group(session, group, status=c.DECLINED, admin_no
     """
     if not admin_note:
         if delete_group:
-            admin_note = f'Converted badge from {AdminAccount.admin_name()} declining and converting {c.DEALER_REG_TERM} "{group.name}.'
+            admin_note = f'Converted badge from {AdminAccount.admin_name() or "server admin"} declining and converting {c.DEALER_REG_TERM} "{group.name}".'
         else:
-            admin_note = f'Converted badge from {AdminAccount.admin_name()} setting {c.DEALER_REG_TERM} "{group.name}" to {c.DEALER_STATUS[status]}.'
-
+            admin_note = f'Converted badge from {AdminAccount.admin_name() or "non-admin"} setting {c.DEALER_REG_TERM} "{group.name}" to {c.DEALER_STATUS[status]}.'
     if not group.is_unpaid:
         group.tables = 0
         for attendee in group.attendees:
@@ -102,12 +101,14 @@ def decline_and_convert_dealer_group(session, group, status=c.DECLINED, admin_no
             attendee.badge_status = c.INVALID_GROUP_STATUS
 
         if delete_group:
-            group.attendees.remove(attendee)
+            attendee.group = None
+            attendee.group_id = None
 
         session.add(attendee)
         session.commit()
 
     if delete_group:
+        group.leader = None
         session.delete(group)
     else:
         group.status = status
@@ -116,10 +117,8 @@ def decline_and_convert_dealer_group(session, group, status=c.DECLINED, admin_no
             (badges_converted, '{} badge{} converted'),
             (emails_sent, '{} email{} sent'),
             (emails_failed, '{} email{} failed to send')]:
-
         if count > 0:
             message.append(template.format(count, pluralize(count)))
-
     return ', '.join(message)
 
 

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -118,7 +118,8 @@ def check_pending_badges():
         subject = c.EVENT_NAME + ' Pending {} Badge Report for ' + localized_now().strftime('%Y-%m-%d')
         with Session() as session:
             for badge_type, to, per_email_filter, site_section in emails:
-                pending = session.query(Attendee).filter_by(badge_status=c.PENDING_STATUS).filter(per_email_filter).all()
+                pending = session.query(Attendee).filter_by(badge_status=c.PENDING_STATUS).filter(Attendee.paid != c.PENDING,
+                                                                                                  per_email_filter).all()
                 if pending and session.no_email(subject.format(badge_type)):
                     body = render('emails/daily_checks/pending.html', {'pending': pending, 'site_section': site_section}, encoding=None)
                     send_email.delay(c.ADMIN_EMAIL, to, subject.format(badge_type), body, format='html', model='n/a')

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -54,7 +54,7 @@ def check_duplicate_registrations():
                     for a in paid:
                         a.badge_status = c.NEW_STATUS
 
-                if dupes:
+                if dupes and session.no_email(subject):
                     body = render('emails/daily_checks/duplicates.html', {'dupes': sorted(dupes.items())}, encoding=None)
                     send_email.delay(c.ADMIN_EMAIL, c.REGDESK_EMAIL, subject, body, format='html', model='n/a')
 
@@ -197,7 +197,6 @@ def email_pending_attendees():
                 
                 if c.ATTENDEE_ACCOUNTS_ENABLED:
                     already_emailed_accounts.append(email_to)
-        
 
 
 @celery.schedule(timedelta(minutes=30))

--- a/uber/templates/emails/daily_checks/pending.html
+++ b/uber/templates/emails/daily_checks/pending.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
     <h3>{{ pending|length }} badges are currently pending</h3>
-    Use the <a href="{{ c.URL_BASE}}/{{ site_section }}/pending_badges">pending badges</a> badge to review and approve these badges.
+    Use the <a href="{{ c.URL_BASE}}/{{ site_section }}/pending_badges">pending badges</a> page to review and approve these badges.
     <ul style="margin-top:0px ; margin-bottom:10px">
     {% for attendee in pending %}
             <li>

--- a/uber/templates/emails/dealers/badge_converted.html
+++ b/uber/templates/emails/dealers/badge_converted.html
@@ -5,7 +5,7 @@
 {{ attendee.first_name }},
 
 <br/><br/>Although your group ({{ group.name }}) {{ 'cancelled their ' + c.DEALER_APP_TERM if group.status == c.CANCELLED else ('was declined' if group.status == c.DECLINED else 'was not taken off the waitlist') }}, we think you may still want to come and enjoy all that {{ c.EVENT_NAME }} has to offer!
-Therefore, we have reserved a badge for you{% if c.PRICE_BUMPS and attendee.badge_cost < c.BADGE_PRICE %} at the price of registration when you first applied{% endif %}.
+Therefore, we have reserved a badge for you{% if c.PRICE_BUMPS and attendee.badge_cost and attendee.badge_cost < c.BADGE_PRICE %} at the price of registration when you first applied{% endif %}.
 Badges went to anyone in your group who had a valid email on the badge, and any unassigned badges were dropped.
 
 <br/><br/>Please note: You are choosing to accept or decline an ATTENDEE badge at the price it would have been had you bought it instead of applying for the {{ c.DEALER_LOC_TERM }}.

--- a/uber/templates/preregistration/disclaimers.html
+++ b/uber/templates/preregistration/disclaimers.html
@@ -28,7 +28,7 @@
   {% if c.CONSENT_FORM_URL %}
     <li>
       Attendees under 18 MUST bring a
-      <a href="http://super.magfest.org/parentalconsentform" target="_blank">signed parental consent form</a>,
+      <a href="{{ c.CONSENT_FORM_URL }}" target="_blank">signed parental consent form</a>,
       which MUST be notarized if the parent is not with the minor when the
       badge is picked up. Also, all children 12 and under will need to be
       accompanied by an adult with a paid badge.

--- a/uber/templates/shifts_admin/index.html
+++ b/uber/templates/shifts_admin/index.html
@@ -129,8 +129,8 @@ $(document).ready(function() {
             agendaEvent: {
                 type: 'timeGrid',
                 visibleRange: {
-                    start: '{{ c.EPOCH.strftime('%Y-%m-%d') }}',
-                    end: '{{ c.ESCHATON.strftime('%Y-%m-%d') }}'
+                    start: '{{ c.EPOCH }}',
+                    end: '{{ c.ESCHATON }}'
                 },
                 buttonText: 'Event',
             },


### PR DESCRIPTION
Includes the following fixes:
- Group leaders no longer get deleted along with their group during dealer badge conversion 😬
- The "select a child badge" validation should no longer erroneously trip for people claiming group badges
- The pending badge report email now only sends if there are pending badges created by admins (vs pending badges of people who didn't finish registering, which happens basically constantly). Also fixes a typo in the email.
- The duplicate registration check should now only send once a day even if there are multiple email tasks running
- The "Event" button on the admin shift schedule now actually shows the last day of the event