### PR TITLE
Allow any admin to decrypt barcodes

### DIFF
--- a/uber/site_sections/barcode.py
+++ b/uber/site_sections/barcode.py
@@ -1,6 +1,6 @@
 from uber.barcode import get_badge_num_from_barcode
 from uber.config import c
-from uber.decorators import all_renderable, ajax
+from uber.decorators import all_renderable, ajax, any_admin_access
 
 
 @all_renderable()
@@ -9,6 +9,7 @@ class Root:
         return {}
 
     @ajax
+    @any_admin_access
     def get_badge_num_from_barcode(self, session, barcode):
         badge_num = -1
         msg = "Success."


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1208 and likely other permissions issues regarding scanning badges by letting any admin call the get_badge_num_from_barcode page handler.