### PR TITLE
Add group promo code claim page

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1233,7 +1233,7 @@ class Session(SessionManager):
                     return ''
                 else:
                     attendee.promo_code_id = None
-                    return 'The promo code you entered is invalid.'
+                    return f"The promo code you entered ({code}) is invalid."
             else:
                 attendee.promo_code = None
                 attendee.promo_code_id = None

--- a/uber/templates/forms/attendee/badge_extras.html
+++ b/uber/templates/forms/attendee/badge_extras.html
@@ -2,7 +2,7 @@
 {% import 'forms/macros.html' as form_macros with context %}
 {% set prereg_merch_available = c.FORMATTED_MERCH_TIERS and c.PREREG_DONATION_OPTS|length > 1 %}
 {% set badge_extras = badge_extras or forms['badge_extras'] %}
-{%- set is_prereg_attendee = c.PAGE_PATH in ['/preregistration/form', '/preregistration/post_form'] -%}
+{%- set is_prereg_attendee = c.PAGE_PATH in ['/preregistration/form', '/preregistration/post_form', '/preregistration/claim_badge'] -%}
 
 {# BLOCK NAMES in this form:
     badge_type

--- a/uber/templates/preregistration/claim_badge.html
+++ b/uber/templates/preregistration/claim_badge.html
@@ -1,0 +1,34 @@
+{% extends "./preregistration/preregbase.html" %}
+{% import 'forms/macros.html' as form_macros with context %}
+{% set title_text = "Claim a Group Badge" %}
+
+{% block content %}
+{% include 'preregistration/disclaimer_popup.html' %}
+<div class="card">
+    <div class="card-body">
+    {{ form_macros.form_validation('prereg-form', 'validate_badge_claim', include_disclaimers_modal=True) }}
+    <form novalidate method="post" action="claim_badge" id="prereg-form">
+        {{ csrf_token() }}
+
+        <div class="row g-sm-3">
+            <div class="col-6">
+                <label class="form-text">Group Code</label>
+                <div class="mb-3"><input type="text" class="form-control" name="promo_code_code" value="{{ attendee.promo_code_code }}"></div>
+            </div>
+        </div>
+        {% include "forms/attendee/badge_flags.html" %}
+        {% include "forms/attendee/badge_extras.html" %}
+        {% include "forms/attendee/personal_info.html" %}
+        {% include "forms/attendee/staffing_info.html" %}
+        {% include "forms/attendee/other_info.html" %}
+        {% include "forms/attendee/consents.html" %}
+
+        {# Deprecated form included for backwards compatibility with old plugins #}
+        {% include "regform.html" %}
+
+        <button type="submit" class="btn btn-primary">Claim Badge</button>
+    </form>
+    </div>
+</div>
+
+{% endblock %}

--- a/uber/templates/static_views/prereg_soldout.html
+++ b/uber/templates/static_views/prereg_soldout.html
@@ -7,5 +7,6 @@
     We'll see you {{ c.EVENT_MONTH }} {{ c.EVENT_START_DAY }} - {{ c.EVENT_END_DAY }}.<br/>
     <br/>
     Please <a href="{{ c.CONTACT_URL }}">contact us</a> if you have any questions.<br/>
+    <br/>You can still <a href="../preregistration/claim_badge">claim a group badge</a> using a group code.
 </body>
 </html>


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1297 by adding a single-page registration form to claim a group badge. It rejects any promo code that isn't attached to a group, any code that is already used, and any group code for a 'full' group. Also adjusts the behavior of the new badge payment page so that, if you select extras while claiming a group code, you're brought directly to that page instead of the confirmation page.