### PR TITLE
Fix form bugs with staff shirts

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -1528,6 +1528,7 @@ c.JOB_DEFAULTS = ['name', 'description', 'duration', 'slots', 'weight', 'visibil
 c.PREREG_SHIRT_OPTS = sorted(c.PREREG_SHIRT_OPTS if c.PREREG_SHIRT_OPTS else c.SHIRT_OPTS)[1:]
 c.PREREG_SHIRTS = {key: val for key, val in c.PREREG_SHIRT_OPTS}
 c.STAFF_SHIRT_OPTS = sorted(c.STAFF_SHIRT_OPTS if len(c.STAFF_SHIRT_OPTS) > 1 else c.SHIRT_OPTS)
+c.SHIRT_OPTS = sorted(c.SHIRT_OPTS)
 c.MERCH_SHIRT_OPTS = [(c.SIZE_UNKNOWN, 'select a size')] + sorted(list(c.SHIRT_OPTS))
 c.MERCH_STAFF_SHIRT_OPTS = [(c.SIZE_UNKNOWN, 'select a size')] + sorted(list(c.STAFF_SHIRT_OPTS))
 shirt_label_lookup = {val: key for key, val in c.SHIRT_OPTS}

--- a/uber/templates/forms/attendee/badge_extras.html
+++ b/uber/templates/forms/attendee/badge_extras.html
@@ -48,9 +48,11 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
                                 attendee.available_amount_extra_opts, disabled_opts=c.SOLD_OUT_MERCH_TIERS,
                                 target_field_id=id_upgrade_prepend ~ "amount_extra") }}
     </div>
-    {{ form_macros.toggle_fields_js(badge_extras.amount_extra, [badge_extras.shirt], off_values=["0"], toggle_required=True, 
-                                    closest_hide_selector='.row' if not attendee.gets_staff_shirt or c.SHIRT_OPTS == c.STAFF_SHIRT_OPTS else '.form-floating',
-                                    source_field_id=id_upgrade_prepend ~ "amount_extra") }}
+    {% if not attendee.gets_staff_shirt or c.SHIRT_OPTS != c.STAFF_SHIRT_OPTS %}
+        {{ form_macros.toggle_fields_js(badge_extras.amount_extra, [badge_extras.shirt], off_values=["0"], toggle_required=True, 
+                                        closest_hide_selector='.row' if not attendee.gets_staff_shirt else '.form-floating',
+                                        source_field_id=id_upgrade_prepend ~ "amount_extra") }}
+    {% endif %}
 {% else %}
     <div class="row g-sm-3">
         <div class="col-12 col-sm-6">


### PR DESCRIPTION
In some cases, SHIRT_OPTS and STAFF_SHIRT_OPTS would be erroneously considered different from each other due to sorting. Additionally, in cases where the staff shirt and shirt opts were the same but all staff get a shirt, the form would hide the shirt size option. This fixes both issues.