### PR TITLE
Add support for plugin overrides of email fixtures

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -126,6 +126,9 @@ class AutomatedEmailFixture:
         before = [d.active_before for d in when if d.active_before]
         self.active_before = max(before) if before else None
 
+        self.template_plugin_name = ""
+        self.template_url = ""
+
     def update_template_plugin_info(self):
         env = JinjaEnv.env()
         try:
@@ -137,6 +140,14 @@ class AutomatedEmailFixture:
             self.template_plugin_name = "ERROR: TEMPLATE NOT FOUND"
             self.template_url = ""
         return self.template_plugin_name, self.template_url
+
+    def update_subject_line(self, subject):
+        self.subject = subject \
+            .replace('{EVENT_NAME}', c.EVENT_NAME) \
+            .replace('{EVENT_YEAR}', c.EVENT_YEAR) \
+            .replace('{EVENT_DATE}', c.EPOCH.strftime('%b %Y'))
+
+        AutomatedEmail._fixtures[self.ident] = self
 
     @property
     def body(self):

--- a/uber/site_sections/email_admin.py
+++ b/uber/site_sections/email_admin.py
@@ -35,7 +35,7 @@ class Root:
         return {'emails': session.query(Email).filter_by(**params).order_by(Email.when).all()}
 
     def pending(self, session, message=''):
-        AutomatedEmail.reconcile_fixtures()
+        AutomatedEmail.reconcile_fixtures(cleanup=False)
         emails_with_count = session.query(AutomatedEmail, AutomatedEmail.email_count).filter(
             AutomatedEmail.subject != '', AutomatedEmail.sender != '',).all()
         emails = []
@@ -83,10 +83,7 @@ class Root:
         }
 
     def update_dates(self, session, ident, **params):
-        email = session.query(AutomatedEmail).filter_by(ident=ident).first()
-        email.apply(params, restricted=False)
-        session.add(email)
-        session.commit()
+        AutomatedEmail.update_fixture(session, ident, **params)
         raise HTTPRedirect('pending_examples?ident={}&message={}', ident, 'Email send dates updated')
 
     def test_email(self, session, subject=None, body=None, from_address=None, to_address=None, **params):

--- a/uber/templates/email_admin/pending_examples.html
+++ b/uber/templates/email_admin/pending_examples.html
@@ -39,7 +39,7 @@
 
 <label for="active_after">Send only after</label>
 <input type='text' class="expiration-date" name="active_after" value="{{ email.active_after|datetime("%Y-%m-%d") }}"/>
-and <label for="active_after">don't send after</label>
+and <label for="active_before">don't send after</label>
 <input type='text' class="expiration-date" name="active_before" value="{{ email.active_before|datetime("%Y-%m-%d") }}"/>
     
 <input type="submit" value="Update Send Date(s)" class="btn btn-sm btn-warning"/>


### PR DESCRIPTION
Also improves several things about email fixtures, including:
- Letting you actually override the email dates (I think this never worked and it became more obvious once we started reconciling fixtures on page load)
- Adding hacky support for actually keeping email date updates between server restarts
- Skipping a lengthy DB call for reconcile_fixtures when it's used while loading the pending emails page
- Only reloading templates if they're not already set in a fixture -- this should be okay because Jinja can only consume new templates on a server restart anyway, and we check the fixture (which starts blank) rather than the DB