### PR TITLE
refactor: replace pytz with Python standard library zoneinfo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ python-barcode[images]==0.15.1
 python-dateutil==2.9.0.post0
 python-jose[cryptography]==3.5.0
 python3-saml==1.16.0
-pytz==2025.2
 pyyaml==6.0.2
 redis==6.2.0
 requests==2.32.4

--- a/tests/uber/models/test_attendee.py
+++ b/tests/uber/models/test_attendee.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import timezone, datetime
 
 import pytest
-import pytz
+
 from mock import Mock
-from pytz import UTC
+
 
 from uber import config
 from uber.config import c
@@ -366,7 +366,7 @@ def test_must_contact():
             department=dept2,
             is_poc=True)]
 
-    start_time = datetime.now(tz=pytz.UTC)
+    start_time = datetime.now(tz=timezone.utc)
 
     job1 = Job(
         name='Job1',
@@ -566,7 +566,8 @@ class TestStaffingAdjustments:
                 attendee_id=a.id,
                 department=dept,
                 department_id=dept.id,
-                is_dept_head=True),
+                is_dept_head=True)
+        ]
         a.assigned_depts = [dept]
         a.dept_memberships_with_role = dept_memberships
         a._staffing_adjustments()

--- a/tests/uber/models/test_badge_funcs.py
+++ b/tests/uber/models/test_badge_funcs.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
 import pytest
-from pytz import UTC
+
 
 from uber.badge_funcs import needs_badge_num
 from uber.config import c

--- a/tests/uber/models/test_config.py
+++ b/tests/uber/models/test_config.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
 import pytest
-from pytz import UTC
+
 
 import uber
 from uber.config import c

--- a/tests/uber/models/test_getattr_fields.py
+++ b/tests/uber/models/test_getattr_fields.py
@@ -1,7 +1,7 @@
-from datetime import datetime
+from datetime import timezone, datetime
 
 import pytest
-from pytz import UTC
+
 
 from uber.config import c
 from uber.models import AdminAccount, Attendee

--- a/tests/uber/models/test_group.py
+++ b/tests/uber/models/test_group.py
@@ -1,8 +1,8 @@
-from datetime import datetime
+from datetime import timezone, datetime
 
 import pytest
 from mock import Mock
-from pytz import UTC
+
 
 from uber.config import c
 from uber.models import Attendee, Group, Session

--- a/tests/uber/models/test_promo_code.py
+++ b/tests/uber/models/test_promo_code.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
 import pytest
-import pytz
+
 from mock import Mock
 
 from uber.models import Attendee, Group, PromoCode, Session
@@ -10,8 +10,8 @@ from uber.payments import PreregCart
 from uber.utils import check
 
 
-next_week = datetime.now(pytz.UTC) + timedelta(days=7)
-last_week = datetime.now(pytz.UTC) - timedelta(days=7)
+next_week = datetime.now(timezone.utc) + timedelta(days=7)
+last_week = datetime.now(timezone.utc) - timedelta(days=7)
 
 
 class TestPromoCodeAdjustments:
@@ -217,7 +217,7 @@ class TestAttendeePromoCodeModelChecks:
             "You are already receiving an age based discount, you can't use a promo code on top of that."
 
     def test_promo_code_not_is_expired(self):
