### PR TITLE
Support paid attendee non-dealer groups

### DIFF
--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -228,11 +228,11 @@ class Group(MagModel, TakesPaymentMixin):
 
     @hybrid_property
     def is_dealer(self):
-        return bool(not self.guest and (self.tables or self.cost or self.status not in [c.IMPORTED, c.UNAPPROVED]))
+        return bool(not self.guest and (self.tables or self.status not in [c.IMPORTED, c.UNAPPROVED]))
 
     @is_dealer.expression
     def is_dealer(cls):
-        return and_(cls.guest == None, or_(cls.tables > 0, cls.cost > 0, not_(cls.status.in_([c.IMPORTED, c.UNAPPROVED]))))
+        return and_(cls.guest == None, or_(cls.tables != 0, not_(cls.status.in_([c.IMPORTED, c.UNAPPROVED]))))
 
     @hybrid_property
     def is_unpaid(self):


### PR DESCRIPTION
I had to add support for dealer groups with no tables to MFF, and since we haven't used paid groups in years I thought it would be safe to just include any group with a cost. However, it's very common for admins to accidentally add a group of free badges as a group of paid badges, and you can't undo that once you've done it without filling in a bunch of junk dealer data. I'll have to add another way for MFF to have dealer groups without paid tables.