### PR TITLE
Use prereg_confirm_email_enabled flag

### DIFF
--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -56,8 +56,8 @@ class PersonalInfo(AddressForm, MagForm):
         ],
         render_kw={'placeholder': 'test@example.com'})
     confirm_email = EmailField('Confirm Email Address', validators=[
-        validators.DataRequired("Please confirm your email address."),
-        ])
+        validators.DataRequired("Please confirm your email address.") if c.PREREG_CONFIRM_EMAIL_ENABLED
+        else validators.Optional()])
     cellphone = TelField('Phone Number', validators=[
         validators.DataRequired("Please provide a phone number."),
         valid_cellphone

--- a/uber/templates/forms/attendee/personal_info.html
+++ b/uber/templates/forms/attendee/personal_info.html
@@ -60,7 +60,7 @@
   <div class="col-12 col-sm-6">
     {{ form_macros.form_input(personal_info.email, extra_field=email_extra_field, value=attendee_email) }}
   </div>
-  {% if attendee.needs_pii_consent or attendee.badge_status == c.PENDING_STATUS %}
+  {% if c.PREREG_CONFIRM_EMAIL_ENABLED and (attendee.needs_pii_consent or attendee.badge_status == c.PENDING_STATUS) %}
   <div class="col-12 col-sm-6">
     {{ form_macros.form_input(personal_info.confirm_email, value=attendee_email if edit_id or attendee.placeholder else '') }}
   </div>


### PR DESCRIPTION
Makes the confirm email input optional for events, controlled by the prereg_confirm_email_enabled flag.