-        expire = datetime.now(pytz.UTC) - timedelta(days=9)
+        expire = datetime.now(timezone.utc) - timedelta(days=9)
         promo_code = PromoCode(discount=1, expiration_date=expire)
         attendee = Attendee(
             promo_code=promo_code,

--- a/tests/uber/models/test_session.py
+++ b/tests/uber/models/test_session.py
@@ -1,14 +1,14 @@
-from datetime import date, datetime, timedelta
+from datetime import timezone, date, datetime, timedelta
 
 import pytest
-import pytz
+
 
 from uber.models import Attendee, Department, Group, Session
 from uber.config import c
 from uber.utils import localized_now
 
 
-next_week = datetime.now(pytz.UTC) + timedelta(days=7)
+next_week = datetime.now(timezone.utc) + timedelta(days=7)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/uber/site_sections/test_preregistration.py
+++ b/tests/uber/site_sections/test_preregistration.py
@@ -1,7 +1,7 @@
-from datetime import datetime, date, timedelta
+from datetime import timezone, datetime, date, timedelta
 
 import pytest
-import pytz
+
 
 from tests.uber.conftest import admin_attendee, assert_unique, POST
 from uber.config import c
@@ -15,7 +15,7 @@ assert admin_attendee
 assert POST
 
 
-next_week = datetime.now(pytz.UTC) + timedelta(days=7)
+next_week = datetime.now(timezone.utc) + timedelta(days=7)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/uber/site_sections/test_registration.py
+++ b/tests/uber/site_sections/test_registration.py
@@ -1,7 +1,7 @@
-from datetime import date, datetime, timedelta
+from datetime import timezone, date, datetime, timedelta
 
 import pytest
-import pytz
+
 import six
 
 from tests.uber.conftest import admin_attendee, assert_unique, csrf_token, POST
@@ -17,7 +17,7 @@ assert csrf_token
 assert POST
 
 
-next_week = datetime.now(pytz.UTC) + timedelta(days=7)
+next_week = datetime.now(timezone.utc) + timedelta(days=7)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/uber/test_api.py
+++ b/tests/uber/test_api.py
@@ -1,8 +1,8 @@
-from datetime import datetime
+from datetime import timezone, datetime
 
 import cherrypy
 import pytest
-import pytz
+
 from cherrypy import HTTPError
 
 from tests.uber.conftest import csrf_token
@@ -65,7 +65,7 @@ class TestAuthByToken(object):
         assert auth_by_token(set()) == expected
 
     def test_revoked(self, monkeypatch, session, api_token):
-        api_token.revoked_time = datetime.now(pytz.UTC)
+        api_token.revoked_time = datetime.now(timezone.utc)
         session.commit()
         session.refresh(api_token)
         monkeypatch.setitem(cherrypy.request.headers, 'X-Auth-Token', api_token.token)

--- a/tests/uber/test_schedule.py
+++ b/tests/uber/test_schedule.py
@@ -1,14 +1,14 @@
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
 import pytest
-import pytz
+
 
 from uber.config import c
 from uber.models import Event, Session
 from uber.site_sections import schedule
 
 
-UTCNOW = datetime.now(pytz.UTC)
+UTCNOW = datetime.now(timezone.utc)
 UTC20DAYSLATER = UTCNOW + timedelta(days=20)
 
 

--- a/uber/api.py
+++ b/uber/api.py
@@ -1,11 +1,10 @@
 import re
 import uuid
 from collections import defaultdict
-from datetime import datetime
+from datetime import timezone, datetime
 from functools import wraps
 
 import cherrypy
-import pytz
 import json
 import six
 import traceback
@@ -298,11 +297,11 @@ def _query_to_names_emails_ids(query, split_names=True):
 
 def _parse_datetime(d):
     if isinstance(d, six.string_types) and d.strip().lower() == 'now':
-        d = datetime.now(pytz.UTC)
+        d = datetime.now(timezone.utc)
     else:
         d = dateparser.parse(d)
     try:
-        d = d.astimezone(pytz.UTC)  # aware object can be in any timezone
+        d = d.astimezone(timezone.utc)  # aware object can be in any timezone
     except ValueError:
         d = c.EVENT_TIMEZONE.localize(d)  # naive assumed to be event timezone
     return d
@@ -1718,7 +1717,7 @@ class PrintJobLookup:
                 if not restart or not errors:
                     results[job.id] = self._build_job_json_data(job)
                     if not dry_run:
-                        job.queued = datetime.now(UTC)
+                        job.queued = datetime.now(timezone.utc)
                         session.add(job)
                         session.commit()
 
@@ -1812,7 +1811,7 @@ class PrintJobLookup:
 
             for job in jobs:
                 results[job.id] = self._build_job_json_data(job)
-                job.printed = datetime.now(UTC)
+                job.printed = datetime.now(timezone.utc)
                 session.add(job)
                 session.commit()
 
@@ -1858,7 +1857,7 @@ class PrintJobLookup:
                     else:
                         job.errors = error
                 else:
-                    job.printed = datetime.now(UTC)
+                    job.printed = datetime.now(timezone.utc)
                 session.add(job)
                 session.commit()
 

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -1,10 +1,9 @@
 import os
 import jinja2
 import logging
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 import pathlib
 
-from pytz import UTC
 from sqlalchemy.orm import joinedload, subqueryload
 
 from uber.config import c
@@ -16,7 +15,6 @@ from uber.models import (AdminAccount, Attendee, AttendeeAccount, ArtShowApplica
 from uber.utils import after, before, days_after, days_before, days_between, localized_now, DeptChecklistConf
 
 log = logging.getLogger(__name__)
-
 
 class AutomatedEmailFixture:
     """
@@ -1721,7 +1719,7 @@ if c.MITS_START:
     MITSEmailFixture(
         'Thanks for showing an interest in MITS!',
         'mits/mits_registered.txt',
-        "lambda team: not team.submitted and team.applied < datetime.now(UTC) - timedelta(hours=1)",
+        "lambda team: not team.submitted and team.applied < datetime.now(timezone.utc) - timedelta(hours=1)",
         'mits_application_created')
 
     # For similar reasons to the above, we wait at least 6 hours before sending this
@@ -1732,7 +1730,7 @@ if c.MITS_START:
     MITSEmailFixture(
         'Last chance to complete your MITS application!',
         'mits/mits_reminder.txt',
-        "lambda team: not team.submitted and team.applied < datetime.now(UTC) - timedelta(hours=6)",
+        "lambda team: not team.submitted and team.applied < datetime.now(timezone.utc) - timedelta(hours=6)",
         'mits_reminder',
         when=[days_before(3, c.MITS_SUBMISSION_DEADLINE)])
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -5,7 +5,7 @@ import inspect
 import math
 import os
 import pycountry
-import pytz
+from zoneinfo import ZoneInfo
 import re
 import redis
 import six
@@ -1860,7 +1860,7 @@ for _opt, _val in c.BADGE_PRICES['stocks'].items():
 c.DATES = {}
 c.TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
 c.DATE_FORMAT = '%Y-%m-%d'
-c.EVENT_TIMEZONE = pytz.timezone(c.EVENT_TIMEZONE)
+c.EVENT_TIMEZONE = ZoneInfo(c.EVENT_TIMEZONE)
 c.make_dates(_config['dates'])
 
 c.DATA_DIRS = {}

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -44,7 +44,7 @@ send_emails = boolean(default=False)
 send_sms = boolean(default=False)
 
 # All dates/times in our code and emails will use this timezone.  This can be
-# any timezone name recogized by the pytz module *and* postgres (IANA)
+# any timezone name recognized by standard IANA timezones *and* postgres (e.g. America/New_York)
 event_timezone = string(default="America/New_York")
 
 # These can be overridden to use Uber for other events.

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -14,9 +14,8 @@ import math
 import os
 import re
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import quote_plus
-from pytz import UTC
 
 import cherrypy
 import jinja2
@@ -35,7 +34,6 @@ from uber.utils import ensure_csrf_token_exists, hour_day_format, localized_now,
 text_type = str
 if sys.version_info[0] == 2:
     text_type = unicode  # noqa: F821
-
 
 def safe_string(text):
     if isinstance(text, Markup):
@@ -118,7 +116,7 @@ def full_date_local(dt):
 
 @JinjaEnv.jinja_export
 def now():
-    return datetime.now(UTC)
+    return datetime.now(timezone.utc)
 
 
 @JinjaEnv.jinja_export
@@ -150,7 +148,6 @@ def timestamp(dt):
 
 @JinjaEnv.jinja_filter
 def timestamp_to_dt(timestamp):
-    from datetime import datetime
     return '' if not timestamp else datetime.fromtimestamp(int(float(timestamp)))
 
 

--- a/uber/email.py
+++ b/uber/email.py
@@ -1,10 +1,9 @@
 import contextlib
 import json
 import logging
-import pytz
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import timezone, datetime
 from sqlalchemy.orm import joinedload
 from sqlalchemy import update, or_
 
@@ -17,7 +16,6 @@ from uber.models import AutomatedEmail, Email
 from uber.utils import listify, localized_now
 
 log = logging.getLogger(__name__)
-
 
 class EmailHandler:
     @reconcile_fixtures
@@ -197,7 +195,7 @@ class EmailService:
 
         queued_emails = session.query(Email).filter(
             Email.status == c.QUEUED, Email.model == model_str,
-            Email.send_after != None, Email.send_after < datetime.now(pytz.UTC)
+            Email.send_after != None, Email.send_after < datetime.now(timezone.utc)
             ).options(joinedload(Email.automated_email)).limit(5000)
 
         if not queued_emails.count():
@@ -311,7 +309,7 @@ class EmailService:
                 current_body = fixture_obj.render_template(fixture_obj.body, render_data)
                 if current_body != email.body:
                     email.body = current_body
-                    email.generated = datetime.now(pytz.UTC)
+                    email.generated = datetime.now(timezone.utc)
                     email.send_after = email.new_send_after
                     email.status_text = f"Requeued {local_now_str}: Email body changed"
                     return
@@ -352,7 +350,7 @@ class EmailService:
                 email.error = f"Error while sending email: {str(error_msg)}"
                 return
             email.status = c.SENT
-            email.sent = datetime.now(pytz.UTC)
+            email.sent = datetime.now(timezone.utc)
             return email
         except Exception as error:
             email.error = f"Error while sending email: {str(error)}"

--- a/uber/files.py
+++ b/uber/files.py
@@ -29,16 +29,13 @@ from rpctools.jsonrpc import ServerProxy
 from urllib.parse import urlparse, urljoin
 from uuid import uuid4
 from phonenumbers import PhoneNumberFormat
-from pytz import UTC
 from sqlalchemy import func, or_, cast, literal, DateTime
 from sqlalchemy.exc import InvalidRequestError
 
 from uber.config import c
 from uber.models import File, uncamel
 
-
 log = logging.getLogger(__name__)
-
 
 class FileHandler(ABC):
     @abstractmethod
@@ -106,7 +103,7 @@ class ServerFileHandler(FileHandler):
                 self.delete()
             else:
                 if update_model:
-                    update_model.last_updated = datetime.now(UTC)
+                    update_model.last_updated = datetime.now(timezone.utc)
                     self.session.add(update_model)
                 if delete_existing:
                     FileService.delete_existing_files(self.session, self.file_obj, self.file_obj.true_flags)

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -6,7 +6,7 @@ import uuid
 import inspect
 import logging
 from collections import defaultdict
-from datetime import date, datetime, timedelta
+from datetime import timezone, date, datetime, timedelta
 from functools import wraps
 from itertools import chain
 from pydantic import ConfigDict
@@ -18,7 +18,6 @@ import cherrypy
 import six
 import sqlalchemy
 from dateutil import parser as dateparser
-from pytz import UTC
 from sqlalchemy import and_, func, or_, create_engine
 from sqlalchemy.dialects.postgresql.json import JSONB
 from sqlalchemy.event import listen
@@ -188,8 +187,8 @@ class MagModel(SQLModel):
         return data
 
     id: str | None = Field(sa_type=Uuid(as_uuid=False), default_factory=lambda: str(uuid4()), primary_key=True)
-    created: datetime = Field(sa_type=DateTime(timezone=True), sa_column_kwargs={'server_default': utcnow()}, default_factory=lambda: datetime.now(UTC))
-    last_updated: datetime = Field(sa_type=DateTime(timezone=True), sa_column_kwargs={'server_default': utcnow()}, default_factory=lambda: datetime.now(UTC))
+    created: datetime = Field(sa_type=DateTime(timezone=True), sa_column_kwargs={'server_default': utcnow()}, default_factory=lambda: datetime.now(timezone.utc))
+    last_updated: datetime = Field(sa_type=DateTime(timezone=True), sa_column_kwargs={'server_default': utcnow()}, default_factory=lambda: datetime.now(timezone.utc))
 
     """
     The two columns below allow tracking any object in external sources,
@@ -439,10 +438,10 @@ class MagModel(SQLModel):
     @presave_adjustment
     def update_last_updated(self):
         if not getattr(self, 'skip_last_updated', None):
-            self.last_updated = datetime.now(UTC)
+            self.last_updated = datetime.now(timezone.utc)
 
     def last_synced_dt(self, key):
-        return dateparser.parse(json.loads(self.last_synced.get(key, '"1970/01/01"'))).replace(tzinfo=UTC)
+        return dateparser.parse(json.loads(self.last_synced.get(key, '"1970/01/01"'))).replace(tzinfo=timezone.utc)
     
     def update_last_synced(self, key, sync_time):
         self.last_synced[key] = json.dumps(str(dateparser.parse(sync_time)))

--- a/uber/models/admin.py
+++ b/uber/models/admin.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
 import cherrypy
-from pytz import UTC
 from sqlalchemy import Sequence, Uuid, String, DateTime
 from sqlalchemy.dialects.postgresql.json import JSONB
 from sqlalchemy.ext.mutable import MutableDict
@@ -16,9 +15,7 @@ from uber.models.types import (default_relationship as relationship, utcnow,
 from uber.models import MagModel
 from uber.utils import listify
 
-
 __all__ = ['AccessGroup', 'AdminAccount', 'EscalationTicket', 'PasswordReset', 'WatchList', 'WorkstationAssignment']
-
 
 # Many to many association table to tie Access Groups with Admin Accounts
 admin_access_group = Table(
@@ -30,7 +27,6 @@ admin_access_group = Table(
     Index('ix_admin_access_group_admin_account_id', 'admin_account_id'),
     Index('ix_admin_access_group_access_group_id', 'access_group_id'),
 )
-
 
 class AdminAccount(MagModel, table=True):
     attendee_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='attendee.id', ondelete='CASCADE', unique=True)
@@ -262,7 +258,7 @@ class AdminAccount(MagModel, table=True):
             self.remove_disabled_api_keys(invalid_api)
 
     def remove_disabled_api_keys(self, invalid_api):
-        revoked_time = datetime.now(UTC)
+        revoked_time = datetime.now(timezone.utc)
         for api_token in self.active_api_tokens:
             if invalid_api.intersection(api_token.access_ints):
                 api_token.revoked_time = revoked_time
@@ -288,13 +284,13 @@ class PasswordReset(MagModel, table=True):
     attendee_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='attendee_account.id', ondelete='CASCADE', unique=True, nullable=True)
     attendee_account: 'AttendeeAccount' = Relationship(back_populates="password_reset", sa_relationship_kwargs={'single_parent': True})
 
-    generated: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    generated: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     hashed: str = Field(sa_type=String, private=True)
     token: str = Field(sa_type=String, private=True)
 
     @property
     def is_expired(self):
-        return self.generated < datetime.now(UTC) - timedelta(hours=c.PASSWORD_RESET_HOURS)
+        return self.generated < datetime.now(timezone.utc) - timedelta(hours=c.PASSWORD_RESET_HOURS)
 
 
 class AccessGroup(MagModel, table=True):
@@ -346,9 +342,9 @@ class AccessGroup(MagModel, table=True):
 
     @property
     def is_valid(self):
-        if self.start_time and self.start_time > datetime.now(UTC):
+        if self.start_time and self.start_time > datetime.now(timezone.utc):
             return False
-        if self.end_time and self.end_time < datetime.now(UTC):
+        if self.end_time and self.end_time < datetime.now(timezone.utc):
             return False
         return True
 

--- a/uber/models/api.py
+++ b/uber/models/api.py
@@ -1,7 +1,6 @@
 import uuid
-from datetime import datetime
+from datetime import timezone, datetime
 
-from pytz import UTC
 from sqlalchemy import String, Uuid, DateTime
 from sqlalchemy.dialects.postgresql.json import JSONB
 from sqlalchemy.ext.mutable import MutableDict
@@ -11,9 +10,7 @@ from uber.config import c
 from uber.models import MagModel
 from uber.models.types import DefaultColumn as Column, MultiChoice, DefaultField as Field, DefaultRelationship as Relationship
 
-
 __all__ = ['ApiToken', 'ApiJob']
-
 
 class ApiToken(MagModel, table=True):
     admin_account_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='admin_account.id', ondelete='CASCADE')
@@ -23,7 +20,7 @@ class ApiToken(MagModel, table=True):
     access: str = Field(sa_type=MultiChoice(c.API_ACCESS_OPTS), default='')
     name: str = ''
     description: str = ''
-    issued_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    issued_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     revoked_time: datetime = Field(sa_type=DateTime(timezone=True), default=None, nullable=True)
 
     @property

--- a/uber/models/art_show.py
+++ b/uber/models/art_show.py
@@ -5,8 +5,7 @@ import logging
 
 from collections import defaultdict
 from sqlalchemy import func, case
-from datetime import datetime
-from pytz import UTC
+from datetime import timezone, datetime
 
 from uber.config import c
 from uber.models import MagModel
@@ -22,10 +21,8 @@ from typing import ClassVar
 
 log = logging.getLogger(__name__)
 
-
 __all__ = ['ArtShowAgentCode', 'ArtShowApplication', 'ArtShowPiece', 'ArtShowPayment', 'ArtShowReceipt', 'ArtShowBidder',
            'ArtShowPanel', 'ArtPanelAssignment']
-
 
 class ArtShowAgentCode(MagModel, table=True):
     app_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='art_show_application.id', ondelete='CASCADE')
