### PR TITLE
Allow deleting credit items

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1055,8 +1055,6 @@ class Attendee(MagModel, TakesPaymentMixin):
     def calc_promo_discount_change(self, promo_code_code):
         badge_cost = self.calculate_badge_cost() * 100
         if self.promo_code:
-            log.debug(badge_cost)
-            log.debug(self.badge_cost_with_promo_code * 100)
             if badge_cost == (self.badge_cost_with_promo_code * 100):
                 current_discount = badge_cost * -1
             else:


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1280 by preventing credit receipt items from being closed. Also removes the ability to try to 'revert' changes to the # of badges, promo code, or DOB as these are all broken or impossible to make work properly.