### PR TITLE
Fix: Default Birthday Config + Restore Age Groups

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -1525,6 +1525,7 @@ c.AGE_GROUP_CONFIGS = {}
 for _name, _section in _config['age_groups'].items():
     _val = getattr(c, _name.upper())
     c.AGE_GROUP_CONFIGS[_val] = dict(_section.dict(), val=_val)
+c.AGE_GROUP_OPTS = [(key, value['desc']) for key,value in c.AGE_GROUP_CONFIGS.items()]
 
 c.RECEIPT_DEPT_CATEGORIES = {}
 for _name, _val in _config['enums']['receipt_item_dept'].items():

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -413,7 +413,7 @@ shift_custom_badges = boolean(default=True)
 # is turned on, then all registration forms will display and collect the exact
 # birthdate. Turning this off will simply display a drop-down selection of the age
 # groups defined below.
-collect_exact_birthdate = boolean(default=False)
+collect_exact_birthdate = boolean(default=True)
 
 # Certain events need attendees' full addresses - others will only want some
 # information. If this is turned off, attendees are only asked for their zipcode,
@@ -1392,13 +1392,33 @@ can_volunteer   = boolean(default=True)
 consent_form    = boolean(default=False)
 
 [[under_13]]
-desc            = string(default="Between 6 and 13")
+desc            = string(default="Between 6 and 12")
 min_age         = integer(default=6)
 max_age         = integer(default=12)
 wristband_color = string(default="red")
 discount        = integer(default=0)
 can_register    = boolean(default=True)
 can_volunteer   = boolean(default=False)
+consent_form    = boolean(default=True)
+
+[[13_to_17]]
+desc            = string(default="Between 13 and 17")
+min_age         = integer(default=13)
+max_age         = integer(default=17)
+wristband_color = string(default="yellow")
+discount        = integer(default=0)
+can_register    = boolean(default=True)
+can_volunteer   = boolean(default=False)
+consent_form    = boolean(default=True)
+
+[[over_17]]
+desc            = string(default="18 and older")
+min_age         = integer(default=18)
+max_age         = integer(default=120)
+wristband_color = string(default="green")
+discount        = integer(default=0)
+can_register    = boolean(default=True)
+can_volunteer   = boolean(default=True)
 consent_form    = boolean(default=True)
 
 [[__many__]]

--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -68,7 +68,7 @@ class PersonalInfo(AddressForm, MagForm):
         else validators.Optional()])
     age_group = SelectField('Age Group', validators=[
         validators.DataRequired("Please select your age group.") if not c.COLLECT_EXACT_BIRTHDATE
-        else validators.Optional()], choices=c.AGE_GROUPS)
+        else validators.Optional()], choices=c.AGE_GROUP_OPTS)
     ec_name = StringField('Emergency Contact Name', validators=[
         validators.DataRequired("Please tell us the name of your emergency contact.")
         ], render_kw={'placeholder': 'Who we should contact if something happens to you'})

--- a/uber/templates/forms/attendee/personal_info.html
+++ b/uber/templates/forms/attendee/personal_info.html
@@ -111,7 +111,7 @@
 {% if c.COLLECT_EXACT_BIRTHDATE %}
   {{ form_macros.form_input(personal_info.birthdate, admin_text=attendee.age_group_conf.desc) }}
 {% else %}
-  TBD
+  {{ form_macros.form_input(personal_info.age_group) }}
 {% endif %}
   </div>
 

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -335,7 +335,7 @@ def get_age_conf_from_birthday(birthdate, today=None):
     age = get_age_from_birthday(birthdate, today)
 
     for val, age_group in c.AGE_GROUP_CONFIGS.items():
-        if val != c.AGE_UNKNOWN and age_group['min_age'] <= age and age <= age_group['max_age']:
+        if val != c.AGE_UNKNOWN and age_group['min_age'] <= age <= age_group['max_age']:
             return age_group
 
     return c.AGE_GROUP_CONFIGS[c.AGE_UNKNOWN]


### PR DESCRIPTION
What it says on the tin. 
Turns birthday collection ON by default so you can use the system better in default mode.
Also restores working age group collection
Added some...sane looking (?) defaults to age groups to make that work ok in default as well. 