### PR TITLE
Make assigned departments editable again

### DIFF
--- a/uber/models/department.py
+++ b/uber/models/department.py
@@ -216,7 +216,7 @@ class Department(MagModel):
         viewonly=True)
     members = relationship(
         'Attendee',
-        backref=backref('assigned_depts', order_by='Department.name', viewonly=True),
+        backref=backref('assigned_depts', order_by='Department.name'),
         cascade='save-update,merge,refresh-expire,expunge',
         order_by='Attendee.full_name',
         secondary='dept_membership')


### PR DESCRIPTION
It turns out the code adds assigned departments through a relationship that had been marked as viewonly. This removes the viewonly marker, which is the quick fix.

The real fix is to adjust how we edit relationships like this -- the heavy abstraction of routing everything through the set_relation_ids functions means that it's difficult to tell which relationships can be made viewonly and which can't. We already have to define setter functions anyway, we might as well require that you specify what class and relationship should be used.