### PR TITLE
Replace missing login page for MIVS

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -2145,7 +2145,7 @@ class Session(SessionManager):
             try:
                 return self.indie_studio(cherrypy.session.get('studio_id'))
             except Exception:
-                raise HTTPRedirect('../mivs/studio')
+                raise HTTPRedirect('../mivs/login_explanation')
 
         def logged_in_judge(self):
             judge = self.admin_attendee().admin_account.judge

--- a/uber/site_sections/mivs.py
+++ b/uber/site_sections/mivs.py
@@ -34,16 +34,7 @@ class Root:
         cherrypy.session['studio_id'] = id
         raise HTTPRedirect('index')
 
-    def login(self, session, message='', studio_name=None, password=None):
-        if cherrypy.request.method == 'POST':
-            studio = session.query(IndieStudio).filter_by(name=studio_name).first()
-            if not studio:
-                message = 'No studio exists with that name'
-            elif not studio.hashed.encode('utf-8') == bcrypt.hashpw(password.encode('utf-8'), studio.hashed.encode('utf-8')):
-                message = 'That is not the correct password'
-            else:
-                raise HTTPRedirect('continue_app?id={}', studio.id)
-
+    def login_explanation(self, message=''):
         return {'message': message}
 
     def studio(self, session, message='', **params):

--- a/uber/templates/mivs/index.html
+++ b/uber/templates/mivs/index.html
@@ -21,7 +21,7 @@
   <h2>MAGFest Indie Videogame Showcase Application</h2>
   This is your application-in-progress for the MAGFest Indie Videogame Showcase for your studio
   <a href="studio">{{ studio.name }}</a>.  If you are not a member of {{ studio.name }} then please
-  <a href="logout">log out</a>.
+  <a href="logout">log out and create a new studio</a>.
 
   {% if studio.group %}
     <h3>Your Badges</h3>

--- a/uber/templates/mivs/login_explanation.html
+++ b/uber/templates/mivs/login_explanation.html
@@ -1,0 +1,27 @@
+{% extends "mivs_base.html" %}
+{% block body %}
+
+<h2>You are not logged in!</h2>
+
+<p>
+    In order to log back into your MAGFest Indie Videogame Showcase application, you can click on the link that we sent when you applied.
+    If you don't see an email, check your spam/junk folder for an email titled "Your MIVS Studio Has Been Registered".
+</p>
+
+{% if c.AFTER_MIVS_START and not c.MIVS_SUBMISSIONS_OPEN %}
+    <p>
+        However, we are already <b>past the final deadline</b>, so you will be able to <b>only view and not edit</b>
+        your application.
+    </p>
+    <p>
+        If you are not yet registered and want to create a new application, you may
+        <a href="studio">click here to do so</a>.
+    </p>
+{% else %}
+    <p>
+        If you have not already registered your studio, then it is unfortunately too late to do so, since we are past
+        the registration deadline.
+    </p>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
We haven't had an actual MIVS studio login for at least five years, which is as far back as I can check. Now we redirect to this explanation page instead of the blank studio page, which was confusing people.