### PR TITLE
Add start and end times to detail box of shifts

### DIFF
--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -524,8 +524,8 @@
       $(".slots-weighting").addClass('d-none');
     }
     $('#shift-desc').html(eventInfo.extendedProps.desc);
-    $('#shift-start-time').html("Start: " + eventInfo.start);
-    $('#shift-end-time').html("End: " + eventInfo.end);
+    $('#shift-start-time').html("Start: " + moment(eventInfo.start).format("h:mma"));
+    $('#shift-end-time').html("End: " + moment(eventInfo.end).format("h:mma"));
 
     let button = '';
     let dropDeadlinePassed = {{ c.AFTER_DROP_SHIFTS_DEADLINE|yesno('true,false') }};

--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -215,6 +215,8 @@
       <div><span id="shift-slots"></span> slots filled</div><div class="ms-auto">x<span id="shift-weight"></span> weighting</div>
     </div>
     <div id="shift-desc"></div>
+    <div id="shift-start-time"></div>
+    <div id="shift-end-time"></div>
   </div>
   <div class="p-1 mt-2 pt-2 border-top text-end">
     <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="toast">Close</button>
@@ -522,6 +524,8 @@
       $(".slots-weighting").addClass('d-none');
     }
     $('#shift-desc').html(eventInfo.extendedProps.desc);
+    $('#shift-start-time').html("Start: " + eventInfo.start);
+    $('#shift-end-time').html("End: " + eventInfo.end);
 
     let button = '';
     let dropDeadlinePassed = {{ c.AFTER_DROP_SHIFTS_DEADLINE|yesno('true,false') }};

--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -215,8 +215,7 @@
       <div><span id="shift-slots"></span> slots filled</div><div class="ms-auto">x<span id="shift-weight"></span> weighting</div>
     </div>
     <div id="shift-desc"></div>
-    <div id="shift-start-time"></div>
-    <div id="shift-end-time"></div>
+    <div id="shift-time"></div>
   </div>
   <div class="p-1 mt-2 pt-2 border-top text-end">
     <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="toast">Close</button>
@@ -524,8 +523,11 @@
       $(".slots-weighting").addClass('d-none');
     }
     $('#shift-desc').html(eventInfo.extendedProps.desc);
-    $('#shift-start-time').html("Start: " + moment(eventInfo.start).format("h:mma"));
-    $('#shift-end-time').html("End: " + moment(eventInfo.end).format("h:mma"));
+    // If the shift crosses the midnight boundary, show the user what day both the start and end of each shift are
+    $('#shift-time').html((moment(eventInfo.start).format("dddd") == moment(eventInfo.end).format("dddd")) ? 
+                          moment(eventInfo.start).format("h:mma") + " – " + moment(eventInfo.end).format("h:mma")
+                          : moment(eventInfo.start).format("dddd h:mma") + " – " + moment(eventInfo.end).format("dddd h:mma"));
+
 
     let button = '';
     let dropDeadlinePassed = {{ c.AFTER_DROP_SHIFTS_DEADLINE|yesno('true,false') }};


### PR DESCRIPTION
Rudimentary change to add start and end times to the shift detail box thus resolving #4538 , currently ends up looking like this: 
<img width="352" height="287" alt="image" src="https://github.com/user-attachments/assets/e58b9b38-e56a-453f-bee2-1b87504e0c8d" />

Tested using a local override in Chrome as I had trouble getting the docker up locally. 