### PR TITLE
Add reminder for gameless MIVS studios

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -900,6 +900,15 @@ if c.MIVS_ENABLED:
         ident='mivs_video_broken')
 
     MIVSEmailFixture(
+        IndieStudio,
+        'Reminder to submit your game to MIVS',
+        'mivs/game_reminder.txt',
+        lambda studio: not studio.games,
+        ident='mivs_studio_submission_reminder',
+        when=days_before(7, c.MIVS_DEADLINE)
+    )
+
+    MIVSEmailFixture(
         IndieGame,
         'Reminder to submit your game to MIVS',
         'mivs/submission_reminder.txt',

--- a/uber/templates/emails/mivs/game_reminder.txt
+++ b/uber/templates/emails/mivs/game_reminder.txt
@@ -1,0 +1,9 @@
+Ahoy {{ studio.primary_contact_first_names }},
+
+Thanks again for registering your studio ({{ studio.name }}) to the MAGFest Indie Videogame Showcase! (MIVS)
+
+We just wanted to remind you that {{ c.MIVS_DEADLINE|datetime_local }} is the last chance to submit a game, including a playable demo with at least 15 minutes of gameplay. You currently do not have any games submitted for consideration.
+
+You can submit a game anytime until the deadline at {{ c.URL_BASE }}/mivs/continue_app?id={{ studio.id }}
+
+{{ c.MIVS_EMAIL_SIGNATURE }}


### PR DESCRIPTION
There's a reminder for incomplete games, but no reminder for MIVS studios that didn't even start a game. This adds one.