### PR TITLE
Fix declined group payment handling

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -2063,7 +2063,7 @@ class Root:
         if not stripe_intent:
             return {'error': "Something went wrong. Please contact us at {}.".format(c.REGDESK_EMAIL)}
 
-        if stripe_intent.latest_charge:
+        if not c.AUTHORIZENET_LOGIN_ID and stripe_intent.status == "succeeded":
             return {'error': "This payment has already been finalized!"}
 
         return {'stripe_intent': stripe_intent,


### PR DESCRIPTION
If a group's payment was declined, we would prevent them from completing it because we were checking for the wrong thing. It now matches how attendee pending payments are handled.