### PR TITLE
Add expiration date for watchlist entries

### DIFF
--- a/alembic/versions/7c43e4352bb0_add_expiration_date_to_watchlist_entries.py
+++ b/alembic/versions/7c43e4352bb0_add_expiration_date_to_watchlist_entries.py
@@ -1,0 +1,59 @@
+"""Add expiration date to WatchList entries
+
+Revision ID: 7c43e4352bb0
+Revises: 2288360ee15d
+Create Date: 2024-05-03 19:56:25.359068
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '7c43e4352bb0'
+down_revision = '2288360ee15d'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('watch_list', sa.Column('expiration', sa.Date(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('watch_list', 'expiration')

--- a/uber/forms/__init__.py
+++ b/uber/forms/__init__.py
@@ -455,3 +455,4 @@ class DictWrapper(dict):
 
 from uber.forms.attendee import *  # noqa: F401,E402,F403
 from uber.forms.group import *  # noqa: F401,E402,F403
+from uber.forms.security import *  # noqa: F401,E402,F403

--- a/uber/forms/security.py
+++ b/uber/forms/security.py
@@ -1,0 +1,51 @@
+import cherrypy
+from datetime import date
+
+from markupsafe import Markup
+from wtforms import (BooleanField, DateField, DateTimeField, EmailField,
+                     HiddenField, SelectField, SelectMultipleField, IntegerField,
+                     StringField, TelField, validators, TextAreaField)
+from wtforms.validators import ValidationError, StopValidation
+
+from uber.config import c
+from uber.forms import (AddressForm, MultiCheckbox, MagForm, SelectAvailableField, SwitchInput, NumberInputGroup,
+                        HiddenBoolField, HiddenIntField, CustomValidation)
+from uber.custom_tags import popup_link
+from uber.badge_funcs import get_real_badge_type
+from uber.models import Attendee, Session, PromoCodeGroup
+from uber.model_checks import invalid_phone_number
+from uber.utils import get_age_conf_from_birthday
+
+
+__all__ = ['WatchListEntry']
+
+
+class WatchListEntry(MagForm):
+    field_validation, new_or_changed_validation = CustomValidation(), CustomValidation()
+
+    first_names = StringField('First Names', render_kw={'placeholder': 'Use commas to separate possible first names.'})
+    last_name = StringField('Last Name')
+    email = EmailField('Email Address', validators=[
+        validators.Optional(),
+        validators.Length(max=255, message="Email addresses cannot be longer than 255 characters."),
+        validators.Email(granular_message=True),
+        ],
+        render_kw={'placeholder': 'test@example.com'})
+    birthdate = DateField('Date of Birth', validators=[validators.Optional()])
+    reason = TextAreaField('Reason', validators=[
+        validators.DataRequired("Please enter the reason this attendee is on the watchlist."),
+        ])
+    action = TextAreaField('Action', validators=[
+        validators.DataRequired("Please describe what, if anything, an attendee should do before "
+                                "they can check in."),
+        ])
+    expiration = DateField('Expiration Date', validators=[validators.Optional()])
+    active = BooleanField('Automatically place matching attendees in the On Hold status.')
+
+    @field_validation.birthdate
+    def birthdate_format(form, field):
+        # TODO: Make WTForms use this message instead of the generic DateField invalid value message
+        if field.data and not isinstance(field.data, date):
+            raise StopValidation('Please use the format YYYY-MM-DD for the date of birth.')
+        elif field.data and field.data > date.today():
+            raise ValidationError('Attendees cannot be born in the future.')

--- a/uber/migration.py
+++ b/uber/migration.py
@@ -50,7 +50,8 @@ def get_plugin_head_revision(plugin_name):
     alembic_config = create_alembic_config()
     script = ScriptDirectory.from_config(alembic_config)
     branch_labels = script.get_revision(plugin_name).branch_labels
-    other_plugins = set(plugin_dirs.keys()).difference(branch_labels)
+    plugin_dirs = [x.name for x in (pathlib.Path(__file__).parents[1] / "plugins").iterdir() if x.is_dir()]
+    other_plugins = set(plugin_dirs).difference(branch_labels)
 
     def _recursive_get_head_revision(revision_text):
         revision = script.get_revision(revision_text)

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -12,6 +12,7 @@ To perform these validations, call the "check" method on the instance you're val
 on success and a string error message on validation failure.
 """
 import re
