### PR TITLE
Refactor placeholder emails

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -501,6 +501,9 @@ admin_email = string(default="Eli Courtwright <eli@courtwright.org>")
 # Daily report emails come from this address.
 reports_email = string(default='%(admin_email)s')
 
+# General emails that don't fit any other category are sent from this address.
+contact_email = string(default="MAGFest <contact@magfest.org>")
+
 # Registration emails such as payment confirmations are sent from this address.
 regdesk_email = string(default="MAGFest Registration <regdesk@magfest.org>")
 

--- a/uber/templates/emails/placeholders/regular.txt
+++ b/uber/templates/emails/placeholders/regular.txt
@@ -1,7 +1,5 @@
 {% if attendee.first_name %}{{ attendee.first_name }},
 
-{% endif %}You've been added to the {{ c.EVENT_NAME }} registration database, but we don't have all of your personal information{% if attendee.amount_unpaid %} and you have not yet paid your outstanding balance of {{ attendee.amount_unpaid|format_currency }}{% endif %}.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info{% if attendee.amount_unpaid %} and pay{% endif %} at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to {{ c.EVENT_NAME }}.
+{% endif %}You've been added to the {{ c.EVENT_NAME }} registration database, but we don't have all of your personal information{% if attendee.amount_unpaid %} and you have not yet paid your outstanding balance of {{ attendee.amount_unpaid|format_currency }}{% endif %}. To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info{% if attendee.amount_unpaid %} and pay{% endif %} at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to {{ c.EVENT_NAME }}.
 
-Please let us know if you have any questions.
-
-{{ c.REGDESK_EMAIL_SIGNATURE }}
+Please reply to this email if you have any questions.


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1308 by refactoring how we define placeholder emails -- they're now all pre-defined lambda functions that we use to make a "generic" filter to catch anyone without a specific placeholder email configured for them. Also removes references to Registration so they stop getting emails for placeholder badges they don't control/make.