### PR TITLE
Add cancellable status list for dealers

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -1586,6 +1586,7 @@ c.STATIC_HASH_LIST = {}
 
 dealer_status_label_lookup = {val: key for key, val in c.DEALER_STATUS_OPTS}
 c.DEALER_EDITABLE_STATUSES = [dealer_status_label_lookup[name] for name in c.DEALER_EDITABLE_STATUS_LIST]
+c.DEALER_CANCELLABLE_STATUSES = [dealer_status_label_lookup[name] for name in c.DEALER_CANCELABLE_STATUS_LIST]
 
 
 # A list of models that have properties defined for exporting for Guidebook

--- a/uber/config.py
+++ b/uber/config.py
@@ -1586,7 +1586,7 @@ c.STATIC_HASH_LIST = {}
 
 dealer_status_label_lookup = {val: key for key, val in c.DEALER_STATUS_OPTS}
 c.DEALER_EDITABLE_STATUSES = [dealer_status_label_lookup[name] for name in c.DEALER_EDITABLE_STATUS_LIST]
-c.DEALER_CANCELLABLE_STATUSES = [dealer_status_label_lookup[name] for name in c.DEALER_CANCELABLE_STATUS_LIST]
+c.DEALER_CANCELLABLE_STATUSES = [dealer_status_label_lookup[name] for name in c.DEALER_CANCELLABLE_STATUS_LIST]
 
 
 # A list of models that have properties defined for exporting for Guidebook

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -339,6 +339,9 @@ group_reapply_attrs = string_list(default=list('name','zip_code','address1','add
 # Possible options: Imported, Pending Approval, Waitlisted, Approved, Declined, Cancelled
 dealer_editable_status_list = string_list(default=list("Pending Approval", "Waitlisted"))
 
+# As above, but this controls whether dealer groups can cancel their own applications
+dealer_cancelable_status_list = string_list(default=list("Pending Approval", "Waitlisted"))
+
 # By default, staff/volunteers are only allowed to work shifts in a maximum of
 # three different departments. Historically, we've found that working in too
 # many different departments can spread people too thin and cause burn out,

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -340,7 +340,7 @@ group_reapply_attrs = string_list(default=list('name','zip_code','address1','add
 dealer_editable_status_list = string_list(default=list("Pending Approval", "Waitlisted"))
 
 # As above, but this controls whether dealer groups can cancel their own applications
-dealer_cancelable_status_list = string_list(default=list("Pending Approval", "Waitlisted"))
+dealer_cancellable_status_list = string_list(default=list("Pending Approval", "Waitlisted"))
 
 # By default, staff/volunteers are only allowed to work shifts in a maximum of
 # three different departments. Historically, we've found that working in too

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -80,12 +80,16 @@
         {% include "groupextra.html" %}
         {% if group.status in c.DEALER_EDITABLE_STATUSES %}
         <button type="submit" class="btn btn-primary" value="Update Application">Update Application</button>
+        {% endif %}
+        {% if group.status in c.DEALER_CANCELLABLE_STATUSES %}
         <button type="submit" class="btn btn-danger" value="Cancel {{ c.DEALER_APP_TERM|title }}" form="cancel_dealer">Cancel Application</button>
         {% endif %}
       </form>
+      {% if group.status in c.DEALER_CANCELLABLE_STATUSES %}
         <form method="post" id="cancel_dealer" action="../preregistration/cancel_dealer" class="form-horizontal" role="form">
           <input type="hidden" name="id" value="{{ group.id }}" />
         </form>
+      {% endif %}
     {% endif%}
 
 {% if group.status not in [c.CANCELLED, c.DECLINED] %}


### PR DESCRIPTION
We were using the configurable editable_status list to control whether or not dealers could cancel their own applications, but Super needs them controlled separately. Now you can let dealers edit their application, but not let them cancel it.