+from datetime import datetime, timedelta
 from functools import wraps
 from urllib.request import urlopen
 
@@ -137,22 +138,22 @@ def ignore_unassigned_and_placeholders(func):
     return with_skipping
 
 
-WatchList.required = [
-    ('reason', 'Reason'),
-    ('action', 'Action')
-]
-
-
 @validation.WatchList
 def include_a_name(entry):
     if not entry.first_names and not entry.last_name:
-        return 'A first or last name is required.'
+        return ('', 'A first or last name is required.')
 
 
 @validation.WatchList
 def include_other_details(entry):
     if not entry.birthdate and not entry.email:
-        return 'Email or date of birth is required.'
+        return ('', 'Email or date of birth is required.')
+
+
+@validation.WatchList
+def not_active_after_expiration(entry):
+    if entry.active and localized_now().date() > entry.expiration:
+        return ('expiration', 'An entry cannot be active with an expiration date in the past.')
 
 
 @validation.MPointsForCash

--- a/uber/models/admin.py
+++ b/uber/models/admin.py
@@ -314,6 +314,7 @@ class WatchList(MagModel):
     birthdate = Column(Date, nullable=True, default=None)
     reason = Column(UnicodeText)
     action = Column(UnicodeText)
+    expiration = Column(Date, nullable=True, default=None)
     active = Column(Boolean, default=True)
     attendees = relationship('Attendee', backref=backref('watch_list', load_on_pending=True))
 
@@ -326,7 +327,7 @@ class WatchList(MagModel):
         return [name.strip().lower() for name in self.first_names.split(',')]
 
     @presave_adjustment
-    def _fix_birthdate(self):
+    def fix_birthdate(self):
         if self.birthdate == '':
             self.birthdate = None
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -844,7 +844,7 @@ class Root:
                     all_errors = validate_model(forms, attendee)
                     if all_errors:
                         # Flatten the errors as we don't have fields on this page
-                        ' '.join([item for sublist in all_errors.values() for item in sublist])
+                        message = ' '.join([item for sublist in all_errors.values() for item in sublist])
                 if message:
                     message += f" Please click 'Edit' next to {attendee.full_name}'s registration to fix any issues."
                     break

--- a/uber/tasks/__init__.py
+++ b/uber/tasks/__init__.py
@@ -64,4 +64,5 @@ from uber.tasks import mivs  # noqa: F401, E402
 from uber.tasks import panels  # noqa: F401, E402
 from uber.tasks import redis  # noqa: F401, E402
 from uber.tasks import registration  # noqa: F401, E402
+from uber.tasks import security  # noqa: F401, E402
 from uber.tasks import sms  # noqa: F401, E402

--- a/uber/tasks/security.py
+++ b/uber/tasks/security.py
@@ -1,0 +1,22 @@
+from datetime import date, timedelta
+
+from uber.models import WatchList, Session
+from uber.tasks import celery
+
+
+__all__ = ['deactivate_expired_watchlist_entries']
+
+
+@celery.schedule(timedelta(hour=12))
+def deactivate_expired_watchlist_entries():
+    with Session() as session:
+        expired_entries = session.query(WatchList).filter(WatchList.active == True,  # noqa: E712
+                                                          WatchList.expiration <= date.today())
+
+        expired_count = expired_entries.count()
+
+        for entry in expired_entries:
+            entry.active = False
+            session.add(entry)
+
+        return f"Deactivated {expired_count} expired watchlist entries."

--- a/uber/templates/registration/attendee_watchlist.html
+++ b/uber/templates/registration/attendee_watchlist.html
@@ -42,7 +42,7 @@ $("form[name='confirm_entry']").submit(function (event) {
       },
       callback: function (result) {
           if (result) {
-            updateWatchlist();
+            formToSubmit.submit();
           }
       }
   });

