### PR TITLE
perf: use tuple projection for Group dropdown query options 

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -332,7 +332,7 @@ class Root:
             'forms': forms,
             'return_to':  return_to,
             'no_badge_num': params.get('no_badge_num'),
-            'group_opts': [(g.id, g.name) for g in session.query(Group).order_by(Group.name).all()],
+            'group_opts': session.query(Group.id, Group.name).order_by(Group.name).all(),
             'unassigned': {
                 group_id: unassigned
                 for group_id, unassigned in session.query(Attendee.group_id, func.count('*')).filter(
@@ -1589,7 +1589,7 @@ class Root:
             'attendee': attendee,
             'forms': forms,
             'tab_view': tab_view,
-            'group_opts': [(g.id, g.name) for g in session.query(Group).order_by(Group.name).all()],
+            'group_opts': session.query(Group.id, Group.name).order_by(Group.name).all(),
         }
 
         if 'attendee_data' in cherrypy.url():


### PR DESCRIPTION
Right now, these queries fetch the entire model from the database, only to discard all other fields. They could instead just query for the desired fields, especially since this is going to be a full table-scan.