### PR TITLE
Fix hardcoded name in the prereg disclaimers

### DIFF
--- a/uber/templates/preregistration/disclaimers.html
+++ b/uber/templates/preregistration/disclaimers.html
@@ -15,7 +15,7 @@
     but you may <a href="https://super.magfest.org/faq/#sell-or-transfer" target="_blank">sell/transfer your badge</a>.
   </li>
   <li>
-    MAGFest has a <a href="https://super.magfest.org/faq/#multiple-badges" target="_blank">one badge per person policy</a>.
+    {{ c.EVENT_NAME }} has a <a href="https://super.magfest.org/faq/#multiple-badges" target="_blank">one badge per person policy</a>.
     If you purchase multiple badges (for your family, as a gift), please
     ensure that each badge is purchased in the name of the individual who the
     badge is intended for. You may use the same email address for multiple


### PR DESCRIPTION
The preregistration disclaimers template had a hard-coded "MAGFest". This PR just templates this out.

Not sure if this is supposed to be the org or the event name, nor what is desired here.