### PR TITLE
Add Streaming Responses

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -53,7 +53,7 @@ def log_pageview(func):
     def with_check(*args, **kwargs):
         with uber.models.Session() as session:
             try:
-                session.admin_account(cherrypy.session.get('account_id'))
+                session.current_admin_account()
             except Exception:
                 pass  # no tracking for non-admins yet
             else:
@@ -579,9 +579,11 @@ def render(template_name_list, data=None, encoding='utf-8'):
     data = renderable_data(data)
     env = JinjaEnv.env()
     template = env.get_or_select_template(template_name_list)
-    rendered = template.render(data)
+    cherrypy.response.stream = True
+    rendered = template.generate(data)
     if encoding:
-        return rendered.encode(encoding)
+        for idx, chunk in enumerate(rendered):
+            yield chunk.encode(encoding)
     return rendered
 
 

--- a/uber/site_sections/reg_reports.py
+++ b/uber/site_sections/reg_reports.py
@@ -60,6 +60,7 @@ class Root:
             'attendees': receipt_query.limit(50).offset(offset),
             'include_pending': include_pending,
         }
+    attendee_receipt_discrepancies._cp_config = {'response.stream': True}
 
     @log_pageview
     def attendees_nonzero_balance(self, session, include_no_receipts=False):


### PR DESCRIPTION
This switches to using generators when rendering Jinja templates with the `@render` decorator. With that pages can be streamed to the client by setting the `response.stream` property to `True` on the exposed pageview function.

For now I'm just enabling this on the Attendee Receipt Discrepancies page until more get tested.