### PR TITLE
feat: migrate WSGI HTTP server from Cheroot to Granian

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ configobj==5.0.9
 email_validator==2.2.0
 fpdf2==2.8.3
 geopy==2.4.1
+granian>=2.1.0
 ics==0.7.2
 TatSu==5.16
 Jinja2==3.1.6

--- a/run_server.py
+++ b/run_server.py
@@ -8,6 +8,8 @@ import cherrypy
 
 import uber.server
 
+cherrypy.engine.start()
+application = cherrypy.tree
+
 if __name__ == '__main__':
-    cherrypy.engine.start()
     cherrypy.engine.block()

--- a/run_server.py
+++ b/run_server.py
@@ -1,15 +1,22 @@
 from __future__ import unicode_literals
 
-import traceback
-import sys
 import os
-
 import cherrypy
+
+is_wsgi = __name__ != '__main__' or os.environ.get("GRANIAN") == "true"
+
+if is_wsgi:
+    cherrypy.config.update({'environment': 'embedded', 'engine.signals.on': False})
+    cherrypy.server.unsubscribe()
 
 import uber.server
 
-cherrypy.engine.start()
+if is_wsgi:
+    cherrypy.server.unsubscribe()
+    cherrypy.engine.start()
+
 application = cherrypy.tree
 
 if __name__ == '__main__':
+    cherrypy.engine.start()
     cherrypy.engine.block()

--- a/uber-wrapper.sh
+++ b/uber-wrapper.sh
@@ -12,7 +12,10 @@ if [ "$1" = 'uber' ]; then
     echo "http://localhost/accounts/insert_test_admin"
     echo "From there the default login is magfest@example.com / magfest"
     python /app/sep.py alembic upgrade heads
-    python -W always::DeprecationWarning /app/run_server.py
+    # Auto-scale worker processes to container cgroups CPU quota (os.process_cpu_count)
+    # or fall back to explicit GRANIAN_WORKERS environment variable override.
+    WORKERS="${GRANIAN_WORKERS:-$(python -c 'import os; print(getattr(os, "process_cpu_count", os.cpu_count)() or 1)')}"
+    exec granian --interface wsgi --host 0.0.0.0 --port 80 --workers "${WORKERS}" --threads "${GRANIAN_THREADS:-2}" run_server:application
 elif [ "$1" = 'celery-beat' ]; then
     celery -A uber.tasks beat --loglevel=DEBUG --pidfile=
 elif [ "$1" = 'celery-worker' ]; then

--- a/uber-wrapper.sh
+++ b/uber-wrapper.sh
@@ -12,10 +12,13 @@ if [ "$1" = 'uber' ]; then
     echo "http://localhost/accounts/insert_test_admin"
     echo "From there the default login is magfest@example.com / magfest"
     python /app/sep.py alembic upgrade heads
-    # Auto-scale worker processes to container cgroups CPU quota (os.process_cpu_count)
-    # or fall back to explicit GRANIAN_WORKERS environment variable override.
-    WORKERS="${GRANIAN_WORKERS:-$(python -c 'import os; print(getattr(os, "process_cpu_count", os.cpu_count)() or 1)')}"
-    exec granian --interface wsgi --host 0.0.0.0 --port 80 --workers "${WORKERS}" --threads "${GRANIAN_THREADS:-2}" run_server:application
+    # Auto-scale worker processes with CPU cores (cgroups quota), capped at 4 by default
+    # for multi-core GIL parallelism while maintaining bounded memory with gc.freeze().
+    export GRANIAN=true
+    DEFAULT_WORKERS="$(python -c 'import os; c = getattr(os, "process_cpu_count", os.cpu_count)() or 1; print(min(c, 4))')"
+    WORKERS="${GRANIAN_WORKERS:-${DEFAULT_WORKERS}}"
+    BLOCKING_THREADS="${GRANIAN_BLOCKING_THREADS:-${GRANIAN_THREADS:-4}}"
+    exec granian --interface wsgi --host 0.0.0.0 --port 80 --workers "${WORKERS}" --blocking-threads "${BLOCKING_THREADS}" run_server:application
 elif [ "$1" = 'celery-beat' ]; then
     celery -A uber.tasks beat --loglevel=DEBUG --pidfile=
 elif [ "$1" = 'celery-worker' ]; then

--- a/uber/errors.py
+++ b/uber/errors.py
@@ -42,7 +42,9 @@ class HTTPRedirect(cherrypy.HTTPRedirect):
             # useful if we want to redirect the user back to the same
             # page after they complete an action, such as logging in
             # example URI: '/uber/registration/form?id=786534'
-            original_location = cherrypy.request.wsgi_environ['REQUEST_URI']
+            original_location = (getattr(cherrypy.request, 'script_name', '') or '') + cherrypy.request.path_info
+            if cherrypy.request.query_string:
+                original_location += '?' + cherrypy.request.query_string
 
             # Note: python does have utility functions for this. if this
             # gets any more complex, use the urllib module

--- a/uber/server.py
+++ b/uber/server.py
@@ -271,3 +271,17 @@ for plugin_name in c.PLUGINS:
     plugin = importlib.import_module(plugin_name)
     if callable(getattr(plugin, 'on_load', None)):
         plugin.on_load()
+
+
+# Freeze all startup-allocated objects (core models, routes, templates, and plugin modules)
+# into Python's permanent GC generation (PEP 556) as the final step of engine startup.
+# Priority 100 ensures this runs last, after all built-in CherryPy plugins have finished
+# initializing (Checker: 50, Monitors: 70, Server socket: 75, DropPrivileges: 77).
+def _freeze_memory():
+    import gc
+    if hasattr(gc, 'freeze'):
+        gc.collect()
+        gc.freeze()
+
+
+cherrypy.engine.subscribe('start', _freeze_memory, priority=100)


### PR DESCRIPTION
Granian is a compiled WSGI-compliant HTTP server built off of Rust, tokio, and hyper. The intent of this PR is to change out the production HTTP server to it (read: all non-local runs). 

In place of Cheroot, Granian will handle all TCP socket management, HTTP request parsing, slow client protection, request buffering, response framing, and socket flushes via natively compiled code.

Unlike Cheroot, which is a multithreaded WSGI implementation, Granian, like Gunicorn or uWSGI, is a multiprocess WSGI implementation, where a new worker process is forked from the supervisor process. This means the system as a whole is not subject to Python's GIL, and thus can have a much better CPU utilization and thus lower P99 latency.  The tradeoff here is that each process is isolated from each other, and thus this results in potentially higher RAM usage, though that might be counterbalanced by the fact that the Python process is no longer handling low-level HTTP server tasks. This memory increase can be partially mitigated via use of `gc.freeze()` to ensure that shared CoW memory isn't touched by the Python garbage collector.

This particular configuration spawns one worker per CPU core (up to 4).