### PR TITLE
Add band claim email

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -507,6 +507,12 @@ def guest_placeholder(a): return a.placeholder and a.badge_type == c.GUEST_BADGE
             and a.group.guest.group_type == c.GUEST)
 
 
+def band_placeholder(a): return a.placeholder and a.badge_type == c.GUEST_BADGE and (
+            not a.group
+            or a.group.guest
+            and a.group.guest.group_type == c.BAND)
+
+
 def dealer_placeholder(a): return a.placeholder and a.is_dealer and a.group.status == c.APPROVED
 
 
@@ -519,12 +525,15 @@ def volunteer_placeholder(a): return a.placeholder and a.registered_local > c.PR
 # a.staffing provided by StopsEmailFixture
 
 
-# TODO: Add an email for MIVS judges, an email for non-Guest guest group badges,
+# TODO: Add an email for MIVS judges, an email for non-Guest or Band guest group badges,
 # and an email for group-leader-created badges
-def generic_placeholder(a): return a.placeholder and (c.AT_THE_CON or not panelist_placeholder(a)
-                                                      and not guest_placeholder(a) and not dealer_placeholder(a)
-                                                      and a.registered_local > min(c.PREREG_OPEN, c.DEALER_REG_START)
-                                                      and not volunteer_placeholder(a))
+def generic_placeholder(a): return a.placeholder and c.AT_THE_CON or (not panelist_placeholder(a)
+                                                                      and not band_placeholder(a)
+                                                                      and not guest_placeholder(a)
+                                                                      and not dealer_placeholder(a)
+                                                                      and a.registered_local > min(c.PREREG_OPEN,
+                                                                                                   c.DEALER_REG_START)
+                                                                      and not volunteer_placeholder(a))
 
 
 AutomatedEmailFixture(
@@ -571,6 +580,14 @@ AutomatedEmailFixture(
     # query=and_(Attendee.placeholder == True, Attendee.badge_type == c.GUEST_BADGE),
     sender=c.GUEST_EMAIL,
     ident='guest_badge_confirmation')
+
+AutomatedEmailFixture(
+    Attendee,
+    'Claim your performer badge for {EVENT_NAME} {EVENT_YEAR}',
+    'placeholders/band.txt',
+    band_placeholder,
+    sender=c.BAND_EMAIL,
+    ident='band_badge_confirmation')
 
 AutomatedEmailFixture(
     Attendee,

--- a/uber/templates/emails/placeholders/band.txt
+++ b/uber/templates/emails/placeholders/band.txt
@@ -1,0 +1,8 @@
+{% if attendee.first_name %}{{ attendee.first_name }},
+
+{% endif %}Thanks for coming out to perform at {{ c.EVENT_NAME }}! We've added you to our registration database for your complimentary badge, but we don't have all of your personal information. To ensure that you can pick up your badge with no hassles, please fill out the rest of your info at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to {{ c.EVENT_NAME }}.
+
+Please let us know if you have any questions by reaching out to us at {{ c.BAND_EMAIL|email_only }}.
+
+Thank you!
+{{ c.BAND_EMAIL_SIGNATURE }}


### PR DESCRIPTION
Plugs one of the holes in our 'badge claim' email system by adding an email for guests in Band groups.