### PR TITLE
Template out statements about preordering merch or donations when disabled

### DIFF
--- a/uber/templates/emails/dealers/payment_confirmation.html
+++ b/uber/templates/emails/dealers/payment_confirmation.html
@@ -6,8 +6,17 @@ Your group ({{ group.name }}) has been preregistered for {{ c.EVENT_NAME }} this
     <br/> <br/>
     Some of your badges are not yet assigned to a specific person. If you assign these badges 
     now then it will take much less time for their owners to pick them up at the festival. 
-    Preassigning badges also allows individual members of your group to purchase a merch package 
-    or donate extra money to {{ c.EVENT_NAME }}. You may preassign your badges on your <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">group management page</a>. The individual registration links on the group management page can be filled out by you, or distributed to your group members for them to fill out themselves.
+    {% if c.ADDONS_ENABLED or c.COLLECT_EXTRA_DONATION %}
+        Preassigning badges also allows individual members of your group to 
+        {% if c.ADDONS_ENABLED and c.COLLECT_EXTRA_DONATION %}
+            purchase a merch package or donate extra money to {{ c.EVENT_NAME }}.
+        {% elif c.ADDONS_ENABLED %}
+            purchase a merch package.
+        {% else %}
+            donate extra money to {{ c.EVENT_NAME }}.
+        {% endif %}
+    {% endif %}
+    You may preassign your badges on your <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">group management page</a>. The individual registration links on the group management page can be filled out by you, or distributed to your group members for them to fill out themselves.
 {% endif %}
 
 <br/><br/>
@@ -16,3 +25,4 @@ If you would like to add badges, then please email us as {{ c.MARKETPLACE_EMAIL 
 <br/><br/>Badges are not mailed out before the event, so your group members may pick up their badge at the registration desk when they arrive at MAGFest. Inform your group to bring a photo ID{{ c.EXTRA_CHECKIN_DOCS }} to the registration desk, where they'll be provided with their badge. If anyone in your group pre-ordered a t-shirt or other merch package, they can pick those up at our merchandise booth. The location and hours of the registration desk and merchandise booth will be emailed prior to the event.
 
 {{ email_signature }}
+

--- a/uber/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/uber/templates/emails/reg_workflow/attendee_confirmation.html
@@ -16,8 +16,17 @@ You ({{ attendee.full_name }}) have preregistered for {{ c.EVENT_NAME_AND_YEAR }
 {% else %}
     and your payment of {{ (attendee.amount_paid / 100)|format_currency }} has been received.
 {% endif %}
-Your registration confirmation number is {{ attendee.id }}, and you can update your information, preorder merch, or donate
-extra money <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">here</a>.
+Your registration confirmation number is {{ attendee.id }}, and you can update your 
+{% if c.ADDONS_ENABLED and c.COLLECT_EXTRA_DONATION %}
+    information, preorder merch, or donate extra money
+{% elif c.ADDONS_ENABLED %}
+    information, or preorder merch
+{% elif c.COLLECT_EXTRA_DONATION %}
+    information, or donate extra money
+{% else %}
+    information
+{% endif %}
+<a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">here</a>.
 
 {% if attendee.is_group_leader %}
     If you don't remember claiming a badge, it may have been created for you by {{ c.EVENT_NAME }} staff. Please

--- a/uber/templates/emails/reg_workflow/group_confirmation.html
+++ b/uber/templates/emails/reg_workflow/group_confirmation.html
@@ -8,16 +8,33 @@ Your {{ group.is_dealer|yesno(c.DEALER_REG_TERM + ",group") }} ({{ group.name }}
 {% if group.unregistered_badges %}
     <br/> <br/>
     Some of your badges are not yet assigned to a specific person. If you assign these badges
-    now then it will take much less time for their owners to pick them up at the event. Preassigning
-    badges also allows individual members of your group to preorder merch or donate
-    extra money. You may preassign your badges on your
+    now then it will take much less time for their owners to pick them up at the event. 
+    {% if c.ADDONS_ENABLED or c.COLLECT_EXTRA_DONATION %}
+        Preassigning badges also allows individual members of your group to 
+        {% if c.ADDONS_ENABLED and c.COLLECT_EXTRA_DONATION %}
+            preorder merch or donate extra money.
+        {% elif c.ADDONS_ENABLED %}
+            preorder merch.
+        {% else %}
+            donate extra money.
+        {% endif %}
+    {% endif %} 
+    You may preassign your badges on your
     <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">group management page</a>.
     The individual registration links on the group management page can be filled out by you, or distributed
     to your group members for them to fill out themselves.
 
-    <b>Your</b> registration confirmation number is {{ group.leader_id }}, and you can update your information, preorder merch,
-    or donate extra money <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader_id }}">here</a>.
-
+    <b>Your</b> registration confirmation number is {{ group.leader_id }}, and you can update your
+    {% if c.ADDONS_ENABLED and c.COLLECT_EXTRA_DONATION %}
+        information, preorder merch, or donate extra money
+    {% elif c.ADDONS_ENABLED %}
+        information, or preorder merch
+    {% elif c.COLLECT_EXTRA_DONATION %}
+        information, or donate extra money
+    {% else %}
+        information
+    {% endif %}
+    <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader_id }}">here</a>.
     {% if not group.is_dealer and group.cost > 0 %}
         <br/> <br/>
         You can add badges to your group using the above link, but you must add


### PR DESCRIPTION
TouhouFest is currently not run by a charitable non-profit and our merch pre-orders are handled separately from registration and have both options disabled..

This PR uses the both `collect_extra_donation` and `addons_enabled` config options to template out attendee facing language when these event features are disabled.