### PR TITLE
Initialize flatpickr properly for shifts/schedule

### DIFF
--- a/uber/templates/schedule/form.html
+++ b/uber/templates/schedule/form.html
@@ -39,7 +39,7 @@
             name="start_time"
             type="text"
             class="form-control"
-            value="{{ event.start_time.astimezone(c.EVENT_TIMEZONE).strftime('%-m/%-d/%Y %-I:%M %p') if event.start_time else '' }}">
+            value="">
             <span class="input-group-text">
               <i class="fa fa-calendar"></i>
             </span>
@@ -92,13 +92,13 @@
 </div>
 
 <script type="text/javascript">
-    $('#start-time').flatpickr({
+    let startFlatpickr = flatpickr('#start-time',{
         allowInput: true,
         enableTime: true,
         altInput: true,
         altFormat: 'n/j/Y h:i K',
         dateFormat: 'Z',
-        defaultDate: '{{ c.PANELS_EPOCH.isoformat()[:-6] }}',
+        defaultDate: '{{ event.start_time.astimezone(c.EVENT_TIMEZONE).isoformat() if event.start_time else c.PANELS_EPOCH.isoformat()[:-6]}}',
         minDate: '{{ c.PANELS_EPOCH.isoformat()[:-6] }}',
         maxDate: '{{ c.PANELS_ESCHATON.isoformat()[:-6] }}'
     });

--- a/uber/templates/shifts_admin/form.html
+++ b/uber/templates/shifts_admin/form.html
@@ -118,7 +118,7 @@
         name="start_time"
         type="text"
         class="form-control"
-        value="{{ job.start_time.astimezone(c.EVENT_TIMEZONE).strftime('%-m/%-d/%Y %-I:%M %p') if job.start_time else '' }}">
+        value="">
         <span class="input-group-text">
           <i class="fa fa-calendar"></i>
         </span>
@@ -140,13 +140,13 @@
   {% endif %}
 
   <script type="text/javascript">
-    $('#start-time').flatpickr({
+      let startFlatpickr = flatpickr('#start-time',{
         allowInput: true,
         enableTime: true,
         altInput: true,
         altFormat: 'n/j/Y h:i K',
         dateFormat: 'Z',
-        defaultDate: '{{ min_date.isoformat()[:-6] }}',
+        defaultDate: '{{ job.start_time.astimezone(c.EVENT_TIMEZONE).isoformat() if job.start_time else min_date.isoformat()[:-6]}}',
         minDate: '{{ min_date.isoformat()[:-6] }}',
         maxDate: '{{ max_date.isoformat()[:-6] }}'
     });


### PR DESCRIPTION
Fixes how flatpickr gets it's date on page load. setting val doesn't work and I did not notice on those two pages.
Also just used flatpickers selector instead of jquery in case we need to do fancier later. 

access groups  and attractions were correct in this regard. 