### PR TITLE
Update department and roles importing

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -1,5 +1,6 @@
 import re
 import uuid
+from collections import defaultdict
 from datetime import datetime
 from functools import wraps
 from pockets import is_listy
@@ -26,7 +27,7 @@ from uber.config import c
 from uber.decorators import department_id_adapter
 from uber.errors import CSRFException
 from uber.models import (AdminAccount, ApiToken, Attendee, AttendeeAccount, Department, DeptMembership,
-                         DeptMembershipRequest, Event, IndieJudge, IndieStudio, Job, Session, Shift, Group,
+                         DeptRole, Event, IndieJudge, IndieStudio, Job, Session, Shift, Group,
                          GuestGroup, Room, HotelRequests, RoomAssignment)
 from uber.models.badge_printing import PrintJob
 from uber.serializer import serializer
@@ -227,8 +228,15 @@ def _prepare_attendees_export(attendees, include_account_ids=False, include_apps
             checklist_admin_depts = {}
             dept_head_depts = {}
             poc_depts = {}
-            for membership in a.dept_memberships:
+            roles_depts = defaultdict(list)
+
+            active_dept_memberships = [m for m in a.dept_memberships if m.has_inherent_role or 
+                                           m.department in a.depts_where_working or m.department.is_shiftless]
+
+            for membership in active_dept_memberships:
                 assigned_depts[membership.department_id] = membership.department.name
+                for role in membership.dept_roles:
+                    roles_depts[membership.department_id].append((role.id, role.name))
                 if membership.is_checklist_admin:
                     checklist_admin_depts[membership.department_id] = membership.department.name
                 if membership.is_dept_head:
@@ -241,10 +249,7 @@ def _prepare_attendees_export(attendees, include_account_ids=False, include_apps
                 'checklist_admin_depts': checklist_admin_depts,
                 'dept_head_depts': dept_head_depts,
                 'poc_depts': poc_depts,
-                'requested_depts': {
-                    (m.department_id if m.department_id else 'All'):
-                    (m.department.name if m.department_id else 'Anywhere')
-                    for m in a.dept_membership_requests},
+                'roles_depts': roles_depts,
             })
 
         attendee_list.append(d)
@@ -686,7 +691,7 @@ class AttendeeLookup:
             if full:
                 options = [
                     subqueryload(Attendee.dept_memberships).subqueryload(DeptMembership.department),
-                    subqueryload(Attendee.dept_membership_requests).subqueryload(DeptMembershipRequest.department)]
+                    subqueryload(Attendee.dept_roles).subqueryload(DeptRole.department)]
             else:
                 options = []
 

--- a/uber/models/department.py
+++ b/uber/models/department.py
@@ -142,6 +142,18 @@ class DeptRole(MagModel):
     @dept_membership_count.expression
     def dept_membership_count(cls):
         return func.count(cls.dept_memberships)
+    
+    @hybrid_property
+    def normalized_name(self):
+        return self.normalize_name(self.name)
+
+    @normalized_name.expression
+    def normalized_name(cls):
+        return func.replace(func.replace(func.lower(cls.name), '_', ''), ' ', '')
+
+    @classmethod
+    def normalize_name(cls, name):
+        return name.lower().replace('_', '').replace(' ', '')
 
     @classproperty
     def _extra_apply_attrs(cls):

--- a/uber/templates/shifts_admin/job_renderer.html
+++ b/uber/templates/shifts_admin/job_renderer.html
@@ -57,8 +57,6 @@
 <script>
     $(setupShiftRatingClickHandler);
 
-
-
     var renderShift = function(shift) {
         return $id('shift_' + shift.id, '<tr></tr>')
             .empty()

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1683,10 +1683,23 @@ class TaskUtils:
         if dept:
             return (id, dept)
         return None
+    
+    @staticmethod
+    def _guess_dept_role(session, dept, id_name):
+        from uber.models import DeptRole
+
+        id, name = id_name
+        role = session.query(DeptRole).filter(DeptRole.department_id == dept.id, or_(
+            DeptRole.id == id,
+            DeptRole.normalized_name == DeptRole.normalize_name(name))).first()
+
+        if role:
+            return role
+        return None
 
     @staticmethod
     def attendee_import(import_job):
-        from uber.models import Attendee, AttendeeAccount, DeptMembership, DeptMembershipRequest
+        from uber.models import Attendee, AttendeeAccount, DeptMembership, DeptRole
         from functools import partial
 
         with uber.models.Session() as session:
@@ -1759,7 +1772,7 @@ class TaskUtils:
                 checklist_admin_depts = attendee.pop('checklist_admin_depts', {})
                 dept_head_depts = attendee.pop('dept_head_depts', {})
                 poc_depts = attendee.pop('poc_depts', {})
-                requested_depts = attendee.pop('requested_depts', {})
+                roles_depts = attendee.pop('roles_depts', {})
 
                 attendee.update({
                     'staffing': True,
@@ -1769,25 +1782,18 @@ class TaskUtils:
                 attendee = Attendee().apply(attendee, restricted=False)
 
                 for id, dept in assigned_depts.items():
-                    attendee.dept_memberships.append(DeptMembership(
+                    dept_membership = DeptMembership(
                         department=dept,
                         attendee=attendee,
                         is_checklist_admin=bool(id in checklist_admin_depts),
                         is_dept_head=bool(id in dept_head_depts),
                         is_poc=bool(id in poc_depts),
-                    ))
-
-                requested_anywhere = requested_depts.pop('All', False)
-                requested_depts = {d[0]: d[1] for d in map(partial(TaskUtils._guess_dept, session),
-                                                           requested_depts.items()) if d}
-
-                if requested_anywhere:
-                    attendee.dept_membership_requests.append(DeptMembershipRequest(attendee=attendee))
-                for id, dept in requested_depts.items():
-                    attendee.dept_membership_requests.append(DeptMembershipRequest(
-                        department=dept,
-                        attendee=attendee,
-                    ))
+                    )
+                    for role_tuple in roles_depts.get(id, []):
+                        role = TaskUtils._guess_dept_role(session, dept, role_tuple)
+                        if role:
+                            dept_membership.dept_roles.append(role)
+                    attendee.dept_memberships.append(dept_membership)
 
             session.add(attendee)
 


### PR DESCRIPTION
Updates how we export and import attendees' departments:
- Stops importing department requests, which are not useful to import year to year -- either someone was accepted to a department or they weren't
- Excludes assigned departments if someone did not sign up for shifts in that department, unless they are a POC/checklist admin/department head or unless the department is marked as shiftless -- this should help cull the dozens of extra staffers in departments like registration
- Imports staffers with their roles in their respective departments (https://magfest.atlassian.net/browse/MAGDEV-426)

Not fully tested yet, will be testing this on the staging servers.