### PR TITLE
Add ability to read minutes for date configs

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -181,7 +181,10 @@ class _Overridable:
             if not _val:
                 _dt = None
             elif ' ' in _val:
-                _dt = self.EVENT_TIMEZONE.localize(datetime.strptime(_val, '%Y-%m-%d %H'))
+                if ':' in _val:
+                    _dt = self.EVENT_TIMEZONE.localize(datetime.strptime(_val, '%Y-%m-%d %H:%M'))
+                else:
+                    _dt = self.EVENT_TIMEZONE.localize(datetime.strptime(_val, '%Y-%m-%d %H'))
             else:
                 _dt = self.EVENT_TIMEZONE.localize(datetime.strptime(_val + ' 23:59', '%Y-%m-%d %H:%M'))
             setattr(self, _opt.upper(), _dt)

--- a/uber/models/panels.py
+++ b/uber/models/panels.py
@@ -141,6 +141,11 @@ class PanelApplication(MagModel):
         if self.event:
             self.event.name = self.name
             self.event.description = self.description
+    
+    @presave_adjustment
+    def set_default_dept(self):
+        if len(c.PANEL_DEPT_OPTS) <= 1 and not self.department:
+            self.department = c.PANELS
 
     @property
     def email(self):

--- a/uber/templates/group_admin/form.html
+++ b/uber/templates/group_admin/form.html
@@ -160,7 +160,7 @@
             {% if attendee == group.leader %}
               N/A
             {% elif not attendee.is_unassigned and not attendee.cannot_delete_badge_reason %}
-              <form method="post" action="../registration/delete_attendee" onSubmit="return confirm('Are you sure you want to unassign this badge?');">
+              <form method="post" action="../registration/delete" onSubmit="return confirm('Are you sure you want to unassign this badge?');">
                 {{ csrf_token() }}
                 <input type="hidden" name="id" value="{{ attendee.id }}" />
                 <input type="hidden" name="return_to" value="../group_admin/form?id={{ group.id }}" />


### PR DESCRIPTION
You can now set both hours and minutes for any date under [dates], which will let Super MAGFest dealer apps be open for half an hour. Also fixes a bug where submitting a panel app would throw a 500 error for certain event configs, and fixes the "unassign" button on the group admin form to use the right page handler.