### PR TITLE
Add in-page warnings for duplicate and banned attendees

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -164,6 +164,21 @@ class Root:
         if all_errors:
             return {"error": all_errors}
 
+        if attendee.is_new:
+            for form in forms.values():
+                form.populate_obj(attendee, is_admin=True)
+
+            if attendee.banned:
+                return {"warning": render('registration/banned.html', {'attendee': attendee,
+                                                                       'session': session}, encoding=None)}
+
+            old = session.valid_attendees().filter_by(first_name=attendee.first_name,
+                                                      last_name=attendee.last_name,
+                                                      email=attendee.email).first()
+            if old:
+                return {"warning": render('registration/duplicate.html', {'attendee': old}, encoding=None),
+                        "button_text": "Yes, I'm sure this is someone else!"}
+
         return {"success": True}
 
     @ajax
@@ -208,14 +223,6 @@ class Root:
             message = save_attendee(session, attendee, params)
 
             if not message:
-                if attendee.is_new and \
-                        session.attendees_with_badges().filter_by(first_name=attendee.first_name,
-                                                                  last_name=attendee.last_name,
-                                                                  email=attendee.email).count():
-                    session.add(attendee)
-                    session.commit()
-                    raise HTTPRedirect('duplicate?id={}&return_to={}', attendee.id, return_to or 'index')
-
                 message = '{} has been saved.'.format(attendee.full_name)
                 stay_on_form = params.get('save_return_to_search', False) is False
                 session.add(attendee)
