### PR TITLE
Only requiring badge numbers if they are enabled

### DIFF
--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -494,7 +494,7 @@ class CheckInForm(MagForm):
     badge_type = HiddenIntField('Badge Type')
     badge_num = StringField('Badge Number', id="checkin_badge_num", default='', validators=[
         validators.DataRequired('Badge number is required.'),
-    ])
+    ] if c.NUMBERED_BADGES else [])
     badge_printed_name = PersonalInfo.badge_printed_name
     got_merch = AdminBadgeExtras.got_merch
     got_staff_merch = AdminStaffingInfo.got_staff_merch


### PR DESCRIPTION
Trying to check in an attendee at stock (with c.NUMBERED_BADGES == False) the dialog is still requiring a badge number while omitting the field to enter one.