### PR TITLE
Improve performance of signups calendar

### DIFF
--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -237,8 +237,9 @@
                 if (json.success) {
                   $("#message-alert").addClass("alert-success").show().children('span').html(message);
                   shiftDetails.hide();
-                  $("#weighted-hours").text(json.hours);
-                  $("#weighted-hours").fadeOut(500).fadeIn(500);
+                  $("#weighted-hours").fadeOut(function() {
+                    $(this).text(json.hours)
+                  }).fadeIn();
                   fetchedEventList.length = 0;
                   ec.refetchEvents();
                 } else {
@@ -278,6 +279,9 @@
                 if (json.success) {
                   $("#message-alert").addClass("alert-success").show().children('span').html(message);
                   shiftDetails.hide();
+                  $("#weighted-hours").fadeOut(function() {
+                    $(this).text(json.hours)
+                  }).fadeIn();
                   fetchedEventList.length = 0;
                   ec.refetchEvents();
                 } else {
@@ -357,31 +361,22 @@
   }
   var possibleEventURLS = {'available': 'get_available_jobs', 'assigned': 'get_assigned_jobs'};
   var fetchEventsURLS = ['get_available_jobs', 'get_assigned_jobs'];
-  var fetchedEventList = new Array();
-  let fetchEvents = function(fetchInfo, successCallback, failureCallback) {
-    if (fetchedEventList.length != 0) {
-      successCallback(fetchedEventList);
-    }
-    for (const url of fetchEventsURLS) {
-      $.ajax({
-        method: 'GET',
-        url: url,
-        dataType: 'json',
-        data: fetchEventsParams,
-        success: function (eventList) {
-          fetchedEventList.push(...eventList);
-        },
-        error: function () {}
-      });   
-    }
+  var fetchedEventList = [];
 
-    console.log(fetchedEventList);
-
-    if (fetchedEventList.length != 0) {
-      successCallback(fetchedEventList);
-    } else {
-      failureCallback('Unable to connect to server, please try again.');
-    }
+  let fetchEvents = async function() {
+      if (fetchedEventList.length > 0) {
+          return fetchedEventList;
+      }
+      let eventParams = new URLSearchParams(fetchEventsParams);
+      try {
+          const responses = await Promise.all(fetchEventsURLS.map(url => fetch(url + "?" + eventParams)));
+          const eventLists = await Promise.all(responses.map((response) => response.json()));
+          let allNewEvents = [].concat(...eventLists);
+          fetchedEventList.push(...allNewEvents);
+          return fetchedEventList;
+      } catch (e) {
+          showErrorMessage('Unable to connect to server, please try again.')
+      }
   }
 
   let addEvents = function(id) {
@@ -427,7 +422,7 @@
       fetchEventsParams[key] = value;
     }
 
-    if ('get_available_jobs' in fetchEventsURLS) {
+    if (fetchEventsURLS.includes('get_available_jobs')) {
       fetchedEventList.length = 0;
       ec.refetchEvents();
     }

--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -60,7 +60,7 @@
       <div id="shifts-info-details" class="accordion-collapse collapse show" aria-labelledby="shifts-info-details-header">
         <div class="accordion-body">
           <p>
-            You are currently signed up for {{ hours }} weighted hours worth of shifts.
+            You are currently signed up for <span id="weighted-hours">{{ hours }}</span> weighted hours worth of shifts.
           </p>
           <p>
             Shifts that will overlap with your existing shifts will be hidden, and you will need to drop a shift to view them.
@@ -237,6 +237,9 @@
                 if (json.success) {
                   $("#message-alert").addClass("alert-success").show().children('span').html(message);
                   shiftDetails.hide();
+                  $("#weighted-hours").text(json.hours);
+                  $("#weighted-hours").fadeOut(500).fadeIn(500);
+                  fetchedEventList.length = 0;
                   ec.refetchEvents();
                 } else {
                   showErrorMessage(json.message);
@@ -266,7 +269,7 @@
               url: 'drop',
               dataType: 'json',
               data: {
-                shift_id: id,
+                job_id: id,
                 csrf_token: csrf_token
               },
               success: function (json) {
@@ -275,6 +278,7 @@
                 if (json.success) {
                   $("#message-alert").addClass("alert-success").show().children('span').html(message);
                   shiftDetails.hide();
+                  fetchedEventList.length = 0;
                   ec.refetchEvents();
                 } else {
                   showErrorMessage(json.message);
@@ -347,18 +351,49 @@
     }
   }
 
+  var fetchEventsParams = {
+    all: '',
+    highlight: '',
+  }
+  var possibleEventURLS = {'available': 'get_available_jobs', 'assigned': 'get_assigned_jobs'};
+  var fetchEventsURLS = ['get_available_jobs', 'get_assigned_jobs'];
+  var fetchedEventList = new Array();
+  let fetchEvents = function(fetchInfo, successCallback, failureCallback) {
+    if (fetchedEventList.length != 0) {
+      successCallback(fetchedEventList);
+    }
+    for (const url of fetchEventsURLS) {
+      $.ajax({
+        method: 'GET',
+        url: url,
+        dataType: 'json',
+        data: fetchEventsParams,
+        success: function (eventList) {
+          fetchedEventList.push(...eventList);
+        },
+        error: function () {}
+      });   
+    }
+
+    console.log(fetchedEventList);
+
+    if (fetchedEventList.length != 0) {
+      successCallback(fetchedEventList);
+    } else {
+      failureCallback('Unable to connect to server, please try again.');
+    }
+  }
+
   let addEvents = function(id) {
-    let eventSources = ec.getOption('eventSources');
-    eventSources.push(possibleEventSources[id]);
-    ec.setOption('eventSources', eventSources);
+    fetchEventsURLS.push(possibleEventURLS[id]);
+    fetchedEventList.length = 0;
     ec.refetchEvents();
     toggleButton(id, 'on');
   }
 
   let removeEvents = function(id) {
-    let eventSources = ec.getOption('eventSources');
-    updatedEventSources = eventSources.filter(function(el) { return el.url != possibleEventSources[id]['url']; });
-    ec.setOption('eventSources', updatedEventSources);
+    fetchEventsURLS = fetchEventsURLS.filter(function(el) { return el != possibleEventURLS[id]; });
+    fetchedEventList.length = 0;
     ec.refetchEvents();
     toggleButton(id, 'off');
   }
@@ -366,7 +401,7 @@
   let setFilters = function (dropdown_name) {
     let choice = $('#' + dropdown_name).val();
     if (choice == "" || choice == "all") {
-      ec.setOption('resources', {{ default_filters|safe }})
+      ec.setOption('resources', {{ default_filters|safe }});
     } else {
       ec.setOption('resources', []);
       addFilter(choice);
@@ -388,14 +423,13 @@
   }
 
   let setFetchParams = function (paramChanges) {
-    currentParams = possibleEventSources['available']['extraParams'];
     for (const [key, value] of Object.entries(paramChanges)) {
-      possibleEventSources['available']['extraParams'][key] = value;
+      fetchEventsParams[key] = value;
     }
-    let eventSources = ec.getOption('eventSources');
-    if (eventSources.filter(function(el) { return el.url == possibleEventSources['available']['url']; })) {
-      removeEvents('available');
-      addEvents('available');
+
+    if ('get_available_jobs' in fetchEventsURLS) {
+      fetchedEventList.length = 0;
+      ec.refetchEvents();
     }
   }
 
@@ -511,20 +545,6 @@
   }
 
   const allFilters = {{ all_filters|safe }}
-  let possibleEventSources = {
-    'available': {
-          url: 'get_available_jobs',
-          method: 'GET',
-          extraParams: {
-            'all': '',
-            'highlight': '',
-          }
-        },
-    'assigned': {
-      url: 'get_assigned_jobs',
-      method: 'GET',
-    }
-  }
 
   const ec = new EventCalendar(document.getElementById('shift_cal'), {
         view: window.matchMedia('(max-width: 576px)').matches ? 'listWeek' : 'timeGridWeek',
@@ -571,7 +591,7 @@
             }
         },
         viewDidMount: showOtherView,
-        eventSources: [possibleEventSources['available'], possibleEventSources['assigned']],
+        eventSources: [{events: fetchEvents}],
         eventContent: renderEvent,
         eventClick: showEventDetails,
         filterEventsWithResources: true,


### PR DESCRIPTION
This should (hopefully) dramatically improve the performance of the signups calendar by rewriting the call for assigned shifts so it stops generating so many DB queries.

There's less that we can immediately do about the call for available jobs, since there's so much processing that happens to figure out what jobs you can actually sign up for. We'll want to tackle that later, but in the meantime, we've added caching to the page so that switching to List view no longer re-fetches jobs from the server (thank you Hayley!).

We also now update the "you are signed up for X hours" text when you sign up for and drop a shift, so people don't have to refresh the page to see their current hours total.