--- a/uber/templates/security_admin/index.html
+++ b/uber/templates/security_admin/index.html
@@ -4,48 +4,82 @@
 {% endblock %}
 {% block content %}
 
-<h1>
-  <a class="btn btn-primary" href="watchlist_form">Add a Watchlist Entry</a>
-</h1>
+  <p><a class="btn btn-primary" href="watchlist_form">Add a Watchlist Entry</a></p>
 
 <div class="card">
   <div class="card-header">
-    <h3 class="card-title">Existing Watchlist Entries</h3>
+    Active Watchlist Entries
   </div>
-  <table class="table table-striped datatable">
-    <thead>
+  <div class="card-body">
+    <table class="table table-striped datatable">
+      <thead>
+        <tr>
+          <th>Details</th>
+          <th>Last Updated</th>
+          <th>Expiration Date</th>
+          <th>Matching Attendee(s)</th>
+          <th>First Name(s)</th>
+          <th>Last Name</th>
+          <th>Email Address</th>
+          <th>Date of Birth</th>
+        </tr>
+      </thead>
+      {% for entry in active_entries %}
       <tr>
-        <th>Entry Status</th>
-        <th>Details</th>
-        <th>Possible Match(es)</th>
-        <th>Confirmed Match(es)</th>
-        <th>First Name(s)</th>
-        <th>Last Name</th>
-        <th>Email Address</th>
-        <th>Date of Birth</th>
+        <td><a href="watchlist_form?id={{ entry.id }}">View Details</a></td>
+        <td>{{ (entry.last_updated.when|default(entry.created.when, true))|full_datetime_local }}</td>
+        <td>{{ entry.expiration }}</td>
+        <td>
+          {% for attendee in entry.attendees_and_guesses %}
+          {{ attendee|form_link }}{% if attendee in entry.attendees %} (Confirmed){% endif %}
+          {% else %}N/A{% endfor %}
+        </td>
+        <td>{{ entry.first_names }}</td>
+        <td>{{ entry.last_name }}</td>
+        <td>{{ entry.email }}</td>
+        <td>{{ entry.birthdate|datetime("%Y-%m-%d") }}</td>
       </tr>
