### PR TITLE
Fix validations not actually running against changes

### DIFF
--- a/uber/site_sections/mits.py
+++ b/uber/site_sections/mits.py
@@ -120,6 +120,7 @@ class Root:
                 raise HTTPRedirect('index?id={}', team.id)
 
         return {
+            'logged_in_account': session.current_attendee_account(),
             'message': message,
             'team': team,
             'applicant': applicant

--- a/uber/site_sections/showcase.py
+++ b/uber/site_sections/showcase.py
@@ -37,6 +37,7 @@ class Root:
                                "Studio created successfully! Submit one or more games to our showcases below.")
 
         return {
+            'logged_in_account': session.current_attendee_account(),
             'message': message,
             'forms': forms,
         }

--- a/uber/templates/mits/team.html
+++ b/uber/templates/mits/team.html
@@ -24,8 +24,25 @@ The tabletop showcase is not open yet. Check back soon!
     {% endif %}
 {% else %}
     {% if team.is_new %}
+        {% if logged_in_account and logged_in_account.mits_teams %}
+        <div class="alert alert-info">
+          {% if logged_in_account.mits_teams|length == 1 %}
+          You have already registered the team "<a href="../showcase/index?id={{ logged_in_account.mits_teams[0].id }}">{{ logged_in_account.mits_teams[0].name }}</a>". You can use the form below if you wish to apply under a second team.
+          {% else %}
+          You have already registered the following teams:
+          <ul>
+            {% for studio in logged_in_account.mits_teams %}
+            <li><a href="../showcase/index?id={{ studio.id }}">{{ studio.name }}</a></li>
+            {% endfor %}
+          </ul>
+          You can use the form below if you wish to apply under a new team.
+          {% endif %}
+        </div>
+        {% endif %}
         <h2>MAGFest Indie Tabletop Showcase Application</h2>
+        {% if not logged_in_account %}
         Have you already filled this out? If so, click <a href="../mits/check_if_applied">here</a>. <br/><br/>
+        {% endif %}
     {% else %}
         <h2>Edit Your Team Information</h2>
     {% endif %}

--- a/uber/templates/showcase/apply.html
+++ b/uber/templates/showcase/apply.html
@@ -4,6 +4,21 @@
 {% block content %}
 
   <div class="card card-body">
+    {% if logged_in_account and logged_in_account.indie_studios %}
+      <div class="alert alert-info">
+        {% if logged_in_account.indie_studios|length == 1 %}
+        You have already registered the studio "<a href="../showcase/index?id={{ logged_in_account.indie_studios[0].id }}">{{ logged_in_account.indie_studios[0].name }}</a>". You can use the form below if you wish to apply under a second studio.
+        {% else %}
+        You have already registered the following studios:
+        <ul>
+          {% for studio in logged_in_account.indie_studios %}
+          <li><a href="../showcase/index?id={{ studio.id }}">{{ studio.name }}</a></li>
+          {% endfor %}
+        </ul>
+        {% if c.INDIE_SHOWCASE_OPEN %}You can use the form below if you wish to apply under a new studio.{% endif %}
+        {% endif %}
+      </div>
+    {% endif %}
     <h2>{{ c.EVENT_NAME }} Indies</h2>
     {% if not c.INDIE_SHOWCASE_OPEN and not c.HAS_SHOWCASE_ADMIN_ACCESS %}
         <p>Applications are currently closed for {{ c.ENABLED_INDIES_STR }}. Please refer to the schedule below.</p>

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -28,6 +28,7 @@ from phonenumbers import PhoneNumberFormat
 from pytz import UTC
 from sqlalchemy import func, or_, cast, literal, DateTime
 from sqlalchemy.orm import make_transient
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from uber.config import c, _config, signnow_sdk, threadlocal
 from uber.errors import CSRFException, HTTPRedirect
@@ -1163,8 +1164,18 @@ def validate_model(session, forms, model, create_preview_model=True, is_admin=Fa
     if not preview_model.session:
         session.add(preview_model)
 
-    if create_preview_model and preview_model not in session.new:
-        rollback_session = session.begin_nested()
+    if create_preview_model:
+        if preview_model in session.new:
+            try:
+                rollback_session = session.begin_nested()
+                preview_model.is_actually_new = True
+                new_objs.append(preview_model)
+            except SQLAlchemyError:
+                # Many new objects being validated aren't ready to be committed to the DB
+                # So we'll just work with this as a transient object
+                session.rollback()
+        else:
+            rollback_session = session.begin_nested()
 
         for form in forms.values():
             form.populate_obj(preview_model, is_admin=is_admin, dry_run=True)
@@ -2217,7 +2228,6 @@ class TaskUtils:
                 account.unused_years = 0
                 attendee.managers.append(account)
 
-            from sqlalchemy.exc import IntegrityError
             from psycopg2.errors import UniqueViolation
 
             try:


### PR DESCRIPTION
We were avoiding committing a session when validating new objects, but this also meant we weren't actually applying changes to them. This was only affecting a few instances in production, but would have affected a lot more due to the changes in https://github.com/magfest/ubersystem/pull/4573 (which was never deployed). We now apply changes to an object regardless of whether we can use begin_nested().

Also adds an alert to the showcase application page if you already have a studio registered, which is how we found this issue.