@@ -664,7 +661,7 @@ class ArtShowPayment(MagModel, table=True):
     
     amount: int = 0
     type: int = Field(sa_column=Column(Choice(c.ART_SHOW_PAYMENT_OPTS)), default=c.STRIPE)
-    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
 
 
 class ArtShowReceipt(MagModel, table=True):

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1,12 +1,11 @@
 import json
 import math
 import re
-from datetime import datetime, timedelta, date
+from datetime import timezone, datetime, timedelta, date
 from markupsafe import Markup
 from uuid import uuid4
 import logging
 
-from pytz import UTC
 from sqlalchemy import and_, case, exists, func, or_, select, not_
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import subqueryload, aliased, selectinload, joinedload
@@ -28,12 +27,9 @@ from uber.utils import add_opt, get_age_from_birthday, get_age_conf_from_birthda
 
 log = logging.getLogger(__name__)
 
-
 __all__ = ['Attendee', 'AttendeeAccount', 'BadgeInfo', 'BadgePickupGroup', 'FoodRestrictions']
 
-
 RE_NONDIGIT = re.compile(r'\D+')
-
 
 # The order of name_suffixes is important. It should be sorted in descending
 # order, using the length of the suffix with periods removed.
@@ -143,9 +139,7 @@ name_suffixes = [
     'IV',
     'II']
 
-
 normalized_name_suffixes = [re.sub(r'[,\.]', '', s.lower()) for s in name_suffixes]
