### PR TITLE
Enable self-service refunds excluding fees

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -418,6 +418,11 @@ self_service_deferrals_open = boolean(default=False)
 # and asked to pay this fee.
 merch_shipping_fee = integer(default=15)
 
+# If true, and we are NOT using Authorize.net, self-service refunds will exclude processing fees.
+# Requires refund_cutoff to be set to enable self-service refunds.
+# Admins can always choose to refund with or without fees when cancelling a receipt.
+exclude_fees_from_refunds = boolean(default=True)
+
 # This URL, if set, will show up alongside or without the above extra donation field
 extra_donation_url = string(default="")
 
@@ -1134,6 +1139,7 @@ refund_start = string(default="")
 
 # Before this date, attendees with single paid badges may self-service refund their badge.
 # Leave this blank to disable self-service refunds.
+# See exclude_fees_from_refunds for setting whether these refunds include processing fees.
 refund_cutoff = string(default="")
 
 # All parts of the site go offline after this date (which is also used in several emails).


### PR DESCRIPTION
Adds a new exclude_fees_from_refunds option (default true) that allows you to control if self-service refunds exclude processing fees or not. This option is disabled for anyone not using Stripe, since we rely on Stripe's API to calculate the processing fee for transactions.