### PR TITLE
Stop unsetting volunteer interests on paid_preregistrations

### DIFF
--- a/uber/payments.py
+++ b/uber/payments.py
@@ -345,8 +345,8 @@ class TransactionRequest:
                 intent_id=intent_id
             )
         else:
-            log.debug('Transaction {self.tracking_id}: creating Stripe Intent to charge {} cents for {}',
-                      self.amount, self.description)
+            log.debug(f'Transaction {self.tracking_id}: creating Stripe Intent to charge '
+                      f'{self.amount} cents for {self.description}')
 
             return stripe.PaymentIntent.create(
                 payment_method_types=['card'],


### PR DESCRIPTION
We were merging the prereg cart with the attendees we just made when we loaded this page, which was silently deleting all their department requests. I have no idea how long this was broken.

Also fixes a silent 500 error when trying to log data for Stripe requests.