-
 
 class BadgeInfo(MagModel, table=True):
     """
@@ -189,14 +183,14 @@ class BadgeInfo(MagModel, table=True):
         if not self.attendee_id:
             return
 
-        self.reported_lost = datetime.now(UTC)
+        self.reported_lost = datetime.now(timezone.utc)
         self.active = False
     
     def check_in(self):
         if not self.attendee_id:
             return
 
-        self.picked_up = self.attendee.checked_in or datetime.now(UTC)
+        self.picked_up = self.attendee.checked_in or datetime.now(timezone.utc)
 
 
 Index('ix_badge_info_attendee_id', BadgeInfo.attendee_id.desc())
@@ -302,7 +296,7 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
     can_transfer: bool = False
 
     reg_station: int | None
-    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     confirmed: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True, default=None)
     checked_in: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
 
@@ -836,7 +830,7 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
         return [badge for badge in self.allocated_badges if badge.active == False and badge.reported_lost != None]
     
     def check_in(self):
-        self.checked_in = datetime.now(UTC)
+        self.checked_in = datetime.now(timezone.utc)
 
         if not self.active_badge:
             new_badge = self.session.get_next_badge_num(self.badge_type_real)

--- a/uber/models/attraction.py
+++ b/uber/models/attraction.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
-import pytz
 from sqlalchemy import and_, cast, exists, func, not_
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -19,11 +18,9 @@ from uber.models.types import (DefaultColumn as Column, default_relationship as 
                                DefaultField as Field, DefaultRelationship as Relationship)
 from uber.utils import evening_datetime, noon_datetime, localized_now, slugify, listify, groupify
 
-
 __all__ = [
     'Attraction', 'AttractionFeature', 'AttractionEvent', 'AttractionSignup',
     'AttractionNotification', 'AttractionNotificationReply']
-
 
 class AttractionMixin():
     populate_schedule: bool = True
@@ -279,7 +276,7 @@ class Attraction(MagModel, AttractionMixin, table=True):
         for event in self.events:
             if event.populate_schedule:
                 event.schedule_item.department_id = self.department_id
-                event.schedule_item.last_updated = datetime.now(pytz.UTC)
+                event.schedule_item.last_updated = datetime.now(timezone.utc)
                 session.add(event.schedule_item)
 
     def signups_requiring_notification(self, session, from_time, to_time, options=None):
@@ -405,7 +402,7 @@ class AttractionFeature(MagModel, AttractionMixin, table=True):
             if event.populate_schedule:
                 event.schedule_item.name = self.name
                 event.schedule_item.description = event.schedule_description
-                event.schedule_item.last_updated = datetime.now(pytz.UTC)
+                event.schedule_item.last_updated = datetime.now(timezone.utc)
                 session.add(event.schedule_item)
 
     @property
@@ -500,7 +497,7 @@ class AttractionEvent(MagModel, AttractionMixin, table=True):
                 self.orig_value_of('signups_open_relative') != self.signups_open_relative or
                 self.orig_value_of('signups_open_time') != self.signups_open_time):
             self.schedule_item.description = self.schedule_description
-            self.schedule_item.last_updated = datetime.now(pytz.UTC)
+            self.schedule_item.last_updated = datetime.now(timezone.utc)
             self.session.add(self.schedule_item)
 
 
@@ -570,7 +567,7 @@ class AttractionEvent(MagModel, AttractionMixin, table=True):
 
     @property
     def time_remaining_to_checkin(self):
-        return self.checkin_start_time - datetime.now(pytz.UTC)
+        return self.checkin_start_time - datetime.now(timezone.utc)
 
     @property
     def time_remaining_to_checkin_label(self):
@@ -578,7 +575,7 @@ class AttractionEvent(MagModel, AttractionMixin, table=True):
 
     @property
     def is_checkin_over(self):
-        return self.checkin_end_time < datetime.now(pytz.UTC)
+        return self.checkin_end_time < datetime.now(timezone.utc)
     
     @property
     def signed_up_attendees(self):
@@ -606,7 +603,7 @@ class AttractionEvent(MagModel, AttractionMixin, table=True):
 
     @property
     def is_started(self):
-        return self.start_time < datetime.now(pytz.UTC)
+        return self.start_time < datetime.now(timezone.utc)
 
     @property
     def remaining_slots(self):
@@ -724,7 +721,7 @@ class AttractionEvent(MagModel, AttractionMixin, table=True):
             updated = True
         
         if updated:
-            event.last_updated = datetime.now(pytz.UTC)
+            event.last_updated = datetime.now(timezone.utc)
             session.add(event)
 
     def overlap(self, event):
@@ -753,7 +750,7 @@ class AttractionSignup(MagModel, table=True):
     attendee_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='attendee.id', ondelete='CASCADE')
     attendee: 'Attendee' = Relationship(back_populates="attraction_signups", sa_relationship_kwargs={'lazy': 'joined'})
 
-    signup_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(pytz.UTC))
+    signup_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     checkin_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: utcmin.datetime, index=True)
     on_waitlist: bool = False
 
@@ -844,7 +841,7 @@ class AttractionNotification(MagModel, table=True):
     notification_type: int = Field(sa_column=Column(Choice(Attendee._NOTIFICATION_PREF_OPTS)), default=0)
     ident: str = Field(default='', index=True)
     sid: str = ''
-    sent_time: datetime = Field(sa_type=DateTime(timezone=True), default=lambda: datetime.now(pytz.UTC))
+    sent_time: datetime = Field(sa_type=DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     subject: str = ''
     body: str = ''
 
@@ -872,8 +869,8 @@ class AttractionNotificationReply(MagModel, table=True):
     from_phonenumber: str = ''
     to_phonenumber: str = ''
     sid: str = Field(default='', index=True)
-    received_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(pytz.UTC))
-    sent_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(pytz.UTC))
+    received_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
+    sent_time: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     body: str = ''
 
     @presave_adjustment

--- a/uber/models/commerce.py
+++ b/uber/models/commerce.py
@@ -1,8 +1,7 @@
-from datetime import datetime
+from datetime import timezone, datetime
 import stripe
 import logging
 
-from pytz import UTC
 from sqlalchemy import func, or_
 
 from sqlalchemy.sql.functions import coalesce
@@ -22,16 +21,14 @@ from uber.payments import ReceiptManager
 
 log = logging.getLogger(__name__)
 
-
 __all__ = [
     'ArbitraryCharge', 'MerchDiscount', 'MerchPickup', 'ModelReceipt', 'MPointsForCash', 'ReceiptDiscount',
     'NoShirt', 'OldMPointExchange', 'ReceiptInfo', 'ReceiptItem', 'ReceiptTransaction', 'Sale', 'TerminalSettlement']
 
-
 class ArbitraryCharge(MagModel, table=True):
     amount: int = 0
     what: str = ''
-    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     reg_station: int | None = Field(default=0, nullable=True)
 
     _repr_attr_names: ClassVar = ['what']
@@ -59,7 +56,7 @@ class MPointsForCash(MagModel, table=True):
     attendee: 'Attendee' = Relationship(back_populates="mpoints_for_cash")
 
     amount: int = 0
-    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
 
 
 class NoShirt(MagModel, table=True):
@@ -77,7 +74,7 @@ class OldMPointExchange(MagModel, table=True):
     attendee: 'Attendee' = Relationship(back_populates="old_mpoint_exchanges")
 
     amount: int = 0
-    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
 
 
 class Sale(MagModel, table=True):
@@ -87,7 +84,7 @@ class Sale(MagModel, table=True):
     what: str = ''
     cash: int = 0
     mpoints: int = 0
-    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     reg_station: int | None = Field(nullable=True)
     payment_method: int = Field(sa_column=Column(Choice(c.SALE_OPTS)), default=c.MERCH)
 
@@ -377,7 +374,7 @@ class ReceiptTransaction(MagModel, table=True):
     amount: int = 0
     txn_total: int = 0
     processing_fee: int = 0
-    added: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    added: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     on_hold: bool = False
     cancelled: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     who: str = ''
@@ -578,7 +575,7 @@ class ReceiptDiscount(MagModel, table=True):
     category: int = Field(sa_column=Column(Choice(c.RECEIPT_CATEGORY_OPTS)), default=c.OTHER)
     desc: str = ''
     who: str = ''
-    added: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    added: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
 
     discount: int | None = Field(nullable=True, default=None)
     applicable_discount: int = 0
@@ -701,7 +698,7 @@ class ReceiptItem(MagModel, table=True):
     comped: bool = False
     reverted: bool = False
     count: int = 1
-    added: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    added: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     closed: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     who: str = ''
     desc: str = ''
@@ -894,7 +891,7 @@ class ReceiptInfo(MagModel, table=True):
 class TerminalSettlement(MagModel, table=True):
     batch_timestamp: str = ''
     batch_who: str = ''
-    requested: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    requested: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     workstation_num: int = 0
     terminal_id: str = ''
     response: dict[str, Any] = Field(sa_type=MutableDict.as_mutable(JSONB), default_factory=dict)

--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -1,12 +1,10 @@
 import re
 import traceback
 import logging
-import pytz
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 from dateutil import parser as dateparser
 
-from pytz import UTC
 from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict
@@ -24,9 +22,7 @@ from uber.utils import normalize_newlines, request_cached_context, groupify, lis
 
 log = logging.getLogger(__name__)
 
-
 __all__ = ['AutomatedEmail', 'Email']
-
 
 class BaseEmailMixin(object):
     model: str = ''
@@ -279,7 +275,7 @@ class Email(MagModel, BaseEmailMixin, table=True):
     render_data: dict[str, Any] = Field(sa_type=JSON, default_factory=dict)
     status: int = Field(sa_column=Column(Choice(c.EMAIL_STATUS_OPTS), index=True), default=c.UNAPPROVED)
     status_text: str = ''
-    generated: str = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    generated: str = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     send_after: str | None = Field(sa_type=DateTime(timezone=True), nullable=True, default=None)
     sent: str | None = Field(sa_type=DateTime(timezone=True), nullable=True, default=None)
     error: str = ''
@@ -322,7 +318,7 @@ class Email(MagModel, BaseEmailMixin, table=True):
     
     @property
     def new_send_after(self):
-        five_minute_delay = datetime.now(pytz.UTC) + timedelta(seconds=300)
+        five_minute_delay = datetime.now(timezone.utc) + timedelta(seconds=300)
         if self.automated_email.active_after and self.automated_email.active_after > five_minute_delay:
             return self.automated_email.active_after
         

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -1,9 +1,8 @@
 import math
-from datetime import datetime
+from datetime import timezone, datetime
 from uuid import uuid4
 
 from decimal import Decimal
-from pytz import UTC
 from sqlalchemy import and_, exists, or_, func, select, not_
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.types import DateTime, Uuid
@@ -17,9 +16,7 @@ from uber.models.types import (Choice, default_relationship as relationship, Def
                                DefaultField as Field, DefaultRelationship as Relationship)
 from uber.utils import add_opt
 
-
 __all__ = ['Group']
-
 
 class Group(MagModel, TakesPaymentMixin, table=True):
     leader_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='attendee.id', nullable=True)
@@ -61,7 +58,7 @@ class Group(MagModel, TakesPaymentMixin, table=True):
     convert_badges: bool = False
     admin_notes: str = ''
     status: int = Field(sa_column=Column(Choice(c.DEALER_STATUS_OPTS)), default=c.UNAPPROVED)
-    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     approved: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     
     attendees: list['Attendee'] = Relationship(back_populates="group",
@@ -93,7 +90,7 @@ class Group(MagModel, TakesPaymentMixin, table=True):
         elif not self.cost:
             self.cost = 0
         if self.status == c.APPROVED and not self.approved:
-            self.approved = datetime.now(UTC)
+            self.approved = datetime.now(timezone.utc)
         if self.leader and self.is_dealer and self.leader.paid == c.PAID_BY_GROUP:
             self.leader.ribbon = add_opt(self.leader.ribbon_ints, c.DEALER_RIBBON)
         if not self.is_unpaid or self.orig_value_of('status') != self.status:
@@ -437,7 +434,7 @@ class Group(MagModel, TakesPaymentMixin, table=True):
     def hours_since_registered(self):
         if not self.registered:
             return 0
-        delta = datetime.now(UTC) - self.registered
+        delta = datetime.now(timezone.utc) - self.registered
         return max(0, delta.total_seconds()) / 60.0 / 60.0
 
     @property

--- a/uber/models/hotel.py
+++ b/uber/models/hotel.py
@@ -2,8 +2,7 @@ import logging
 import random
 
 import checkdigit.verhoeff as verhoeff
-from datetime import timedelta, datetime, date
-from pytz import UTC
+from datetime import timezone, timedelta, datetime, date
 from markupsafe import Markup
 from sqlalchemy import Sequence, case
 from sqlalchemy.dialects.postgresql.json import JSONB
@@ -21,9 +20,7 @@ from uber.utils import RegistrationCode
 
 log = logging.getLogger(__name__)
 
-
 __all__ = ['NightsMixin', 'HotelRequests', 'Room', 'RoomAssignment', 'LotteryApplication']
-
 
 def _night(name):
     day = getattr(c, name.upper())
@@ -91,7 +88,7 @@ class Room(MagModel, NightsMixin, table=True):
     message: str = ''
     locked_in: bool = False
     nights: str = Field(sa_type=MultiChoice(c.NIGHT_OPTS), default='')
-    created: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    created: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
 
     assignments: list['RoomAssignment'] = Relationship(back_populates="room",
                                                        sa_relationship_kwargs={'cascade': 'all,delete-orphan', 'passive_deletes': True})

--- a/uber/models/marketplace.py
+++ b/uber/models/marketplace.py
@@ -5,16 +5,13 @@ from uber.decorators import presave_adjustment
 from uber.models.types import (Choice, default_relationship as relationship, DefaultColumn as Column,
                                DefaultField as Field, DefaultRelationship as Relationship)
 
-from datetime import datetime
+from datetime import timezone, datetime
 from markupsafe import Markup
-from pytz import UTC
 from sqlalchemy.orm import backref
 from sqlalchemy.types import Uuid, DateTime
 from typing import ClassVar
 
-
 __all__ = ['ArtistMarketplaceApplication']
-
 
 class ArtistMarketplaceApplication(MagModel, table=True):
     MATCHING_DEALER_FIELDS: ClassVar = ['email_address', 'website', 'name']
@@ -31,7 +28,7 @@ class ArtistMarketplaceApplication(MagModel, table=True):
     accessibility_requests: str = ''
 
     status: int = Field(sa_column=Column(Choice(c.MARKETPLACE_STATUS_OPTS)), default=c.PENDING)
-    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     accepted: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     admin_notes: str = ''
     overridden_price: int | None = Field(default=0, nullable=True)

--- a/uber/models/mits.py
+++ b/uber/models/mits.py
@@ -1,9 +1,8 @@
 import os
 import cherrypy
 from functools import wraps
-from datetime import datetime
+from datetime import timezone, datetime
 
-from pytz import UTC
 from sqlalchemy import and_
 from sqlalchemy.types import Uuid, DateTime
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -15,9 +14,7 @@ from uber.models.types import (Choice, MultiChoice, DefaultColumn as Column,
                                DefaultField as Field, DefaultRelationship as Relationship)
 from uber.utils import slugify
 
-
 __all__ = ['MITSTeam', 'MITSApplicant', 'MITSPanelApplication', 'MITSGame', 'MITSTimes']
-
 
 class MITSTeam(MagModel, table=True):
     attendee_account_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='attendee_account.id', nullable=True)
@@ -35,7 +32,7 @@ class MITSTeam(MagModel, table=True):
     waiver_signature: str = ''
     waiver_signed: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
 
-    applied: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    applied: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     status: int = Field(sa_column=Column(Choice(c.MITS_APP_STATUS), admin_only=True), default=c.PENDING)
 
     applicants: list['MITSApplicant'] = Relationship(

--- a/uber/models/panels.py
+++ b/uber/models/panels.py
@@ -1,7 +1,6 @@
 import re
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
-from pytz import UTC
 from sqlalchemy.schema import ForeignKey, Table, UniqueConstraint, Index
 from sqlalchemy.types import Boolean, Integer, Uuid, String, DateTime
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -13,9 +12,7 @@ from uber.models import MagModel
 from uber.models.types import (utcnow, Choice, DefaultColumn as Column, MultiChoice, UniqueList,
                                DefaultField as Field, DefaultRelationship as Relationship)
 
-
 __all__ = ['AssignedPanelist', 'Event', 'EventLocation', 'EventFeedback', 'PanelApplicant', 'PanelApplication']
-
 
 # Many to many association table to tie Panel Applicants with Panel Applications
 panel_applicant_application = Table(
@@ -27,7 +24,6 @@ panel_applicant_application = Table(
     Index('ix_admin_panel_application_panel_applicant_id', 'panel_applicant_id'),
     Index('ix_admin_panel_application_panel_application_id', 'panel_application_id'),
 )
-
 
 class EventLocation(MagModel, table=True):
     department_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='department.id', nullable=True)
@@ -76,7 +72,7 @@ class EventLocation(MagModel, table=True):
                 event_updated = True
 
             if event_updated:
-                event.last_updated = datetime.now(UTC)
+                event.last_updated = datetime.now(timezone.utc)
                 session.add(event)
 
 
@@ -215,7 +211,7 @@ class PanelApplication(MagModel, table=True):
     record: int = Field(sa_column=Column(Choice(c.LIVESTREAM_OPTS)), default=c.OPT_IN)
     panelist_bringing: str = ''
     extra_info: str = ''
-    applied: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    applied: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     accepted: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     confirmed: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     status: int = Field(sa_column=Column(Choice(c.PANEL_APP_STATUS_OPTS)), default=c.PENDING, admin_only=True)
@@ -237,7 +233,7 @@ class PanelApplication(MagModel, table=True):
                     updated = True
                     setattr(self.event, key, getattr(self, key, ''))
         if updated:
-            self.event.last_updated = datetime.now(UTC)
+            self.event.last_updated = datetime.now(timezone.utc)
     
     @presave_adjustment
     def set_default_dept(self):
@@ -327,7 +323,7 @@ class PanelApplication(MagModel, table=True):
 
     @property
     def after_confirm_deadline(self):
-        return self.confirm_deadline and self.confirm_deadline < datetime.now(UTC)
+        return self.confirm_deadline and self.confirm_deadline < datetime.now(timezone.utc)
 
     @hybrid_property
     def has_been_accepted(self):

--- a/uber/models/promo_code.py
+++ b/uber/models/promo_code.py
@@ -2,10 +2,9 @@ import random
 import re
 import string
 from collections import OrderedDict
-from datetime import datetime
+from datetime import timezone, datetime
 
 import six
-from pytz import UTC
 from dateutil import parser as dateparser
 from sqlalchemy import exists, func, select, CheckConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -19,9 +18,7 @@ from uber.models import MagModel
 from uber.models.types import MultiChoice, DefaultColumn as Column, Choice, DefaultField as Field, DefaultRelationship as Relationship
 from uber.utils import localized_now, RegistrationCode
 
-
 __all__ = ['PromoCodeWord', 'PromoCodeGroup', 'PromoCode']
-
 
 class PromoCodeWord(MagModel, table=True):
     """
