### PR TITLE
Update panel application and guidebook exports

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -1921,14 +1921,6 @@ c.FINAL_MIVS_GAME_STATUSES = [c.ACCEPTED, c.WAITLISTED, c.DECLINED, c.CANCELLED]
 # used for computing the difference between the "drop-dead deadline" and the "soft deadline"
 c.SOFT_MIVS_JUDGING_DEADLINE = c.MIVS_JUDGING_DEADLINE - timedelta(days=7)
 
-# Automatically generates all the previous MIVS years based on the eschaton and c.MIVS_START_YEAR
-c.PREV_MIVS_YEAR_OPTS, c.PREV_MIVS_YEARS = [], {}
-for num in range(c.ESCHATON.year - c.MIVS_START_YEAR):
-    val = c.MIVS_START_YEAR + num
-    desc = c.EVENT_NAME + ' MIVS ' + str(val)
-    c.PREV_MIVS_YEAR_OPTS.append((val, desc))
-    c.PREV_MIVS_YEARS[val] = desc
-
 
 # =============================
 # mits

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -640,12 +640,6 @@ hotel_lottery_pref_ranking = boolean(default=True)
 # Email address which will send emails
 mivs_email = string(default="MAGFest Indie Videogame Showcase <mivs@magfest.org>")
 
-# The first year this showcase started. Used to calculate alumni options.
-mivs_start_year = integer(default="2015")
-
-# TODO: enforce this, possibly (dunno if it's really necessary, hard drive space is pretty cheap)
-mivs_max_screenshot_size = integer(default=5242880)
-
 # Number of comped badges per accepted game.
 mivs_indie_badge_comps = integer(default=2)
 

--- a/uber/forms/panels.py
+++ b/uber/forms/panels.py
@@ -53,7 +53,7 @@ class PanelistCredentials(MagForm):
 
 class PanelInfo(MagForm):
     dynamic_choices_fields = {'department': lambda: [("", 'Please select an option')] + c.PANELS_DEPT_OPTS}
-    name = StringField("Panel Name")
+    name = StringField("Panel Name", description="The title that will appear on the event schedule. Max 120 characters.")
     department = SelectField("Department")
     presentation = SelectField("Type of Panel", coerce=int,
                                choices=[(0, 'Please select an option')] + c.PRESENTATION_OPTS)

--- a/uber/models/mits.py
+++ b/uber/models/mits.py
@@ -209,8 +209,8 @@ class MITSGame(MagModel):
     @property
     def guidebook_data(self):
         return {
-            'guidebook_name': self.team.name,
-            'guidebook_subtitle': self.name,
+            'guidebook_name': self.name,
+            'guidebook_subtitle': self.team.name,
             'guidebook_desc': self.description,
             'guidebook_location': '',
             'guidebook_header': self.guidebook_images[0][0],

--- a/uber/models/showcase.py
+++ b/uber/models/showcase.py
@@ -492,8 +492,8 @@ class IndieGame(MagModel, ReviewMixin):
     @property
     def guidebook_data(self):
         return {
-            'guidebook_name': self.studio.name,
-            'guidebook_subtitle': self.title,
+            'guidebook_name': self.title,
+            'guidebook_subtitle': self.studio.name,
             'guidebook_desc': self.description,
             'guidebook_location': '',
             'guidebook_header': self.guidebook_images[0][0],

--- a/uber/validations/panels.py
+++ b/uber/validations/panels.py
@@ -20,7 +20,7 @@ PanelInfo.field_validation.required_fields = {
     'length': "Please estimate how long this panel will need to be.",
     'length_text': ('Please specify how long your panel will be.', 'length', lambda x: x == c.OTHER),
     'length_reason': ('Please explain why your panel needs to be longer than sixty minutes.',
-                      'length', lambda x: x != c.SIXTY_MIN),
+                      'length', lambda x: x != c.SIXTY_MIN and x != 0),
     'description': "Please enter a description of what this panel will be about.",
     'presentation': "Please select a panel type.",
     'other_presentation': ('Since you selected "Other" for your type of panel, please describe it.',
@@ -43,6 +43,9 @@ if len(c.PANEL_CONTENT_OPTS) > 1:
     PanelInfo.field_validation.required_fields['granular_rating'] = "Please select what your panel's content will contain, or None."
 elif len(c.PANEL_RATING_OPTS) > 1:
     PanelInfo.field_validation.required_fields['rating'] = "Please select a content rating for your panel."
+
+
+PanelInfo.field_validation.validations['name']['length'] = validators.Length(max=120, message="Panel titles cannot be more than 120 characters.")
 
 
 @PanelInfo.field_validation('department')


### PR DESCRIPTION
Restricts panel name length, updates the title and subtitle for MIVS/MITS guidebook exports, and cleans up an orphaned set of form options.