### PR TITLE
Installing openssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install setuptools==77.0.3
 # Alternatively, build lxml from source to link against system libxml2: RUN uv pip install --system --no-binary lxml lxml
 RUN --mount=type=cache,target=/var/cache/apk \
     apk --update-cache upgrade && \
-    apk add git libxml2 xmlsec-dev build-base jq curl && \
+    apk add git libxml2 xmlsec-dev build-base jq curl openssh && \
     sh /tmp/install-uv.sh && \
     rm /tmp/install-uv.sh
 


### PR DESCRIPTION
When pulling config from a private repo we need openssh to fetch it.