@@ -134,7 +131,7 @@ class PromoCodeGroup(MagModel, table=True):
 
     name: str = ''
     code: str = ''
-    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
 
     promo_codes: list['PromoCode'] = Relationship(
         back_populates="group", sa_relationship_kwargs={'lazy': 'selectin'})
@@ -205,7 +202,7 @@ class PromoCodeGroup(MagModel, table=True):
     def hours_since_registered(self):
         if not self.registered:
             return 0
-        delta = datetime.now(UTC) - self.registered
+        delta = datetime.now(timezone.utc) - self.registered
         return max(0, delta.total_seconds()) / 60.0 / 60.0
 
     @property

--- a/uber/models/showcase.py
+++ b/uber/models/showcase.py
@@ -3,10 +3,9 @@ import re
 import cherrypy
 import logging
 
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 from functools import wraps
 from markupsafe import Markup
-from pytz import UTC
 from sqlalchemy import func, case, or_
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.types import Boolean, Integer, String, DateTime, Uuid
@@ -23,11 +22,9 @@ from uber.utils import localized_now, make_url, remove_opt, slugify
 
 log = logging.getLogger(__name__)
 
-
 __all__ = [
     'IndieJudge', 'IndieStudio', 'IndieDeveloper', 'IndieGame',
     'IndieGameCode', 'IndieGameReview']
-
 
 class ReviewMixin:
     @property
@@ -144,7 +141,7 @@ class IndieStudio(MagModel, table=True):
 
     status: int = Field(sa_column=Choice(c.MIVS_STUDIO_STATUS_OPTS), default=c.NEW)  # Remove?
     staff_notes: str = ''
-    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
 
     accepted_core_hours: bool = False
     discussion_emails: str = ''
@@ -426,7 +423,7 @@ class IndieGame(MagModel, ReviewMixin, table=True):
     submitted: bool = False
     status: int = Field(sa_column=Column(Choice(c.MIVS_GAME_STATUS_OPTS), default=c.NEW))
     judge_notes: str = ''
-    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     waitlisted: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     accepted: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
 
@@ -440,12 +437,12 @@ class IndieGame(MagModel, ReviewMixin, table=True):
     @presave_adjustment
     def accepted_time(self):
         if self.status == c.ACCEPTED and not self.accepted:
-            self.accepted = datetime.now(UTC)
+            self.accepted = datetime.now(timezone.utc)
 
     @presave_adjustment
     def waitlisted_time(self):
         if self.status == c.WAITLISTED and not self.waitlisted:
-            self.waitlisted = datetime.now(UTC)
+            self.waitlisted = datetime.now(timezone.utc)
 
     @property
     def email(self):

--- a/uber/models/tabletop.py
+++ b/uber/models/tabletop.py
@@ -1,15 +1,12 @@
-from datetime import datetime
+from datetime import timezone, datetime
 
-from pytz import UTC
 from sqlalchemy.types import Boolean, DateTime, String, Uuid
 from typing import ClassVar
 
 from uber.models import MagModel
 from uber.models.types import DefaultField as Field, DefaultRelationship as Relationship
 
-
 __all__ = ['TabletopGame', 'TabletopCheckout']
-
 
 class TabletopGame(MagModel, table=True):
     attendee_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='attendee.id', ondelete='CASCADE')
@@ -40,5 +37,5 @@ class TabletopCheckout(MagModel, table=True):
     attendee_id: str | None = Field(sa_type=Uuid(as_uuid=False), foreign_key='attendee.id', ondelete='CASCADE')
     attendee: 'Attendee' = Relationship(back_populates="checkouts", sa_relationship_kwargs={'lazy': 'joined'})
 
-    checked_out: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    checked_out: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     returned: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)

--- a/uber/models/tracking.py
+++ b/uber/models/tracking.py
@@ -2,13 +2,12 @@ import json
 import six
 import sys
 import logging
-from datetime import datetime
+from datetime import timezone, datetime
 from markupsafe import Markup
 from threading import current_thread
 from urllib.parse import parse_qsl
 
 import cherrypy
-from pytz import UTC
 from sqlalchemy.ext import associationproxy
 
 from sqlalchemy import Sequence
@@ -32,9 +31,8 @@ __all__ = ['PageViewTracking', 'ReportTracking', 'Tracking', 'TxnRequestTracking
 
 serializer.register(associationproxy._AssociationList, list)
 
-
 class ReportTracking(MagModel, table=True):
-    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     who: str = ''
     supervisor: str = ''
     page: str = ''
@@ -59,7 +57,7 @@ class ReportTracking(MagModel, table=True):
 
 
 class PageViewTracking(MagModel, table=True):
-    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     who: str = ''
     supervisor: str = ''
     page: str = ''
@@ -113,7 +111,7 @@ class PageViewTracking(MagModel, table=True):
 class Tracking(MagModel, table=True):
     fk_id: str = Field(sa_type=Uuid(as_uuid=False), index=True)
     model: str = ''
-    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC), index=True)
+    when: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc), index=True)
     who: str = Field(default='', index=True)
     supervisor: str = ''
     page: str = ''
@@ -286,7 +284,7 @@ class TxnRequestTracking(MagModel, table=True):
     workstation_num: int = 0
     terminal_id: str = ''
     who: str = ''
-    requested: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
+    requested: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(timezone.utc))
     resolved: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     success: bool = False
     response: dict[Any, Any] = Field(sa_type=MutableDict.as_mutable(JSONB), default_factory=dict)

--- a/uber/models/types.py
+++ b/uber/models/types.py
@@ -1,11 +1,10 @@
 from collections.abc import Mapping
 from collections import OrderedDict
-from datetime import datetime, time, timedelta
+from datetime import timezone, datetime, time, timedelta
 from PIL import Image
 import re
 import shutil
 
