### PR TITLE
Fix guest-submitted panel apps

### DIFF
--- a/uber/site_sections/panels.py
+++ b/uber/site_sections/panels.py
@@ -161,8 +161,8 @@ def process_panel_app(session, app, panelist, other_panelists_compiled, **params
 
     message = check(app) or check_other_panelists(other_panelists_compiled) or ''
     if not message:
-        for panelist in other_panelists_compiled:
-            panelist.app_id = app.id
+        for other_panelist in other_panelists_compiled:
+            other_panelist.app_id = app.id
         session.add_all([app, panelist] + other_panelists_compiled)
 
     return message


### PR DESCRIPTION
If a guest submitted a panel with any other panelists listed, a variable collision removed the 'submitter' panelist object we create to tie the panel to the guest group. Fixes https://magfest.atlassian.net/browse/MAGDEV-1332.