### PR TITLE
Update schedule changes list based on review

### DIFF
--- a/uber/menu.py
+++ b/uber/menu.py
@@ -125,6 +125,7 @@ c.MENU = MenuItem(name='Root', submenu=[
     MenuItem(name='Schedule', submenu=[
         MenuItem(name=get_external_schedule_menu_name(), href='../schedule/'),
         MenuItem(name='Edit Schedule', href='../schedule/edit'),
+        MenuItem(name='Schedule Changes', href='../schedule_reports/'),
     ]),
 
     MenuItem(name='Statistics', submenu=[

--- a/uber/models/mits.py
+++ b/uber/models/mits.py
@@ -221,18 +221,8 @@ class MITSGame(MagModel):
         if not self.pictures:
             return ['', ''], ['', '']
 
-        header = None
-        thumbnail = None
-        for image in self.pictures:
-            if image.is_header and not header:
-                header = image
-            if image.is_thumbnail and not thumbnail:
-                thumbnail = image
-
-        if not header:
-            header = self.pictures[0]
-        if not thumbnail:
-            thumbnail = self.pictures[1] if len(self.pictures) > 1 else self.pictures[0]
+        header = self.guidebook_header
+        thumbnail = self.guidebook_thumbnail
 
         prepend = sluggify(self.name) + '_'
 

--- a/uber/models/mivs.py
+++ b/uber/models/mivs.py
@@ -510,12 +510,6 @@ class IndieGame(MagModel, ReviewMixin):
 
         header = self.guidebook_header
         thumbnail = self.guidebook_thumbnail
-
-        if not header:
-            header = self.images[0]
-        if not thumbnail:
-            thumbnail = self.images[1] if len(self.images) > 1 else self.images[0]
-
         prepend = sluggify(self.title) + '_'
 
         return [prepend + header.filename, prepend + thumbnail.filename], [header, thumbnail]

--- a/uber/tasks/panels.py
+++ b/uber/tasks/panels.py
@@ -45,7 +45,7 @@ def check_stale_guidebook_models():
             body = render('emails/guidebook_updates.txt', {
                 'stale_models': stale_models,
             }, encoding=None)
-            send_email.delay(c.REPORTS_EMAIL, "guidebook@magfest.org",
+            send_email.delay(c.REPORTS_EMAIL, "gb-ops@magfest.org",
                                 f"Guidebook Updates: {localized_now().strftime("%A %-I:%M %p")}",
                                 body, ident="guidebook_updates"
                                 )

--- a/uber/templates/schedule_reports/index.html
+++ b/uber/templates/schedule_reports/index.html
@@ -180,9 +180,12 @@
                   {{ current_data[key + 'time'] }}
                   {% if current_data[key + 'time'] != synced_data[key + 'time'] %}</em>{% endif %}
               {% else %}
-                {% if current_data[key] != synced_data[key] %}<em>{% endif %}
-                {{ current_data[key] }}
-                {% if current_data[key] != synced_data[key] %}</em>{% endif %}
+                {% if current_data[key] != synced_data[key] %}
+                  <em>{{ current_data[key]|linebreaksbr }}</em>
+                  {% if key == 'name' and synced_data[key] %}<br/>(Previously: {{ synced_data[key]|linebreaksbr }}){% endif %}
+                {% else %}
+                {{ current_data[key]|linebreaksbr }}
+                {% endif %}
               {% endif %}
             </td>
             {% endfor %}
@@ -190,7 +193,9 @@
             <td class="align-middle">{{ result.last_synced_dt('guidebook')|datetime_local("%-I:%M %p %b %-d, %Y") if result.last_synced['guidebook'] else "Never" }}</td>
             <td class="align-middle">
               <div class="d-flex gap-1 align-items-center text-nowrap">
+                {% if c.HAS_SCHEDULE_ACCESS %}
                 <a href="../schedule/form?id={{ result.id }}" target="_blank" class="btn btn-primary">View</a>
+                {% endif %}
                 <form method="post" class="sync-item" action="mark_item_synced">
                   {{ csrf_token() }}
                   <input type="hidden" name="selected_model" value="schedule" />
@@ -248,9 +253,10 @@
                 {% endif %}
               {% else %}
                 {% if current_data[key] != synced_data[key] %}
-                  <em>{{ current_data[key] }}</em>
+                  <em>{{ current_data[key]|linebreaksbr }}</em>
+                  {% if key == 'name' and synced_data[key] %}<br/>(Previously: {{ synced_data[key]|linebreaksbr }}){% endif %}
                 {% else %}
-                  {{ current_data[key] }}
+                  {{ current_data[key]|linebreaksbr }}
                 {% endif %}
               {% endif %}
             </td>
@@ -259,7 +265,9 @@
             <td class="align-middle">{{ result.last_synced_dt('guidebook')|datetime_local("%-I:%M %p %b %-d, %Y") if result.last_synced['guidebook'] else "Never" }}</td>
             <td class="align-middle">
               <div class="d-flex gap-1 align-items-center text-nowrap">
-              <a href="{{ result.guidebook_edit_link }}" target="_blank" class="btn btn-primary">View</a>
+              {% if result.guidebook_edit_link.split('/')[1] in (c.GETTABLE_SITE_PAGES[0] + c.ADMIN_ACCESS_SET|list) %}
+                <a href="{{ result.guidebook_edit_link }}" target="_blank" class="btn btn-primary">View</a>
+              {% endif %}
               <form method="post" class="sync-item" action="mark_item_synced">
                 {{ csrf_token() }}
                 <input type="hidden" name="selected_model" value="{{ model }}" />


### PR DESCRIPTION
Adds a bunch of fixes/updates to the new schedule changes list:
- No longer exports header/thumbnail for MIVS and MITS if there isn't a designated header/thumbnail
- Displays old session names if the name changed, as that's how we would find the session to change in Guidebook
- Changes the email address the at-con update notifications get sent to
- Fixes linebreaks in data so that they render correctly on the page
- Adds a link to the changes list to the top bar menu (under "Schedule")
- Only shows the "View" link next to items if it goes to a public page or if you have access

Unfortunately, while Guidebook only accepts XLS files and not XLSX files, our xlsxwriter library will not output XLS files. We could output CSV files instead but that invites encoding errors if anyone opens the file and saves it before importing into Guidebook, so for now we just have to resave exported files as XLS files.