### PR TITLE
Don't kill instance if celery is disabled

### DIFF
--- a/uber/site_sections/devtools.py
+++ b/uber/site_sections/devtools.py
@@ -221,10 +221,15 @@ class Root:
         session.execute(text('SELECT 1'))
         db_read_time += time.perf_counter()
 
-        payload = random.randrange(1024)
-        task_run_time = -time.perf_counter()
-        response = ping.delay(payload).wait(timeout=2)
-        task_run_time += time.perf_counter()
+        if os.environ.get("ENABLE_CELERY", "true").lower() == "true":
+            payload = random.randrange(1024)
+            task_run_time = -time.perf_counter()
+            response = ping.delay(payload).wait(timeout=2)
+            task_run_time += time.perf_counter()
+        else:
+            task_run_time = 0
+            payload = "Not Run, ENABLE_CELERY != true"
+            response = "Not Run, ENABLE_CELERY != true"
 
         return json.dumps({
             'server_current_timestamp': int(datetime.utcnow().timestamp()),


### PR DESCRIPTION
Currently we end up in a loop of killing container instances if celery is not enabled. This isn't a health issue with the instance,  so we should check for that and report health anyways.