### PR TITLE
Don't send generic claim email to first admins

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -490,7 +490,8 @@ class StopsEmailFixture(AutomatedEmailFixture):
 
 
 # TODO: Refactor all this into something less lazy
-def deferred_attendee_placeholder(a): return a.placeholder and (a.registered_local <= min(c.PREREG_OPEN, c.DEALER_REG_START)
+def deferred_attendee_placeholder(a): return a.placeholder and (a.registered_local <= min(c.PREREG_OPEN,
+                                                                                          c.DEALER_REG_START)
                                                                 and a.badge_type == c.ATTENDEE_BADGE
                                                                 and a.paid == c.NEED_NOT_PAY
                                                                 and "staff import".lower() not in a.admin_notes.lower()
@@ -520,10 +521,9 @@ def volunteer_placeholder(a): return a.placeholder and a.registered_local > c.PR
 
 # TODO: Add an email for MIVS judges, an email for non-Guest guest group badges,
 # and an email for group-leader-created badges
-def generic_placeholder(a): return a.placeholder and (c.AT_THE_CON or not deferred_attendee_placeholder(a)
-                                                      and not panelist_placeholder(a)
+def generic_placeholder(a): return a.placeholder and (c.AT_THE_CON or not panelist_placeholder(a)
                                                       and not guest_placeholder(a) and not dealer_placeholder(a)
-                                                      and not staff_import_placeholder(a)
+                                                      and a.registered_local > min(c.PREREG_OPEN, c.DEALER_REG_START)
                                                       and not volunteer_placeholder(a))
 
 


### PR DESCRIPTION
Our process for setting up the first admins in the system meant that, if I was too slow giving people admin accounts, they got the generic placeholder claim email. This is confusing, so now we don't send anyone the generic claim email if their badge was created before either dealer launch or prereg, whichever came first. This technically creates a hole in the claim email system but hopefully we aren't creating a ton of random badges before dealer/prereg launch.