### PR TITLE
Fix duplicate key error for cancelled prereg payments

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1118,7 +1118,7 @@ class Session(SessionManager):
             if cls:
                 return self.query(cls).filter_by(id=receipt.owner_id).first()
 
-        def refresh_receipt_and_model(self, model):
+        def refresh_receipt_and_model(self, model, is_prereg=False):
             receipt = self.get_receipt_by_model(model)
             if receipt:
                 for txn in receipt.pending_txns:
@@ -1137,8 +1137,9 @@ class Session(SessionManager):
                     model.paid = c.NEED_NOT_PAY
                 elif receipt.current_amount_owed > 0 and model.paid == c.NEED_NOT_PAY:
                     model.paid = c.NOT_PAID
-                self.add(model)
-                self.commit()
+                if not is_prereg:
+                    self.merge(model)
+                    self.commit()
             
             try:
                 self.refresh(model)

--- a/uber/site_sections/dept_admin.py
+++ b/uber/site_sections/dept_admin.py
@@ -201,14 +201,16 @@ class Root:
     def dept_members_export(self, out, session, department_id, message='', **params):
         department = session.query(Department).get(department_id)
         headers = ['Name', 'Legal Name', 'Email', 'Phone Number', 'Emergency Contact',
-                   'Weighted Hours', 'Badge Status', 'Placeholder']
+                   'Weighted Hours', 'Badge Status', 'Placeholder', 'Has Shifts']
 
         out.writerow(headers)
         for attendee in department.members:
             row = [attendee.full_name, attendee.legal_name, attendee.email, attendee.cellphone,
                    attendee.ec_name + ": " + attendee.ec_phone,
                    attendee.weighted_hours_in(department),
-                   attendee.badge_status_label, yesno(attendee.placeholder, 'Yes,No')]
+                   attendee.badge_status_label,
+                   yesno(attendee.placeholder, 'Yes,No'),
+                   yesno(attendee.weighted_hours_in(department) > 0, 'Yes,No')]
 
             out.writerow(row)
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -95,7 +95,7 @@ def update_prereg_cart(session):
         if not existing_model:
             existing_model = session.query(Group).filter_by(id=id).first()
         if existing_model:
-            receipt = session.refresh_receipt_and_model(existing_model)
+            receipt = session.refresh_receipt_and_model(existing_model, is_prereg=True)
             if receipt and receipt.current_amount_owed:
                 PreregCart.unpaid_preregs[id] = PreregCart.pending_preregs[id]
             elif receipt:
@@ -831,7 +831,7 @@ class Root:
                 receipts = []
                 for model in cart.models:
                     charge_receipt, charge_receipt_items = ReceiptManager.create_new_receipt(model, create_model=True)
-                    existing_receipt = session.refresh_receipt_and_model(model)
+                    existing_receipt = session.refresh_receipt_and_model(model, is_prereg=True)
                     if existing_receipt:
                         # Multiple attendees can have the same transaction during pre-reg,
                         # so we always cancel any incomplete transactions

--- a/uber/site_sections/reg_reports.py
+++ b/uber/site_sections/reg_reports.py
@@ -48,12 +48,12 @@ class Root:
         if page <= 0:
             offset = 0
         else:
-            offset = (page - 1) * 100
+            offset = (page - 1) * 50
 
         return {
             'current_page': page,
             'pages': (receipt_query.count() // 100) + 1,
-            'attendees': receipt_query.limit(100).offset(offset),
+            'attendees': receipt_query.limit(50).offset(offset),
             'include_pending': include_pending,
         }
     


### PR DESCRIPTION
Also lowers the pagination number for the receipt discrepancies page, and adds "has shifts" to the department volunteer export.