### PR TITLE
Fix SSO ID issue with certain admin accounts

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1279,11 +1279,16 @@ class UberSession(sqlalchemy.orm.Session):
         def add_attendee_to_account(self, attendee, account):
             unclaimed_account = account.hashed != '' and not account.is_sso_account
 
+            if attendee.admin_account and attendee.admin_account.sso_id and attendee.admin_account.sso_id != account.sso_id:
+                log.error(f"Tried to add attendee {attendee.full_name} to account {account.email}, but their admin account has already been claimed.")
+                return
+
             if c.ONE_MANAGER_PER_BADGE and attendee.managers and not unclaimed_account:
                 attendee.managers.clear()
             if attendee not in account.attendees:
                 account.unused_years = 0
                 account.attendees.append(attendee)
+                attendee.admin_account.sso_id = account.sso_id
 
         def match_attendee_to_account(self, attendee):
             existing_account = self.query(AttendeeAccount

--- a/uber/templates/accounts/index.html
+++ b/uber/templates/accounts/index.html
@@ -138,6 +138,9 @@ table form {
               <br>
               <small><i>Assigned to {{ account.attendee.assigned_depts|map('form_link')|list|readable_join|safe }}</i></small>
             {% endif %}
+            {% if c.OIDC_ENABLED or account.sso_id %}
+            <div class="form-text">{% if account.sso_id %}SSO ID: {{ account.sso_id }}{% else %}No SSO Account{% endif %}</div>
+            {% endif %}
           </td>
           <td>
             <a href="update_password_of_other?id={{account.id}}">Change Password</a>

--- a/uber/templates/reg_admin/attendee_account_form.html
+++ b/uber/templates/reg_admin/attendee_account_form.html
@@ -30,6 +30,7 @@
         </div>
     </form>
 </div>
+{% if c.LOCAL_ACCOUNTS_DISABLED or account.sso_id %}<div class="form-text">{% if account.sso_id %}SSO ID: {{ account.sso_id }}{% else %}No SSO Account{% endif %}</div>{% endif %}
 <div class="card">
     <div class="card-header">
         Registrations

--- a/uber/templates/reg_admin/attendee_accounts.html
+++ b/uber/templates/reg_admin/attendee_accounts.html
@@ -87,7 +87,10 @@
     <tbody>
     {% for account in accounts %}
         <tr id="{{ account.email|idize }}">
-        <td>{{ account|form_link }}</td>
+        <td>
+          {{ account|form_link }}
+          {% if c.LOCAL_ACCOUNTS_DISABLED %}<div class="form-text">{% if account.sso_id %}SSO ID: {{ account.sso_id }}{% else %}No SSO Account{% endif %}</div>{% endif %}
+        </td>
         <td>{{ account.imported|yesno("Yes,No") }}</td>
         <td>{{ account.unused_years }}</td>
         <td> {% for attendee in account.attendees %} 

--- a/uber/templates/registration/no_attendee_account.html
+++ b/uber/templates/registration/no_attendee_account.html
@@ -41,7 +41,7 @@ Choose an option below to give them access to their badge.{% if attendee.group a
         </div>
     </div>
     </form>
-    {% if c.HAS_ACCOUNTS_ACCESS %}
+    {% if c.HAS_ACCOUNTS_ACCESS and not attendee.admin_account %}
     <div class="d-flex gap-3 align-items-center">
         <div><a href="../accounts/" class="btn btn-warning">Create Admin Account <i class="fa fa-external-link"></i></a></div>
         <div>


### PR DESCRIPTION
If you added an admin attendee to an existing account, the system would fail to tie their admin account to their existing SSO ID, meaning there was no way for them to activate their admin account. We now make sure to copy the SSO ID from the existing account to an admin account, unless that account already has one. We also now display the SSO ID for admin and attendee accounts, which would have made debugging this issue easier.