-import pytz
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.attributes import flag_modified
@@ -21,7 +20,6 @@ __all__ = [
     'default_relationship', 'relationship', 'utcmin', 'utcnow', 'Choice',
     'Column', 'DefaultColumn', 'DefaultField', 'DefaultRelationship', 'MultiChoice',
     'TakesPaymentMixin']
-
 
 def DefaultColumn(*args, admin_only=False, private=False, **kwargs):
     """
@@ -154,7 +152,7 @@ class utcmax(FunctionElement):
     See utcmin and utcnow for more details.
 
     """
-    datetime = datetime(9999, 12, 31, 23, 59, 59, tzinfo=pytz.UTC)
+    datetime = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
     type = DateTime(timezone=True)
 
 
@@ -192,7 +190,7 @@ class utcmin(FunctionElement):
         Attendee.checkin_time > utcmin.datetime
 
     """
-    datetime = datetime(1, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
+    datetime = datetime(1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     type = DateTime(timezone=True)
 
 
@@ -212,7 +210,7 @@ class utcnow(FunctionElement):
     indicating when the row was first created.  Normally we could do something
     like this::
 
-        created = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+        created = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     Unfortunately, there are some cases where we instantiate a model and then
     don't save it until sometime later.  This happens when someone registers
@@ -221,7 +219,7 @@ class utcnow(FunctionElement):
     can set a timestamp based on when the row was inserted rather than when
     the model was instantiated::
 
-        created = Column(DateTime(timezone=True), server_default=utcnow(), default=lambda: datetime.now(UTC))
+        created = Column(DateTime(timezone=True), server_default=utcnow(), default=lambda: datetime.now(timezone.utc))
 
     The pg_utcnow and sqlite_utcnow functions below define the implementation
     for postgres and sqlite, and new functions will need to be written if/when

--- a/uber/payments.py
+++ b/uber/payments.py
@@ -1,8 +1,7 @@
 import checkdigit.verhoeff as verhoeff
-import pytz
 from typing import Iterable
 from collections import OrderedDict, defaultdict
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 from dateutil.parser import parse
 from uuid import uuid4
 from sqlalchemy.orm import selectinload
@@ -438,8 +437,8 @@ class AuthNetRequestMixin:
             return ("This transaction cannot be refunded because of an invalid status: "
                     f"{self.response.transactionStatus}.")
         else:
-            if parse(str(self.response.submitTimeUTC)).replace(tzinfo=pytz.UTC) \
-                    < datetime.now(pytz.UTC) - timedelta(days=180):
+            if parse(str(self.response.submitTimeUTC)).replace(tzinfo=timezone.utc) \
+                    < datetime.now(timezone.utc) - timedelta(days=180):
                 return "This transaction is more than 180 days old and cannot be refunded automatically."
 
             if self.response.settleAmount * 100 < amount:
@@ -1082,7 +1081,7 @@ class RefundRequest(TransactionRequest):
 
             return_response_json = return_response.json()
             self.tracker.response = return_response_json
-            self.tracker.resolved = datetime.now(UTC)
+            self.tracker.resolved = datetime.now(timezone.utc)
 
             self.spin_request.log_api_response(return_response_json)
 
@@ -1190,7 +1189,7 @@ class SpinTerminalRequest(TransactionRequest):
         except AttributeError:
             response_json = response
         self.tracker.response = response_json
-        self.tracker.resolved = datetime.now(UTC)
+        self.tracker.resolved = datetime.now(timezone.utc)
 
         receipt_items_to_add = self.get_receipt_items_to_add()
         if receipt_items_to_add:
@@ -1214,7 +1213,7 @@ class SpinTerminalRequest(TransactionRequest):
 
             if self.tracker:
                 self.tracker.response = void_response_json
-                self.tracker.resolved = datetime.now(pytz.UTC)
+                self.tracker.resolved = datetime.now(timezone.utc)
 
             self.log_api_response(void_response_json)
             if self.api_response_successful(void_response_json):

--- a/uber/site_sections/api.py
+++ b/uber/site_sections/api.py
@@ -1,8 +1,7 @@
 import re
-from datetime import datetime
+from datetime import timezone, datetime
 
 import cherrypy
-import pytz
 import inspect
 from sqlalchemy.orm import joinedload
 
@@ -11,7 +10,6 @@ from uber.decorators import ajax, all_renderable, not_site_mappable, public, sit
 from uber.errors import HTTPRedirect
 from uber.models import AdminAccount, ApiJob, ApiToken
 from uber.utils import check
-
 
 @all_renderable()
 class Root:
@@ -90,7 +88,7 @@ class Root:
             raise HTTPRedirect('index')
 
         api_token = session.api_token(id)
-        api_token.revoked_time = datetime.now(pytz.UTC)
+        api_token.revoked_time = datetime.now(timezone.utc)
         raise HTTPRedirect(
             'index?message={}', 'Successfully revoked API token')
 

--- a/uber/site_sections/attractions.py
+++ b/uber/site_sections/attractions.py
@@ -1,8 +1,7 @@
 import uuid
-from datetime import datetime
+from datetime import timezone, datetime
 
 import cherrypy
-from pytz import UTC
 from sqlalchemy import or_
 from sqlalchemy.orm import subqueryload
 
@@ -108,7 +107,7 @@ class Root:
         if not attraction:
             raise HTTPRedirect('index?attendee_id={}', params.get('attendee_id', ''))
 
-        no_events = datetime.max.replace(tzinfo=UTC)  # features with no events should sort to the end
+        no_events = datetime.max.replace(tzinfo=timezone.utc)  # features with no events should sort to the end
         features = attraction.public_features
         return {
             'attraction': attraction,

--- a/uber/site_sections/attractions_admin.py
+++ b/uber/site_sections/attractions_admin.py
@@ -1,9 +1,8 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
 import cherrypy
 from dateutil import parser as dateparser
-import pytz
 from sqlalchemy.orm import subqueryload, joinedload, selectinload, defaultload
 
 from uber.config import c
@@ -17,7 +16,6 @@ from uber.site_sections.attractions import _attendee_for_badge_num
 from uber.tasks.attractions import send_waitlist_notification
 from uber.utils import localized_now, filename_safe, validate_model, get_api_service_from_server, slugify
 
-
 event_spec = {
     'id': True,
     'event_location_id': True,
@@ -28,7 +26,6 @@ event_spec = {
     'time_span_label': True,
     'slots': True,
     'feature': True}
-
 
 signup_spec = {
     'attraction_id': True,
@@ -42,7 +39,6 @@ signup_spec = {
     },
     'event': event_spec}
 
-
 dummy_signup = {
     'is_signed_up': False,
     'signup_time': None,
@@ -51,12 +47,11 @@ dummy_signup = {
     'waitlist_position': None,
     'is_checked_in': False}
 
-
 def import_signups_open_time(attraction_feature_event, old_signups_open_time):
     if not old_signups_open_time:
         attraction_feature_event.signups_open_time = None
         return
-    signups_open_time = pytz.UTC.localize(dateparser.parse(old_signups_open_time))
+    signups_open_time = dateparser.parse(old_signups_open_time).replace(tzinfo=timezone.utc)
     attraction_feature_event.signups_open_time = signups_open_time.replace(year=signups_open_time.year + 1)
 
 
@@ -158,7 +153,7 @@ class Root:
                                     to_feature.department_id = to_dept.id
 
                         for from_event in from_feature['events']:
-                            start_time = pytz.UTC.localize(dateparser.parse(from_event['start_time'])) + EPOCH_DELTA
+                            start_time = dateparser.parse(from_event['start_time']).replace(tzinfo=timezone.utc) + EPOCH_DELTA
                             if not new_feature:
                                 existing_event = session.query(AttractionEvent).join(AttractionFeature).filter(
                                     AttractionFeature.id == to_feature.id,
@@ -273,7 +268,7 @@ class Root:
 
         for event in feature.events_by_location_by_day[params.get('location')][params.get('day')]:
             event.signups_open_relative = 0
-            event.signups_open_time = datetime.now(pytz.UTC)
+            event.signups_open_time = datetime.now(timezone.utc)
             session.add(event)
 
         session.commit()
@@ -836,7 +831,7 @@ class Root:
             elif signup.on_waitlist:
                 message = "This attendee is still on the waitlist for this event."
             else:
-                signup.checkin_time = datetime.now(pytz.UTC)
+                signup.checkin_time = datetime.now(timezone.utc)
                 session.commit()
                 return {'result': signup.checkin_time.astimezone(c.EVENT_TIMEZONE)}
         if message:

--- a/uber/site_sections/dealer_admin.py
+++ b/uber/site_sections/dealer_admin.py
@@ -1,7 +1,6 @@
 import cherrypy
 import logging
-from datetime import datetime
-from pytz import UTC
+from datetime import timezone, datetime
 from sqlalchemy.orm import subqueryload
 
 from uber.email import EmailService
@@ -14,7 +13,6 @@ from uber.payments import ReceiptManager
 from uber.utils import remove_opt, SignNowRequest
 
 log = logging.getLogger(__name__)
-
 
 def convert_dealer_badge(session, attendee, admin_note=''):
     """
@@ -223,7 +221,7 @@ class Root:
             raise HTTPRedirect("../group_admin/form?id={}&message={}", id,
                                f"Error sending SignNow link: {signnow_request.error_message}")
         else:
-            signnow_request.document.last_emailed = datetime.now(UTC)
+            signnow_request.document.last_emailed = datetime.now(timezone.utc)
             session.add(signnow_request.document)
             raise HTTPRedirect("../group_admin/form?id={}&message={}", id, "SignNow link sent!")
 

