### PR TITLE
Add 'decline' button for dealer custom messages

### DIFF
--- a/uber/site_sections/dealer_admin.py
+++ b/uber/site_sections/dealer_admin.py
@@ -208,7 +208,7 @@ class Root:
         return {'group': group}
 
     @ajax
-    def unapprove(self, session, id, action, email_text, message=''):
+    def unapprove(self, session, id, action, email_text, convert=False, message=''):
         assert action in ['waitlisted', 'declined']
         group = session.group(id)
         subject = 'Your {} {} has been {}'.format(c.EVENT_NAME, c.DEALER_REG_TERM, action)
@@ -222,8 +222,10 @@ class Root:
                 model=group.to_dict('id'))
         if action == 'waitlisted':
             group.status = c.WAITLISTED
-        else:
+        elif convert == True:
             message = decline_and_convert_dealer_group(session, group)
+        else:
+            group.status = c.DECLINED
         session.commit()
         return {'success': True,
                 'message': message}

--- a/uber/templates/forms/group/table_info.html
+++ b/uber/templates/forms/group/table_info.html
@@ -79,8 +79,9 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
         (The email subject will be "Your {{ c.EVENT_NAME }} {{ c.DEALER_REG_TERM|title }} has been [waitlisted | declined]")
         <textarea name="email_text" class="form-control" rows="5" cols="50"></textarea> <br/>
         <button class="btn btn-warning" onClick="unapprove('waitlisted'); return false;">Waitlist</button>
-        <button class="btn btn-danger" onClick="unapprove('declined'); return false;">Reject and Convert Badges</button>
-        <p class="form-text">Rejected {{ c.DEALER_TERM }}s are able to register at the price they would have paid when they applied.</p>
+        <button class="btn btn-danger" onClick="unapprove('declined', false); return false;">Decline</button>
+        <button class="btn btn-danger" onClick="unapprove('declined', true); return false;">Decline and Convert Badges</button>
+        <p class="help-block">("Decline and Convert Badges" will immediately email {{ c.DEALER_TERM }}s to register at the price they would have paid when they applied. <a href="../dealer_admin/convert_example?id={{ group.id }}" target="_blank">Read more here.</a>)</p>
       </div>
       <script type="text/javascript">
         var unapprove = function(action, convert) {
@@ -98,7 +99,15 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
               if (json.message) {
                 window.location = "index?message="+ json.message + "#dealers";
               } else {
-                $("#status").text("Waitlisted");
+                let status_val;
+                if (action == 'waitlisted') {
+                  status_val = "{{ c.WAITLISTED }}";
+                } else {
+                  status_val = "{{ c.DECLINED }}";
+                }
+                $("#status").val(status_val);
+                $("#setStatus").hide();
+                $("#message-alert").addClass("alert-info").show().children('span').html("{{ c.DEALER_TERM.title() }} " + action + " and email sent.");
               }
             }, 'json');
           }


### PR DESCRIPTION
Fixes https://magfest.atlassian.net/browse/MAGDEV-1400. If you wanted to send a custom message when waitlisting or declining a dealer, you couldn't decline a dealer without converting their badges. It also wasn't clear what converting actually did, since the link explaining it doesn't show up until someone is declined. This adds a new decline button and a link to the converted badge explanation, and also makes some feedback better when you don't reject + convert.