@@ -486,13 +493,6 @@ class Root:
                 or_(and_(Tracking.links.like('%attendee({})%'.format(id))),
                     and_(Tracking.model == 'Attendee', Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'pageviews': session.query(PageViewTracking).filter(PageViewTracking.which == repr(attendee))
-        }
-
-    def duplicate(self, session, id, return_to='index'):
-        attendee = session.attendee(id)
-        return {
-            'attendee': attendee,
-            'return_to': return_to
         }
 
     def delete(self, session, id, return_to='index?', return_msg=False, **params):
@@ -1404,13 +1404,6 @@ class Root:
 
         if cherrypy.request.method == 'POST':
             message = save_attendee(session, attendee, params)
-
-        if not message:
-            if attendee.is_new and \
-                    session.attendees_with_badges().filter_by(first_name=attendee.first_name,
-                                                              last_name=attendee.last_name,
-                                                              email=attendee.email).count():
-                message = 'An attendee with this name and email address already exists.'
 
         if not message:
             success = True

--- a/uber/site_sections/security_admin.py
+++ b/uber/site_sections/security_admin.py
@@ -37,12 +37,15 @@ class Root:
             changed_attendees = 0
 
             if not message:
+                entry_pii_updated = entry.is_new or any(
+                    [entry.orig_value_of(attr) != getattr(entry, attr) for attr in ['first_names', 'last_name',
+                                                                                    'email', 'birthdate']])
                 session.add(entry)
                 session.commit()
 
                 if entry.active:
                     for attendee in entry.attendee_guesses:
-                        if attendee.badge_status == c.NEW_STATUS:
+                        if entry_pii_updated and attendee.is_valid and attendee.badge_status != c.WATCHED_STATUS:
                             attendee.badge_status = c.WATCHED_STATUS
                             changed_attendees += 1
                             session.add(attendee)

--- a/uber/templates/accounts/index.html
+++ b/uber/templates/accounts/index.html
@@ -13,7 +13,7 @@ table form {
     <span class="card-title">New Account</span>
   </div>
   <div class="card-body">
-    <form id="new_admin" method="post" action="update" onsubmit="return check_passwords()" role="form">
+    <form id="new_admin" method="post" action="update" {% if c.AT_OR_POST_CON %}onsubmit="return check_passwords()" {% endif %}role="form">
       <input type="hidden" name="id" value="None" />
       {{ csrf_token() }}
       <div class="row mb-sm-2">
@@ -111,6 +111,7 @@ table form {
 </div>
 
 <script>
+{% if c.AT_OR_POST_CON %}
 function check_passwords() {
     if (document.getElementById("password").value != document.getElementById("check-password").value) {
         alert("Passwords must match");
@@ -118,6 +119,7 @@ function check_passwords() {
     }
     return true;
 }
+{% endif %}
 
 $(document).ready(function() {
     $('table').on('click', '.delete-button', function (event) {

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -215,6 +215,13 @@
             return false;
         };
 
+        let serverValidationPassed;
+        resetServerValidation = function() {
+            if (serverValidationPassed !== undefined) {
+                serverValidationPassed = false;
+            }
+        }
+
         $(function() {
             {% if c.PRE_CON and c.SLOW_LOAD_CHECK %}
             $(window).on('load', function() {
@@ -536,11 +543,14 @@
         <![endif]-->
       <script type="text/javascript">
           $(window).on("runJavaScript", function() {
-              $('.form-control-static').each(function(index) {
-                  if($( this ).text().trim() == '' && $(this).is(":visible")) {
-                      $(this).parents('.form-group').hide();
-                  }
-              })
+            $('.form-control-static').each(function(index) {
+                if($( this ).text().trim() == '' && $(this).is(":visible")) {
+                    $(this).parents('.form-group').hide();
+                }
+            })
+            $(':input').on('change', resetServerValidation);
+            $(':textarea').on('change', resetServerValidation);
+            $(':select').on('change', resetServerValidation);
           });
       </script>
       {% if admin_area %}

--- a/uber/templates/forms/macros.html
+++ b/uber/templates/forms/macros.html
@@ -347,7 +347,7 @@
 <div class="alert" role="alert" id="form-validations-{{ form_id }}"><span></span></div>
 
 <script type="text/javascript">
-  var serverValidationPassed = false;
+  serverValidationPassed = false;
   
   var runServerValidations_{{ form_id|replace('-','_') }} = function($form, submit_button_name) {
     var form_list = {{ form_list|safe }}.join(',')
@@ -361,31 +361,46 @@
         $(this).removeClass('is-invalid');
         $("#" + field_id + "-validation").hide();
       });
-      if (response.error) {
-        $("#form-validations-{{ form_id }}").addClass("alert-danger").children('span').html(
-          "Please correct the following errors:" +
-          "<ul></ul>"
+      if (response.warning) {
+        let buttonText = response.button_text ? response.button_text : 'I understand, please continue!';
+        $("#form-validations-{{ form_id }}").addClass("alert-warning").children('span').html(
+          response.warning +
+          "<button form='{{ form_id }}' class='btn btn-primary' name='"+ submit_button_name +"'>" +
+            buttonText +
+          "</button>"
           );
-        $.each(response.error, function(key, val) {
-          val = val.join(" ");
-          if ($("#" + key).length != 0 && $("#" + key).attr('type') != 'checkbox') {
-            var field_label = $("label[for='" + key + "'] .form-label").text();
-            if (field_label == '') { field_label = $("#" + key).children("legend").children(".form-label").text(); }
-            if (field_label == '') {
-              $("#form-validations-{{ form_id }}").find("ul").append("<li>" + val + "</li>");
-            } else {
-              $("#form-validations-{{ form_id }}").find("ul").append("<li>" + field_label + ": " + val + "</li>");
-              $("#" + key).addClass("is-invalid");
-            }
+        $("#form-validations-{{ form_id }}").show();
+        $('html, body').animate({scrollTop: $("#form-validations-{{ form_id }}").offset().top}, 50);
+        serverValidationPassed = true;
+      } else if (response.error) {
+          if (typeof response.error === "string") {
+            $("#form-validations-{{ form_id }}").addClass("alert-danger").children('span').html(response.error);
           } else {
-            $("#form-validations-{{ form_id }}").find("ul").append("<li>" + val + "</li>");
-          }
+            $("#form-validations-{{ form_id }}").addClass("alert-danger").children('span').html(
+              "Please correct the following errors:" +
+              "<ul></ul>"
+            );
+            $.each(response.error, function(key, val) {
+              val = val.join(" ");
+              if ($("#" + key).length != 0 && $("#" + key).attr('type') != 'checkbox') {
+                var field_label = $("label[for='" + key + "'] .form-label").text();
+                if (field_label == '') { field_label = $("#" + key).children("legend").children(".form-label").text(); }
+                if (field_label == '') {
+                  $("#form-validations-{{ form_id }}").find("ul").append("<li>" + val + "</li>");
+                } else {
+                  $("#form-validations-{{ form_id }}").find("ul").append("<li>" + field_label + ": " + val + "</li>");
+                  $("#" + key).addClass("is-invalid");
+                }
+              } else {
+                $("#form-validations-{{ form_id }}").find("ul").append("<li>" + val + "</li>");
+              }
 
-          if ($("#" + key + "-validation").length != 0)
-          {
-            $("#" + key + "-validation").html(val).show();
+              if ($("#" + key + "-validation").length != 0)
+              {
+                $("#" + key + "-validation").html(val).show();
+              }
+            });
           }
-        });
         $("#form-validations-{{ form_id }}").show();
         $('html, body').animate({scrollTop: $("#form-validations-{{ form_id }}").offset().top}, 50);
       } else {
@@ -412,24 +427,28 @@
 {%- endmacro %}
 
 {% macro submit_validation_and_disclaimer(form_id, include_disclaimers_modal=false, callback='') %}
-$("#{{ form_id }}").submit(function (event) { 
-    if(!serverValidationPassed) {
-      if (event.originalEvent !== undefined) {
-        runServerValidations_{{ form_id|replace('-','_') }}($(this), event.originalEvent.submitter.name);
-      } else {
-        runServerValidations_{{ form_id|replace('-','_') }}($(this), '');
-      }
+$("#{{ form_id }}").submit(function (event) {
+  let submit_button_name = '';
+  if (event.originalEvent !== undefined) {
+    submit_button_name = event.originalEvent.submitter.name;
+  }
+
+  if(!serverValidationPassed) {
+    event.preventDefault();
+    runServerValidations_{{ form_id|replace('-','_') }}($(this), submit_button_name);
+    return false;
+  }
+  {% if include_disclaimers_modal %}
+    if(!disclaimersConfirmed) {
+      event.preventDefault();
+      openDisclaimersModal();
       return false;
     }
-    {% if include_disclaimers_modal %}
-      if(!disclaimersConfirmed) {
-          openDisclaimersModal();
-          return false;
-      }
-    {% endif %}
-    {% if callback %}
-      {{ callback|safe }};
-      return false;
-    {% endif %}
+  {% endif %}
+  {% if callback %}
+    event.preventDefault();
+    {{ callback|safe }};
+    return false;
+  {% endif %}
 });
 {%- endmacro %}

--- a/uber/templates/registration/banned.html
+++ b/uber/templates/registration/banned.html
@@ -1,0 +1,26 @@
+
+<p class="text-center h4">This attendee may been banned from {{ c.EVENT_NAME }}!</p>
+
+<p>
+    {{ attendee.full_name }}'s' information matches at least one entry on our watchlist{% if c.HAS_SECURITY_ADMIN_ACCESS %}:
+    <ul>
+    {% for entry in session.guess_attendee_watchentry(attendee) %}
+        <li>
+            <a href="../security_admin/watchlist_form?id={{ entry.id }}" target="_blank">{{ entry.full_name }}</a>
+            {% if entry.email or entry.birthdate %}
+            ({{ entry.email }}{{' ' if entry.email and entry.birthdate else ''}}{{ entry.birthdate|default('', true) }})
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+    {% else %}.{% endif %}
+</p>
+
+<p>
+    Please only proceed if you are sure this person has not been banned from the event. If you proceed,
+    Registration and Safety/Security will receive an email and will check and confirm whether or not 
+    this is the same person as the one on the watchlist. If this attendee is cleared, they will then 
+    receive any relevant emails to claim their badge.
+</p>
+
+<p>If you are at all not sure what to do, contact your Safety/Security department at {{ c.SECURITY_EMAIL|email_only|email_to_link }}.</p>

--- a/uber/templates/registration/duplicate.html
+++ b/uber/templates/registration/duplicate.html
@@ -1,59 +1,33 @@
-{% extends "base.html" %}{% set admin_area=True %}
-{% block title %}That attendee already has a badge{% endblock %}
-{% block content %}
-<div class="card">
-    <div class="card-body">
-    <h2>This attendee already has a badge!</h2>
+<p class="text-center h4">This attendee already has a badge!</p>
 
-      We already have a <a href="form?id={{ attendee.id }}">{{ attendee.full_name }}</a> with email address {{ attendee.email }} in our database with a
-    {% if attendee.paid == c.PAID_BY_GROUP and attendee.group.status == c.WAITLISTED %}
-        waitlisted
-    {% elif attendee.paid == c.HAS_PAID or attendee.paid == c.PAID_BY_GROUP %}
-        paid
-    {% elif attendee.paid == c.NEED_NOT_PAY %}
-        complementary
-    {% elif attendee.paid == c.NOT_PAID %}
-        unpaid
-    {% else %}
-        {{ attendee.paid_label }}
-    {% endif %}
-    {{ attendee.badge_type_label }}
-    {% if attendee.ribbon %}
-        ({{ attendee.ribbon_labels|join(", ") }})
-    {% endif %}
-    badge{% if attendee.group %}
-        (with the group <a href="./group/form?id={{ attendee.group.id }}">{{ attendee.group.name }}</a>)
-    {% endif %}.
+<p>
+    We already have a <a href="form?id={{ attendee.id }}">{{ attendee.full_name }}</a> with email address {{ attendee.email }} in our database with a
+{% if attendee.paid == c.PAID_BY_GROUP and attendee.group.is_dealer and attendee.group.status != c.APPROVED %}
+    {{ attendee.group.status_label }}
+{% elif attendee.paid == c.HAS_PAID or attendee.paid == c.PAID_BY_GROUP %}
+    paid
+{% elif attendee.paid == c.NEED_NOT_PAY %}
+    complimentary
+{% elif attendee.paid == c.NOT_PAID %}
+    unpaid
+{% else %}
+    {{ attendee.paid_label }}
+{% endif %}
+{{ attendee.badge_type_label }}
+{% if attendee.ribbon %}
+    ({{ attendee.ribbon_labels|join(", ") }})
+{% endif %}
+badge{% if attendee.group %}
+    (with the group <a href="./group/form?id={{ attendee.group.id }}">{{ attendee.group.name }}</a>)
+{%- endif -%}.
+</p>
 
-    <br/> <br/>
+<p>If you're <strong>absolutely</strong> sure that this is someone else, please confirm this. We highly recommend
+editing the attendee's name if at all possible, as badges with duplicate names may be picked up by the wrong
+person.
+{% if attendee.paid == c.PAID_BY_GROUP and attendee.group.status == c.WAITLISTED %}
+    Please keep in mind that {{ c.DEALER_TERM }}s have an option to buy their badge once the {{ c.DEALER_LOC_TERM }} fills up, so you
+    normally do not need to create an additional badge for them.
+{% endif %}</p>
 
-    If you're <strong>absolutely</strong> sure that this is someone else, please confirm this. We highly recommend
-    editing the attendee's name if at all possible, as badges with duplicate names may be picked up by the wrong
-    person.
-    {% if attendee.paid == c.PAID_BY_GROUP and attendee.group.status == c.WAITLISTED %}
-        Please keep in mind that {{ c.DEALER_TERM }}s have an option to buy their badge once the {{ c.DEALER_LOC_TERM }} fills up, so you
-        normally do not need to create an additional badge for them.
-    {% endif %}
-    If you are at all not sure what to do, contact your Registration department at {{ c.REGDESK_EMAIL }}.
-
-    <br/> <br/>
-
-    <table style="width:auto" align="center">
-    <tr>
-        <td><a class="btn btn-outline-secondary" href="{{ return_to }}">Yes, I'm sure this is someone else!</a></td>
-        <td> &nbsp;&nbsp;&nbsp;&nbsp; </td>
-        <td><a class="btn btn-primary" href="form?id={{ attendee.id }}">Maybe, let me see the created badge again!</a></td>
-        <td> &nbsp;&nbsp;&nbsp;&nbsp; </td>
-        <td>
-            <form method="post" action="delete">
-            <input type="hidden" name="id" value="{{ attendee.id }}"/>
-            {{ csrf_token() }}
-            <button class="btn btn-danger" type="submit">Whoops, delete the new badge!</button>
-            </form>
-        </td>
-    </tr>
-    </table>
-    </div>
-</div>
-
-{% endblock %}
+<p>If you are at all not sure what to do, contact your Registration department at {{ c.REGDESK_EMAIL|email_only|email_to_link }}.</p>

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -179,9 +179,7 @@
 <div class="col-12 col-lg-10">
 <a id="badge_flags"></a>
 {% include "forms/attendee/admin_badge_flags.html" %}
-{% if not attendee.is_new %}
 <button type="submit" class="btn btn-primary" value="Upload">Save</button>
-{% endif %}
 <hr/>
 <a id="personal_info"></a>
 {% include "forms/attendee/personal_info.html" %}


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-468 by extending our validations to allow warnings, which will mark validations as having passed and therefore let the user continue submitting the form after they read the warning. Also fixes our error messaging system to be able to handle string errors, a problem that plagued us continuously last year by silencing various errors from the server (including CSRF token errors).