### PR TITLE
Fix updating before/after dates on pending emails

### DIFF
--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -277,6 +277,12 @@ class OtherInfo(MagForm):
             return list(self._fields.keys())
 
         return locked_fields
+    
+    def promo_code_code_label(self):
+        if c.GROUPS_ENABLED:
+            return 'Group or Promo Code'
+        else:
+            return 'Promo Code'
 
     @new_or_changed_validation.promo_code_code
     def promo_code_valid(form, field):

--- a/uber/payments.py
+++ b/uber/payments.py
@@ -465,7 +465,7 @@ class TransactionRequest:
         refund_amount = self.amount or txn.amount_left
 
         log.debug('REFUND: attempting to refund card transaction with ID {} {} cents for {}',
-                  txn.stripe_id, refund_amount, txn.desc)
+                  txn.stripe_id, str(refund_amount), txn.desc)
 
         message = self.stripe_or_authnet_refund(txn, int(refund_amount))
         if message:
@@ -1034,7 +1034,7 @@ class SpinTerminalRequest(TransactionRequest):
                     "Please set your workstation number and try again.")
 
         log.debug('REFUND: attempting to refund card transaction with ID {} {} cents for {}',
-                  txn.stripe_id, refund_amount, txn.desc)
+                  txn.stripe_id, str(refund_amount), txn.desc)
 
         self.tracker = TxnRequestTracking(workstation_num=cherrypy.session.get('reg_station', '0'),
                                           terminal_id=self.terminal_id, who=AdminAccount.admin_name())

--- a/uber/templates/forms/group.html
+++ b/uber/templates/forms/group.html
@@ -111,7 +111,7 @@
   {% elif group.status == c.CANCELLED %}
     <div class="alert alert-info pb-0" role="alert">
       <p>You have <strong>cancelled</strong> your {{ c.DEALER_APP_TERM }}. If this was a mistake, please contact us at
-      <a href="mailto:{{ c.MARKETPLACE_EMAIL }}">{{ c.MARKETPLACE_EMAIL }}</a>.</p>
+      {{ c.MARKETPLACE_EMAIL|email_only|email_to_link }}.</p>
     </div>
   {% else %}
     <div class="alert alert-{{ 'danger' if group.status == c.DECLINED else 'warning' }} pb-0" role="alert">


### PR DESCRIPTION
Fixes a bug where you couldn't change the send dates of an email that already had them because it couldn't save the original value in a JSON column. Also includes a few minor updates: the promo code field is now labelled "Group or Promo Code" if groups are enabled, and a bug with debug logging transaction is also fixed.