### PR TITLE
perf: disable CherryPy sessions for static file handlers and static views.

### DIFF
--- a/uber/server.py
+++ b/uber/server.py
@@ -143,6 +143,10 @@ cherrypy.tools.custom_verbose_logger = cherrypy.Tool('before_error_response', lo
 
 
 class StaticViews:
+    _cp_config = {
+        'tools.sessions.on': False,
+    }
+
     @classmethod
     def path_args_to_string(cls, path_args):
         return '/'.join(path_args)
@@ -210,6 +214,8 @@ def error_page_404(status, message, traceback, version):
 
 
 c.APPCONF['/']['error_page.404'] = error_page_404
+c.APPCONF['/static'] = {'tools.sessions.on': False}
+c.APPCONF['/static_views'] = {'tools.sessions.on': False}
 
 cherrypy.tree.mount(Root(), c.CHERRYPY_MOUNT_PATH, c.APPCONF)
 static_overrides(os.path.join(c.MODULE_ROOT, 'static'))

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1584,6 +1584,7 @@ def static_overrides(dirname):
         for fname in files:
             appconf['/static' + relpath + '/' + fname] = {
                 'tools.staticfile.on': True,
+                'tools.sessions.on': False,
                 'tools.staticfile.filename': os.path.join(dpath, fname)
             }
 


### PR DESCRIPTION
By default, CherryPy sessions are enabled globally at the root mount path. Static assets (`/static/`) and static template views (`/static_views/`) inherit this configuration, causing CherryPy to attach `Set-Cookie` headers and create unnecessary session records and queries on every static asset request.

This prevents reverse proxies (such as nginx) and CDNs from caching static assets and wastes session storage (Redis/memory/disk) for unauthenticated visitors. Yes, you can force them to cache anyway, but that does not eliminate the extra compute load incurred on these requests.

This commit explicitly sets `'tools.sessions.on': False` for static routes in c.APPCONF, static_overrides(), and the StaticViews controller class.