### PR TITLE
Automatically convert declined dealer badges

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -825,6 +825,9 @@ secure_document_url = string(default='')
 # I.e., /preregistration/dealer_registration?invite_code={DEALER_INVITE_CODE}
 dealer_invite_code = string(default="")
 
+# If this is set, the nightly task that converts declined dealers' badges will also delete their group
+delete_declined_groups = boolean(default=False)
+
 # If maps_enabled is true, this key will be used to actually render the map.
 google_maps_api_key = string(default="")
 

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -125,7 +125,7 @@ def age_discount(attendee):
 @credit_calculation.Attendee
 def group_discount(attendee):
     if c.GROUP_DISCOUNT and attendee.qualifies_for_discounts and not attendee.age_discount and (
-                attendee.promo_code_groups or attendee.group):
+                attendee.promo_code_groups or attendee.group) and attendee.paid == c.PAID_BY_GROUP:
         return ("Group Discount", c.GROUP_DISCOUNT * 100 * -1, None)
     
 

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -192,8 +192,6 @@ class Root:
                         raise HTTPRedirect(
                             'index?message={}', group.name + ' is uploaded as ' + group.status_label)
                 elif group.is_dealer:
-                    #if group.status == c.DECLINED and group.orig_value_of('status') != c.DECLINED:
-                    #    message = decline_and_convert_dealer_group(session, group)
                     if group.status == c.APPROVED and group.orig_value_of('status') != c.APPROVED:
                         for attendee in group.attendees:
                             attendee.ribbon = add_opt(attendee.ribbon_ints, c.DEALER_RIBBON)

--- a/uber/tasks/groups.py
+++ b/uber/tasks/groups.py
@@ -12,14 +12,14 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from uber.config import c
 from uber.decorators import render
-from uber.models import ApiJob, Attendee, Email, Session, ReceiptTransaction
+from uber.models import ApiJob, Attendee, Email, Group, Session, ReceiptTransaction
 from uber.tasks.email import send_email
 from uber.tasks import celery
 from uber.utils import localized_now, TaskUtils, SignNowRequest
 from uber.payments import ReceiptManager
 
 
-__all__ = ['check_document_signed']
+__all__ = ['check_document_signed', 'convert_declined_groups']
 
 
 @celery.schedule(crontab(minute=0, hour='*/6'))
@@ -43,3 +43,14 @@ def check_document_signed():
                         signnow_request.document.link = signnow_link
                         session.add(signnow_request.document)
                         session.commit()
+
+
+@celery.schedule(crontab(minute=0, hour='*/6'))
+def convert_declined_groups():
+    from uber.site_sections.dealer_admin import decline_and_convert_dealer_group
+
+    with Session() as session:
+        declined_groups = session.query(Group).filter(Group.status == c.DECLINED,
+                                                      Group.badges_purchased > 0)
+        for group in declined_groups:
+            decline_and_convert_dealer_group(session, group, delete_group=c.DELETE_DECLINED_GROUPS)


### PR DESCRIPTION
Our old way of doing this was tricky -- dealers would get a declined email AFTER they were told their badges were converted. It also meant that if a dealer was declined by mistake, their badges would be converted instantly, a difficult process to reverse.

Now we run a nightly task that converts badges. Dealer groups are either left around (for MFF) or deleted (for MAGFest) based on the new delete_declined_groups config option.