### PR TITLE
Refactor password hashing

### DIFF
--- a/uber/site_sections/mivs_admin.py
+++ b/uber/site_sections/mivs_admin.py
@@ -49,8 +49,7 @@ class Root:
                                         placeholder=True, badge_type=c.ATTENDEE_BADGE, paid=c.NEED_NOT_PAY)
                     session.add(attendee)
 
-                password = genpasswd()
-                attendee.admin_account = session.create_admin_account(attendee, password, judge=judge)
+                attendee.admin_account, password = session.create_admin_account(attendee, judge=judge)
                 email_body = render('emails/accounts/new_account.txt', {
                     'password': password,
                     'account': attendee.admin_account,

--- a/uber/site_sections/saml.py
+++ b/uber/site_sections/saml.py
@@ -59,7 +59,7 @@ class Root:
                             session.add(matching_attendee)
                             session.commit()
 
-                        admin_account = session.create_admin_account(matching_attendee, generate_pwd=False)
+                        admin_account, pwd = session.create_admin_account(matching_attendee, generate_pwd=False)
                         all_access_group = session.query(AccessGroup).filter_by(name="All Access").first()
                         if not all_access_group:
                             all_access_group = AccessGroup(

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1,3 +1,4 @@
+import bcrypt
 import cherrypy
 import importlib
 import math
@@ -718,6 +719,10 @@ def genpasswd(short=False):
             return ' '.join(random.choice(words) for i in range(4))
         characters = string.ascii_letters + string.digits
         return ''.join(random.choice(characters) for i in range(8))
+
+
+def create_new_hash(password):
+    return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
 
 
 # ======================================================================


### PR DESCRIPTION
Fixes creating MIVS judges. Also refactors creating a new hash into a utility function, since the encoding/decoding involved makes it complicated enough to warrant its own function. I'm hoping this will also fix whatever bug sometimes causes people's admin passwords to not work, but I have no way to reproduce that so we'll see.