### PR TITLE
Fix shifts item on volunteer checklist (West and Stock)

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -2204,7 +2204,7 @@ class Attendee(MagModel, TakesPaymentMixin):
             return not self.placeholder and (
                 not c.VOLUNTEER_AGREEMENT_ENABLED or self.agreed_to_volunteer_agreement) and (
                 not c.EMERGENCY_PROCEDURES_ENABLED or self.reviewed_emergency_procedures) \
-                and c.SHIFTS_CREATED
+                and c.AFTER_SHIFTS_CREATED
 
         return not self.placeholder and self.food_restrictions_filled_out and self.shirt_info_marked and (
             not self.hotel_eligible
@@ -2214,7 +2214,7 @@ class Attendee(MagModel, TakesPaymentMixin):
             or c.HOTEL_REQUESTS_URL) and (
             not c.VOLUNTEER_AGREEMENT_ENABLED or self.agreed_to_volunteer_agreement) and (
             not c.EMERGENCY_PROCEDURES_ENABLED or self.reviewed_emergency_procedures) \
-            and c.SHIFTS_CREATED
+            and c.AFTER_SHIFTS_CREATED
 
     @property
     def hotel_nights(self):

--- a/uber/templates/staffing/shifts_item.html
+++ b/uber/templates/staffing/shifts_item.html
@@ -8,6 +8,6 @@
         {% else %}
             Sign up
         {% endif %}
-        for shifts{% if c.BEFORE_SHIFTS_CREATED %} starting on {{ c.SHIFTS_CREATED.astimezone(c.EVENT_TIMEZONE).strftime('%B %-e') }}{% endif %}.
+        for shifts{% if c.BEFORE_SHIFTS_CREATED %} starting on {{ c.SHIFTS_CREATED.astimezone(c.EVENT_TIMEZONE).strftime('%B %-e') }}{% endif %}.{% if c.DROP_SHIFTS_DEADLINE %} (after {{ c.DROP_SHIFTS_DEADLINE.astimezone(c.EVENT_TIMEZONE).strftime('%B %-e') }}, you cannot drop shifts, but you can continue to sign up for shifts through the event){% endif %}
     </li>
 {% endif %}


### PR DESCRIPTION
We weren't actually enforcing the shifts_created date properly. Our event plugins also had very similar override templates for the shifts_item, so this combines them into one.