### PR TITLE
Fix email template links

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -133,9 +133,9 @@ class AutomatedEmailFixture:
         env = JinjaEnv.env()
         try:
             template_path = pathlib.Path(env.get_or_select_template(os.path.join('emails', self.template)).filename)
-            self.template_plugin_name = template_path.parts[3]
+            self.template_plugin_name = template_path.parts[2]
             self.template_url = (f"https://github.com/magfest/{self.template_plugin_name}/tree/main/"
-                                 f"{self.template_plugin_name}/{pathlib.Path(*template_path.parts[5:]).as_posix()}")
+                                 f"{self.template_plugin_name}/{pathlib.Path(*template_path.parts[3:]).as_posix()}")
         except jinja2.exceptions.TemplateNotFound:
             self.template_plugin_name = "ERROR: TEMPLATE NOT FOUND"
             self.template_url = ""


### PR DESCRIPTION
When we got rid of Sideboard, we changed the template structure of Uber enough that it broke the links we were building to go to email templates. This fixes that.