### PR TITLE
Use existing session where possible

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -778,7 +778,7 @@ class AttendeeLookup:
         Example `params` dictionary for setting extra parameters:
         <pre>{"placeholder": "yes", "legal_name": "First Last", "cellphone": "5555555555"}</pre>
         """
-        with Session() as session:
+        with Session(create_savepoint=True) as session:
             attendee_query = session.query(Attendee).filter(Attendee.first_name.ilike(first_name),
                                                             Attendee.last_name.ilike(last_name),
                                                             Attendee.email.ilike(email))
@@ -820,7 +820,7 @@ class AttendeeLookup:
         Example:
         <pre>{"first_name": "First", "paid": "doesn't need to", "ribbon": "Volunteer, Panelist"}</pre>
         """
-        with Session() as session:
+        with Session(create_savepoint=True) as session:
             attendee = session.attendee(id, allow_invalid=True)
 
             if not attendee:

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -2378,10 +2378,10 @@ class HybridSessionProxy:
 
     def __call__(self, create_savepoint=False, *args, **kwargs):
         """
-        Creates or returns the current session.
+        Creates a new session or returns the current session.
 
         create_savepoint (bool): Flush the current session to the DB and create a savepoint.
-                                 This enables using session.rollback() to undo changes.
+                                 This lets you use session.rollback() to undo only changes made after the savepoint.
                                  This is ignored if we're returning a new session.
         """
         try:

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -2376,11 +2376,38 @@ class HybridSessionProxy:
         """
         return getattr(_ScopedSession, name)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, create_savepoint=False, *args, **kwargs):
         """
-        Create isolated session, to match old behavior on 'with Session() as session'
+        Creates or returns the current session.
+
+        create_savepoint (bool): Flush the current session to the DB and create a savepoint.
+                                 This enables using session.rollback() to undo changes.
+                                 This is ignored if we're returning a new session.
         """
-        return SessionFactory(*args, **kwargs)
+        try:
+            req = cherrypy.request
+            
+            if 'bind' not in kwargs:
+                if not hasattr(req, 'db_connection'):
+                    req.db_connection = engine.connect()
+                    
+                    def release_connection():
+                        req.db_connection.close()
+                    req.hooks.attach('on_end_request', release_connection)
+                    
+                kwargs['bind'] = req.db_connection
+
+            session = SessionFactory(*args, **kwargs)
+
+            if create_savepoint and kwargs.get('bind') == getattr(req, 'db_connection', None) and req.db_connection.in_transaction():
+                session.begin_nested()
+
+            return session
+
+        except AttributeError:
+            # We are outside of a web request (e.g., Celery workers, cron jobs, test scripts)
+            # Fall back to standard unmanaged behavior.
+            return SessionFactory(*args, **kwargs)
 
 Session = HybridSessionProxy()
 

--- a/uber/site_sections/promo_codes.py
+++ b/uber/site_sections/promo_codes.py
@@ -36,9 +36,8 @@ class Root:
         text = text.strip()
         words = []
         if text:
-            with Session() as session:
-                old_words = set(s for (s,) in session.query(PromoCodeWord.normalized_word).filter(
-                    PromoCodeWord.part_of_speech == part_of_speech).all())
+            old_words = set(s for (s,) in session.query(PromoCodeWord.normalized_word).filter(
+                PromoCodeWord.part_of_speech == part_of_speech).all())
 
             for word in [s for s in shlex.split(text.replace(',', ' ')) if s]:
                 if PromoCodeWord.normalize_word(word) not in old_words:

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -2109,7 +2109,7 @@ class TaskUtils:
         from uber.models import Attendee, AttendeeAccount, DeptMembership, DeptRole
         from functools import partial
 
-        with uber.models.Session() as session:
+        with uber.models.Session(create_savepoint=True) as session:
             service, message, target_url = get_api_service_from_server(import_job.target_server,
                                                                        import_job.api_token)
 


### PR DESCRIPTION
This is a redux of https://github.com/magfest/ubersystem/pull/4549 with a slightly different approach: instead of always returning a 'nested' session (it's not actually nested -- more on that below), we just return the current session unless a flag is passed to specifically enable nesting. We add this flag to the few cases where a rollback is used in a `with Session() as session` block.

True nested sessions are no longer supported in SQLAlchemy. Instead, when you run `session.begin_nested`, the session is flushed to the database along with the SAVEPOINT command. This allows you to run session.rollback() to go back to the savepoint.

The problem is, we inspect session state for objects -- particularly via the `is_new` property. Since running session.begin_nested flushes the current session, `is_new` returns False for any objects that were pending when you made a 'nested' session. We don't want that in most cases, so we want to use nested sessions sparingly.