### PR TITLE
Fix generic placeholder emails

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -530,13 +530,13 @@ def volunteer_placeholder(a): return a.placeholder and a.registered_local > c.PR
 
 # TODO: Add an email for MIVS judges, an email for non-Guest or Band guest group badges,
 # and an email for group-leader-created badges
-def generic_placeholder(a): return a.placeholder and (c.AT_THE_CON or not panelist_placeholder(a)
-                                                      and not band_placeholder(a)
-                                                      and not guest_placeholder(a)
-                                                      and not dealer_placeholder(a)
+def generic_placeholder(a): return a.placeholder and (c.AT_THE_CON or not deferred_attendee_placeholder
+                                                      and not panelist_placeholder(a) and not guest_placeholder(a)
+                                                      and not band_placeholder(a) and not dealer_placeholder(a)
+                                                      and not staff_import_placeholder(a)
+                                                      and not volunteer_placeholder(a)
                                                       and a.registered_local > min(c.PREREG_OPEN,
-                                                                                   c.DEALER_REG_START)
-                                                      and not volunteer_placeholder(a))
+                                                                                   c.DEALER_REG_START))
 
 
 AutomatedEmailFixture(
@@ -545,7 +545,6 @@ AutomatedEmailFixture(
     'placeholders/regular.txt',
     lambda a: generic_placeholder(a) and a.paid == c.NEED_NOT_PAY,
     sender=c.CONTACT_EMAIL,
-    needs_approval=False,
     allow_at_the_con=True,
     ident='generic_badge_confirmation_comped')
 
@@ -555,7 +554,6 @@ AutomatedEmailFixture(
     'placeholders/regular.txt',
     lambda a: generic_placeholder(a) and a.paid != c.NEED_NOT_PAY,
     sender=c.CONTACT_EMAIL,
-    needs_approval=False,
     allow_at_the_con=True,
     ident='generic_badge_confirmation')
 


### PR DESCRIPTION
Stops the generic placeholder emails from being sent to people who qualified for the staff import emails. Also sets them to need approval so we can make sure in the future they only start going out after we're ready for badges to be claimed.