### PR TITLE
perf: disable Jinja and CherryPy file autoreload in production mode

### DIFF
--- a/uber/jinja.py
+++ b/uber/jinja.py
@@ -186,6 +186,8 @@ class JinjaEnv:
         params = {
             'loader': AbsolutePathLoader(cls._template_dirs),
             'autoescape': True,
+            # In production, disable automatic template mtime disk checks to save CPU cycles and file stat overhead.
+            'auto_reload': bool(getattr(c, 'DEVELOPMENT', False)),
             'lstrip_blocks': True,
             'trim_blocks': True,
             'keep_trailing_newline': True,

--- a/uber/jinja.py
+++ b/uber/jinja.py
@@ -187,7 +187,7 @@ class JinjaEnv:
             'loader': AbsolutePathLoader(cls._template_dirs),
             'autoescape': True,
             # In production, disable automatic template mtime disk checks to save CPU cycles and file stat overhead.
-            'auto_reload': bool(getattr(c, 'DEVELOPMENT', False)),
+            'auto_reload': bool(getattr(c, 'DEV_BOX', False)),
             'lstrip_blocks': True,
             'trim_blocks': True,
             'keep_trailing_newline': True,

--- a/uber/server.py
+++ b/uber/server.py
@@ -227,6 +227,10 @@ if isinstance(storage_type, str):
     cherrypy_config['tools.sessions.storage_class'] = getattr(cherrypy.lib.sessions, storage_type)
 cherrypy.config.update(cherrypy_config)
 
+# In production, disable CherryPy's background file monitoring thread to save CPU stat cycles.
+if not getattr(c, 'DEVELOPMENT', False):
+    cherrypy.engine.autoreload.unsubscribe()
+
 libpthread_path = ctypes.util.find_library("pthread")
 pthread_setname_np = None
 if libpthread_path:

--- a/uber/server.py
+++ b/uber/server.py
@@ -228,7 +228,7 @@ if isinstance(storage_type, str):
 cherrypy.config.update(cherrypy_config)
 
 # In production, disable CherryPy's background file monitoring thread to save CPU stat cycles.
-if not getattr(c, 'DEVELOPMENT', False):
+if not c.DEV_BOX:
     cherrypy.engine.autoreload.unsubscribe()
 
 libpthread_path = ctypes.util.find_library("pthread")


### PR DESCRIPTION
By default, both CherryPy and Jinja2 have their hotreload enabled, even in otherwise static deployments like Ubersystem production deployments.

* CherryPy spawns a background thread and [checks every loaded Python module](https://github.com/cherrypy/cherrypy/blob/1f75bc9eed8e0e385f64f368bd69f58d96fb8c2b/cherrypy/process/plugins.py#L729-L758) via `os.stat` once every second.
* Jinja2 executes `os.path.getmtime` on every template file on every HTTP request ( during `get_template`, `{% extend %}`, and `{% include %}`) to check if the template has been updated on disk.

This PR disables both of them in non-development configurations to save the extra CPU cycles, extra memory, disk IO, and end-user latency.