### PR TITLE
Update hotel lottery form for MAGFest

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -423,6 +423,52 @@ class Config(_Overridable):
     def STAFF_HOTEL_LOTTERY_OPEN(self):
         return c.AFTER_HOTEL_LOTTERY_STAFF_START and c.BEFORE_HOTEL_LOTTERY_STAFF_DEADLINE
 
+    @property
+    def SHOW_HOTEL_LOTTERY_DATE_OPTS(self):
+        return c.HOTEL_LOTTERY_CHECKIN_START != c.HOTEL_LOTTERY_CHECKIN_END
+
+    @property
+    def HOTEL_LOTTERY_FORM_STEPS(self):
+        """
+        We have to run our form validations based on which 'step' in the form someone is, but
+        the number of steps depends on the entry type and event config. This builds
+        a dict that allows you to look up each step number based on a key.
+        """
+
+        steps = {}
+        step = 1
+
+        steps['room_checkin_name'] = step
+        step += 1
+        if c.SHOW_HOTEL_LOTTERY_DATE_OPTS:
+            steps['room_dates'] = step
+            step += 1
+        steps['room_hotel_type'] = step
+        step += 1
+        if c.HOTEL_LOTTERY_PREF_RANKING:
+            steps['room_selection_pref'] = step
+            step += 1
+        steps['room_final_step'] = step
+
+        step = 1
+        steps['suite_agreement'] = step
+        step += 1
+        steps['suite_checkin_name'] = step
+        step += 1
+        if c.SHOW_HOTEL_LOTTERY_DATE_OPTS:
+            steps['suite_dates'] = step
+            step += 1
+        steps['suite_type'] = step
+        step += 1
+        steps['suite_hotel_type'] = step
+        step += 1
+        if c.HOTEL_LOTTERY_PREF_RANKING:
+            steps['suite_selection_pref'] = step
+            step += 1
+        steps['suite_final_step'] = step
+
+        return steps
+
     @request_cached_property
     @dynamic
     def DEALER_APPS(self):