-    </thead>
-{% for entry in watchlist_entries %}
-    <tr>
-      <td>{{ entry.active|yesno("Active,Inactive") }}</td>
-      <td><a href="watchlist_form?id={{ entry.id }}">View Entry Details</a></td>
-      <td>
-        {% for attendee in entry.attendee_guesses %}
-        {{ attendee|form_link }}
-        {% else %}N/A{% endfor %}
-      </td>
-      <td>
-        {% for attendee in entry.attendees %}
-        {{ attendee|form_link }}
-        {% else %}N/A{% endfor %}
-      </td>
-      <td>{{ entry.first_names }}</td>
-      <td>{{ entry.last_name }}</td>
-      <td>{{ entry.email }}</td>
-      <td>{{ entry.birthdate|datetime("%Y-%m-%d") }}</td>
-    </tr>
-{% endfor %}
-  </table>
+      {% endfor %}
+    </table>
+  </div>
+</div>
+<br/>
+<div class="card">
+  <div class="card-header">
+    Inactive Watchlist Entries
+  </div>
+  <div class="card-body">
+    <table class="table table-striped datatable">
+      <thead>
+        <tr>
+          <th>Details</th>
+          <th>Last Updated</th>
+          <th>Expiration Date</th>
+          <th>Matched Attendee(s)</th>
+          <th>First Name(s)</th>
+          <th>Last Name</th>
+          <th>Email Address</th>
+          <th>Date of Birth</th>
+        </tr>
+      </thead>
+      {% for entry in inactive_entries %}
+      <tr>
+        <td><a href="watchlist_form?id={{ entry.id }}">View Details</a></td>
+        <td>{{ (entry.last_updated.when|default(entry.created.when, true))|full_datetime_local }}</td>
+        <td>{{ entry.expiration }}</td>
+        <td>
+          {% for attendee in entry.attendees %}
+          {{ attendee|form_link }} ({{ attendee.badge_status_label }})
+          {% else %}N/A{% endfor %}
+        </td>
+        <td>{{ entry.first_names }}</td>
+        <td>{{ entry.last_name }}</td>
+        <td>{{ entry.email }}</td>
+        <td>{{ entry.birthdate|datetime("%Y-%m-%d") }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </div>
 </div>
 
 {% endblock %}

--- a/uber/templates/security_admin/watchlist_form.html
+++ b/uber/templates/security_admin/watchlist_form.html
@@ -1,4 +1,10 @@
 {% extends "base.html" %}{% set admin_area=True %}
+
+{% import 'macros.html' as macros with context %}
+{% import 'forms/macros.html' as form_macros with context %}
+
+{% set watchlist_entry = watchlist_entry or forms['watch_list_entry'] %}
+
 {% block title %}Watchlist Entry Form{% endblock %}
 {% block content %}
 {% if entry.is_new %}
@@ -45,27 +51,55 @@
     {{ csrf_token() }}
     <input type="hidden" name="id" value="{{ entry.db_id }}" />
 
-    {{ macros.form_group(entry, "first_names", placeholder="Use commas to separate possible first names.") }}
-    {{ macros.form_group(entry, "last_name") }}
-    {{ macros.form_group(entry, "email") }}
-
-    <div class="form-group">
-    <label for="birthdate" class="col-sm-3 control-label">Date of Birth</label>
-    <div class="col-sm-6">
-      <input type='text' class="form-control date" name="birthdate" value="{{ entry.birthdate|datetime("%Y-%m-%d") }}"/>
-    </div>
-  </div>
-
-    {{ macros.form_group(entry, "reason", type="textarea", help="The reason this attendee is on the watchlist.") }}
-    {{ macros.form_group(entry, "action", type="textarea", help="What, if anything, the attendee should do before checking in.") }}
-    <div class="form-group" id="audio_needs">
-      <label class="col-sm-3 control-label">Active?</label>
-      <div class="col-sm-9 checkbox">
-        {{ macros.checkbox(entry, "active", label="This entry will automatically place matching attendees in the On Hold status") }}
+    {% if not entry.is_new %}
+      <div class="row g-sm-3">
+        <div class="col">
+          <div class="form-text">Created</div>
+          <div class="mb-3">{{ entry.created.when|full_datetime_local }} by {{ entry.created.who }}</div>
+        </div>
+        {% if entry.last_updated %}
+        <div class="col">
+          <div class="form-text">Last Updated</div>
+          <div class="mb-3">{{ entry.last_updated.when|full_datetime_local }} by {{ entry.last_updated.who }}</div>
+        </div>
+        {% endif %}
+      </div>
+    {% endif %}
+    <div class="row g-sm-3">
+      <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(watchlist_entry.first_names) }}
+      </div>
+      <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(watchlist_entry.last_name) }}
       </div>
     </div>
-    
-
+    <div class="row g-sm-3">
+      <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(watchlist_entry.email) }}
+      </div>
+      <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(watchlist_entry.birthdate) }}
+      </div>
+    </div>
+    <div class="row g-sm-3">
+      <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(watchlist_entry.reason, admin_text="The reason this attendee is on the watchlist.") }}
+      </div>
+      <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(watchlist_entry.action, admin_text="What, if anything, the attendee should do before checking in.") }}
+      </div>
+    </div>
+    <div class="row g-sm-3">
+      <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(watchlist_entry.expiration, admin_text="The watchlist will deactivate on this day.") }}
+      </div>
+    </div>
+    <div class="row g-sm-3">
+      <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(watchlist_entry.active) }}
+      </div>
+    </div>
+  
     {% if not page_ro %}
       <div class="form-entry">
         <div class="col-sm-6 col-sm-offset-3">


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-1210. Watchlist entries past their expiration date are set inactive every 12 hours. Matched attendees for expired entries do NOT automatically get cleared for attending, but they are listed on the watchlist page so admins can easily clear them manually.

Also converts the watchlist form to the new form system, and shows the watchlist creation and last updated date on the form. The last updated date is also shown on the index page.