### PR TITLE
Update how pending badges work

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -541,8 +541,9 @@ class Config(_Overridable):
         if c.AT_THE_CON and self.ONE_DAYS_ENABLED and self.ONE_DAY_BADGE_AVAILABLE:
             badge_types.append({
                 'name': 'Single Day',
-                'desc': 'Can be upgrated to a weekend badge later.',
-                'value': c.ONE_DAY_BADGE
+                'desc': 'Can be upgraded to a weekend badge later.',
+                'value': c.ONE_DAY_BADGE,
+                'price': c.ONEDAY_BADGE_PRICE
             })
         badge_types.append({
             'name': 'Attendee',

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -344,6 +344,11 @@ dealer_editable_status_list = string_list(default=list("Pending Approval", "Wait
 # As above, but this controls whether dealer groups can cancel their own applications
 dealer_cancellable_status_list = string_list(default=list("Pending Approval", "Waitlisted"))
 
+# If True, admins who don't have full access to /registration/ can only create badges
+# in Pending status. These badges get put into a list that admins with /registration/
+# access must review and approve before those individuals will receive any emails.
+admin_badges_need_approval = boolean(default=False)
+
 # By default, staff/volunteers are only allowed to work shifts in a maximum of
 # three different departments. Historically, we've found that working in too
 # many different departments can spread people too thin and cause burn out,

--- a/uber/menu.py
+++ b/uber/menu.py
@@ -115,13 +115,11 @@ c.MENU = MenuItem(name='Root', submenu=[
 
     MenuItem(name='People', submenu=[
         MenuItem(name='Attendees', href='../registration/'),
-        MenuItem(name='Pending Badges', href='../registration/pending_badges'),
-        MenuItem(name='Promo Code Groups', href='../registration/promo_code_groups'),
         MenuItem(name='Groups', href='../group_admin/'),
         MenuItem(name='Dealers', href='../group_admin/#dealers', access_override='dealer_admin'),
         MenuItem(name='Guests', href='../group_admin/#guests', access_override='guest_admin'),
         MenuItem(name='Bands', href='../group_admin/#bands', access_override='band_admin'),
-        MenuItem(name='MIVS', href='../group_admin/#mivs', access_override='mivs_admin'),
+        
     ]),
 
     MenuItem(name='Schedule', submenu=[
@@ -136,9 +134,24 @@ c.MENU = MenuItem(name='Root', submenu=[
 ])
 
 
+if c.MIVS_ENABLED:
+    c.MENU['People'].append_menu_item(MenuItem(name='MIVS', href='../group_admin/#mivs',
+                                               access_override='mivs_admin'), position=5)
+
+
+if c.GROUPS_ENABLED:
+    c.MENU['People'].append_menu_item(MenuItem(name='Promo Code Groups',
+                                               href='../registration/promo_code_groups'), position=2)
+
+
 if c.ATTENDEE_ACCOUNTS_ENABLED:
     c.MENU['People'].append_menu_item(MenuItem(name='Attendee Accounts',
                                                href='../reg_admin/attendee_accounts'), position=1)
+
+
+if c.ADMIN_BADGES_NEED_APPROVAL:
+    c.MENU['People'].append_menu_item(MenuItem(name='Pending Badges',
+                                               href='../registration/pending_badges'), position=1)
 
 
 if c.ATTRACTIONS_ENABLED:

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -804,17 +804,6 @@ class Session(SessionManager):
                 return max([admin.max_level_access(section,
                                                    read_only=read_only) for section in attendee.access_sections])
 
-        def admin_can_create_attendee(self, attendee):
-            admin = self.current_admin_account()
-            if not admin:
-                return
-
-            if admin.full_registration_admin:
-                return True
-
-            return admin.full_shifts_admin if attendee.badge_type == c.STAFF_BADGE else \
-                self.admin_attendee_max_access(attendee) >= AccessGroup.DEPT
-
         def viewable_groups(self):
             from uber.models import Group, GuestGroup
             admin = self.current_admin_account()

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -752,6 +752,20 @@ class Attendee(MagModel, TakesPaymentMixin):
         from uber.models import Session
         with Session() as session:
             return session.admin_attendee_max_access(self, read_only=False)
+        
+    @property
+    def cannot_edit_badge_status_reason(self):
+        full_reg_admin = False
+        from uber.models import Session
+        with Session() as session:
+            full_reg_admin = bool(session.current_admin_account().full_registration_admin)
+        if c.ADMIN_BADGES_NEED_APPROVAL and not full_reg_admin and self.badge_status == c.PENDING_STATUS:
+            return "This badge must be approved by an admin."
+        if self.badge_status == c.WATCHED_STATUS and not c.HAS_SECURITY_ADMIN_ACCESS:
+            return "Please escalate this case to someone with access to the watchlist."
+        if c.AT_THE_CON and not c.HAS_REG_ADMIN_ACCESS:
+            return "Altering the badge status is disabled during the event. The system will update it automatically."
+        return ''
 
     @property
     def ribbon_and_or_badge(self):

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -139,10 +139,10 @@ class Root:
                 group.auto_recalc = False
 
             if group.is_new or group.badges != group_info_form.badges.data:
-                test_permissions = Attendee(badge_type=group.new_badge_type, ribbon=group.new_ribbons,
-                                            paid=c.PAID_BY_GROUP)
-                new_badge_status = c.PENDING_STATUS if not session.admin_can_create_attendee(test_permissions)\
-                    else c.NEW_STATUS
+                if c.ADMIN_BADGES_NEED_APPROVAL and not session.current_admin_account().full_registration_admin:
+                    new_badge_status = c.PENDING_STATUS
+                else:
+                    new_badge_status = c.NEW_STATUS
                 message = session.assign_badges(
                     group,
                     group_info_form.badges.data or int(bool(group.leader_first_name)),

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -228,7 +228,11 @@ class Root:
             message = save_attendee(session, attendee, params)
 
             if not message:
-                message = '{} has been saved.'.format(attendee.full_name)
+                message = '{} has been saved'.format(attendee.full_name)
+                if attendee.is_new and c.ADMIN_BADGES_NEED_APPROVAL and not session.current_admin_account().full_registration_admin:
+                    attendee.badge_status = c.PENDING_STATUS
+                    message += ' as a pending badge'
+
                 stay_on_form = params.get('save_return_to_search', False) is False
                 session.add(attendee)
                 session.commit()
@@ -1424,9 +1428,7 @@ class Root:
             success = True
             message = '{} has been saved'.format(attendee.full_name)
 
-            if (attendee.is_new or attendee.badge_type != attendee.orig_value_of('badge_type')
-                    or attendee.group_id != attendee.orig_value_of('group_id'))\
-                    and not session.admin_can_create_attendee(attendee):
+            if attendee.is_new and c.ADMIN_BADGES_NEED_APPROVAL and not session.current_admin_account().full_registration_admin:
                 attendee.badge_status = c.PENDING_STATUS
                 message += ' as a pending badge'
 

--- a/uber/templates/forms/attendee/admin_badge_flags.html
+++ b/uber/templates/forms/attendee/admin_badge_flags.html
@@ -126,11 +126,10 @@
 
 
 {% block badge_info %}
-{% set admin_can_change_status = not c.AT_THE_CON or c.HAS_REG_ADMIN_ACCESS or c.HAS_SECURITY_ADMIN_ACCESS %}
 <div class="row g-sm-3">
     <div class="col-12 col-sm-4">{{ form_macros.form_input(badge_flags.badge_status,
-            help_text='' if admin_can_change_status else "Altering the badge status is disabled during the event. The system will update it automatically.",
-            disabled=not admin_can_change_status) }}</div>
+            admin_text=attendee.cannot_edit_badge_status_reason,
+            disabled=(attendee.cannot_edit_badge_status_reason != '')) }}</div>
     <div class="col-12 col-sm-4">{{ form_macros.form_input(badge_flags.badge_type) }}</div>
     <div class="col-12 col-sm-4">{{ form_macros.form_input(badge_flags.badge_num,
             extra_field=form_macros.toggle_checkbox(badge_flags.no_badge_num, [badge_flags.badge_num], hide_on_checked=True, prop="readonly", checked=not attendee.badge_num)) }}</div>

--- a/uber/templates/registration/pending_badges.html
+++ b/uber/templates/registration/pending_badges.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% block title %}Panelist Badges{% endblock %}}
+{% block title %}Pending Badges{% endblock %}
 {% block content %}
   <script>
       var hideRows = function (id) {
@@ -17,7 +17,8 @@
       };
   </script>
 
-  <h3>Pending badges</h3>
+<div class="card card-body">
+  <h3>Pending Badges</h3>
 
   The following is a list of badges that have been submitted for creation.
 
@@ -25,6 +26,7 @@
     <thead>
     <tr>
       <th>Name</th>
+      <th>Group</th>
       <th>Email</th>
       <th>Badge Type</th>
       <th>Ribbons</th>
@@ -38,13 +40,14 @@
     {% for badge in pending_badges %}
       <tr id="{{ badge.id }}">
         <td>
-          <a href="#attendee_form?id={{ badge.id }}" target="_blank">{{ badge.full_name }}</a>
+          <a href="#attendee_form?id={{ badge.id }}">{{ badge.full_name }}</a>
           {% if badge.legal_name %}(Name on Photo ID: {{ badge.legal_name }}){% endif %}
         </td>
+        <td>{{ badge.group.name if badge.group else '' }}</td>
         <td>{{ badge.email|email_to_link }}</td>
         <td>{{ badge.badge_type_label }}</td>
         <td>{{ badge.ribbon_labels|join(", ") }}</td>
-        <td>{{ "Need Not Pay" if badge.paid == c.NEED_NOT_PAY else badge.badge_cost }}</td>
+        <td>{{ "Need Not Pay" if badge.paid == c.NEED_NOT_PAY else badge.badge_cost|format_currency }}</td>
         <td>{{ badge.created_info.who }}</td>
         <td>{{ badge.admin_notes }}</td>
         <td><button class="btn btn-primary" onClick="approve('{{ badge.id }}')">Approve Badge</button></td>
@@ -52,5 +55,6 @@
     {% endfor %}
     </tbody>
   </table>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
Fixes https://magfest.atlassian.net/browse/MAGDEV-1331 by adding a new setting that makes ALL non-registration-admin badges pending. Also updates under what circumstances you can change the badge status to both accommodate this change (so you can't just immediately set the badge status from Pending to New) and to better manage how we handle badges on the watchlist.