--- a/uber/config.py
+++ b/uber/config.py
@@ -436,8 +436,7 @@ class Config(_Overridable):
         """
 
         steps = {}
-        step = 1
-        steps['room_checkin_name'] = step
+        step = 0
         if c.SHOW_HOTEL_LOTTERY_DATE_OPTS:
             step += 1
             steps['room_dates'] = step
@@ -452,8 +451,6 @@ class Config(_Overridable):
 
         step = 1
         steps['suite_agreement'] = step
-        step += 1
-        steps['suite_checkin_name'] = step
         if c.SHOW_HOTEL_LOTTERY_DATE_OPTS:
             step += 1
             steps['suite_dates'] = step

--- a/uber/config.py
+++ b/uber/config.py
@@ -437,34 +437,33 @@ class Config(_Overridable):
 
         steps = {}
         step = 1
-
         steps['room_checkin_name'] = step
-        step += 1
         if c.SHOW_HOTEL_LOTTERY_DATE_OPTS:
+            step += 1
             steps['room_dates'] = step
-            step += 1
-        steps['room_hotel_type'] = step
         step += 1
+        steps['room_ada_info'] = step
+        step += 1
+        steps['room_hotel_type'] = step
         if c.HOTEL_LOTTERY_PREF_RANKING:
-            steps['room_selection_pref'] = step
             step += 1
+            steps['room_selection_pref'] = step
         steps['room_final_step'] = step
 
         step = 1
         steps['suite_agreement'] = step
         step += 1
         steps['suite_checkin_name'] = step
-        step += 1
         if c.SHOW_HOTEL_LOTTERY_DATE_OPTS:
-            steps['suite_dates'] = step
             step += 1
+            steps['suite_dates'] = step
+        step += 1
         steps['suite_type'] = step
         step += 1
         steps['suite_hotel_type'] = step
-        step += 1
         if c.HOTEL_LOTTERY_PREF_RANKING:
-            steps['suite_selection_pref'] = step
             step += 1
+            steps['suite_selection_pref'] = step
         steps['suite_final_step'] = step
 
         return steps

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -641,6 +641,9 @@ art_email_signature = string(default="- The MAGFest Console Department")
 # This URL is printed in the hotel lottery pages to direct attendees to read more about the lottery.
 hotel_lottery_url = string(default="")
 
+# If true, then users are asked to rank which choices are most important to them (listed under [[priorities]] but it's dates, room type, hotel)
+hotel_lottery_pref_ranking = boolean(default=True)
+
 # =============================
 # mivs
 # =============================

--- a/uber/forms/hotel_lottery.py
+++ b/uber/forms/hotel_lottery.py
@@ -128,9 +128,9 @@ class RoomLottery(MagForm):
 
         room_step = int(application.current_step) if application.current_step else 0
 
-        if not c.HOTEL_LOTTERY_PREF_RANKING or room_step <= c.HOTEL_LOTTERY_FORM_STEPS['room_selection_pref']:
+        if not c.HOTEL_LOTTERY_PREF_RANKING or room_step < c.HOTEL_LOTTERY_FORM_STEPS['room_selection_pref']:
             optional_list.append('selection_priorities')
-        if room_step <= c.HOTEL_LOTTERY_FORM_STEPS['room_hotel_type']:
+        if room_step < c.HOTEL_LOTTERY_FORM_STEPS['room_hotel_type']:
             optional_list.extend(['room_type_preference', 'hotel_preference'])
         elif not c.HOTEL_LOTTERY_HOTELS_OPTS:
             optional_list.append('hotel_preference')
@@ -219,11 +219,11 @@ class SuiteLottery(RoomLottery):
 
         suite_step = int(application.current_step) if application.current_step else 0
 
-        if not c.HOTEL_LOTTERY_PREF_RANKING or suite_step <= c.HOTEL_LOTTERY_FORM_STEPS['suite_selection_pref']:
+        if not c.HOTEL_LOTTERY_PREF_RANKING or suite_step < c.HOTEL_LOTTERY_FORM_STEPS['suite_selection_pref']:
             optional_list.append('selection_priorities')
-        if suite_step <= c.HOTEL_LOTTERY_FORM_STEPS['suite_hotel_type'] or application.room_opt_out:
+        if suite_step < c.HOTEL_LOTTERY_FORM_STEPS['suite_hotel_type'] or application.room_opt_out:
             optional_list.extend(['room_type_preference', 'hotel_preference'])
-        if suite_step <= c.HOTEL_LOTTERY_FORM_STEPS['suite_type']:
+        if suite_step < c.HOTEL_LOTTERY_FORM_STEPS['suite_type']:
             optional_list.append('suite_type_preference')
         if not c.SHOW_HOTEL_LOTTERY_DATE_OPTS or suite_step < c.HOTEL_LOTTERY_FORM_STEPS['suite_dates']:
             optional_list.extend(['earliest_checkin_date', 'latest_checkout_date'])

--- a/uber/forms/hotel_lottery.py
+++ b/uber/forms/hotel_lottery.py
@@ -121,11 +121,13 @@ class RoomLottery(MagForm):
 
         room_step = int(application.current_step) if application.current_step else 0
 
-        if room_step < 5:
+        if not c.HOTEL_LOTTERY_PREF_RANKING or room_step <= c.HOTEL_LOTTERY_FORM_STEPS['room_selection_pref']:
             optional_list.append('selection_priorities')
-        if room_step < 4:
+        if room_step <= c.HOTEL_LOTTERY_FORM_STEPS['room_hotel_type']:
             optional_list.extend(['room_type_preference', 'hotel_preference'])
-        if room_step < 2:
+        elif not c.HOTEL_LOTTERY_HOTELS_OPTS:
+            optional_list.append('hotel_preference')
+        if not c.SHOW_HOTEL_LOTTERY_DATE_OPTS or room_step < c.HOTEL_LOTTERY_FORM_STEPS['room_dates']:
             optional_list.extend(['earliest_checkin_date', 'latest_checkout_date'])
 
         return optional_list
@@ -210,15 +212,15 @@ class SuiteLottery(RoomLottery):
 
         suite_step = int(application.current_step) if application.current_step else 0
 
-        if suite_step < 6:
+        if not c.HOTEL_LOTTERY_PREF_RANKING or suite_step <= c.HOTEL_LOTTERY_FORM_STEPS['suite_selection_pref']:
             optional_list.append('selection_priorities')
-        if suite_step < 5 or application.room_opt_out:
+        if suite_step <= c.HOTEL_LOTTERY_FORM_STEPS['suite_hotel_type'] or application.room_opt_out:
             optional_list.extend(['room_type_preference', 'hotel_preference'])
-        if suite_step < 4:
+        if suite_step <= c.HOTEL_LOTTERY_FORM_STEPS['suite_type']:
             optional_list.append('suite_type_preference')
-        if suite_step < 3:
+        if not c.SHOW_HOTEL_LOTTERY_DATE_OPTS or suite_step < c.HOTEL_LOTTERY_FORM_STEPS['suite_dates']:
             optional_list.extend(['earliest_checkin_date', 'latest_checkout_date'])
-        if suite_step < 2:
+        if suite_step <= c.HOTEL_LOTTERY_FORM_STEPS['suite_checkin_name']:
             optional_list.extend(['legal_first_name', 'legal_last_name', 'cellphone'])
 
         return optional_list

--- a/uber/forms/hotel_lottery.py
+++ b/uber/forms/hotel_lottery.py
@@ -171,8 +171,8 @@ class RoomLottery(MagForm):
     @field_validation.latest_checkin_date
     def after_preferred_checkin(form, field):
         if field.data and field.data < form.earliest_checkin_date.data:
-            raise StopValidation("It does not make sense to have your latest acceptable check-in date \
-                                  earlier than your preferred check-in date.")
+            raise StopValidation("Please make sure your latest acceptable check-in date \
+                                  is later than your preferred check-in date.")
 
     @field_validation.latest_checkout_date
     def latest_checkin_within_range(form, field):
@@ -185,8 +185,8 @@ class RoomLottery(MagForm):
     @field_validation.earliest_checkout_date
     def before_preferred_checkout(form, field):
         if field.data and field.data > form.latest_checkout_date.data:
-            raise ValidationError("It does not make sense to have your earliest acceptable check-out date \
-                                  later than your preferred check-out date.")
+            raise ValidationError("Please make sure your earliest acceptable check-out date \
+                                  is earlier than your preferred check-out date.")
 
     @field_validation.selection_priorities
     def all_options_ranked(form, field):

--- a/uber/forms/hotel_lottery.py
+++ b/uber/forms/hotel_lottery.py
@@ -51,7 +51,9 @@ class LotteryRoomGroup(MagForm):
 
     room_group_name = StringField('Room Group Name',
                                   description='This will be shared with anyone you invite to your room group.',
-                                  validators=[validators.DataRequired("Please enter a name for your room group.")])
+                                  validators=[
+                                      validators.DataRequired("Please enter a name for your room group."),
+                                      validators.Length(max=40, message="Room group names cannot be longer than 40 characters.")])
     invite_code = StringField('Room Group Invite Code',
                               description='Send this code to up to three friends to invite them to your room group.',
                               render_kw={'readonly': "true"})

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -310,7 +310,7 @@ def attendee_tournament_cellphone(app):
 @validation.LotteryApplication
 def room_meets_night_requirements(app):
     if app.any_dates_different and (app.entry_type == c.ROOM_ENTRY or 
-            app.entry_type == c.SUITE_ENTRY and not app.room_opt_out):
+            app.entry_type == c.SUITE_ENTRY and not app.room_opt_out) and app.earliest_checkin_date and app.latest_checkout_date:
         latest_checkin, earliest_checkout = app.shortest_check_in_out_dates
         nights = app.build_nights_map(latest_checkin, earliest_checkout)
         if not nights:
@@ -325,7 +325,7 @@ def room_meets_night_requirements(app):
 
 @validation.LotteryApplication
 def suite_meets_night_requirements(app):
-    if app.any_dates_different and app.entry_type == c.SUITE_ENTRY:
+    if app.any_dates_different and app.entry_type == c.SUITE_ENTRY and app.earliest_checkin_date and app.latest_checkout_date:
         latest_checkin, earliest_checkout = app.shortest_check_in_out_dates
         nights = app.build_nights_map(latest_checkin, earliest_checkout)
         night_counter = 0

--- a/uber/models/hotel.py
+++ b/uber/models/hotel.py
@@ -276,7 +276,9 @@ class LotteryApplication(MagModel):
     
     @property
     def last_step(self):
-        return 6 if self.entry_type and self.entry_type == c.SUITE_ENTRY else 5
+        if self.entry_type == c.SUITE_ENTRY:
+            return c.HOTEL_LOTTERY_FORM_STEPS['suite_final_step']
+        return c.HOTEL_LOTTERY_FORM_STEPS['room_final_step']
 
     @property
     def homepage_link(self):

--- a/uber/site_sections/hotel_lottery.py
+++ b/uber/site_sections/hotel_lottery.py
@@ -136,16 +136,29 @@ class Root:
         else:
             forms = load_forms(params, application, forms_list)
 
+        contact_form_dict = load_forms(params, application, ["LotteryInfo"])
+
         return {
             'id': application.id,
             'attendee_id': attendee_id,
             'homepage_account': session.get_attendee_account_by_attendee(application.attendee),
             'forms': forms,
+            'lottery_info': contact_form_dict['lottery_info'],
             'message': message,
             'confirm': params.get('confirm', ''),
             'action': params.get('action', ''),
             'application': application
         }
+    
+    @requires_account(LotteryApplication)
+    def update_contact_info(self, session, id, **params):
+        application = session.lottery_application(id)
+        forms = load_forms(params, application, ["LotteryInfo"])
+        for form in forms.values():
+            form.populate_obj(application)
+        raise HTTPRedirect('index?id={}&message={}',
+                           application.id,
+                           "Contact information updated!")
 
     @requires_account(LotteryApplication)
     def enter_attendee_lottery(self, session, id=None, **params):

--- a/uber/site_sections/hotel_lottery.py
+++ b/uber/site_sections/hotel_lottery.py
@@ -241,13 +241,13 @@ class Root:
             else:
                 application.is_staff_entry = False
 
+            application.current_step = 999
             session.commit()
             session.refresh(application)
 
             if not application.guarantee_policy_accepted:
                 raise HTTPRedirect('guarantee_confirm?id={}', application.id)
             else:
-                application.current_step = 999
                 application.last_submitted = datetime.now()
 
                 body = render('emails/hotel/hotel_lottery_entry.html', {
@@ -305,13 +305,13 @@ class Root:
             else:
                 application.is_staff_entry = False
 
+            application.current_step = 999
             session.commit()
             session.refresh(application)
 
             if not application.guarantee_policy_accepted:
                 raise HTTPRedirect('guarantee_confirm?id={}', application.id)
             else:
-                application.current_step = 999
                 application.last_submitted = datetime.now()
 
                 body = render('emails/hotel/hotel_lottery_entry.html', {
@@ -403,7 +403,6 @@ class Root:
                 form.populate_obj(application)
 
             maybe_swapped = application.last_submitted != None
-            application.current_step = 999
             application.last_submitted = datetime.now()
             application.status = c.COMPLETE
 

--- a/uber/templates/confirm_tabs.html
+++ b/uber/templates/confirm_tabs.html
@@ -65,4 +65,36 @@
     </a>
   </li>
 {% endif %}
+{% if attendee.lottery_application and attendee.lottery_application.status == c.COMPLETE and (c.HOTEL_LOTTERY_OPEN or c.STAFF_HOTEL_LOTTERY_OPEN) %}
+{% set which_page, button_text = attendee.lottery_application.homepage_link %}
+<li class="nav-item" role="presentation">
+  <a href="../hotel_lottery/{{ which_page }}" class="nav-link{% if 'hotel_lottery' in c.PAGE_PATH %} active{% endif %}">
+    <span class="fa fa-hotel"></span> {{ button_text }}
+  </a>
+</li>
+{% endif %}
+{% if not c.ACCOUNTS_ENABLED %}
+<li class="nav-item ms-auto">
+  <div class="input-group me-2">
+    {% if c.ART_SHOW_ENABLED and c.ART_SHOW_OPEN and not attendee.art_show_applications %}
+    <a class="p-0" href="../art_show_applications/index?attendee_id={{ attendee.id }}">
+      <button type="button" class="btn btn-outline-primary"><i class="fa fa-tags"></i>&nbsp; Apply for Art Show</button>
+    </a>
+    {% endif %}
+    {% if c.AFTER_MARKETPLACE_REG_START and c.BEFORE_MARKETPLACE_DEADLINE and not attendee.marketplace_application and (attendee.has_badge or attendee.badge_status == c.UNAPPROVED_DEALER_STATUS) %}
+    <a class="p-0" href="../marketplace/apply?attendee_id={{ attendee.id }}">
+      <button type="button" class="btn btn-outline-primary"><i class="fa fa-shopping-cart"></i> Apply for Marketplace</button>
+    </a>
+    {% endif %}
+    {% if c.HOTEL_LOTTERY_OPEN or c.STAFF_HOTEL_LOTTERY_OPEN and (attendee.badge_type == c.STAFF_BADGE or c.STAFF_RIBBON in attendee.ribbon_ints) %}
+    <a class="p-0" href="../hotel_lottery/start?attendee_id={{ attendee.id }}">
+      <button type="button" class="btn btn-outline-primary"><i class="fa fa-hotel"></i>&nbsp; Enter Hotel Lottery</button>
+    </a>
+    {% endif %}
+  </div>
+</li>
+{% endif %}
 </ul>
+
+{% if not attendee.art_show_applications and c.ART_SHOW_OPEN %}
+{% endif %}

--- a/uber/templates/confirm_tabs.html
+++ b/uber/templates/confirm_tabs.html
@@ -86,10 +86,16 @@
       <button type="button" class="btn btn-outline-primary"><i class="fa fa-shopping-cart"></i> Apply for Marketplace</button>
     </a>
     {% endif %}
-    {% if c.HOTEL_LOTTERY_OPEN or c.STAFF_HOTEL_LOTTERY_OPEN and (attendee.badge_type == c.STAFF_BADGE or c.STAFF_RIBBON in attendee.ribbon_ints) %}
-    <a class="p-0" href="../hotel_lottery/start?attendee_id={{ attendee.id }}">
-      <button type="button" class="btn btn-outline-primary"><i class="fa fa-hotel"></i>&nbsp; Enter Hotel Lottery</button>
-    </a>
+    {% if c.HOTEL_LOTTERY_OPEN or c.STAFF_HOTEL_LOTTERY_OPEN and (attendee.badge_type == c.STAFF_BADGE or c.STAFF_RIBBON in attendee.ribbon_ints) and (not attendee.lottery_application or attendee.lottery_application.status != c.COMPLETE) %}
+      {% if attendee.hotel_lottery_eligible %}
+      <a class="p-0" href="../hotel_lottery/start?attendee_id={{ attendee.id }}">
+        <button type="button" class="btn btn-outline-primary"><i class="fa fa-hotel"></i>&nbsp; Enter Hotel Lottery</button>
+      </a>
+      {% else %}
+      <span class="tooltip-wrapper" tabindex="0" data-bs-toggle="tooltip" data-placement="top" title="{{ attendee.hotel_lottery_ineligible_reason }}">
+      <button type="button" class="btn btn-secondary" disabled><i class="fa fa-hotel"></i>&nbsp; Enter Hotel Lottery</button>
+      </span>
+      {% endif %}
     {% endif %}
   </div>
 </li>

--- a/uber/templates/confirm_tabs.html
+++ b/uber/templates/confirm_tabs.html
@@ -86,7 +86,7 @@
       <button type="button" class="btn btn-outline-primary"><i class="fa fa-shopping-cart"></i> Apply for Marketplace</button>
     </a>
     {% endif %}
-    {% if c.HOTEL_LOTTERY_OPEN or c.STAFF_HOTEL_LOTTERY_OPEN and (attendee.badge_type == c.STAFF_BADGE or c.STAFF_RIBBON in attendee.ribbon_ints) and (not attendee.lottery_application or attendee.lottery_application.status != c.COMPLETE) %}
+    {% if 'hotel_lottery' not in c.PAGE_PATH and c.HOTEL_LOTTERY_OPEN or c.STAFF_HOTEL_LOTTERY_OPEN and (attendee.badge_type == c.STAFF_BADGE or c.STAFF_RIBBON in attendee.ribbon_ints) and (not attendee.lottery_application or attendee.lottery_application.status != c.COMPLETE) %}
       {% if attendee.hotel_lottery_eligible %}
       <a class="p-0" href="../hotel_lottery/start?attendee_id={{ attendee.id }}">
         <button type="button" class="btn btn-outline-primary"><i class="fa fa-hotel"></i>&nbsp; Enter Hotel Lottery</button>

--- a/uber/templates/emails/hotel/entry_details.html
+++ b/uber/templates/emails/hotel/entry_details.html
@@ -14,10 +14,12 @@
 <li><strong>Check-in Name</strong>: {{ application.legal_first_name }} {{ application.legal_last_name }}</li>
 <li><strong>Contact Phone #</strong>: {{ application.cellphone }}</li>
 {% endif %}
+{% if c.SHOW_HOTEL_LOTTERY_DATE_OPTS %}
 <li><strong>Preferred Check-In/Out Dates</strong>: {{ app_or_parent.earliest_checkin_date.strftime('%m/%d/%Y') }} to {{ app_or_parent.latest_checkout_date.strftime('%m/%d/%Y') }}</li>
 {% if app_or_parent.latest_checkin_date or app_or_parent.earliest_checkout_date %}
 {% set acceptable_check_in_date, acceptable_check_out_date = app_or_parent.shortest_check_in_out_dates %}
 <li><strong>Acceptable Check-In/Out Dates</strong>: {{ acceptable_check_in_date.strftime('%m/%d/%Y') }} to {{ acceptable_check_out_date.strftime('%m/%d/%Y') }}</li>
+{% endif %}
 {% endif %}
 {% endmacro %}
 
@@ -26,7 +28,9 @@
 <ul>
     {{ basic_entry_details(application, app_or_parent, confirmation=confirmation) }}
     <li><strong>Suite Type Preference</strong>: {{ app_or_parent.suite_type_preference_labels|readable_join }}</li>
+    {% if c.HOTEL_LOTTERY_PREF_RANKING %}
     <li><strong>Preference Priorities</strong>: {{ app_or_parent.selection_priorities_labels|readable_join }}</li>
+    {% endif %}
 </ul>
 {% if not app_or_parent.room_opt_out %}
 <u>Room Entry Details</u>
@@ -34,12 +38,14 @@
 {% endif %}
 <ul>
     {% if app_or_parent.entry_type == c.ROOM_ENTRY %}{{ basic_entry_details(application, app_or_parent, confirmation=confirmation) }}{% endif %}
+    {% if c.HOTEL_LOTTERY_HOTELS_OPTS %}
     <li><strong>Hotel Preference</strong>: {{ app_or_parent.hotel_preference_labels|readable_join }}</li>
+    {% endif %}
     <li><strong>Room Type Preference</strong>: {{ app_or_parent.room_type_preference_labels|readable_join }}{% if application.wants_ada and not application.parent_application %} (ADA Room Requested){% endif %}</li>
     {% if application.wants_ada and not application.parent_application %}
     <li><strong>ADA Room Accommodations Requested</strong>: {{ app_or_parent.ada_requests }}</li>
     {% endif %}
-    {% if app_or_parent.entry_type == c.ROOM_ENTRY %}
+    {% if app_or_parent.entry_type == c.ROOM_ENTRY and c.HOTEL_LOTTERY_PREF_RANKING %}
     <li><strong>Preference Priorities</strong>: {{ app_or_parent.selection_priorities_labels|readable_join }}</li>
     {% endif %}
 </ul>

--- a/uber/templates/emails/hotel/hotel_lottery_entry.html
+++ b/uber/templates/emails/hotel/hotel_lottery_entry.html
@@ -5,8 +5,13 @@
 <body>
 <p>
     {{ application.attendee.full_name }},<br/>
-    Thank you for {{ action_str }} for {{ c.EVENT_NAME_AND_YEAR }}! Your {% if application.entry_type == c.SUITE_ENTRY %} suite{% elif application.entry_type == c.GROUP_ENTRY %} group's{% endif %} entry details are below.
+    Thank you for {{ action_str }} for {{ c.EVENT_NAME_AND_YEAR }}! Your{% if application.entry_type == c.SUITE_ENTRY %} suite{% elif application.entry_type == c.GROUP_ENTRY %} group's{% endif %} entry details are below.
 </p>
+{% if maybe_swapped and application.entry_type == c.ROOM_ENTRY %}
+<p>
+    <strong>IMPORTANT</strong>: If you originally entered the lottery for a suite, please note that your current lottery entry is <strong>ONLY</strong> for a standard room. If this was a mistake, you can <a href="{{ c.URL_BASE }}/hotel_lottery/index?id={{ application.id }}" target="_blank">change your entry</a> to a suite entry.
+</p>
+{% endif %}
 {% if new_conf %}
 <p>
     <strong>IMPORTANT</strong>: Your previous lottery entry has been <strong>withdrawn</strong> and your old confirmation number is invalid. Your new confirmation number is below.
@@ -19,7 +24,7 @@
     Room groups are given additional weighting in the lottery. Note that in order to join a room group you must have a valid registration for {{ c.EVENT_NAME }}.
 </p>
 {% endif %}
-<p>You can review{% if application.entry_type != c.GROUP_ENTRY %} and update{% endif %} your {% if application.entry_type == c.SUITE_ENTRY %} suite{% elif application.entry_type == c.GROUP_ENTRY %} group's{% endif %} lottery entry by logging into your <a href="{{ c.URL_BASE }}/hotel_lottery/index?attendee_id={{ application.attendee.id }}" target="_blank">lottery options page</a>.</p>
+<p>You can review{% if application.entry_type != c.GROUP_ENTRY %} and update{% endif %} your{% if application.entry_type == c.SUITE_ENTRY %} suite{% elif application.entry_type == c.GROUP_ENTRY %} group's{% endif %} lottery entry by logging into your <a href="{{ c.URL_BASE }}/hotel_lottery/index?attendee_id={{ application.attendee.id }}" target="_blank">lottery options page</a>.</p>
 {% set confirmation = True %}
 {% include 'emails/hotel/entry_details.html' with context %}
 </body>

--- a/uber/templates/hotel_lottery/contact_info_form.html
+++ b/uber/templates/hotel_lottery/contact_info_form.html
@@ -1,0 +1,25 @@
+{% set attendee = attendee or application.attendee %}
+<h2>Hotel Contact Information</h2>
+
+<p>
+    Hotels require your first and last name to match the photo ID you use during check-in, plus a phone number they can contact you at.
+    {% if 'index' not in c.PAGE_PATH %}
+    We need this information even if you are planning to join a room group. Please verify your first name, last name, and phone number below.
+    {% else %}
+    You can update your contact information below. Please make sure it is accurate!
+    {% endif %}
+</p>
+
+<div class="row g-sm-3">
+    <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(lottery_info.legal_first_name, value=lottery_info.legal_first_name.data or attendee.legal_first_name) }}
+    </div>
+    <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(lottery_info.legal_last_name, value=lottery_info.legal_last_name.data or attendee.legal_last_name) }}
+    </div>
+</div>
+<div class="row g-sm-3">
+    <div class="col-12 col-sm-6">
+        {{ form_macros.form_input(lottery_info.cellphone, value=lottery_info.cellphone.data or attendee.cellphone) }}
+    </div>
+</div>

--- a/uber/templates/hotel_lottery/index.html
+++ b/uber/templates/hotel_lottery/index.html
@@ -173,6 +173,17 @@
             {% endif %}
             {% if application.parent_application or application.entry_type %}
             <hr/>
+
+            {% import 'forms/macros.html' as form_macros with context %}
+            {{ form_macros.form_validation('contact-info-form', 'validate_hotel_lottery', form_list=['LotteryInfo']) }}
+            <form novalidate method="post" id="contact-info-form" action="update_contact_info">
+                <input type="hidden" name="id" value="{{ application.id }}" />
+                <input type="hidden" name="terms_accepted" value="{{ application.terms_accepted }}" />
+                <input type="hidden" name="data_policy_accepted" value="{{ application.data_policy_accepted }}" />
+                {{ csrf_token() }}
+                {% include 'hotel_lottery/contact_info_form.html' with context %}
+                <button type="submit" class="btn btn-primary mb-3">Update Contact Info</button>
+            </form>
             {% endif %}
 
             {% if application.parent_application or application.room_group_name %}

--- a/uber/templates/hotel_lottery/index.html
+++ b/uber/templates/hotel_lottery/index.html
@@ -95,6 +95,10 @@
 <h1>{{ c.EVENT_NAME }}{% if c.BEFORE_HOTEL_LOTTERY_FORM_START %} Staff{% endif %} Hotel Lottery <span class="text-muted h4">for {{ application.attendee.full_name }}</span></h1>
 <div class="card">
     <div class="card-body">
+        {% if not c.ATTENDEE_ACCOUNTS_ENABLED %}
+        {% set attendee = application.attendee %}
+        {% include 'confirm_tabs.html' with context %}
+        {% endif %}
         <div id="select-action" class="collapse">
             <p>
                 Welcome {% if application.status == c.COMPLETE %}back {% endif %} to the {{ c.EVENT_NAME }} hotel lottery!

--- a/uber/templates/hotel_lottery/index.html
+++ b/uber/templates/hotel_lottery/index.html
@@ -46,6 +46,41 @@
         });
     }
 
+    swapConfirm = function(event) {
+        var formToSubmit = this;
+        event.preventDefault();
+        bootbox.confirm({
+            title: "Change Entry Type?",
+            {% if application.entry_type == c.SUITE_ENTRY %}
+            message: "<p>This will convert your suite lottery entry to a standard room entry.</p>" + 
+                     "<p><strong>Your entry will be considered incomplete until you confirm your entry details on the next page.</strong></p>" +
+                     "<p>Are you sure?</p>",
+            {% else %}
+            message: "<p>This will convert your room lottery entry to a suite entry. You'll still be able to enter the lottery for a standard room.</p>" + 
+                     "<p><strong>Your entry will be considered incomplete until you confirm your entry details on the next page.</strong></p>" +
+                     {% if application.wants_ada %}
+                     "<p>Additionally, <span class='text-danger'>we cannot accommodate ADA requests for suite entries</span>, so your ADA request and details will be removed from your entry.</p>" +
+                     {% endif %}
+                    "</p><p>Are you sure?</p>",
+            {% endif %}
+            buttons: {
+                confirm: {
+                    label: 'Yes, Change to {{ "Suite" if application.entry_type == c.ROOM_ENTRY else "Room" }} Entry',
+                    className: 'btn-primary'
+                },
+                cancel: {
+                    label: 'Nevermind',
+                    className: 'btn-outline-secondary'
+                }
+            },
+            callback: function (result) {
+                if(result) {
+                    formToSubmit.submit();
+                }
+            }
+        });
+    }
+
     $().ready(function () {
         {% if confirm != '' %}
         $('#confirm').show();
@@ -53,6 +88,7 @@
         $('#select-action').show();
         {% endif %}
         if($('#leave-group').length) { $("#leave-group").submit(leaveConfirm); }
+        if($('#switch-type').length) { $("#switch-type").submit(swapConfirm); }
     })
 </script>
 
@@ -130,11 +166,6 @@
                 </div>
                 {% endif %}
             </div>
-            {% if application.status == c.COMPLETE and application.entry_type != c.GROUP_ENTRY and not app_locked and c.HOTEL_LOTTERY_OPEN %}
-            <p>
-                <strong>Note</strong>: if you wish to enter for a {{ 'suite' if app_or_parent.entry_type == c.ROOM_ENTRY else 'standard room' }} instead of a {{ app_or_parent.entry_type_label|lower }}, please withdraw your current application and start over.
-            </p>
-            {% endif %}
             {% if application.status != c.COMPLETE and not application.parent_application and not app_locked and c.HOTEL_LOTTERY_OPEN %}
             <p>
                 You are currently not eligible to create a group. Use the buttons above to create a room or suite lottery entry first.
@@ -179,10 +210,16 @@
                     You have an <span class="text-danger">incomplete</span> {{ app_or_parent.entry_type_label|lower }} application.
                     You are <strong>NOT</strong> entered into the {{ app_or_parent.entry_type_label|lower }} lottery until you complete your application.
                 </p>
-                <p><strong>Note</strong>: if you wish to enter for a {{ 'suite' if app_or_parent.entry_type == c.ROOM_ENTRY else 'standard room' }} instead of a {{ app_or_parent.entry_type_label|lower }}, please withdraw your current application and start over.</p>
                 <div class="row g-1">
                     <div class="col col-auto">
                     <a class="btn btn-primary" href="{{ 'suite' if app_or_parent.entry_type == c.SUITE_ENTRY else 'room' }}_lottery?id={{ application.id }}">Complete {{ app_or_parent.entry_type_label }} Lottery Entry</a>
+                    </div>
+                    <div class="col col-auto">
+                        <form method="post" action="switch_entry_type" id="switch-type">
+                            <input type="hidden" name="id" value="{{ application.id }}">
+                            {{ csrf_token() }}
+                            <button class="btn btn-info">Change to {{ 'Room' if application.entry_type == c.SUITE_ENTRY else 'Suite' }} Entry</button>
+                        </form>
                     </div>
                     <div class="col col-auto">
                         <form id="withdraw-lottery" method="post" action="withdraw_entry">
@@ -193,9 +230,18 @@
                 </div>
                 {% endif %}
                 {% if not application.parent_application and app_or_parent.status == c.COMPLETE %}
-                <h2>
-                    Your {{ app_or_parent.entry_type_label }} Lottery Application
-                    {% if not app_locked and c.HOTEL_LOTTERY_OPEN %}<a href="{{ 'suite' if app_or_parent.entry_type == c.SUITE_ENTRY else 'room' }}_lottery?id={{ application.id }}" class="btn btn-primary"><i class="fa fa-pencil"></i> Edit</a>{% endif %}
+                <h2 class="d-flex gap-2">
+                    <div>Your {{ app_or_parent.entry_type_label }} Lottery Application</div>
+                    {% if not app_locked and c.HOTEL_LOTTERY_OPEN %}
+                    <div><a href="{{ 'suite' if app_or_parent.entry_type == c.SUITE_ENTRY else 'room' }}_lottery?id={{ application.id }}" class="btn btn-primary"><i class="fa fa-pencil"></i> Edit</a></div>
+                    <div>
+                        <form method="post" action="switch_entry_type" id="switch-type">
+                            <input type="hidden" name="id" value="{{ application.id }}">
+                            {{ csrf_token() }}
+                            <button class="btn btn-info"><i class="fa fa-refresh"></i> Change to {{ 'Room' if app_or_parent.entry_type == c.SUITE_ENTRY else 'Suite' }} Entry</button>
+                        </form>
+                    </div>
+                    {% endif %}
                 </h2>
                 <div class="h5 text-muted">Confirmation # {{ app_or_parent.confirmation_num }}</div>
                 {% endif %}

--- a/uber/templates/hotel_lottery/lottery_tos.html
+++ b/uber/templates/hotel_lottery/lottery_tos.html
@@ -1,4 +1,3 @@
-{% if 'index' not in c.PAGE_PATH %}<h2>How the Room Lottery Works</h2>{% endif %}
 <p>
     The {{ c.EVENT_NAME }} room lottery is open and applicable to all available room types at all {{ c.EVENT_NAME }} partner hotels, including suites, ADA rooms, and standard rooms.
     These rooms are only available through the lottery, and any unclaimed/cancelled rooms will be made available subsequently via booking links on our website as they become available.

--- a/uber/templates/hotel_lottery/room_lottery_form.html
+++ b/uber/templates/hotel_lottery/room_lottery_form.html
@@ -64,9 +64,12 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
         if (response.step_completed != '') {
             step = parseInt(response.step_completed);
         }
-        if (step >= {{ application.last_step }}) {
+        {% block last_step_js %}
+        if (step >= {{ c.HOTEL_LOTTERY_FORM_STEPS['room_final_step'] }}) {
             $('#{{ room_text }}-lottery-form').submit();
-        } else {
+        }
+        {% endblock %}
+        else {
             if (step == 1) {
                 $('#return-btn').text("Return to Options");
             }

--- a/uber/templates/hotel_lottery/room_lottery_form.html
+++ b/uber/templates/hotel_lottery/room_lottery_form.html
@@ -65,7 +65,7 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
             step = parseInt(response.step_completed);
         }
         {% block last_step_js %}
-        if (step >= 5) {
+        if (step >= {{ application.last_step }}) {
             $('#{{ room_text }}-lottery-form').submit();
         }
         {% endblock %}
@@ -159,6 +159,7 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
 {% if steps.update({'counter': steps.counter + 1}) %}{% endif %}
 {% endblock %}
 
+{% if c.SHOW_HOTEL_LOTTERY_DATE_OPTS %}
 {% block check_in_out_dates %}
 {% set room_requirements = app_or_parent.suite_requirements_str if 'suite_lottery' in forms else app_or_parent.room_requirements_str %}
 <div class="accordion-item">
@@ -222,6 +223,7 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
 </div>
 {% if steps.update({'counter': steps.counter + 1}) %}{% endif %}
 {% endblock %}
+{% endif %}
 
 {% block ada_info %}
 <div class="accordion-item">
@@ -303,7 +305,9 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
 
             {% block hotel_and_room_type_ranking_form %}
             <div class="hotel_and_room_type_ranking">
+            {% if c.HOTEL_LOTTERY_HOTELS_OPTS %}
             {{ form_macros.form_input(room_or_suite_lottery.hotel_preference, readonly=read_only) }}
+            {% endif %}
             {{ form_macros.form_input(room_or_suite_lottery.room_type_preference, readonly=read_only) }}
             </div>
             {% if not read_only and application.current_step <= steps.counter %}
@@ -325,6 +329,7 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
 {% if steps.update({'counter': steps.counter + 1}) %}{% endif %}
 {% endblock %}
 
+{% if c.HOTEL_LOTTERY_PREF_RANKING %}
 {% block priorities %}
 <div class="accordion-item">
     <h3 class="accordion-header" id="step-{{ steps.counter }}-header">
@@ -363,3 +368,4 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
 </div>
 {% if steps.update({'counter': steps.counter + 1}) %}{% endif %}
 {% endblock %}
+{% endif %}

--- a/uber/templates/hotel_lottery/room_lottery_form.html
+++ b/uber/templates/hotel_lottery/room_lottery_form.html
@@ -64,12 +64,9 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
         if (response.step_completed != '') {
             step = parseInt(response.step_completed);
         }
-        {% block last_step_js %}
         if (step >= {{ application.last_step }}) {
             $('#{{ room_text }}-lottery-form').submit();
-        }
-        {% endblock %}
-        else {
+        } else {
             if (step == 1) {
                 $('#return-btn').text("Return to Options");
             }
@@ -84,6 +81,7 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
             serverValidationPassed = false;
         }
     };
+    var isSubmitting = false
 
     $().ready(function() {
         {% if application.current_step != 0 %}
@@ -102,6 +100,18 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
         {% elif application.status != c.COMPLETE %}
         $('#form-validations-{{ room_text }}-lottery-form').detach().prependTo($('#step-1').find('.accordion-body'));
         {% endif %}
+
+        $('#{{ room_text }}-lottery-form').submit(function(){
+            isSubmitting = true
+        })
+
+        $('#{{ room_text }}-lottery-form').data('initial-state', $('#{{ room_text }}-lottery-form').serialize());
+
+        $(window).on('beforeunload', function() {
+            if (!isSubmitting && $('#{{ room_text }}-lottery-form').serialize() != $('#{{ room_text }}-lottery-form').data('initial-state')){
+                return true
+            }
+        });
     })
 </script>
 {% endif %}

--- a/uber/templates/hotel_lottery/room_lottery_form.html
+++ b/uber/templates/hotel_lottery/room_lottery_form.html
@@ -109,56 +109,6 @@ Due to the extra scaffolding involved on this form, each block also has a _desc 
 
 {% block terms %}{% endblock %}
 
-{% block legal_name %}
-<div class="accordion-item">
-    <h3 class="accordion-header" id="step-{{ steps.counter }}-header">
-        <button class="accordion-button{% if steps.counter != 1 %} collapsed{% endif %}" type="button" id="step-{{ steps.counter }}-button" data-bs-toggle="collapse" data-bs-target="#step-{{ steps.counter }}" aria-expanded="true" aria-controls="step-{{ steps.counter }}">
-            Step {{ steps.counter }}: Check-in Name & Phone Number
-        </button>
-    </h3>
-    <div id="step-{{ steps.counter }}" class="accordion-collapse collapse{% if steps.counter == 1 %} show{% endif %}" aria-labelledby="step-{{ steps.counter }}-header">
-        <div class="accordion-body">
-            {% block legal_name_desc %}
-            <p>
-                Hotels require your first and last name to match the photo ID you use during check-in, plus a phone number they can contact you at.
-                Please verify your first name, last name, and phone number below.
-            </p>
-            {% endblock %}
-
-            {% block legal_name_form %}
-            <div class="row g-sm-3">
-                <div class="col-12 col-sm-6">
-                    {{ form_macros.form_input(room_or_suite_lottery.legal_first_name, readonly=read_only, value=room_or_suite_lottery.legal_first_name.data or application.attendee.legal_first_name) }}
-                </div>
-                <div class="col-12 col-sm-6">
-                    {{ form_macros.form_input(room_or_suite_lottery.legal_last_name, readonly=read_only, value=room_or_suite_lottery.legal_last_name.data or application.attendee.legal_last_name) }}
-                </div>
-            </div>
-            <div class="row g-sm-3">
-                <div class="col-12 col-sm-6">
-                    {{ form_macros.form_input(room_or_suite_lottery.cellphone, readonly=read_only, value=room_or_suite_lottery.cellphone.data or application.attendee.cellphone) }}
-                </div>
-            </div>
-
-            {% if not read_only and application.current_step <= steps.counter %}
-            <div class="row justify-content-end">
-                <div class="col col-auto">
-                    <button type="submit" id="step-{{ steps.counter }}-submit" class="btn btn-primary" name="current_step" value="{{ steps.counter }}">Save and Continue</button>
-                </div>
-            </div>
-            {% endif %}
-            {% if not read_only and application.status != c.COMPLETE %}
-            <div class="collapse text-end" id="step-{{ steps.counter }}-save-reminder">
-                <em>Scroll down to your current step and click "Save and Continue" to save changes.</em>
-            </div>
-            {% endif %}
-            {% endblock %}
-        </div>
-    </div>
-</div>
-{% if steps.update({'counter': steps.counter + 1}) %}{% endif %}
-{% endblock %}
-
 {% if c.SHOW_HOTEL_LOTTERY_DATE_OPTS %}
 {% block check_in_out_dates %}
 {% set room_requirements = app_or_parent.suite_requirements_str if 'suite_lottery' in forms else app_or_parent.room_requirements_str %}

--- a/uber/templates/hotel_lottery/suite_lottery_form.html
+++ b/uber/templates/hotel_lottery/suite_lottery_form.html
@@ -1,11 +1,5 @@
 {% extends 'hotel_lottery/room_lottery_form.html' %}
 
-{% block last_step_js %}
-    if (step >= 6) {
-        $('#{{ room_text }}-lottery-form').submit();
-    }
-{% endblock %}
-
 {% block form_js %}
 {{ super() }}
 

--- a/uber/templates/hotel_lottery/suite_lottery_form.html
+++ b/uber/templates/hotel_lottery/suite_lottery_form.html
@@ -14,6 +14,12 @@
 </script>
 {% endblock %}
 
+{% block last_step_js %}
+    if (step >= {{ c.HOTEL_LOTTERY_FORM_STEPS['suite_final_step'] }}) {
+        $('#{{ room_text }}-lottery-form').submit();
+    }
+{% endblock %}
+
 {% block ada_info %}{% endblock %}
 
 {% block terms %}

--- a/uber/templates/hotel_lottery/terms.html
+++ b/uber/templates/hotel_lottery/terms.html
@@ -14,6 +14,7 @@
             <input type="hidden" name="attendee_id" value="{{ attendee_id }}" />
             {{ csrf_token() }}
 
+            <h2>How the Room Lottery Works</h2>
             {% include 'hotel_lottery/lottery_tos.html' with context %}
 
             {{ form_macros.form_input(lottery_info.terms_accepted) }}
@@ -21,6 +22,8 @@
             {% include 'hotel_lottery/data_policy.html' with context %}
 
             {{ form_macros.form_input(lottery_info.data_policy_accepted) }}
+
+            {% include 'hotel_lottery/contact_info_form.html' with context %}
 
                 <button type="submit" name="group" value="true" class="btn btn-primary">Join Room Group</button>
                 <button type="submit" name="room" value="true" class="btn btn-secondary">Enter Room Lottery</button>

--- a/uber/templates/hotel_lottery_admin/form.html
+++ b/uber/templates/hotel_lottery_admin/form.html
@@ -150,6 +150,7 @@
     </div>
 </div>
 
+{% if c.SHOW_HOTEL_LOTTERY_DATE_OPTS %}
 <div class="row g-sm-3">
     <div class="col-12 col-sm-6">{{ form_macros.form_input(lottery_admin_info.earliest_checkin_date) }}</div>
     <div class="col-12 col-sm-6">{{ form_macros.form_input(lottery_admin_info.latest_checkout_date) }}</div>
@@ -158,6 +159,7 @@
     <div class="col-12 col-sm-6">{{ form_macros.form_input(lottery_admin_info.latest_checkin_date) }}</div>
     <div class="col-12 col-sm-6">{{ form_macros.form_input(lottery_admin_info.earliest_checkout_date) }}</div>
 </div>
+{% endif %}
 
 <div class="row g-sm-3">
     <div class="col-12 col-sm-6">{{ form_macros.form_input(lottery_admin_info.wants_ada) }}</div>
@@ -167,7 +169,9 @@
 {{ form_macros.form_input(lottery_admin_info.suite_type_preference) }}
 {{ form_macros.form_input(lottery_admin_info.hotel_preference) }}
 {{ form_macros.form_input(lottery_admin_info.room_type_preference) }}
+{% if c.HOTEL_LOTTERY_PREF_RANKING %}
 {{ form_macros.form_input(lottery_admin_info.selection_priorities) }}
+{% endif %}
 
 <div class="row g-sm-3">
     <div class="col-12 col-sm-6">

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -26,9 +26,7 @@
     Registration Information
   </div>
   <div class="card-body">
-    {% if (c.ATTRACTIONS_ENABLED and attractions) or attendee.promo_code_groups or attendee.art_show_applications or attendee.marketplace_application or attendee.is_group_leader %}
       {% include 'confirm_tabs.html' with context %}
-    {% endif %}
 
       {% if attendee.badge_status == c.PENDING_STATUS and attendee.paid == c.PENDING and attendee.transfer_code %}
       <div class="alert alert-warning" role="alert">

--- a/uber/templates/registration/menu.html
+++ b/uber/templates/registration/menu.html
@@ -16,6 +16,7 @@
 {{ macros.nav_menu(
     attendee, c.PAGE_PATH,
     "../registration/form?id={id}", "Attendee Data", True,
+    "../hotel_lottery_admin/form?id={lottery_application.id}", "Hotel Lottery Entry", attendee.lottery_application and c.HAS_HOTEL_LOTTERY_ADMIN_ACCESS,
     "../registration/shifts?id={id}&return_to=../registration/index", "Shifts", attendee.staffing and c.HAS_SHIFTS_ADMIN_ACCESS,
     "../registration/history?id={id}", "History", True,
     "../badge_printing/attendee_print_jobs?id={id}", "Badge Print Jobs", c.HAS_BADGE_PRINTING_ACCESS and c.BADGE_PRINTING_ENABLED,


### PR DESCRIPTION
Includes several changes to the hotel lottery entry system -- several of these are actually requested by MFF but made sense to do in this fork first:
- Make the hotel lottery entry system work when attendee accounts are turned off
- Allow switching between Suite and Room hotel entry types
- Limit characters for hotel room group names
- Move name/phone entry to first step so that it is required for ALL entrants, including room group members
- Add link to the hotel lottery entry on /registration/form
- Update validation wording based on feedback
- Warn before closing your hotel lottery form if you've made changes