### PR TITLE
Group size rebalance

### DIFF
--- a/test_solver.py
+++ b/test_solver.py
@@ -104,6 +104,35 @@ def solve_lottery(applications, hotel_rooms):
     # Set up our data structures
     for hotel_room in hotel_rooms:
         hotel_room["constraints"] = []
+
+    ####ORIGINAL SOLUTION UNCOMMENT FOR COMPARATIVE TESTING
+    # entries = {}
+    # for app in applications:
+    #     if app.entry_type and not app.parent_application:
+    #         entry = {
+    #             "members": [app],
+    #             "hotels": app.hotel_preference.split(","),
+    #             "room_types": app.room_type_preference.split(","),
+    #             "constraints": []
+    #         }
+    #         entries[app.id] = entry
+    #         for hotel_room in hotel_rooms:
+    #             if hotel_room["id"] in entry["hotels"]:
+    #                 weight = weight_entry(entry, hotel_room)                 
+                    
+    #                 # Each constraint is a tuple of (BoolVar(), weight, hotel_room)
+    #                 constraint = solver.BoolVar(f'{app.id}_assigned_to_{hotel_room["id"]}')
+    #                 entry["constraints"].append((constraint, weight, hotel_room))
+    #                 hotel_room["constraints"].append(constraint)
+                    
+    # for app in applications:
+    #     if app.entry_type and app.parent_application in entries:
+    #         entries[app.parent_application]["members"].append(app)
+    ###########
+    
+
+    
+    #### PROPOSED CHANGE COMMENT/UNCOMMENT FOR TESTING
     entries = {}
     for app in applications:
         if app.entry_type and not app.parent_application:
@@ -127,6 +156,7 @@ def solve_lottery(applications, hotel_rooms):
                 constraint = solver.BoolVar(f'{app_id}_assigned_to_{hotel_room["id"]}')
                 entry["constraints"].append((constraint, weight, hotel_room))
                 hotel_room["constraints"].append(constraint)
+    ######################
 
     ## Limit capacity of each room to fit the groups
     for app, entry in entries.items():

--- a/test_solver.py
+++ b/test_solver.py
@@ -145,7 +145,7 @@ def solve_lottery(applications, hotel_rooms):
             entries[app.id] = entry
 
     for app in applications:
-        if app.entry_type and app.parent_application in entries:
+        if app.parent_application in entries:
             entries[app.parent_application]["members"].append(app)
 
     for app_id, entry in entries.items():

--- a/uber/site_sections/hotel_lottery_admin.py
+++ b/uber/site_sections/hotel_lottery_admin.py
@@ -122,7 +122,7 @@ def solve_lottery(applications, hotel_rooms, lottery_type=c.ROOM_ENTRY):
             entries[app.id] = entry
                     
    for app in applications:
-        if app.entry_type and app.parent_application in entries:
+        if app.entry_type == lottery_type and app.parent_application in entries:
             entries[app.parent_application]["members"].append(app)
 
     for app_id, entry in entries.items():

--- a/uber/site_sections/hotel_lottery_admin.py
+++ b/uber/site_sections/hotel_lottery_admin.py
@@ -122,7 +122,7 @@ def solve_lottery(applications, hotel_rooms, lottery_type=c.ROOM_ENTRY):
             entries[app.id] = entry
                     
    for app in applications:
-        if app.entry_type == lottery_type and app.parent_application in entries:
+        if app.parent_application in entries:
             entries[app.parent_application]["members"].append(app)
 
     for app_id, entry in entries.items():


### PR DESCRIPTION
In case the un-pushed branch doesn't materialize, this is the atomic fix for the group size issue. This change includes a testable implementation, but addresses the two core issues:

1. The logic that appends members to a group needs to be fixed so that it doesn't filter out all roommates. There shouldn't be a lottery type gate here, right? If a person is part of a group, they should always be treated as such
2. The groups need to be appended prior to solving setting the application weights, otherwise there is no weighting at all for groups


Please pull this, look at the test solver, and compare by commenting the A/B sections for testing if there's a question of whether this works. 


In the current state, a group of four has about 25% the chance of getting a room as a group of individuals that have submitted individually. The modelled impact of this is that MagFest books approximately half the target number of guests. More concerning from a hotel relationship/legality point of view: if the group size isn't respected for capacity, there might be issues with fire code and room capacity.
