### PR TITLE
Allow updating email dates through code

### DIFF
--- a/alembic/versions/9168e926974e_add_tracking_fixture_changes_to_.py
+++ b/alembic/versions/9168e926974e_add_tracking_fixture_changes_to_.py
@@ -1,0 +1,59 @@
+"""Add tracking fixture changes to automated emails
+
+Revision ID: 9168e926974e
+Revises: e4a1d20d687b
+Create Date: 2024-03-15 23:27:27.119664
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '9168e926974e'
+down_revision = 'e4a1d20d687b'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('automated_email', sa.Column('revert_changes', postgresql.JSONB(astext_type=sa.Text()), server_default='{}', nullable=False))
+
+
+def downgrade():
+    op.drop_column('automated_email', 'revert_changes')

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -421,12 +421,13 @@ if c.DEALER_REG_START:
         needs_approval=True,
         ident='dealer_reg_approved')
 
-    MarketplaceEmailFixture(
-        'Please complete your {} {}!'.format(c.EVENT_NAME, c.DEALER_APP_TERM.capitalize()),
-        'dealers/signnow_request.html',
-        lambda g: g.status == c.APPROVED and c.SIGNNOW_DEALER_TEMPLATE_ID and not g.signnow_document_signed,
-        needs_approval=True,
-        ident='dealer_signnow_email')
+    if c.SIGNNOW_DEALER_TEMPLATE_ID:
+        MarketplaceEmailFixture(
+            'Please complete your {} {}!'.format(c.EVENT_NAME, c.DEALER_APP_TERM.capitalize()),
+            'dealers/signnow_request.html',
+            lambda g: g.status == c.APPROVED and c.SIGNNOW_DEALER_TEMPLATE_ID and not g.signnow_document_signed,
+            needs_approval=True,
+            ident='dealer_signnow_email')
 
     MarketplaceEmailFixture(
         'Reminder to pay for your {} {}'.format(c.EVENT_NAME, c.DEALER_REG_TERM.capitalize()),
@@ -436,6 +437,7 @@ if c.DEALER_REG_START:
         #     Group.status == c.APPROVED,
         #     Group.approved < (func.now() - timedelta(days=30)),
         #     Group.is_unpaid == True),
+        when=days_before(60, c.DEALER_PAYMENT_DUE, 7),
         needs_approval=True,
         ident='dealer_reg_payment_reminder')
 

--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -7,7 +7,9 @@ from pockets.autolog import log
 from pytz import UTC
 from residue import CoerceUTF8 as UnicodeText, UTCDateTime, UUID
 from sqlalchemy import func, or_, select, update
+from sqlalchemy.dialects.postgresql.json import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import ForeignKey
 from sqlalchemy.types import Boolean, Integer
@@ -79,6 +81,7 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
 
     active_after = Column(UTCDateTime, nullable=True, default=None)
     active_before = Column(UTCDateTime, nullable=True, default=None)
+    revert_changes = Column(MutableDict.as_mutable(JSONB), default={})
 
     emails = relationship('Email', backref='automated_email', order_by='Email.id')
 
@@ -128,14 +131,41 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
         
         kwargs.pop('csrf_token', None)
 
+        automated_email = session.query(AutomatedEmail).filter_by(ident=ident).first() or AutomatedEmail()
         for key, val in kwargs.items():
             if not hasattr(fixture, key):
                 log.debug(f"We tried to update fixture ident {ident} with parameter {key}, "
                           f"but there's no attribute named {key}!")
-            else:
+            elif getattr(fixture, key) != val and (getattr(fixture, key) or val):
+                if key not in automated_email.revert_changes:
+                    automated_email.revert_changes[key] = getattr(fixture, key)
                 setattr(fixture, key, val)
 
+        updated_email = automated_email.reconcile(fixture)
+        session.add(updated_email)
+        session.commit()
+
+        # Check to see if any properties got changed back to their original value
+        listed_changes = updated_email.revert_changes.copy()
+        for key in listed_changes:
+            if getattr(updated_email, key) == updated_email.revert_changes[key] or (
+                    not getattr(updated_email, key) and not updated_email.revert_changes[key]):
+                updated_email.revert_changes.pop(key)
+        session.add(updated_email)
+    
+    @staticmethod
+    def reset_fixture_attr(session, ident, key):
+        fixture = AutomatedEmail._fixtures.get(ident, None)
+        if not fixture:
+            log.error(f"We tried to update fixture ident {ident}, but it wasn't in our list of email fixtures!")
+            return
+        
         automated_email = session.query(AutomatedEmail).filter_by(ident=ident).first() or AutomatedEmail()
+        revert_val = automated_email.revert_changes.get(key, None)
+
+        setattr(fixture, key, revert_val)
+        automated_email.revert_changes.pop(key, None)
+
         session.add(automated_email.reconcile(fixture))
 
     @staticmethod
@@ -146,11 +176,9 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
                 automated_email = session.query(AutomatedEmail).filter_by(ident=ident).first() or AutomatedEmail()
 
                 if automated_email:
-                    # Load certain changes from DB to avoid blowing away dynamic updates
-                    # This should be refactored into something more robust if we need to expand it
-                    for key in ['active_after', 'active_before']:
-                        if getattr(automated_email, key, '') != getattr(fixture, key, ''):
-                            AutomatedEmail.update_fixture(session, ident, **{key: getattr(automated_email, key, '')})
+                    # Load changes from DB to avoid blowing away dynamic updates
+                    for key in automated_email.revert_changes:
+                        AutomatedEmail.update_fixture(session, ident, **{key: getattr(automated_email, key, '')})
 
                 # Load plugin overrides
                 for ident, key, val in AutomatedEmail.email_overrides:

--- a/uber/site_sections/email_admin.py
+++ b/uber/site_sections/email_admin.py
@@ -86,6 +86,11 @@ class Root:
         AutomatedEmail.update_fixture(session, ident, **params)
         raise HTTPRedirect('pending_examples?ident={}&message={}', ident, 'Email send dates updated')
 
+    def reset_fixture_attr(self, session, ident, key):
+        AutomatedEmail.reset_fixture_attr(session, ident, key)
+        raise HTTPRedirect('pending_examples?ident={}&message={}',
+                           ident, f'{key} has been reset to its original value')
+
     def test_email(self, session, subject=None, body=None, from_address=None, to_address=None, **params):
         """
         Testing only: send a test email as a system user