--- a/uber/site_sections/dept_checklist.py
+++ b/uber/site_sections/dept_checklist.py
@@ -1,7 +1,6 @@
 import cherrypy
-from datetime import datetime
+from datetime import timezone, datetime
 
-from pytz import UTC
 from sqlalchemy.orm import joinedload, subqueryload
 
 from uber.config import c
@@ -11,7 +10,6 @@ from uber.errors import HTTPRedirect
 from uber.forms import load_forms
 from uber.models import Attendee, Department, DeptChecklistItem, BulkPrintingRequest, HotelRequests, RoomAssignment, Shift
 from uber.utils import check, check_csrf, days_before, DeptChecklistConf, redirect_to_allowed_dept, validate_model
-
 
 def _submit_checklist_item(session, department_id, submitted, csrf_token, slug, custom_message=''):
     if not department_id:
@@ -140,7 +138,7 @@ class Root:
                     status['completed_by'] = checklist_item.attendee.full_name
                 elif days_before(7, item.deadline)():
                     status['approaching'] = True
-                elif item.deadline < datetime.now(UTC):
+                elif item.deadline < datetime.now(timezone.utc):
                     status['missed'] = True
                 statuses.append(status)
             if not filtered or can_admin_checklist:
@@ -179,7 +177,7 @@ class Root:
                     out.writecell('', format={'bg_color': 'green'})
                 elif days_before(7, item.deadline)():
                     out.writecell('', format={'bg_color': 'orange'})
-                elif item.deadline < datetime.now(UTC):
+                elif item.deadline < datetime.now(timezone.utc):
                     out.writecell('', format={'bg_color': 'red'})
                 else:
                     out.writecell('')

--- a/uber/site_sections/devtools.py
+++ b/uber/site_sections/devtools.py
@@ -12,10 +12,9 @@ import six
 import pypsutil
 import cherrypy
 import threading
-from datetime import datetime
+from datetime import timezone, datetime
 
 from sqlalchemy.dialects.postgresql.json import JSONB
-from pytz import UTC
 from sqlalchemy.types import DateTime
 from sqlalchemy import text
 
@@ -25,9 +24,7 @@ from uber.tasks.health import ping
 
 log = logging.getLogger(__name__)
 
-
 # admin utilities.  should not be used during normal ubersystem operations except by developers / sysadmins
-
 
 # quick n dirty. don't use for anything real.
 def run_shell_cmd(command_line, working_dir=None):
@@ -234,7 +231,7 @@ class Root:
         db_read_time += time.perf_counter()
 
         return json.dumps({
-            'server_current_timestamp': int(datetime.now(UTC).timestamp()),
+            'server_current_timestamp': int(datetime.now(timezone.utc).timestamp()),
             'session_read_count': read_count,
             'session_commit_time': session_commit_time,
             'db_read_time': db_read_time,

--- a/uber/site_sections/email_admin.py
+++ b/uber/site_sections/email_admin.py
@@ -1,7 +1,6 @@
 import cherrypy
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 import logging
-import pytz
 import traceback
 
 from sqlalchemy import func, or_, any_
@@ -18,7 +17,6 @@ from uber.utils import check, get_page, listify, groupify, validate_model, local
 from uber.tasks.email import check_emails_for_fixture
 
 log = logging.getLogger(__name__)
-
 
 def filter_emails_by_dept_id(session, email_model, emails, department_id, email_depts):
     depts_by_sender = {}
@@ -75,7 +73,7 @@ class Root:
             send_after = params.get('send_after', False)
 
         if not send_after:
-            fifteen_mins = datetime.now(pytz.UTC) + timedelta(seconds=900)
+            fifteen_mins = datetime.now(timezone.utc) + timedelta(seconds=900)
             emails = emails.filter(or_(Email.send_after == None, Email.send_after < fifteen_mins))
 
         if search_text:
@@ -365,7 +363,7 @@ class Root:
         if email.status != c.QUEUED:
             return {'success': False, 'message': 'That email is not currently queued and cannot be sent.'}
         
-        one_minute = datetime.now(pytz.UTC) + timedelta(seconds=60)
+        one_minute = datetime.now(timezone.utc) + timedelta(seconds=60)
         if email.send_after < one_minute:
             return {'success': False, 'message': 'This email cannot be sent by an admin because it may already be in the process of sending.'}
         email.status = c.SENT

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -2,8 +2,7 @@ import cherrypy
 import logging
 
 from collections import defaultdict
-from datetime import datetime
-from pytz import UTC
+from datetime import timezone, datetime
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import joinedload
 
@@ -19,7 +18,6 @@ from uber.utils import check, validate_model, add_opt, SignNowRequest
 from uber.payments import ReceiptManager
 
 log = logging.getLogger(__name__)
-
 
 @all_renderable()
 class Root:
@@ -143,7 +141,7 @@ class Root:
 
                 if not signnow_signed and not signnow_request.document.last_emailed:
                     signnow_request.send_dealer_signing_invite()
-                    signnow_request.document.last_emailed = datetime.now(UTC)
+                    signnow_request.document.last_emailed = datetime.now(timezone.utc)
 
                 signnow_last_emailed = signnow_request.document.last_emailed
                 session.commit()

--- a/uber/site_sections/merch_reports.py
+++ b/uber/site_sections/merch_reports.py
@@ -1,13 +1,11 @@
 from collections import defaultdict, OrderedDict
-from datetime import datetime
-from pytz import UTC
+from datetime import timezone, datetime
 from sqlalchemy import or_
 
 from uber.config import c
 from uber.custom_tags import format_currency, datetime_local_filter
 from uber.decorators import all_renderable, csv_file
 from uber.models import Attendee
-
 
 def sort(d, label_list):
     return sorted(d.items(), key=lambda tup: label_list.index(tup[0]))
@@ -89,7 +87,7 @@ class Root:
                 label(shirt_label)][status(attendee.got_merch)] += attendee.num_free_event_shirts
             if attendee.paid_for_a_shirt:
                 counts['paid_event_shirts'][label(shirt_label)][status(attendee.got_merch)] += 1
-                sale_week = (min(datetime.now(UTC), c.ESCHATON) - attendee.registered).days // 7
+                sale_week = (min(datetime.now(timezone.utc), c.ESCHATON) - attendee.registered).days // 7
                 sales_by_week[min(sale_week, 52)] += 1
 
         for week in range(48, -1, -1):

--- a/uber/site_sections/mits.py
+++ b/uber/site_sections/mits.py
@@ -1,11 +1,10 @@
 import shutil
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 from PIL import Image
 import logging
 
 import cherrypy
 from cherrypy.lib.static import serve_file
-from pytz import UTC
 
 from uber.email import EmailService
 from uber.config import c
@@ -17,7 +16,6 @@ from uber.models import Email, File, MITSTeam, MITSApplicant, MITSGame, MITSPane
 from uber.utils import check, localized_now, GuidebookUtils, listify
 
 log = logging.getLogger(__name__)
-
 
 @all_renderable(public=True)
 class Root:
@@ -442,7 +440,7 @@ class Root:
         elif c.AFTER_MITS_SUBMISSION_DEADLINE and not team.accepted:
             raise HTTPRedirect('index?id={}&message={}', team.id, 'You cannot submit an application past the deadline.')
         else:
-            team.submitted = datetime.now(UTC)
+            team.submitted = datetime.now(timezone.utc)
             raise HTTPRedirect('index?id={}&message={}', team.id, 'Your application has been submitted!')
 
     def accepted_teams(self, session):

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -4,14 +4,13 @@ import os
 import secrets
 import re
 import shutil
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 from functools import wraps
 from io import BytesIO
 
 import cherrypy
 from cherrypy.lib.static import serve_file
 from aztec_code_generator import AztecCode
-from pytz import UTC
 from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
@@ -33,7 +32,6 @@ from uber.site_sections.preregistration import check_if_can_reg
 from uber.utils import add_opt, check, check_pii_consent, get_page, hour_day_format, \
     localized_now, Order, validate_model, normalize_email_legacy
 from uber.payments import TransactionRequest, ReceiptManager, SpinTerminalRequest
-
 
 def check_atd(func):
     @wraps(func)
@@ -477,7 +475,7 @@ class Root:
             if response:
                 response_json = response.json()
                 if req.api_response_successful(response_json):
-                    tracker.resolved = datetime.now(UTC)
+                    tracker.resolved = datetime.now(timezone.utc)
                     tracker.response = response_json
                     tracker.internal_error = ''
                     session.add(tracker)
@@ -490,7 +488,7 @@ class Root:
                     error = req.error_message_from_response(response_json)
                     if error != "Not found":
                         return {'success': False, 'message': f"Error checking status of last transaction: {error}"}
-                    tracker.resolved = datetime.now(UTC)
+                    tracker.resolved = datetime.now(timezone.utc)
                     session.add(tracker)
                     session.commit()
                     prior_error = terminal_status.get('last_error')
@@ -1243,7 +1241,7 @@ class Root:
             restrict_to = [Attendee.paid == c.NOT_PAID, Attendee.placeholder == False]  # noqa: E712
         else:
             restrict_to = [
-                Attendee.paid != c.NEED_NOT_PAY, Attendee.registered > datetime.now(UTC) - timedelta(minutes=90)]
+                Attendee.paid != c.NEED_NOT_PAY, Attendee.registered > datetime.now(timezone.utc) - timedelta(minutes=90)]
 
         return {
             'message':    message,
@@ -1563,7 +1561,7 @@ class Root:
             'badges_sold': c.BADGES_SOLD,
             'remaining_badges': c.REMAINING_BADGES,
             'badges_price': c.BADGE_PRICE,
-            'server_current_timestamp': int(datetime.now(UTC).timestamp()),
+            'server_current_timestamp': int(datetime.now(timezone.utc).timestamp()),
             'warn_if_server_browser_time_mismatch': c.WARN_IF_SERVER_BROWSER_TIME_MISMATCH
         })
 

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -1,11 +1,10 @@
 import json
 import ics
