### PR TITLE
Add temporarily disabling of emergency procedures

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -360,7 +360,8 @@ shiftless_depts = string_list(default=list())
 # signed up for in order to receive a specific perk. If any of these is set to 0,
 # that perk is turned off for the event.
 
-# Volunteers with Staff badges always get a staff shirt as long as this is more than 0
+# If shirts_per_staffer is set to 0 and this is not set to 0, staff get the same shirt
+# that volunteers get. Otherwise, they get separate staff shirts with separate sizes.
 hours_for_shirt = integer(default=6)
 
 # Access to staff suite and/or tea room
@@ -426,7 +427,7 @@ out_of_shirts = boolean(default=False)
 
 # This is the number of staff shirts that each staffer gets.
 # You can populate [[staff_event_shirt]] to allow staff to choose to
-# replace 1 or more of their staff shirts with event shirts
+# replace 1 or more of their staff shirts with event shirts.
 #
 # Staff shirts are for wearing on-shift. Use hours_for_shirt
 # to grant staff and volunteers an event shirt instead.
@@ -488,6 +489,11 @@ volunteer_agreement_enabled = boolean(default=False)
 
 # Much like the volunteer agreement, but for an emergency procedures document.
 emergency_procedures_enabled = boolean(default=False)
+
+# Emergency procedures documents might not always be ready when the volunteer
+# checklist opens. When this is turned off, the link is removed from the step
+# and the deadline is replaced with "Coming Soon!"
+emergency_procedures_ready = boolean(default=False)
 
 # This controls whether we ask volunteers to provide a name for a credits roll.
 volunteer_credits_roll = boolean(default=False)

--- a/uber/templates/staffing/emergency_procedures_item.html
+++ b/uber/templates/staffing/emergency_procedures_item.html
@@ -3,12 +3,12 @@
 <li>
     {{ macros.checklist_image(attendee.reviewed_emergency_procedures) }}
     {% if not attendee.reviewed_emergency_procedures %}
-        Please review
+        Please review our
     {% else %}
         You have acknowledged that you reviewed our
     {% endif %}
-    {% if not attendee.placeholder and (attendee.agreed_to_volunteer_agreement or not c.VOLUNTEER_AGREEMENT_ENABLED) %}<a href="emergency_procedures">Emergency Procedures</a>{% else %}Emergency Procedures{% endif %}
+    {% if c.EMERGENCY_PROCEDURES_READY and not attendee.placeholder and (attendee.agreed_to_volunteer_agreement or not c.VOLUNTEER_AGREEMENT_ENABLED) %}<a href="emergency_procedures">Emergency Procedures</a>{% else %}Emergency Procedures{% endif %}
     {% if not attendee.reviewed_emergency_procedures %} and acknowledge that you have done so{% endif %}. 
-    (Deadline: {{ c.EMERGENCY_PROCEDURES_DEADLINE }})
+    {% if c.EMERGENCY_PROCEDURES_READY %}(Deadline: {{ c.EMERGENCY_PROCEDURES_DEADLINE }}){% else %}(Coming Soon!){% endif %}
 </li>
 {% endif %}


### PR DESCRIPTION
We usually don't have these procedures ready when we launch the volunteer checklist, so we now can disable the link using config. Also cleans up some of the logic around volunteer shirts.