### PR TITLE
Fix dealer conversion and add reminder email

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -610,6 +610,16 @@ AutomatedEmailFixture(
     sender=c.MARKETPLACE_EMAIL,
     ident='dealer_info_required')
 
+AutomatedEmailFixture(
+    Attendee,
+    f'Last chance to claim your badge for {c.EVENT_NAME}',
+    'dealers/claim_badge.html',
+    lambda a: a.placeholder and 'converted badge' in a.admin_notes.lower(),
+    sender=c.MARKETPLACE_EMAIL,
+    when=days_before(7, c.PREREG_HOTEL_ELIGIBILITY_CUTOFF),
+    ident='converted_dealer_last_chance',
+)
+
 StopsEmailFixture(
     'Claim your Staff badge for {EVENT_NAME} {EVENT_YEAR}!',
     'placeholders/imported_volunteer.txt',

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -325,6 +325,8 @@ def dealer_badge_credit(attendee, new_attendee=None):
 
     if old_cost == new_cost:
         return
+    if attendee.paid != new_attendee.paid and new_attendee.paid == c.NOT_PAID:
+        return # This cost change will be in the paid status receipt item
     
     if attendee.is_dealer and new_attendee.is_dealer:
         return

--- a/uber/templates/emails/dealers/claim_badge.html
+++ b/uber/templates/emails/dealers/claim_badge.html
@@ -1,0 +1,11 @@
+<html>
+<head></head>
+<body>
+{{ attendee.first_name }},
+
+<br/><br/>
+This is a reminder that if you still want to come to {{ c.EVENT_NAME }} as an attendee, you must claim your badge by {{ c.PREREG_HOTEL_ELIGIBILITY_CUTOFF|datetime_local }}. Badges not claimed by this date will be purged from our system and you will have to repurchase a badge if you decide to attend.
+
+<br/><br/>Click here to claim your badge at any time before {{ c.PREREG_HOTEL_ELIGIBILITY_CUTOFF|datetime_local }}: <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}" target="_blank">{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}</a>
+
+<br/><br/><em>Important Note</em>: <strong>{{ c.PREREG_HOTEL_ELIGIBILITY_CUTOFF|datetime_local }} is also the cut-off date for eligibility in the {{ c.EVENT_NAME }} hotel lottery</strong>. If you do not claim your badge, you will NOT be eligible for the hotel lottery even if you repurchase a badge later. Make sure you claim your badge to keep your eligibility for the hotel lottery!


### PR DESCRIPTION
Fixes a couple bugs when calculating the receipt changes for dealers being converted to individual badges. Also adds an optional reminder email to poke dealers before the prereg hotel cut-off date.