### PR TITLE
Fix transferring badges

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -323,7 +323,7 @@ transferable_badge_types = string_list(default=list('attendee_badge'))
 # other events with custom fields can add fields.
 #
 # This list is also used for repurchasing badges or purchasing importing badges
-untransferable_attrs = string_list(default=list('first_name','last_name','legal_name','email','birthdate','zip_code','international','ec_name','ec_phone','cellphone','interests','age_group','staffing','requested_depts'))
+untransferable_attrs = string_list(default=list('first_name','last_name','legal_name','email','birthdate','zip_code','international','ec_name','ec_phone','onsite_contact','no_onsite_contact','cellphone','interests','age_group','staffing','requested_depts'))
 
 # A list of attributes that get applied to the dealer prereg form if a dealer
 # chooses to reapply with an imported group

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -820,7 +820,6 @@ class Attendee(MagModel, TakesPaymentMixin):
             cost = self.new_badge_cost
 
         if c.BADGE_PROMO_CODES_ENABLED and self.promo_code and use_promo_code:
-            log.debug(self.promo_code.calculate_discounted_price(cost))
             return self.promo_code.calculate_discounted_price(cost)
         else:
             return cost
@@ -891,7 +890,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         # (if it exists) is greater than half off, we use that instead.
         import math
         if self.age_now_or_at_con and self.age_now_or_at_con < 13:
-            half_off = math.ceil(c.BADGE_PRICE / 2)
+            half_off = math.ceil(self.new_badge_cost / 2)
             if not self.age_group_conf['discount'] or self.age_group_conf['discount'] < half_off:
                 return -half_off
         return -self.age_group_conf['discount']
@@ -1037,6 +1036,9 @@ class Attendee(MagModel, TakesPaymentMixin):
         return current_cost, new_cost
 
     def calc_age_discount_change(self, birthdate):
+        if not self.qualifies_for_discounts:
+            return 0, 0
+        
         preview_attendee = Attendee(**self.to_dict())
         preview_attendee.birthdate = birthdate
         if self.badge_cost:

--- a/uber/templates/forms/attendee/other_info.html
+++ b/uber/templates/forms/attendee/other_info.html
@@ -16,7 +16,7 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
 
 
 {% block promo_code %}
-{% if not badge_flags and c.BADGE_PROMO_CODES_ENABLED and (not attendee.active_receipt or admin_area) %}
+{% if not badge_flags and not old and c.BADGE_PROMO_CODES_ENABLED and (not attendee.active_receipt or admin_area) %}
     {% set promo_code_admin_text %}
         {% if c.HAS_REG_ADMIN_ACCESS and attendee.promo_code_code %}
         <a href="" id="remove_promo_code" onClick="removePromoCode(event)">Remove Promo Code</a>

--- a/uber/templates/preregistration/transfer_badge.html
+++ b/uber/templates/preregistration/transfer_badge.html
@@ -1,6 +1,6 @@
 {% extends "./preregistration/preregbase.html" %}
-{% import "forms/attendee.html" as attendee_fields with context %}
-{% block backlink %}{% endblock %}
+{% import 'forms/macros.html' as form_macros with context %}
+
 {% set title_text = "Transfer Your " ~ c.EVENT_NAME ~ " Registration" %}
 {% block content %}
 
@@ -14,26 +14,24 @@
       our Registration Desk; that will belong to whomever the badge is transferred.
     </p>
 
-    <form method="POST" action="transfer_badge" class="form-horizontal">
-      {{ csrf_token() }}
-      <input type="hidden" name="id" value="{{ attendee.id }}" />
+    {% if receipt and receipt.current_amount_owed %}
+    <div class="alert alert-danger" role="alert">
+      This badge currently has an outstanding balance of <strong>{{ (receipt.current_amount_owed / 100)|format_currency }}</strong>.
+      You will be prompted for payment after transferring the badge.
+    </div>
+    {% endif %}
 
-      {% include 'forms/prereg_intro.html' %}
-      {{ attendee_fields.name }}
-      {{ attendee_fields.staffing }}
-      {{ attendee_fields.job_interests }}
-      {{ attendee_fields.age }}
-      {{ attendee_fields.email }}
-      {{ attendee_fields.address }}
-      {{ attendee_fields.emergency_contact }}
-      {{ attendee_fields.onsite_contact }}
-      {{ attendee_fields.cellphone }}
-      {{ attendee_fields.promo_code }}
-      {{ attendee_fields.interests }}
-      {{ attendee_fields.found_how }}
-      {{ attendee_fields.comments }}
-      {{ attendee_fields.can_spam }}
-      {{ attendee_fields.pii_consent_checkbox }}
+    {{ form_macros.form_validation('transfer-badge') }}
+
+    <form method="POST" novalidate action="transfer_badge" id="transfer-badge">
+      {{ csrf_token() }}
+      <input type="hidden" name="id" value="{{ old.id }}" />
+
+      {% include "forms/attendee/personal_info.html" %}
+      {% include "forms/attendee/staffing_info.html" %}
+      {% include "forms/attendee/other_info.html" %}
+      {% include "forms/attendee/consents.html" %}
+
       {# Deprecated form included for backwards compatibility with old plugins #}
       {% include "regform.html" %}
 


### PR DESCRIPTION
Updates the transfer badge form to the new form system. Also adds the onsite_contact fields to the nontransferable field list. Fixes https://jira.magfest.net/browse/MAGDEV-1298 while ensuring that receipts are transferred to the new badge.