--- a/uber/templates/email_admin/pending_examples.html
+++ b/uber/templates/email_admin/pending_examples.html
@@ -3,65 +3,91 @@
 {% block content %}
 
 <div class="card">
-<h2>{{ (examples|default([(None, email)], True)|first).1.subject }}</h2>
-<div class="center">
-  <a href="pending">Return to pending email list</a>
-</div>
-<br>
-{% if not email.active_when_label %}
-{% set active_when_text = "It will be sent as soon as it's approved." if email.needs_approval else "" %}
-{% else %}
-{% set active_when_text = "It will be sent " + email.active_when_label + "." %}
-{% endif %}
-{% if not email.needs_approval %}
-    This email is pre-approved. {{ active_when_text }}<br/><br/>
-{% else %}
-    {% if not email.approved %}
-        <form method="post" action="approve">
-        {{ csrf_token() }}
-        This email is currently <b>unapproved</b>. {{ active_when_text }}
-        <input type="hidden" name="ident" value="{{ email.ident }}" />
-        <input type="submit" value="Approve" class="btn btn-sm btn-success"/>
-        </form>
-    {% else %}
-        <form method="post" action="unapprove">
-        {{ csrf_token() }}
-        This email is currently <b>approved</b>. {{ active_when_text }}
-        <input type="hidden" name="ident" value="{{ email.ident }}" />
-        <input type="submit" value="Undo Approval" class="btn btn-sm btn-warning"/>
-        </form>
-    {% endif %}<br/>
-{% endif %}
+  <div class="card-body">
+    <p><a href="pending">Return to pending email list</a></p>
 
-<form method="post" action="update_dates">
-{{ csrf_token() }}
-<input type="hidden" name="ident" value="{{ email.ident }}" />
+    <h2>{{ (examples|default([(None, email)], True)|first).1.subject }}</h2>
+  
+    <p>
+      {% if not email.active_when_label %}
+      {% set active_when_text = "It will be sent as soon as it's approved." if email.needs_approval else "" %}
+      {% else %}
+      {% set active_when_text = "It will be sent " + email.active_when_label + "." %}
+      {% endif %}
+      {% if not email.needs_approval %}
+          This email is pre-approved. {{ active_when_text }}
+      {% else %}
+          {% if not email.approved %}
+              <form method="post" action="approve">
+              {{ csrf_token() }}
+              This email is currently <b>unapproved</b>. {{ active_when_text }}
+              <input type="hidden" name="ident" value="{{ email.ident }}" />
+              <input type="submit" value="Approve" class="btn btn-sm btn-success"/>
+              </form>
+          {% else %}
+              <form method="post" action="unapprove">
+              {{ csrf_token() }}
+              This email is currently <b>approved</b>. {{ active_when_text }}
+              <input type="hidden" name="ident" value="{{ email.ident }}" />
+              <input type="submit" value="Undo Approval" class="btn btn-sm btn-warning"/>
+              </form>
+          {% endif %}
+      {% endif %}
+    </p>
 
