### PR TITLE
Fix amount_unpaid for group badges with receipts

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -984,7 +984,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def amount_unpaid(self):
-        if self.paid == c.PAID_BY_GROUP:
+        if self.paid == c.PAID_BY_GROUP and not self.active_receipt:
             personal_cost = max(0, self.total_cost - self.badge_cost)
         else:
             personal_cost = self.total_cost

--- a/uber/templates/group_admin/dealers.html
+++ b/uber/templates/group_admin/dealers.html
@@ -43,7 +43,7 @@
         <td style="text-align:left" data-order="{{ group.name }}" data-search="{{ group.name }}"> 
           <a href="form?id={{ group.id }}">{{ group.name|default('?????', boolean=True) }}</a></td>
         <td>
-            {{ group.status_label }}{% if group.convert_badges and group.badges_purchased %} <span class="text-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="This {{ c.DEALER_TERM }}'s badges will be converted to individual badges tonight!"><i class="fa fa-exclamation-circle" aria-hidden="true"></i></span>{% endif %}
+            {{ group.status_label }}{% if group.convert_badges and group.badges_purchased %} <span class="text-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="This {{ c.DEALER_TERM }}'s badges will be converted to individual badges tonight!"><i class="fa fa-exclamation-circle"></i></span>{% endif %}
         </td>
         <td>{{ group.website|url_to_link(target="_blank", is_relative=False) }}</td>
         <td data-order="{{ group.badges_purchased }}" data-search="{{ group.badges_purchased }}"> {{ group.badges_purchased }} / {{ group.badges }} </td>


### PR DESCRIPTION
Found this while working on something else -- if you had a group badge with an add-on, "amount unpaid" would actually remove your badge cost from your receipt total. Now it will not.