### PR TITLE
Fix display bugs on ratings overview page

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1994,7 +1994,7 @@ class Attendee(MagModel, TakesPaymentMixin):
                 'rating': shift.rating_label,
                 'comment': shift.comment,
                 'job': {
-                    'location': shift.job.location_label,
+                    'location': shift.job.department_name,
                     'name': shift.job.name,
                     'weight': shift.job.weight,
                     'when': (

--- a/uber/templates/staffing_reports/ratings.html
+++ b/uber/templates/staffing_reports/ratings.html
@@ -18,9 +18,9 @@
     </tr>
     {% for shift in attendee.shifts %}
         <tr>
-            <td><nobr>{{ shift.job.name }} ({{ shift.job.location_label }})</nobr></td>
+            <td><nobr>{{ shift.job.name }} ({{ shift.job.department_name }})</nobr></td>
             <td>{{ shift.job.timespan() }}</td>
-            <td><nobr>x{{ shift.job.weight }} ({{ shift.job.total_hours }} hours total)</nobr></td>
+            <td><nobr>x{{ shift.job.weight }} ({{ shift.job.weighted_hours }} hours total)</nobr></td>
             <td>{{ shift.worked_label }}</td>
             <td>
                 {{ shift.rating_label }}


### PR DESCRIPTION
This page was showing the total hours for a job (the job's actual length multiplied by how many slots the job had), which is not what we want in this context. Also fixes references to "location_label," which was removed from jobs long ago as part of moving departments into the DB