-import pytz
 import cherrypy
 import logging
 
 from collections import defaultdict
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, timezone
 from dateutil import parser as dateparser
 from time import mktime
 from sqlalchemy.orm import joinedload, selectinload
@@ -18,7 +17,6 @@ from uber.models import AssignedPanelist, Attendee, Event, EventLocation, PanelA
 from uber.utils import check, localized_now, normalize_newlines, validate_model, load_locations_from_config, listify
 
 log = logging.getLogger(__name__)
-
 
 @all_renderable()
 class Root:
@@ -375,7 +373,7 @@ class Root:
         event = session.event(id)
         if not event:
             return {'success': False, 'message': "Event not found. Try refreshing the page."}
-        event.start_time = c.EVENT_TIMEZONE.localize(dateparser.parse(start_time)).astimezone(pytz.UTC)
+        event.start_time = dateparser.parse(start_time).replace(tzinfo=c.EVENT_TIMEZONE).astimezone(timezone.utc)
         event.duration = event.duration + (int(delta_seconds) / 60)
         event.event_location_id = location_id
         session.commit()

--- a/uber/site_sections/services.py
+++ b/uber/site_sections/services.py
@@ -2,8 +2,7 @@ import os
 import stripe
 import logging
 import cherrypy
-import pytz
-from datetime import datetime
+from datetime import timezone, datetime
 from cherrypy.lib.static import serve_file
 from sqlalchemy.orm.exc import NoResultFound
 from urllib.parse import urlparse, parse_qsl
@@ -18,9 +17,7 @@ from uber.utils import check, filename_extension
 from uber.files import FileService
 from uber.payments import ReceiptManager
 
-
 log = logging.getLogger(__name__)
-
 
 @all_renderable(public=True)
 class Root:
@@ -50,7 +47,7 @@ class Root:
 
         admin_account_id = getattr(cherrypy.request, 'admin_account', None)
         attendee_account_id = getattr(cherrypy.request, 'attendee_account', None)
-        now = datetime.now(pytz.UTC)
+        now = datetime.now(timezone.utc)
         if admin_account_id:
             login_account = session.get(AdminAccount, admin_account_id)
             login_account.last_signed_in = now

--- a/uber/site_sections/staffing_admin.py
+++ b/uber/site_sections/staffing_admin.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import cherrypy
 from dateutil import parser as dateparser
-from pytz import UTC
 from sqlalchemy.orm import joinedload, selectinload
 
 from uber.config import c
@@ -10,7 +9,6 @@ from uber.decorators import all_renderable, ajax, ajax_gettable, site_mappable
 from uber.errors import HTTPRedirect
 from uber.models import Attendee, Attraction, Department, DeptRole, Job, JobTemplate
 from uber.utils import get_api_service_from_server, slugify
-
 
 def _create_copy_department(from_department):
     to_department = Department()

--- a/uber/tasks/attractions.py
+++ b/uber/tasks/attractions.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 
-import pytz
 import logging
 from sqlalchemy.orm import subqueryload
 
@@ -18,9 +17,7 @@ from uber.utils import normalize_phone, groupify
 
 log = logging.getLogger(__name__)
 
-
 __all__ = ['attractions_check_notification_replies', 'send_waitlist_notification', 'attractions_send_notifications']
-
 
 def attractions_check_notification_replies():
     twilio_client = get_twilio_client(c.PANELS_TWILIO_SID, c.PANELS_TWILIO_TOKEN)
@@ -65,8 +62,8 @@ def attractions_check_notification_replies():
                 from_phonenumber=message.from_,
                 to_phonenumber=message.to,
                 sid=message.sid,
-                received_time=datetime.now(pytz.UTC),
-                sent_time=message.date_sent.replace(tzinfo=pytz.UTC),
+                received_time=datetime.now(timezone.utc),
+                sent_time=message.date_sent.replace(tzinfo=timezone.utc),
                 body=message.body))
             session.commit()
 
@@ -127,7 +124,7 @@ def send_waitlist_notification(signup_id):
                 notification_type=type_,
                 ident=ident,
                 sid=sid,
-                sent_time=datetime.now(pytz.UTC),
+                sent_time=datetime.now(timezone.utc),
                 subject=subject,
                 body=body))
             session.commit()
@@ -138,7 +135,7 @@ def attractions_send_notifications():
 
     with Session() as session:
         for attraction in session.query(Attraction):
-            now = datetime.now(pytz.UTC)
+            now = datetime.now(timezone.utc)
             from_time = now - timedelta(seconds=300)
             to_time = now + timedelta(seconds=300)
             signups = attraction.signups_requiring_notification(session, from_time, to_time, [
@@ -248,7 +245,7 @@ def attractions_send_notifications():
                         notification_type=type_,
                         ident=ident,
                         sid=sid,
-                        sent_time=datetime.now(pytz.UTC),
+                        sent_time=datetime.now(timezone.utc),
                         subject=subject,
                         body=body))
                     session.commit()

--- a/uber/tasks/email.py
+++ b/uber/tasks/email.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from datetime import timedelta, datetime
-import pytz
 import uuid
 from time import sleep, time
 import traceback
@@ -20,7 +19,6 @@ from uber.models import AutomatedEmail, Email, MagModel, UberSession, Session
 from uber.tasks import celery
 
 log = logging.getLogger(__name__)
-
 
 __all__ = ['notify_admins_of_pending_emails', 'send_automated_emails', 'send_email', 'check_emails_for_fixture']
 

--- a/uber/tasks/groups.py
+++ b/uber/tasks/groups.py
@@ -1,7 +1,6 @@
-import pytz
 import logging
 
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 from celery.schedules import crontab
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -15,7 +14,6 @@ from uber.utils import SignNowRequest, localized_now
 log = logging.getLogger(__name__)
 
 __all__ = ['check_document_signed', 'convert_declined_groups']
-
 
 @celery.schedule(crontab(minute=0, hour='*/6'))
 def check_document_signed():
@@ -59,7 +57,7 @@ def rock_island_updates():
     with Session() as session:
         updated_ri_inventories = session.query(GuestGroup).join(
             GuestMerch, GuestGroup.merch).filter(
-                GuestMerch.inventory_updated > datetime.now(pytz.UTC) - timedelta(hours=24))
+                GuestMerch.inventory_updated > datetime.now(timezone.utc) - timedelta(hours=24))
         if updated_ri_inventories.count():
             EmailService.queue_email(session, 'rock_island_updates_admin', to=c.ROCK_ISLAND_EMAIL,
                                      subject=f'{c.EVENT_NAME} Rock Island Inventory Updates for {localized_now().strftime('%Y-%m-%d')}',

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -1,11 +1,10 @@
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import timezone, datetime, timedelta
 from itertools import chain
 
 import stripe
 import time
 import logging
-import pytz
 from celery.schedules import crontab
 from sqlalchemy import not_, or_, insert
 from sqlalchemy.orm import joinedload, raiseload, subqueryload
@@ -23,15 +22,12 @@ from uber.payments import ReceiptManager, TransactionRequest
 
 log = logging.getLogger(__name__)
 
-
 if c.AUTHORIZENET_LOGIN_ID:
     from authorizenet import apicontractsv1, apicontrollers
-
 
 __all__ = ['check_duplicate_registrations', 'check_placeholder_registrations', 'check_pending_badges',
            'check_unassigned_volunteers', 'check_near_cap', 'check_missed_stripe_payments', 'process_api_queue',
            'process_terminal_sale', 'send_receipt_email', 'create_badge_nums', 'create_badge_pickup_groups', 'update_receipt']
-
 
 @celery.schedule(timedelta(days=1))
 def create_badge_nums():
@@ -250,16 +246,16 @@ def email_pending_attendees():
     already_emailed_accounts = []
 
     with Session() as session:
-        four_days_old = datetime.now(pytz.UTC) - timedelta(hours=96)
+        four_days_old = datetime.now(timezone.utc) - timedelta(hours=96)
         pending_badges = session.query(Attendee).filter(
             Attendee.paid == c.PENDING,
             Attendee.badge_status == c.PENDING_STATUS,
             Attendee.transfer_code == '',
-            Attendee.registered < datetime.now(pytz.UTC) - timedelta(hours=24)).order_by(Attendee.registered)
+            Attendee.registered < datetime.now(timezone.utc) - timedelta(hours=24)).order_by(Attendee.registered)
         for badge in pending_badges:
             # Update `compare_date` to prevent early deletion of badges registered before a certain date
             # Implemented for MFF 2023 but let's be honest, we'll probably need it again
-            compare_date = max(badge.registered, datetime(2023, 9, 25, tzinfo=pytz.UTC))
+            compare_date = max(badge.registered, datetime(2023, 9, 25, tzinfo=timezone.utc))
             if compare_date < four_days_old:
                 badge.badge_status = c.INVALID_STATUS
                 session.commit()

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -25,7 +25,7 @@ from rpctools.jsonrpc import ServerProxy
 from urllib.parse import urlparse, urljoin
 from uuid import uuid4
 from phonenumbers import PhoneNumberFormat
-from pytz import UTC
+from datetime import timezone
 from sqlalchemy import func, or_, cast, literal, DateTime
 from sqlalchemy.orm import make_transient
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError


### PR DESCRIPTION
This removes the `pytz` dependency, which is now deprecated in favor of `datetime.timzeone` in the standard library.