### PR TITLE
Allow unsetting of all admin accesses from an account

### DIFF
--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -53,6 +53,9 @@ class Root:
             message = "Please select an attendee to create an admin account for."
         
         if not message:
+            if 'access_groups_ids' not in params:
+                params['access_groups_ids'] = []
+
             account = session.admin_account(params)
 
             if account.is_new and not c.SAML_SETTINGS:


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1286 by checking explicitly for the case where an account is updated with none of the checkboxes checked.