-<label for="active_after">Send only after</label>
-<input type='text' class="expiration-date" name="active_after" value="{{ email.active_after|datetime("%Y-%m-%d") }}"/>
-and <label for="active_before">don't send after</label>
-<input type='text' class="expiration-date" name="active_before" value="{{ email.active_before|datetime("%Y-%m-%d") }}"/>
-    
-<input type="submit" value="Update Send Date(s)" class="btn btn-sm btn-warning"/>
-</form><br/>
+    <form method="post" action="update_dates">
+    {{ csrf_token() }}
+    <input type="hidden" name="ident" value="{{ email.ident }}" />
 
-{% if email.unapproved_count > 0 %}
-  There are {{ email.unapproved_count }} copies of this email that will be sent once it's approved.
-{% else %}
-  There are no unsent copies of this email waiting to be approved.
-{% endif %} (note: this is updated approximately every {{ '5' if c.DEV_BOX else '15' }} minutes)<br/><br/>
+    <label for="active_after">Send only after</label>
+    <input type='text' class="expiration-date" name="active_after" value="{{ email.active_after|datetime("%Y-%m-%d") }}"/>
+    and <label for="active_before">don't send after</label>
+    <input type='text' class="expiration-date" name="active_before" value="{{ email.active_before|datetime("%Y-%m-%d") }}"/>
+        
+    <input type="submit" value="Update Send Date(s)" class="btn btn-sm btn-warning"/>
+    </form><br/>
 
-{% if examples %}
-  The following are some examples of this email looks like when sent:
-  {% for model, example in examples %}
-    <h3>To: {{ model|form_link }} ({{ example.to|readable_join }})</h3>
-    {{ macros.preview_email(example) }}
-  {% endfor %}
-{% else %}
-  We couldn't find recipients matching the email criteria in a random sample of 1000 possible recipients.<br><br>
-  Here's what the template looks like though:<br>
-  {{ macros.preview_email(email) }}
-{% endif %}
+    {% for key, val in email.revert_changes.items() %}
+      {% if loop.first %}
+        <p>This email has had the following properties updated:
+          <table class="table table-bordered table-hover">
+            <thead>
+              <th>Property</th>
+              <th>New Value</th>
+              <th>Old Value</th>
+              <th></th>
+            </thead>
+      {% endif %}
+      <tr>
+        <td>{{ key }}</td><td>{{ email|attr(key) }}</td><td>{{ val }}</td>
+        <td><a href="reset_fixture_attr?ident={{ email.ident }}&key={{ key }}" class="btn btn-warning">Revert</a></td>
+      </tr>
+      {% if loop.last %}
+          </table>
+        </p>
+      {% endif %}
+    {% endfor %}
+
+    <p>
+      {% if email.unapproved_count > 0 %}
+        There are {{ email.unapproved_count }} copies of this email that will be sent once it's approved.
+      {% else %}
+        There are no unsent copies of this email waiting to be approved.
+      {% endif %} (note: this is updated approximately every {{ '5' if c.DEV_BOX else '15' }} minutes)
+    </p>
+
+  {% if examples %}
+    The following are some examples of this email looks like when sent:
+    {% for model, example in examples %}
+      <h3>To: {{ model|form_link }} ({{ example.to|readable_join }})</h3>
+      {{ macros.preview_email(example) }}
+    {% endfor %}
+  {% else %}
+    <p>We couldn't find recipients matching the email criteria in a random sample of 1000 possible recipients.</p>
+    <p>Here's what the template looks like though:<br>
+    {{ macros.preview_email(email) }}</p>
+  {% endif %}
+  </div>
 </div>
 
 


### PR DESCRIPTION
The previous change made it so that code updates to email dates NEVER worked. We now track which dates have been changed to avoid that. We also show admins a list of changes on each email and allow them to revert those changes back to the default.