### PR TITLE
Disable cache for now

### DIFF
--- a/.github/workflows/ci-docker.yaml
+++ b/.github/workflows/ci-docker.yaml
@@ -57,8 +57,8 @@ jobs:
           context: "."
           push: true
           tags: ghcr.io/${{ matrix.name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
 
   build:
     permissions:
@@ -103,5 +103,5 @@ jobs:
           context: "."
           push: true
           tags: ghcr.io/${{ vars.UBER_REPO || github.repository }}:${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max


### PR DESCRIPTION
Our cache is pulling in old versions of plugins. We need to resolve the branch name to a specific commit before calling docker build to make caching work correctly. Until that's figured out let's just disable the cache entirely.