### PR TITLE
Remove c.PATH property for getting site section

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -282,9 +282,6 @@ class Config(_Overridable):
     For all of the datetime config options, we also define BEFORE_ and AFTER_ properties, e.g. you can
     check the booleans returned by c.BEFORE_PLACEHOLDER_DEADLINE or c.AFTER_PLACEHOLDER_DEADLINE
     """
-    def __init__(self):
-        self._PATH = cherrypy.request.path_info.replace(cherrypy.request.path_info.split('/')[-1], '').strip('/')
-
     def get_oneday_price(self, dt):
         return self.BADGE_PRICES['single_day'].get(dt.strftime('%A'), self.DEFAULT_SINGLE_DAY)
 
@@ -837,14 +834,6 @@ class Config(_Overridable):
     @property
     def PAGE(self):
         return cherrypy.request.path_info.split('/')[-1]
-
-    @property
-    def PATH(self):
-        return self._PATH
-
-    @PATH.setter
-    def PATH(self, value):
-        self._PATH = value
 
     @request_cached_property
     @dynamic

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -707,20 +707,20 @@ def restricted(func):
     @wraps(func)
     def with_restrictions(*args, **kwargs):
         if not func.public:
-            if c.PATH == 'staffing':
+            if '/staffing/' in c.PAGE_PATH:
                 if not cherrypy.session.get('staffer_id'):
                     raise HTTPRedirect('../staffing/login?message=You+are+not+logged+in', save_location=True)
 
             elif cherrypy.session.get('account_id') is None:
                 raise HTTPRedirect('../accounts/login?message=You+are+not+logged+in', save_location=True)
 
-            elif c.PATH == 'mivs_judging':
+            elif '/mivs_judging/' in c.PAGE_PATH:
                 if not uber.models.AdminAccount.is_mivs_judge_or_admin:
-                    return 'You need to be a MIVS Judge or have access for either {} or {}'.format(c.PATH, c.PAGE_PATH)
+                    return f'You need to be a MIVS Judge or have access to {c.PAGE_PATH}'
 
             else:
                 if not c.has_section_or_page_access(include_read_only=True):
-                    return 'You need access for either {} or {}.'.format(c.PATH, c.PAGE_PATH)
+                    return f'You need access to {c.PAGE_PATH}.'
 
         return func(*args, **kwargs)
     return with_restrictions


### PR DESCRIPTION
We already have a c.PATH used in absolute URLs, this extra c.PATH wasn't working correctly and was only used in one place.