### PR TITLE
Update at-con workflow to work with prereg page

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -286,7 +286,7 @@ class Config(_Overridable):
     @dynamic
     def ATTENDEE_BADGE_COUNT(self):
         """
-        Adds paid promo codes to the badge count, since these are promised badges and this propery is used for our
+        Adds paid promo codes to the badge count, since these are promised badges and this property is used for our
         badge sales cap. Free PC groups are excluded as they often have far more badges than will ever be claimed.
         """
         from uber.models import Session, Attendee, Group, PromoCode, PromoCodeGroup
@@ -495,7 +495,7 @@ class Config(_Overridable):
             'price': c.BADGE_PRICE,
             }]
         
-        if c.GROUPS_ENABLED:
+        if c.GROUPS_ENABLED and (c.BEFORE_GROUP_PREREG_TAKEDOWN or not c.AT_THE_CON):
             reg_type_opts.append({
                 'name': "Group Leader",
                 'desc': Markup(f"Register a group of {c.MIN_GROUP_SIZE} people or more at ${c.GROUP_PRICE} per badge. \

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -725,8 +725,8 @@ def csrf_token():
 
 
 @JinjaEnv.jinja_export
-def stripe_form(action, model=None, **params):
-    new_params = {'params': {}}
+def stripe_form(action, model=None, text="Pay with Card", **params):
+    new_params = {'params': {}, 'text': text}
     for key, val in params.items():
         new_params['params'][key] = val
     new_params['action'] = action

--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -412,7 +412,7 @@ class ReceiptTransaction(MagModel):
             log.error(e)
 
     def check_paid_from_stripe(self, intent=None):
-        if self.charge_id or c.AUTHORIZENET_LOGIN_ID or self.method != c.STRIPE:
+        if self.charge_id or c.AUTHORIZENET_LOGIN_ID or self.method not in [c.STRIPE, c.MANUAL]:
             return
 
         intent = intent or self.get_stripe_intent()

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -145,7 +145,8 @@ class Root:
             'message': message,
             'processors': {
                 c.STRIPE: "Authorize.net" if c.AUTHORIZENET_LOGIN_ID else "Stripe",
-                c.SQUARE: "SPIn" if c.SPIN_TERMINAL_AUTH_KEY else "Square"}
+                c.SQUARE: "SPIn" if c.SPIN_TERMINAL_AUTH_KEY else "Square",
+                c.MANUAL: "Stripe"}
         }
 
     def create_receipt(self, session, id='', blank=False):

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -1036,7 +1036,7 @@ class Root:
         for attendee in attendees:
             receipt = session.get_receipt_by_model(attendee, create_if_none="DEFAULT")
             if receipt.current_amount_owed:
-                if attendee.paid == c.NOT_PAID:
+                if attendee.paid in [c.NOT_PAID, c.PENDING]:
                     attendee.paid = c.HAS_PAID
                 if int(payment_method) == c.STRIPE_ERROR:
                     desc = f"Automated message: Stripe payment manually verified by {AdminAccount.admin_name()}."

--- a/uber/templates/check_in.html
+++ b/uber/templates/check_in.html
@@ -12,9 +12,6 @@ minor_printer_id = "{{ workstation_assignment.minor_or_adult_printer_id if works
 var loadCheckInFormModal = function (attendeeID) {
     $('#checkin_modal .modal-content').load('../registration/check_in_form?id=' + attendeeID, function() {
         if ($('.check-in').length) {
-            $('#checkin_modal').on('hidden.bs.modal', function (e) {
-                $('#stripeModal').remove();
-            });
             $('#payment-loading-message').hide();
         } else {
             showErrorMessage("Form loading failed.");

--- a/uber/templates/forms/attendee/check_in_form.html
+++ b/uber/templates/forms/attendee/check_in_form.html
@@ -46,6 +46,9 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
         <div class="col">
             {{ form_macros.form_input(check_in_form.badge_num, force_hidden=attendee.badge_num, hidden_field_text=attendee.badge_num) }}
         </div>
+        <script type="text/javascript">
+            $().ready(function() { $('#badge_num').focus(); });
+        </script>
     {% endif %}
     {% if c.COLLECT_EXACT_BIRTHDATE %}
         <div class="col">

--- a/uber/templates/preregistration/at_door_confirmation.html
+++ b/uber/templates/preregistration/at_door_confirmation.html
@@ -10,13 +10,13 @@
     <p>
         Thank you for completing your at-door registration{{ completed_registrations|length|pluralize }}!
         Your badge{{ completed_registrations|length|pluralize }} for {{ completed_registrations|readable_join }} 
-        ha{{ 's' if completed_registrations|length == 1 else 've' }} been registered under your account
+        ha{{ 's' if completed_registrations|length == 1 else 've' }} been {% if account %}registered under your account
         {{ account.email }}. You can <a href="../preregistration/homepage" target="_blank">log into your account</a> to view all 
-        your badges at any time.
+        your badges at any time{% else %} reserved for you to pay for and pick up at the Registration desk{% endif %}.
     </p>
 
     <p> 
-        {% if account.at_door_attendees|length > completed_registrations|length %}
+        {% if account and account.at_door_attendees|length > completed_registrations|length %}
             It looks like your account already has at least one prior at-door registration.
         {% endif %}
         If you think you may have made a mistake, like registering the same badge twice, there's no need to worry -- you can
@@ -24,18 +24,20 @@
     </p>
 
     <h2>Next Steps</h2>
+    {% block next_steps %}
     <p>
         Please join the line for at-door payments when you're ready to pay for and pick up your badge. Once you get near 
         the front of the line, keep an eye out for stations marked "Cash" or "Card" and make sure to go to a "Cash" station if you
         want to pay with cash.
-        You can show the check-in barcode below to the volunteer at the registration desk to quickly look up your pending 
+        {% if qr_code_id %}You can show the check-in barcode below to the volunteer at the registration desk to quickly look up your pending 
         registration{{ completed_registrations|length|pluralize }}. In addition to this barcode,
-        <strong>please have your photo ID{{ completed_registrations|length|pluralize }} and payment ready when you get to the front
+        <strong>p{% else %}<strong>P{% endif %}lease have your photo ID{{ completed_registrations|length|pluralize }} and payment ready when you get to the front
         of the line!</strong> This is a huge help for making badge pick-up faster for everyone. Thanks again!
     </p>
-    <p class="text-center">
+    {% endblock %}
+    {% if qr_code_id %}<p class="text-center">
         <img src="../registration/qrcode_generator?data={{ account.public_id }}" />
-    </p>
+    </p>{% endif %}
   </div>
 
   <div class="card-body">

--- a/uber/templates/preregistration/index_payment_form.html
+++ b/uber/templates/preregistration/index_payment_form.html
@@ -4,11 +4,13 @@
       <a href="form">{{ macros.stripe_button("Add Another Registration") }}</a>
       or
     {% if cart.total_cost > 0 %}
-        {% if c.AT_THE_CON and c.ATTENDEE_ACCOUNTS_ENABLED and c.SPIN_TERMINAL_AUTH_KEY %}
+    {% if c.AT_THE_CON %}
+        {% if c.SPIN_TERMINAL_AUTH_KEY %}
             <a href="at_door_confirmation" class="btn btn-success">Confirm Registrations and Get Check-in Barcode</a>
         {% else %}
             {{ stripe_form('prereg_payment') }}
         {% endif %}
+    {% endif %}
     {% else %}
         <a href="process_free_prereg">{{ macros.stripe_button("Complete Registration!") }}</a>
     {% endif %}
@@ -18,7 +20,14 @@
 <div class="row">
     <div class="text-center">
         {% if cart.total_cost > 0 %}
-            {{ stripe_form('prereg_payment') }}
+            {% if c.AT_THE_CON and c.ATTENDEE_ACCOUNTS_ENABLED and c.SPIN_TERMINAL_AUTH_KEY %}
+                <a href="at_door_confirmation" class="btn btn-success">Confirm Registrations and Get Check-in Barcode</a>
+            {% else %}
+                {{ stripe_form('prereg_payment', text="Pay with Card Now") }}
+                {% if c.AT_THE_CON %}
+                <a href="at_door_confirmation" class="btn btn-success">Pay with Cash/Card at Desk</a>
+                {% endif %}
+            {% endif %}
         {% else %}
             <a href="process_free_prereg">{{ macros.stripe_button("Complete Registration!") }}</a>
         {% endif %}

--- a/uber/templates/preregistration/stripeForm.html
+++ b/uber/templates/preregistration/stripeForm.html
@@ -45,7 +45,7 @@
     {% set stripe_loaded = true %}
 {% endif %}
 <button class="btn btn-info stripe-btn"{% if 'stripe_button_id' in params %} id="{{ params['stripe_button_id'] }}"{% endif %} onClick="callStripeAction();">
-<span class="display: block; min-height: 30px;">Pay with Card</span>
+<span class="display: block; min-height: 30px;">{{ text }}</span>
 </button>
 {% if not stripeModal %}
 <div id="stripeModal" class="modal" style="color:black;" tabindex="-1" role="dialog" data-bs-backdrop="static">

--- a/uber/templates/registration/check_in_cart_form.html
+++ b/uber/templates/registration/check_in_cart_form.html
@@ -126,7 +126,6 @@
     {% endif %}
 </div>
 <script type="text/javascript">
-    var checkinModal = bootstrap.Modal.getOrCreateInstance($('#checkin_modal'));
     var toggleMarkButton = function (dropdown) {
         var $button = $(dropdown).parent().parent().find(':submit');
         if ($(dropdown).val()) {

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -54,9 +54,6 @@ var toggleMarkButton = function (dropdown) {
 };
 loadCheckInForm = function (json=null) {
     if ($('#stripeModal').length) {
-        $('#stripeModal').off('hidden.bs.modal');
-        var stripeModal = bootstrap.Modal.getOrCreateInstance($('#stripeModal'))
-        stripeModal.hide();
         $('#stripeModal').remove();
     }
     
@@ -70,9 +67,8 @@ loadCheckInForm = function (json=null) {
 }
 var resumeStripeAction = callStripeAction;
 var callStripeAction = function() {
-    $('#checkin_modal').off('hidden.bs.modal');
-    checkinModal = bootstrap.Modal.getOrCreateInstance($('#checkin_modal'));
-    checkinModal.hide();
+    $('#checkin_modal .btn-close').trigger('click');
+    $('#checkin_modal .modal-content').html('');
     $('#stripeModal').on('hidden.bs.modal', function (e) {
         $('#stripeModal').remove();
     })

--- a/uber/templates/registration/minor_check_form.html
+++ b/uber/templates/registration/minor_check_form.html
@@ -25,7 +25,6 @@
 </div>
   
 <script type="text/javascript">
-    var checkinModal = bootstrap.Modal.getOrCreateInstance($('#checkin_modal'));
     var changeButtonLabel = function () {
         var old_printer_id = "{{ printer_id }}";
         if ($.val('printer_id') != old_printer_id) {


### PR DESCRIPTION
Updates the 'at-door confirmation' page to work without attendee accounts so that MAGFest can also use the prereg page during the event. Also fixes some bugs with the check in modal Stripe form not working with Bootstrap 5 and not marking people as paid correctly. Also fixes https://jira.magfest.net/browse/MAGDEV-1211 by forcing focus on the badge input field -- validations were already made to work correctly earlier for MFF.