### PR TITLE
refactor: convert legacy str.format calls to modern f-strings

### DIFF
--- a/uber/__init__.py
+++ b/uber/__init__.py
@@ -36,7 +36,7 @@ def create_data_dirs():
 
     for directory in c.DATA_DIRS.values():
         if not os.path.exists(directory):
-            log.info('Creating directory {}'.format(directory))
+            log.info(f'Creating directory {directory}')
             os.makedirs(directory, mode=0o744)
 
 cherrypy.engine.subscribe('start', create_data_dirs, priority=98)

--- a/uber/api.py
+++ b/uber/api.py
@@ -114,7 +114,7 @@ def _make_jsonrpc_handler(services, debug=c.DEV_BOX, precall=lambda body: None):
             return error(http_error.code, ERR_FUNC_EXCEPTION, http_error._message)
         except Exception as e:
             log.error('Unexpected error', exc_info=True)
-            message = 'Unexpected error: {}'.format(e)
+            message = f'Unexpected error: {e}'
             if debug:
                 message += '\n' + traceback.format_exc()
             return error(500, ERR_FUNC_EXCEPTION, message)
@@ -127,7 +127,7 @@ jsonrpc_services = {}
 
 def register_jsonrpc(service, name=None):
     name = name or service.__name__
-    assert name not in jsonrpc_services, '{} has already been registered'.format(name)
+    assert name not in jsonrpc_services, f'{name} has already been registered'
     jsonrpc_services[name] = service
 
 
@@ -338,12 +338,12 @@ def auth_by_token(required_access):
     with Session() as session:
         api_token = session.query(ApiToken).filter_by(token=token).first()
         if not api_token:
-            return (403, 'Auth token not recognized: {}'.format(token))
+            return (403, f'Auth token not recognized: {token}')
         if api_token.revoked_time:
-            return (403, 'Revoked auth token: {}'.format(token))
+            return (403, f'Revoked auth token: {token}')
         for access_level in required_access:
             if not getattr(api_token, access_level, None):
-                return (403, 'Insufficient access for auth token: {}'.format(token))
+                return (403, f'Insufficient access for auth token: {token}')
         cherrypy.session['account_id'] = api_token.admin_account_id
     return None
 
@@ -633,7 +633,7 @@ class AttendeeLookup:
             if attendee:
                 return attendee.to_dict(fields)
             else:
-                raise HTTPError(404, 'No attendee found with badge #{}'.format(badge_num))
+                raise HTTPError(404, f'No attendee found with badge #{badge_num}')
 
     def search(self, query, full=False):
         """
@@ -835,7 +835,7 @@ class AttendeeLookup:
 
             for key, val in params.items():
                 if not hasattr(Attendee, key):
-                    return HTTPError(400, 'Attendee has no field {}'.format(key))
+                    return HTTPError(400, f'Attendee has no field {key}')
                 setattr(attendee, key, val)
 
             message = check(attendee)
@@ -946,7 +946,7 @@ class AttendeeAccountLookup:
 
                 attendees = {}
                 for attendee in a.attendees:
-                    attendees[attendee.id] = attendee.full_name + " <{}>".format(attendee.email)
+                    attendees[attendee.id] = attendee.full_name + f" <{attendee.email}>"
 
                 d.update({
                     'attendees': attendees,
@@ -980,7 +980,7 @@ class AttractionLookup:
         with Session() as session:
             attraction = session.get(Attraction, attraction_id)
             if not attraction:
-                raise HTTPError(404, 'Attraction id not found: {}'.format(attraction_id))
+                raise HTTPError(404, f'Attraction id not found: {attraction_id}')
             return attraction.to_dict({
                 'id': True,
                 'name': True,
@@ -1113,7 +1113,7 @@ class JobLookup:
         with Session() as session:
             shift = session.get(Shift, shift_id)
             if not shift:
-                raise HTTPError(404, 'Shift id not found:{}'.format(shift_id))
+                raise HTTPError(404, f'Shift id not found:{shift_id}')
 
             session.delete(shift)
             session.commit()
@@ -1140,13 +1140,13 @@ class JobLookup:
             status = int(status)
             assert c.WORKED_STATUS[status] is not None
         except Exception:
-            raise HTTPError(400, 'Invalid status: {}'.format(status))
+            raise HTTPError(400, f'Invalid status: {status}')
 
         try:
             rating = int(rating)
             assert c.RATINGS[rating] is not None
         except Exception:
-            raise HTTPError(400, 'Invalid rating: {}'.format(rating))
+            raise HTTPError(400, f'Invalid rating: {rating}')
 
         if rating in (c.RATED_BAD, c.RATED_GREAT) and not comment:
             raise HTTPError(400, 'You must leave a comment explaining why the staffer was rated as: {}'.format(
@@ -1155,7 +1155,7 @@ class JobLookup:
         with Session() as session:
             shift = session.get(Shift, shift_id)
             if not shift:
-                raise HTTPError(404, 'Shift id not found:{}'.format(shift_id))
+                raise HTTPError(404, f'Shift id not found:{shift_id}')
 
             shift.worked = status
             shift.rating = rating
@@ -1234,7 +1234,7 @@ class GroupLookup:
                 attendees = {}
                 for attendee in g.attendees:
                     if not attendee.is_unassigned:
-                        attendees[attendee.id] = attendee.full_name + " <{}>".format(attendee.email)
+                        attendees[attendee.id] = attendee.full_name + f" <{attendee.email}>"
 
                 d.update({
                     'assigned_attendees': attendees,
@@ -1330,7 +1330,7 @@ class GroupLookup:
                 attendees = {}
                 for attendee in g.attendees:
                     if not attendee.is_unassigned:
-                        attendees[attendee.id] = attendee.full_name + " <{}>".format(attendee.email)
+                        attendees[attendee.id] = attendee.full_name + f" <{attendee.email}>"
 
                 d.update({
                     'assigned_attendees': attendees,
@@ -1363,7 +1363,7 @@ class DepartmentLookup:
         with Session() as session:
             department = session.get(Department, department_id)
             if not department:
-                raise HTTPError(404, 'Department id not found: {}'.format(department_id))
+                raise HTTPError(404, f'Department id not found: {department_id}')
             if full:
                 attendee_fields = AttendeeLookup.fields_full
             else:
@@ -1392,7 +1392,7 @@ class DepartmentLookup:
         with Session() as session:
             department = session.get(Department, department_id)
             if not department:
-                raise HTTPError(404, 'Department id not found: {}'.format(department_id))
+                raise HTTPError(404, f'Department id not found: {department_id}')
             return department.to_dict({
                 'id': True,
                 'name': True,
@@ -1507,7 +1507,7 @@ class ConfigLookup:
         if field.upper() in self.fields:
             return getattr(c, field.upper())
         else:
-            raise HTTPError(404, 'Config field not found: {}'.format(field))
+            raise HTTPError(404, f'Config field not found: {field}')
 
 
 @all_api_auth('api_read')
@@ -1533,7 +1533,7 @@ class HotelLookup:
             if id:
                 room = session.get(Room, id)
                 if not room:
-                    return HTTPError(404, "Could not locate room {}".format(id))
+                    return HTTPError(404, f"Could not locate room {id}")
             else:
                 room = Room()
             for attr in ['notes', 'message', 'locked_in', 'nights', 'created']:
@@ -1556,7 +1556,7 @@ class HotelLookup:
             if id:
                 hotel_request = session.get(HotelRequests, id)
                 if not hotel_request:
-                    return HTTPError(404, "Could not locate request {}".format(id))
+                    return HTTPError(404, f"Could not locate request {id}")
             else:
                 hotel_request = HotelRequests()
             for attr in ['attendee_id', 'nights', 'wanted_roommates', 'unwanted_roommates',
@@ -1580,7 +1580,7 @@ class HotelLookup:
             if id:
                 assignment = session.query(RoomAssignment).filter(RoomAssignment.id == id).one_or_none()
                 if not assignment:
-                    return HTTPError(404, "Could not locate room assignment {}".format(id))
+                    return HTTPError(404, f"Could not locate room assignment {id}")
             else:
                 assignment = RoomAssignment()
             for attr in ['room_id', 'attendee_id']:
@@ -1655,7 +1655,7 @@ class BarcodeLookup:
             if attendee:
                 return attendee.to_dict(fields)
             else:
-                raise HTTPError(404, 'Valid barcode, but no attendee found with Badge #{}'.format(badge_num))
+                raise HTTPError(404, f'Valid barcode, but no attendee found with Badge #{badge_num}')
 
     def lookup_badge_number_from_barcode(self, barcode_value):
         """

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -1006,7 +1006,7 @@ class DeptChecklistEmailFixture(AutomatedEmailFixture):
             f'{c.EVENT_NAME} Department Checklist: ' + conf.name,
             'shifts/dept_checklist.txt',
             "lambda a: a.admin_account and any(not d.checklist_item_for_slug(conf.slug) for d in a.checklist_admin_depts)",
-            'department_checklist_{}'.format(conf.name),
+            f'department_checklist_{conf.name}',
             when=when,
             sender=c.STAFF_EMAIL,
             extra_data={'conf': conf},

--- a/uber/barcode/__init__.py
+++ b/uber/barcode/__init__.py
@@ -42,7 +42,7 @@ def generate_barcode_from_badge_num(badge_num, event_id=None, salt=None, key=Non
 
     key_len = len(key)
     if key_len != 10:
-        raise ValueError('key length should be exactly 10 bytes, length={}'.format(key_len))
+        raise ValueError(f'key length should be exactly 10 bytes, length={key_len}')
 
     # 4 bytes of data are going to be packed into an ecnrypted barcode:
     # byte 1: 1 byte event ID
@@ -51,7 +51,7 @@ def generate_barcode_from_badge_num(badge_num, event_id=None, salt=None, key=Non
     salted_val = badge_num + (0 if not salt else salt)
 
     if salted_val > 0xFFFFFF:
-        raise ValueError('either badge_number or salt is too large to turn into a barcode: {}'.format(badge_num))
+        raise ValueError(f'either badge_number or salt is too large to turn into a barcode: {badge_num}')
 
     # create a 5-byte result with event_id and salted_val packed in there
     data_to_encrypt = struct.pack('>BI', event_id, salted_val)
@@ -132,7 +132,7 @@ def verify_barcode_is_valid_code128_charset(str):
 
 def assert_is_valid_rams_barcode(barcode):
     if not verify_is_valid_rams_barcode(barcode):
-        raise ValueError("barcode validation error: invalid format for barcode: {}".format(barcode))
+        raise ValueError(f"barcode validation error: invalid format for barcode: {barcode}")
 
 
 def _barcode_raw_encrypt(value, key):

--- a/uber/config.py
+++ b/uber/config.py
@@ -945,12 +945,12 @@ class Config(_Overridable):
         """
         opts = []
         if self.ATTENDEE_BADGE_AVAILABLE:
-            opts.append((self.ATTENDEE_BADGE, 'Full Weekend Badge (${})'.format(self.BADGE_PRICE)))
+            opts.append((self.ATTENDEE_BADGE, f'Full Weekend Badge (${self.BADGE_PRICE})'))
         for badge_type in self.BADGE_TYPE_PRICES:
             if badge_type not in opts:
                 opts.append(
                     (badge_type, '{} (${})'.format(self.BADGES[badge_type], self.BADGE_TYPE_PRICES[badge_type])))
-            opts.append((self.ATTENDEE_BADGE, 'Standard (${})'.format(self.BADGE_PRICE)))
+            opts.append((self.ATTENDEE_BADGE, f'Standard (${self.BADGE_PRICE})'))
         if self.ONE_DAYS_ENABLED:
             if self.PRESELL_ONE_DAYS:
                 day = max(uber.utils.localized_now(), self.EPOCH)
@@ -959,10 +959,10 @@ class Config(_Overridable):
                     price = self.BADGE_PRICES['single_day'].get(day_name) or self.DEFAULT_SINGLE_DAY
                     badge = getattr(self, day_name.upper())
                     if getattr(self, day_name.upper() + '_AVAILABLE', None):
-                        opts.append((badge, day_name + ' Badge (${})'.format(price)))
+                        opts.append((badge, day_name + f' Badge (${price})'))
                     day += timedelta(days=1)
             elif self.ONE_DAY_BADGE_AVAILABLE:
-                opts.append((self.ONE_DAY_BADGE, 'Single Day Badge (${})'.format(self.ONEDAY_BADGE_PRICE)))
+                opts.append((self.ONE_DAY_BADGE, f'Single Day Badge (${self.ONEDAY_BADGE_PRICE})'))
         return opts
 
     @property
@@ -1590,7 +1590,7 @@ class Config(_Overridable):
         elif name.lower() in _config['secret']:
             return _config['secret'][name.lower()]
         else:
-            raise AttributeError('no such attribute {}'.format(name))
+            raise AttributeError(f'no such attribute {name}')
 
 
 class AWSSecretFetcher:
@@ -1729,7 +1729,7 @@ def parse_config(plugin_name, module_dir):
     spec = configobj.ConfigObj(str(specfile), interpolation=False, list_values=False, encoding='utf-8', _inspec=True)
 
     # to allow more/better interpolations
-    root_conf = ['root = "{}"\n'.format(module_dir.parents[0]), 'module_root = "{}"\n'.format(module_dir)]
+    root_conf = [f'root = "{module_dir.parents[0]}"\n', 'module_root = "{}"\n'.format(module_dir)]
     temp_config = configobj.ConfigObj(root_conf, interpolation=False, encoding='utf-8')
 
     for config_path in get_config_files(plugin_name, module_dir):
@@ -2005,7 +2005,7 @@ c.PANEL_STRICT_LENGTH_OPTS = [opt for opt in c.PANEL_LENGTH_OPTS if opt != c.OTH
 
 c.EVENT_YEAR = c.EPOCH.strftime('%Y')
 c.EVENT_DATE = c.EPOCH.strftime('%b %Y')
-c.EVENT_NAME_AND_YEAR = c.EVENT_NAME + (' {}'.format(c.EVENT_YEAR) if c.EVENT_YEAR else '')
+c.EVENT_NAME_AND_YEAR = c.EVENT_NAME + (f' {c.EVENT_YEAR}' if c.EVENT_YEAR else '')
 c.EVENT_MONTH = c.EPOCH.strftime('%B')
 c.EVENT_START_DAY = int(c.EPOCH.strftime('%d')) % 100
 c.EVENT_END_DAY = int(c.ESCHATON.strftime('%d')) % 100

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -728,10 +728,10 @@ def pages(page, count):
     pages = []
     for pagenum in range(1, int(math.ceil(count / 100)) + 1):
         if pagenum == page:
-            pages.append('<li class="page-item active"><a class="page-link" href="#">{}</a></li>'.format(pagenum))
+            pages.append(f'<li class="page-item active"><a class="page-link" href="#">{pagenum}</a></li>')
         else:
             path = cherrypy.request.request_line.split()[1].split('/')[-1]
-            page_qs = 'page={}'.format(pagenum)
+            page_qs = f'page={pagenum}'
             if 'page=' in path:
                 path = re.sub(r'page=\d+', page_qs, path)
             else:

--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -196,7 +196,7 @@ def check_can_edit_dept(session, department_id=None, inherent_role=None, overrid
             AdminAccount.id == account_id,
             AdminAccount.attendee_id == DeptMembership.attendee_id]
         if inherent_role in ('dept_head', 'poc', 'checklist_admin'):
-            role_attr = 'is_{}'.format(inherent_role)
+            role_attr = f'is_{inherent_role}'
             dh_filter.append(getattr(DeptMembership, role_attr) == True)  # noqa: E712
         else:
             dh_filter.append(DeptMembership.has_inherent_role)
@@ -208,10 +208,10 @@ def check_can_edit_dept(session, department_id=None, inherent_role=None, overrid
         if not is_dept_admin:
             if department_id:
                 department = session.get(Department, department_id)
-                dept_msg = ' of {}'.format(department.name)
+                dept_msg = f' of {department.name}'
             else:
                 dept_msg = ''
-            return 'You must be a department admin{} to complete that action.'.format(dept_msg)
+            return f'You must be a department admin{dept_msg} to complete that action.'
 
 
 def check_dept_admin(session, department_id=None, inherent_role=None):
@@ -410,7 +410,7 @@ def ajax(func):
     def returns_json(*args, **kwargs):
         cherrypy.response.headers['Content-Type'] = 'application/json'
         try:
-            assert cherrypy.request.method == 'POST', 'POST required, got {}'.format(cherrypy.request.method)
+            assert cherrypy.request.method == 'POST', f'POST required, got {cherrypy.request.method}'
             check_csrf(kwargs.pop('csrf_token', None))
         except Exception:
             traceback.print_exc()
@@ -663,12 +663,12 @@ def run_threaded(thread_name='', lock=None, blocking=True, timeout=-1):
                         finally:
                             lock.release()
                     else:
-                        log.warn("Can't acquire lock, skipping background thread: {}".format(name))
+                        log.warn(f"Can't acquire lock, skipping background thread: {name}")
                 thread = threading.Thread(target=locked_func, *args, **kwargs)
             else:
                 thread = threading.Thread(target=func, *args, **kwargs)
             thread.name = name
-            log.debug('Starting background thread: {}'.format(name))
+            log.debug(f'Starting background thread: {name}')
             thread.start()
         return with_run_threaded
 
@@ -797,7 +797,7 @@ def renderable(func):
                 ajax_or_redirect(func, '../landing/invalid?message=', message)
         except TypeError as e:
             # Very restrictive pattern so we don't accidentally match legit errors
-            pattern = r"^{}\(\) missing 1 required positional argument: '\S*?id'$".format(func.__name__)
+            pattern = rf"^{func.__name__}\(\) missing 1 required positional argument: '\S*?id'$"
             if re.fullmatch(pattern, str(e)):
                 # NOTE: We are NOT logging the exception if the user entered an invalid URL
                 message = 'Looks like you tried to access a page without all the query parameters. '\

--- a/uber/forms/__init__.py
+++ b/uber/forms/__init__.py
@@ -352,7 +352,7 @@ class MagForm(Form):
                     real_target = target
                     modules.append(module_name)
         if match_count == 0:
-            raise ValueError('Could not find a form with the name {}'.format(form_name))
+            raise ValueError(f'Could not find a form with the name {form_name}')
         elif match_count > 1:
             raise ValueError(f'There is more than one form with the name {form_name}. '
                              'Please specify which model this form is for.')

--- a/uber/forms/group.py
+++ b/uber/forms/group.py
@@ -88,7 +88,7 @@ class AdminTableInfo(TableInfo, AdminGroupInfo):
         if c.MAX_DEALERS:
             return "This {} can add up to {} badges.".format(c.DEALER_TERM, c.MAX_DEALERS)
         else:
-            return "This {} can add badges up to their personal maximum.".format(c.DEALER_TERM)
+            return f"This {c.DEALER_TERM} can add badges up to their personal maximum."
 
 
 class LeaderInfo(MagForm):

--- a/uber/forms/widgets.py
+++ b/uber/forms/widgets.py
@@ -28,9 +28,9 @@ class MultiCheckbox():
                 options['disabled'] = True
             if checked:
                 options['checked'] = 'checked'
-            html.append('<label for="{}" class="checkbox-label">'.format(choice_id))
+            html.append(f'<label for="{choice_id}" class="checkbox-label">')
             html.append('<input {} /> '.format(html_params(**options)))
-            html.append('{}</label>'.format(label))
+            html.append(f'{label}</label>')
         return Markup(''.join(html))
 
 
@@ -126,10 +126,10 @@ class NumberInputGroup(TextInput):
     def __call__(self, field, **kwargs):
         html = []
         if self.prefix:
-            html.append('<span class="input-group-text">{}</span>'.format(self.prefix))
+            html.append(f'<span class="input-group-text">{self.prefix}</span>')
         html.append(super().__call__(field, **kwargs))
         if self.suffix:
-            html.append('<span class="input-group-text rounded-end">{}</span>'.format(self.suffix))
+            html.append(f'<span class="input-group-text rounded-end">{self.suffix}</span>')
 
         return Markup(''.join(html))
 

--- a/uber/menu.py
+++ b/uber/menu.py
@@ -88,7 +88,7 @@ def get_external_schedule_menu_name():
     if getattr(c, 'ALT_SCHEDULE_URL', ''):
         try:
             url = urlparse(c.ALT_SCHEDULE_URL)
-            return 'View External Public Schedule on {}'.format(url.netloc)
+            return f'View External Public Schedule on {url.netloc}'
         except Exception:
             log.warning('Menu: Unable to parse ALT_SCHEDULE_URL: "{}"', c.ALT_SCHEDULE_URL)
             return 'View External Public Schedule'

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -104,7 +104,7 @@ def admin_has_required_api_access(api_token):
         for access_level in set(api_token.access_ints):
             access_name = 'api_' + c.API_ACCESS[access_level].lower()
             if not getattr(admin_account, access_name, None):
-                return 'You do not have permission to create a token with {} access'.format(c.API_ACCESS[access_level])
+                return f'You do not have permission to create a token with {c.API_ACCESS[access_level]} access'
 
 
 def invalid_phone_number(s):
@@ -529,7 +529,7 @@ def payment_nan(guest_group):
     try:
         int(float(guest_group.payment if guest_group.payment else 0))
     except Exception:
-        return "What you entered for Payment ({}) isn't even a number".format(guest_group.payment)
+        return f"What you entered for Payment ({guest_group.payment}) isn't even a number"
 
 
 @validation.GuestGroup
@@ -805,7 +805,7 @@ def promo_code_is_useful(attendee):
             return ('promo_code', f"You can't apply a promo code after you've paid or if you're in a group.")
         if attendee.promo_code_discounts_badge:
             if attendee.is_dealer:
-                return ('promo_code', "You can't apply a promo code to a {}.".format(c.DEALER_REG_TERM))
+                return ('promo_code', f"You can't apply a promo code to a {c.DEALER_REG_TERM}.")
             elif attendee.age_discount != 0:
                 return ('promo_code',
                         "You are already receiving an age based discount, you can't use a promo code on top of that.")
@@ -846,9 +846,9 @@ def allowed_to_volunteer(attendee):
 @validation.Attendee
 def banned_volunteer(attendee):
     if attendee.staffing_or_will_be and attendee.full_name in c.BANNED_STAFFERS:
-        return ('staffing', "We've declined to invite {} back as a volunteer, ".format(attendee.full_name) + (
+        return ('staffing', f"We've declined to invite {attendee.full_name} back as a volunteer, " + (
                     'talk to STOPS to override if necessary' if c.AT_THE_CON else
-                    'Please contact us via {} if you believe this is in error'.format(c.CONTACT_URL)))
+                    f'Please contact us via {c.CONTACT_URL} if you believe this is in error'))
 
 
 @validation.Attendee

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -711,7 +711,7 @@ class MagModel(SQLModel):
             if (not restricted or column.name in self.unrestricted) \
                     and (column.type is JSON or isinstance(column.type, JSON)):
 
-                fields = getattr(self, '_{}_fields'.format(column.name), {})
+                fields = getattr(self, f'_{column.name}_fields', {})
                 for field in fields.keys():
                     if field in params:
                         setattr(self, field, params[field])
@@ -840,9 +840,9 @@ class UberSession(sqlalchemy.orm.Session):
             conditions = []
             if len(self.column_descriptions) == 1 and filters:
                 for colname, val in filters.items():
-                    conditions.append(getattr(self.model, colname).ilike('%{}%'.format(val)))
+                    conditions.append(getattr(self.model, colname).ilike(f'%{val}%'))
             if attr and val:
-                conditions.append(attr.ilike('%{}%'.format(val)))
+                conditions.append(attr.ilike(f'%{val}%'))
             return and_(*conditions)
 
         def icontains(self, attr=None, val=None, **filters):
@@ -1092,7 +1092,7 @@ class UberSession(sqlalchemy.orm.Session):
             conf = DeptChecklistConf.instances.get(slug)
             if not conf:
                 raise ValueError(
-                    "Can't access dept checklist INI settings for section '{}', check your INI file".format(slug))
+                    f"Can't access dept checklist INI settings for section '{slug}', check your INI file")
 
             if not department_id:
                 return {'conf': conf, 'relevant': False, 'completed': None}
@@ -1156,7 +1156,7 @@ class UberSession(sqlalchemy.orm.Session):
                     try:
                         birthdate = dateparser.parse(attendee.birthdate).date()
                     except Exception:
-                        log.debug('Error parsing attendee birthdate: {}'.format(attendee.birthdate))
+                        log.debug(f'Error parsing attendee birthdate: {attendee.birthdate}')
                     else:
                         or_clauses.append(WatchList.birthdate == birthdate)
                 elif isinstance(attendee.birthdate, datetime):
@@ -1587,7 +1587,7 @@ class UberSession(sqlalchemy.orm.Session):
 
             for field in fields:
                 if not attendee_fields.get(field) and field != 'ribbon_labels':
-                    errors.append("Field missing: {}.".format(field))
+                    errors.append(f"Field missing: {field}.")
 
             if self.query(PrintJob).filter_by(attendee_id=attendee.id, printed=None, errors="").first():
                 errors.append("Badge is already queued to print.")
@@ -1640,7 +1640,7 @@ class UberSession(sqlalchemy.orm.Session):
 
             for field in fields:
                 if not attendee_fields.get(field) and field != 'ribbon_labels':
-                    errors.append("Field missing: {}.".format(field))
+                    errors.append(f"Field missing: {field}.")
                 elif attendee_fields.get(field) != job.json_data.get(field):
                     job.json_data[field] = attendee_fields.get(field)
 
@@ -1977,13 +1977,13 @@ class UberSession(sqlalchemy.orm.Session):
                             try:
                                 getattr(Attendee, target)
                             except AttributeError:
-                                return None, 'ERROR: {} is not a valid attribute'.format(target)
+                                return None, f'ERROR: {target} is not a valid attribute'
                             # Are we a searchable property?
                             if isinstance(getattr(Attendee, target) == search_term,
                                           sqlalchemy.sql.elements.BinaryExpression):
                                 attr_search_filter = self.get_truth(getattr(Attendee, target), op, search_term)
                             else:
-                                return None, 'ERROR: {} is not a searchable attribute'.format(target)
+                                return None, f'ERROR: {target} is not a searchable attribute'
 
                         if term.endswith(' OR') or last_term and last_term.endswith(' OR'):
                             or_checks.append(attr_search_filter)
@@ -2304,7 +2304,7 @@ class UberSession(sqlalchemy.orm.Session):
         models_by_class = {ModelClass.__name__: ModelClass for ModelClass in cls.all_models()}
         if name in models_by_class:
             return models_by_class[name]
-        raise ValueError('Unrecognized model: {}'.format(name))
+        raise ValueError(f'Unrecognized model: {name}')
 
     @classmethod
     def model_mixin(cls, model):
@@ -2317,7 +2317,7 @@ class UberSession(sqlalchemy.orm.Session):
                 if target.__name__ == model.__name__:
                     break
             else:
-                raise ValueError('No existing model with name {}'.format(model.__name__))
+                raise ValueError(f'No existing model with name {model.__name__}')
 
         new_fields = {}
         new_annotations = {}

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1318,7 +1318,7 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
     @is_dealer.expression
     def is_dealer(cls):
         return or_(
-            cls.ribbon.like('%{}%'.format(c.DEALER_RIBBON)),
+            cls.ribbon.like(f'%{c.DEALER_RIBBON}%'),
             and_(
                 cls.paid == c.PAID_BY_GROUP,
                 exists().select_from(Group).where(
@@ -1348,8 +1348,8 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
         so this property allows you to easily override the message shown to staffers
         without having to override the entire cannot_check_in_reason function.
         """
-        regdesk_info_append = " [{}]".format(self.regdesk_info) if self.regdesk_info else ""
-        return "MUST TALK TO MANAGER before picking up badge{}".format(regdesk_info_append)
+        regdesk_info_append = f" [{self.regdesk_info}]" if self.regdesk_info else ""
+        return f"MUST TALK TO MANAGER before picking up badge{regdesk_info_append}"
 
     @property
     def cannot_check_in_reason(self):
@@ -1361,10 +1361,10 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
         if self.badge_status == c.WATCHED_STATUS:
             if self.banned or not self.regdesk_info:
                 return self.watchlist_warning
-            return self.regdesk_info or "Badge status is {}".format(self.badge_status_label)
+            return self.regdesk_info or f"Badge status is {self.badge_status_label}"
 
         if self.badge_status not in [c.COMPLETED_STATUS, c.NEW_STATUS]:
-            return "Badge status is {}".format(self.badge_status_label)
+            return f"Badge status is {self.badge_status_label}"
 
         if self.group and self.paid == c.PAID_BY_GROUP and self.group.is_dealer \
                 and self.group.status not in c.DEALER_ACCEPTED_STATUSES:
@@ -1694,7 +1694,7 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
         if self.admin_account:
             reasons.append("they have an admin account")
         if self.badge_type not in c.TRANSFERABLE_BADGE_TYPES:
-            reasons.append("their badge type ({}) is not transferable".format(self.badge_type_label))
+            reasons.append(f"their badge type ({self.badge_type_label}) is not transferable")
         if self.dept_memberships_with_inherent_role:
             reasons.append("they are a department head, checklist admin, \
                            or point of contact for the following departments: {}".format(
@@ -1790,7 +1790,7 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
     def donation_swag(self):
         donation_items = [
             desc for amount, desc in sorted(c.DONATION_TIERS.items()) if amount and (self.amount_extra or 0) >= amount]
-        extra_donations = ['Extra donation of ${}'.format(self.extra_donation)] if self.extra_donation else []
+        extra_donations = [f'Extra donation of ${self.extra_donation}'] if self.extra_donation else []
         return donation_items + extra_donations
 
     @property
@@ -1876,9 +1876,9 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
             if self.shirt_size_marked:
                 try:
                     if c.STAFF_SHIRT_OPTS != c.SHIRT_OPTS:
-                        staff_shirts += ' [{}]'.format(c.STAFF_SHIRTS[self.staff_shirt])
+                        staff_shirts += f' [{c.STAFF_SHIRTS[self.staff_shirt]}]'
                     else:
-                        staff_shirts += ' [{}]'.format(c.SHIRTS[self.shirt])
+                        staff_shirts += f' [{c.SHIRTS[self.shirt]}]'
                 except KeyError:
                     staff_shirts += ' [{}]'.format("Size unknown")
             merch.append(staff_shirts)
@@ -1900,7 +1900,7 @@ class Attendee(MagModel, TakesPaymentMixin, table=True):
         stuff = [] if not self.ribbon else ['a ' + s + ' ribbon' for s in self.ribbon_labels]
 
         if c.WRISTBANDS_ENABLED:
-            stuff.append('a {} wristband'.format(c.WRISTBAND_COLORS[self.age_group]))
+            stuff.append(f'a {c.WRISTBAND_COLORS[self.age_group]} wristband')
         if self.regdesk_info:
             stuff.append(self.regdesk_info)
         return (' with ' if stuff else '') + readable_join(stuff)

--- a/uber/models/attraction.py
+++ b/uber/models/attraction.py
@@ -307,9 +307,9 @@ class Attraction(MagModel, AttractionMixin, table=True):
                 event_filters += [
                     AttractionEvent.start_time >= from_time + notice_delta,
                     AttractionEvent.start_time < to_time + notice_delta]
-                notice_ident = func.concat(AttractionSignup.attraction_event_id, '_{}'.format(advance_notice))
+                notice_ident = func.concat(AttractionSignup.attraction_event_id, f'_{advance_notice}')
                 notice_param = bindparam(
-                    'advance_notice_{}'.format(advance_notice), advance_notice).label('advance_notice')
+                    f'advance_notice_{advance_notice}', advance_notice).label('advance_notice')
 
             subquery = session.query(AttractionSignup, notice_param).filter(
                 AttractionSignup.is_unchecked_in,

--- a/uber/models/guests.py
+++ b/uber/models/guests.py
@@ -172,7 +172,7 @@ class GuestGroup(MagModel, table=True):
     @property
     def panel_status(self):
         application_count = len(self.group.leader.submitted_panels)
-        return '{} Panel Application(s)'.format(application_count) \
+        return f'{application_count} Panel Application(s)' \
             if self.group.leader.submitted_panels else self.status('panel')
 
     @property
@@ -408,11 +408,11 @@ class GuestMerch(MagModel, table=True):
 
     @property
     def rock_island_url(self):
-        return '../guest_reports/rock_island?id={}'.format(self.guest_id)
+        return f'../guest_reports/rock_island?id={self.guest_id}'
 
     @property
     def rock_island_csv_url(self):
-        return '../guest_reports/rock_island_csv?id={}'.format(self.guest_id)
+        return f'../guest_reports/rock_island_csv?id={self.guest_id}'
     
     @property
     def rock_island_square_export_url(self):
@@ -485,7 +485,7 @@ class GuestMerch(MagModel, table=True):
                 match = cls._inventory_file_regex.match(name)
                 if match and getattr(file, 'filename', None):
                     file_type = match.group(1).upper()
-                    config_name = 'ALLOWED_INVENTORY_{}_EXTENSIONS'.format(file_type)
+                    config_name = f'ALLOWED_INVENTORY_{file_type}_EXTENSIONS'
                     extensions = getattr(c, config_name, [])
                     ext = filename_extension(file.filename)
                     if extensions and ext not in extensions:
@@ -513,9 +513,9 @@ class GuestMerch(MagModel, table=True):
             for name, file in [(n, f) for (n, f) in item.items() if f]:
                 match = self._inventory_file_regex.match(name)
                 if match:
-                    download_file_attr = '{}_download_filename'.format(name)
-                    file_attr = '{}_filename'.format(name)
-                    content_type_attr = '{}_content_type'.format(name)
+                    download_file_attr = f'{name}_download_filename'
+                    file_attr = f'{name}_filename'
+                    content_type_attr = f'{name}_content_type'
                     del item[name]
                     if getattr(file, 'filename', None):
                         item[download_file_attr] = file.filename
@@ -535,17 +535,17 @@ class GuestMerch(MagModel, table=True):
     def item_subcategories(cls, item_type):
         s = {getattr(c, s): s for s in c.MERCH_TYPES_VARS}[int(item_type)]
         return (
-            getattr(c, '{}_VARIETIES'.format(s), defaultdict(lambda: {})),
-            getattr(c, '{}_CUTS'.format(s), defaultdict(lambda: {})),
-            getattr(c, '{}_SIZES'.format(s), defaultdict(lambda: {})))
+            getattr(c, f'{s}_VARIETIES', defaultdict(lambda: {})),
+            getattr(c, f'{s}_CUTS', defaultdict(lambda: {})),
+            getattr(c, f'{s}_SIZES', defaultdict(lambda: {})))
 
     @classmethod
     def item_subcategories_opts(cls, item_type):
         s = {getattr(c, s): s for s in c.MERCH_TYPES_VARS}[int(item_type)]
         return (
-            getattr(c, '{}_VARIETIES_OPTS'.format(s), defaultdict(lambda: [])),
-            getattr(c, '{}_CUTS_OPTS'.format(s), defaultdict(lambda: [])),
-            getattr(c, '{}_SIZES_OPTS'.format(s), defaultdict(lambda: [])))
+            getattr(c, f'{s}_VARIETIES_OPTS', defaultdict(lambda: [])),
+            getattr(c, f'{s}_CUTS_OPTS', defaultdict(lambda: [])),
+            getattr(c, f'{s}_SIZES_OPTS', defaultdict(lambda: [])))
 
     @classmethod
     def line_items(cls, item):

--- a/uber/models/promo_code.py
+++ b/uber/models/promo_code.py
@@ -343,11 +343,11 @@ class PromoCode(MagModel, table=True):
             return 'Comped item(s)'
 
         if self.discount_type == c.FIXED_DISCOUNT:
-            return '${} discount'.format(self.discount)
+            return f'${self.discount} discount'
         elif self.discount_type == c.FIXED_PRICE:
-            return '${} price'.format(self.discount)
+            return f'${self.discount} price'
         else:
-            return '%{} discount'.format(self.discount)
+            return f'%{self.discount} discount'
 
     @hybrid_property
     def is_expired(self):

--- a/uber/models/tracking.py
+++ b/uber/models/tracking.py
@@ -193,13 +193,13 @@ class Tracking(MagModel, table=True):
                 try:
                     old_val_repr = cls.repr(column, old_val)
                 except Exception:
-                    log.error('Tracking repr({}) failed on old value'.format(attr), exc_info=True)
+                    log.error(f'Tracking repr({attr}) failed on old value', exc_info=True)
                     old_val_repr = '<ERROR>'
 
                 try:
                     new_val_repr = cls.repr(column, new_val)
                 except Exception:
-                    log.error('Tracking repr({}) failed on new value'.format(attr), exc_info=True)
+                    log.error(f'Tracking repr({attr}) failed on new value', exc_info=True)
                     new_val_repr = '<ERROR>'
 
                 diff[attr] = "'{} -> {}'".format(old_val_repr, new_val_repr)
@@ -240,7 +240,7 @@ class Tracking(MagModel, table=True):
             if not data:
                 return
         else:
-            data = 'id={}'.format(instance.id)
+            data = f'id={instance.id}'
 
         links = ', '.join(
             '{}({})'.format(list(column.foreign_keys)[0].column.table.name, getattr(instance, name))
@@ -263,7 +263,7 @@ class Tracking(MagModel, table=True):
             dict.pop('receipt_changes', None)
             snapshot = json.dumps(dict, cls=serializer)
         except TypeError as e:
-            snapshot = "Could not save JSON dump due to error: {}".format(e)
+            snapshot = f"Could not save JSON dump due to error: {e}"
 
         session.add(Tracking(
             model=instance.__class__.__name__,

--- a/uber/payments.py
+++ b/uber/payments.py
@@ -144,7 +144,7 @@ class PreregCart:
                     d[key] = params.get(key)
             return d
         else:
-            raise AssertionError('{} is not an attendee or group'.format(m))
+            raise AssertionError(f'{m} is not an attendee or group')
 
     @classmethod
     def from_sessionized(cls, d):
@@ -305,7 +305,7 @@ class PreregCart:
                 return ""
             attendee.promo_code_id = None
             session.commit()
-            return "The promo code you're using for {} has been used already.".format(attendee.full_name)
+            return f"The promo code you're using for {attendee.full_name} has been used already."
 
     def prereg_receipt_preview(self):
         """
@@ -804,7 +804,7 @@ class TransactionRequest(AuthNetRequestMixin if c.AUTHORIZENET_LOGIN_ID else Str
         """
 
         if not self.amount or self.amount <= 0:
-            log.error('Was asked for a Stripe Intent but the currently owed amount is invalid: {}'.format(self.amount))
+            log.error(f'Was asked for a Stripe Intent but the currently owed amount is invalid: {self.amount}')
             return "There was an error calculating the amount. Please refresh the page or contact the system admin."
 
         if self.amount > 999999:

--- a/uber/sep_commands.py
+++ b/uber/sep_commands.py
@@ -34,7 +34,7 @@ def entry_point(func):
                  of the command, and an exception is raised if a function with
                  the same name has already been registered as an entry point
     """
-    assert func.__name__ not in _entry_points, 'An entry point named {} has already been implemented'.format(func.__name__)
+    assert func.__name__ not in _entry_points, f'An entry point named {func.__name__} has already been implemented'
     _entry_points[func.__name__] = func
     return func
 

--- a/uber/serializer.py
+++ b/uber/serializer.py
@@ -40,7 +40,7 @@ class serializer(json.JSONEncoder):
                              the value to serialize and returns a json-
                              serializable value
         """
-        assert type not in cls._registry, '{} already has a preprocessor defined'.format(type)
+        assert type not in cls._registry, f'{type} already has a preprocessor defined'
         cls._registry[type] = preprocessor
 
 serializer.register(datetime.date, lambda d: d.strftime('%Y-%m-%d'))

--- a/uber/server.py
+++ b/uber/server.py
@@ -157,7 +157,7 @@ class StaticViews:
 
     @classmethod
     def raise_not_found(cls, path, e=None):
-        raise cherrypy.HTTPError(404, "The path '{}' was not found.".format(path)) from e
+        raise cherrypy.HTTPError(404, f"The path '{path}' was not found.") from e
 
     @cherrypy.expose
     def index(self):

--- a/uber/site_sections/accounts.py
+++ b/uber/site_sections/accounts.py
@@ -43,7 +43,7 @@ class Root:
             {
                 'id': id,
                 'displayText': '{} - {}{}'.format(name.title(), c.BADGES[badge_type],
-                                                  ' #{}'.format(badge_num) if badge_num else '')
+                                                  f' #{badge_num}' if badge_num else '')
             }
             for id, name, badge_type, badge_num in attendee_attrs
         ]

--- a/uber/site_sections/art_show_admin.py
+++ b/uber/site_sections/art_show_admin.py
@@ -62,7 +62,7 @@ class Root:
                                                      Attendee.badge_status != c.WATCHED_STATUS)
 
         attendees = [
-            (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], ' #{}'.format(badge_num) if badge_num else ''))
+            (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], f' #{badge_num}' if badge_num else ''))
             for id, name, badge_type, badge_num in attendee_attrs]
 
         if cherrypy.request.method == 'POST':
@@ -140,7 +140,7 @@ class Root:
         return {
             'app': app,
             'changes': session.query(Tracking).filter(
-                or_(Tracking.links.like('%art_show_application({})%'.format(id)),
+                or_(Tracking.links.like(f'%art_show_application({id})%'),
                     and_(Tracking.model == 'ArtShowApplication', Tracking.fk_id == id))
                     ).order_by(Tracking.when).all(),
             'pageviews': session.query(PageViewTracking).filter(PageViewTracking.which == repr(app)
@@ -181,7 +181,7 @@ class Root:
                     ArtShowPiece.piece_id == piece_id
                 )
                 if not piece.count():
-                    message = 'ERROR: Could not find piece with code {}.'.format(piece_code)
+                    message = f'ERROR: Could not find piece with code {piece_code}.'
                 elif piece.count() > 1:
                     message = 'ERROR: Multiple pieces matched the code you entered for some reason.'
                 else:
@@ -244,7 +244,7 @@ class Root:
                                     message = f'ERROR: Attendee with badge number {badge_num} did not sign up for bidding.'
                 if not message and not found_bidder:
                     if not bidder.count():
-                        message = 'ERROR: Could not find bidder with number {}.'.format(bidder_num)
+                        message = f'ERROR: Could not find bidder with number {bidder_num}.'
                     elif bidder.count() > 1:
                         message = 'ERROR: Multiple bidders matched the number you entered for some reason.'
                     else:
@@ -343,7 +343,7 @@ class Root:
                                                      Attendee.badge_status != c.WATCHED_STATUS)
 
         attendees = [
-            (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], ' #{}'.format(badge_num) if badge_num else ''))
+            (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], f' #{badge_num}' if badge_num else ''))
             for id, name, badge_type, badge_num in attendee_attrs]
 
         return {
@@ -539,7 +539,7 @@ class Root:
 
         if cherrypy.request.method == 'POST':
             for app in valid_apps:
-                field_name = '{}_locations'.format(app.id)
+                field_name = f'{app.id}_locations'
                 if field_name in params:
                     app.locations = params.get(field_name)
                     session.add(app)
@@ -827,7 +827,7 @@ class Root:
         filename = filename + "_" + localized_now().strftime("%m%d%Y_%H%M")
 
         cherrypy.response.headers['Content-Type'] = 'application/pdf'
-        cherrypy.response.headers['Content-Disposition'] = 'inline; filename={}.pdf'.format(filename)
+        cherrypy.response.headers['Content-Disposition'] = f'inline; filename={filename}.pdf'
         return bytes(pdf.output())
 
     def bidder_signup(self, session, message='', page=1, search_text='', order=''):
@@ -860,7 +860,7 @@ class Root:
                     try:
                         badge_num = int(search_text)
                     except Exception:
-                        filters.append(Attendee.badge_printed_name.ilike('%{}%'.format(search_text)))
+                        filters.append(Attendee.badge_printed_name.ilike(f'%{search_text}%'))
                     else:
                         filters.append(or_(BadgeInfo.ident == badge_num,
                                            and_(Attendee.art_show_bidder != None,
@@ -1082,7 +1082,7 @@ class Root:
                         ArtShowApplication.artist_id_ad == artist_id.upper())
                 )
             else:
-                pieces = session.query(ArtShowPiece).filter(ArtShowPiece.name.ilike('%{}%'.format(search_text)))
+                pieces = session.query(ArtShowPiece).filter(ArtShowPiece.name.ilike(f'%{search_text}%'))
 
             unpaid_pieces_query = pieces.join(ArtShowReceipt).filter(ArtShowReceipt.closed != None,  # noqa: E711
                                                                      ArtShowPiece.status != c.PAID)
@@ -1094,12 +1094,12 @@ class Root:
             unclaimed_pieces = [piece for piece in unclaimed_pieces_query if piece.sale_price > 0]
 
             if pieces.count() == 0:
-                message = "No pieces found with ID or title {}.".format(search_text)
+                message = f"No pieces found with ID or title {search_text}."
             elif len(unclaimed_pieces) == 0 and len(unpaid_pieces) == 0:
                 if pieces.count() == 1:
                     msg_piece = pieces.one()
                     if msg_piece.receipt == receipt:
-                        message = "That piece ({}) is already on this receipt.".format(msg_piece.artist_and_piece_id)
+                        message = f"That piece ({msg_piece.artist_and_piece_id}) is already on this receipt."
                     elif not msg_piece.sale_price or msg_piece.sale_price <= 0:
                         message = "That piece ({}) doesn't have a valid sale price." \
                             .format(msg_piece.artist_and_piece_id)
@@ -1113,9 +1113,9 @@ class Root:
                         message = "That piece ({}) was already sold to another buyer."\
                             .format(msg_piece.artist_and_piece_id)
                 else:
-                    message = "None of the matching pieces for '{}' can be claimed.".format(search_text)
+                    message = f"None of the matching pieces for '{search_text}' can be claimed."
             elif len(unclaimed_pieces) > 1 or (len(unclaimed_pieces) == 0 and len(unpaid_pieces) > 1):
-                message = "There were multiple pieces found matching '{}.' Please choose one.".format(search_text)
+                message = f"There were multiple pieces found matching '{search_text}.' Please choose one."
                 must_choose = True
 
             if not message:
@@ -1129,7 +1129,7 @@ class Root:
                 if not message:
                     piece.receipt = receipt
                     session.add(piece)
-                    message = 'Piece {} successfully claimed'.format(piece.artist_and_piece_id)
+                    message = f'Piece {piece.artist_and_piece_id} successfully claimed'
 
             if not must_choose:
                 raise HTTPRedirect('pieces_bought?id={}&message={}', receipt.id, message)
@@ -1164,7 +1164,7 @@ class Root:
             session.add(piece)
             raise HTTPRedirect('pieces_bought?id={}&message={}',
                                receipt.id,
-                               'Piece {} successfully unclaimed'.format(piece.artist_and_piece_id))
+                               f'Piece {piece.artist_and_piece_id} successfully unclaimed')
 
     def record_payment(self, session, id, amount='', type=c.CASH):
         receipt = session.art_show_receipt(id)
@@ -1345,7 +1345,7 @@ class Root:
             return {
                 'stripe_intent': charge.intent,
                 'success_url': 'pieces_bought?id={}&message={}'.format(attendee.id, 'Charge successfully processed'),
-                'cancel_url': 'cancel_payment?id={}'.format(payment.id)
+                'cancel_url': f'cancel_payment?id={payment.id}'
             }
 
     @ajax

--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -164,7 +164,7 @@ class Root:
             'receipt': receipt,
             'incomplete_txn': receipt.get_last_incomplete_txn() if receipt else None,
             'homepage_account': session.get_attendee_account_by_attendee(app.attendee),
-            'return_to': 'edit?id={}'.format(app.id),
+            'return_to': f'edit?id={app.id}',
         }
     
     @ajax

--- a/uber/site_sections/attractions.py
+++ b/uber/site_sections/attractions.py
@@ -180,7 +180,7 @@ class Root:
     def verify_badge_num(self, session, badge_num, **params):
         attendee = _attendee_for_badge_num(session, badge_num)
         if not attendee:
-            return {'error': 'Unrecognized badge number: {}'.format(badge_num)}
+            return {'error': f'Unrecognized badge number: {badge_num}'}
 
         if attendee.attractions_opt_out:
             return {'error': 'That attendee has disabled attraction signups'}
@@ -195,13 +195,13 @@ class Root:
                          last_name='', email='', zip_code='', **params):
         event = _model_for_id(session, AttractionEvent, id)
         if not event:
-            return {'error': 'Unrecognized event id: {}'.format(id)}
+            return {'error': f'Unrecognized event id: {id}'}
 
         if badge_num or event.feature.badge_num_required:
             attendee = _attendee_for_badge_num(session, badge_num)
             if not attendee:
                 return {
-                    'error': 'Unrecognized badge number: {}'.format(badge_num)
+                    'error': f'Unrecognized badge number: {badge_num}'
                 }
         else:
             attendee = _attendee_for_info(session, first_name, last_name,
@@ -230,7 +230,7 @@ class Root:
                             attendee.first_name, event.feature.name)}
 
             if not event.signups_open:
-                return {'error': '{} is not yet available for signups'.format(event.label)}
+                return {'error': f'{event.label} is not yet available for signups'}
 
             if event.is_sold_out:
                 if event.waitlist_open:
@@ -242,7 +242,7 @@ class Root:
                     ))
                     on_waitlist = True
                 else:
-                    return {'error': '{} is already sold out'.format(event.label)}
+                    return {'error': f'{event.label} is already sold out'}
             else:
                 event.attendee_signups.append(attendee)
                 session.add(event)

--- a/uber/site_sections/attractions_admin.py
+++ b/uber/site_sections/attractions_admin.py
@@ -101,7 +101,7 @@ class Root:
             service, uri = None, ''
         else:
             service, message, target_url = get_api_service_from_server(target_server, api_token)
-            uri = '{}/jsonrpc/'.format(target_url)
+            uri = f'{target_url}/jsonrpc/'
 
         if not message and service:
             existing_attractions_by_slug = {attraction.slug: attraction for attraction in session.query(Attraction)}
@@ -236,7 +236,7 @@ class Root:
             raise HTTPRedirect(
                 'form?id={}&message={}',
                 attraction.id,
-                '{} updated successfully.'.format(attraction.name))
+                f'{attraction.name} updated successfully.')
 
         return {
             'admin_account': session.current_admin_account(),
@@ -333,7 +333,7 @@ class Root:
             session.delete(attraction)
             raise HTTPRedirect(
                 'index?message={}',
-                'The {} attraction was deleted'.format(attraction.name))
+                f'The {attraction.name} attraction was deleted')
 
         raise HTTPRedirect('form?id={}', id)
 
@@ -717,7 +717,7 @@ class Root:
                 .subqueryload(AttractionEvent.feature))
 
             if not attendee:
-                return {'error': 'Unrecognized badge number: {}'.format(badge_num)}
+                return {'error': f'Unrecognized badge number: {badge_num}'}
 
             signups = attendee.attraction_signups
             other_events = []

--- a/uber/site_sections/badge_printing.py
+++ b/uber/site_sections/badge_printing.py
@@ -43,7 +43,7 @@ def pre_print_check(session, attendee, printer_id, dry_run=False, **params):
             return print_id, '{}adge sent to printer.'.format("B" if not c.BADGE_REPRINT_FEE or attendee.times_printed == 0
                                                           else "Free reprint recorded and b")
     else:
-        return print_id, 'To print this badge, please complete payment for the reprint fee of ${}.'.format(fee_amount)
+        return print_id, f'To print this badge, please complete payment for the reprint fee of ${fee_amount}.'
     return print_id, 'Badge sent to printer.'
 
 
@@ -74,7 +74,7 @@ class Root:
     def print_next_badge(self, session, printer_id=''):
         badge = session.get_next_badge_to_print(printer_id=printer_id)
         if not badge:
-            raise HTTPRedirect('badge_waiting?printer_id={}'.format(printer_id))
+            raise HTTPRedirect(f'badge_waiting?printer_id={printer_id}')
 
         attendee = badge.attendee
 
@@ -160,7 +160,7 @@ class Root:
                                         receipt_id=receipt.id,
                                         department=c.REG_RECEIPT_ITEM,
                                         category=c.BADGE_REPRINT,
-                                        desc="Badge reprint fee (${})".format(reprint_fee),
+                                        desc=f"Badge reprint fee (${reprint_fee})",
                                         amount=reprint_fee * 100,
                                         fk_id=print_id,
                                         fk_model="PrintJob",
@@ -230,7 +230,7 @@ class Root:
                     session.add(ReceiptItem(receipt_id=receipt.id,
                                             department=c.REG_RECEIPT_ITEM,
                                             category=c.BADGE_REPRINT,
-                                            desc="Badge reprint cancelled (${})".format(job.print_fee),
+                                            desc=f"Badge reprint cancelled (${job.print_fee})",
                                             amount=job.print_fee * 100 * -1,
                                             count=1,
                                             who=AdminAccount.admin_name() or 'non-admin',

--- a/uber/site_sections/dealer_admin.py
+++ b/uber/site_sections/dealer_admin.py
@@ -88,7 +88,7 @@ def decline_and_convert_dealer_group(session, group, status=c.DECLINED, admin_no
         for attendee in group.attendees:
             attendee.append_admin_note(admin_note)
             attendee.ribbon = remove_opt(attendee.ribbon_ints, c.DEALER_RIBBON)
-        return 'Group {} status removed'.format(c.DEALER_TERM)
+        return f'Group {c.DEALER_TERM} status removed'
 
     if status == c.WAITLISTED:
         ident = 'dealer_waitlist_exhausted'

--- a/uber/site_sections/dept_admin.py
+++ b/uber/site_sections/dept_admin.py
@@ -88,7 +88,7 @@ class Root:
             session.delete(department)
             raise HTTPRedirect(
                 'index?message={}',
-                'The {} department was deleted'.format(department.name))
+                f'The {department.name} department was deleted')
 
         raise HTTPRedirect('form?id={}', id)
 
@@ -148,7 +148,7 @@ class Root:
             self, session, department_id, attendee_id, role, value=None):
 
         assert role in ('dept_head', 'poc', 'checklist_admin'), \
-            'Unknown role: "{}"'.format(role)
+            f'Unknown role: "{role}"'
 
         admin_role = 'dept_head' if role == 'dept_head' else None
         message = check_dept_admin(session, department_id, admin_role)
@@ -214,7 +214,7 @@ class Root:
 
         headers = ['Name', 'Email', 'Badge', 'Placeholder']
         if requested_any:
-            headers.append('Explicitly Requested {}'.format(department.name))
+            headers.append(f'Explicitly Requested {department.name}')
 
         out.writerow(headers)
         for attendee in requesting_attendees:
@@ -332,7 +332,7 @@ class Root:
                 raise HTTPRedirect(
                     'form?id={}&message={}',
                     department_id,
-                    'The {} role was deleted'.format(dept_role.name))
+                    f'The {dept_role.name} role was deleted')
 
         if not message:
             raise HTTPRedirect('form?id={}', department_id)

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -76,11 +76,11 @@ class Root:
         attendee = session.attendee(id)
         if attendee.group:
             if c.HAS_REGISTRATION_ACCESS:
-                link = '../registration/form?id={}&'.format(attendee.id)
+                link = f'../registration/form?id={attendee.id}&'
             else:
                 link = '../accounts/homepage?'
             raise HTTPRedirect('{}message={}', link, "That attendee is already in a group!")
-        group = Group(name="{}'s Group".format(attendee.full_name))
+        group = Group(name=f"{attendee.full_name}'s Group")
         attendee.group = group
         group.leader = attendee
         session.add(group)
@@ -296,7 +296,7 @@ class Root:
         return {
             'group': group,
             'changes': session.query(Tracking).filter(or_(
-                Tracking.links.like('%group({})%'.format(id)),
+                Tracking.links.like(f'%group({id})%'),
                 and_(Tracking.model == 'Group', Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'pageviews': session.query(PageViewTracking).filter(PageViewTracking.which == repr(group)
                                                                 ).order_by(PageViewTracking.when).all(),
@@ -365,9 +365,9 @@ class Root:
                     if field in params:
                         field_name = "load-in" if field == 'estimated_loadin_minutes' else 'performance'
                         if not params.get(field):
-                            message = "Please enter more than 0 estimated {} minutes".format(field_name)
+                            message = f"Please enter more than 0 estimated {field_name} minutes"
                         elif not str(params.get(field, '')).isdigit():
-                            message = "Please enter a whole number for estimated {} minutes".format(field_name)
+                            message = f"Please enter a whole number for estimated {field_name} minutes"
             if not message:
                 raise HTTPRedirect('index?message={}{}', guest.group.name, ' data uploaded')
 

--- a/uber/site_sections/guests.py
+++ b/uber/site_sections/guests.py
@@ -529,7 +529,7 @@ class Root:
                 session.add(guest)
                 raise HTTPRedirect('index?id={}&message={}', guest.id, 'You have accepted the MIVS core hours.')
             else:
-                message = "Something is wrong with your group -- please contact us at {}.".format(c.INDIE_SHOWCASE_EMAIL)
+                message = f"Something is wrong with your group -- please contact us at {c.INDIE_SHOWCASE_EMAIL}."
         return {
             'guest': guest,
             'message': message,
@@ -545,7 +545,7 @@ class Root:
                 session.add(guest)
                 raise HTTPRedirect('index?id={}&message={}', guest.id, 'Discussion email addresses updated.')
             else:
-                message = "Something is wrong with your group -- please contact us at {}.".format(c.INDIE_SHOWCASE_EMAIL)
+                message = f"Something is wrong with your group -- please contact us at {c.INDIE_SHOWCASE_EMAIL}."
         return {
             'guest': guest,
             'message': message,
@@ -560,7 +560,7 @@ class Root:
                 session.add(guest)
                 raise HTTPRedirect('index?id={}&message={}', guest.id, 'You have confirmed that you read the handbook.')
             else:
-                message = "Something is wrong with your group -- please contact us at {}.".format(c.INDIE_SHOWCASE_EMAIL)
+                message = f"Something is wrong with your group -- please contact us at {c.INDIE_SHOWCASE_EMAIL}."
         return {
             'guest': guest,
             'message': message,
@@ -578,7 +578,7 @@ class Root:
                 else:
                     message = "Please enter the secret phrase!"
             else:
-                message = "Something is wrong with your group -- please contact us at {}.".format(c.MIVS_EMAIL)
+                message = f"Something is wrong with your group -- please contact us at {c.MIVS_EMAIL}."
         return {
             'guest': guest,
             'message': message,
@@ -596,7 +596,7 @@ class Root:
                     session.add(guest)
                     raise HTTPRedirect('index?id={}&message={}', guest.id, 'Thanks for filling out the logistics form!')
             else:
-                message = "Something is wrong with your group -- please contact us at {}.".format(c.INDIE_ARCADE_EMAIL)
+                message = f"Something is wrong with your group -- please contact us at {c.INDIE_ARCADE_EMAIL}."
         return {
             'guest': guest,
             'message': message,
@@ -632,7 +632,7 @@ class Root:
                                        guest.id,
                                        'Hotel needs updated.')
             else:
-                message = "Something is wrong with your group -- please contact us at {}.".format(c.INDIE_SHOWCASE_EMAIL)
+                message = f"Something is wrong with your group -- please contact us at {c.INDIE_SHOWCASE_EMAIL}."
         return {
             'guest': guest,
             'message': message,
@@ -657,7 +657,7 @@ class Root:
                                        guest.id,
                                        'Selling preferences updated.')
             else:
-                message = "Something is wrong with your group -- please contact us at {}.".format(c.INDIE_SHOWCASE_EMAIL)
+                message = f"Something is wrong with your group -- please contact us at {c.INDIE_SHOWCASE_EMAIL}."
         return {
             'guest': guest,
             'message': message,
@@ -691,7 +691,7 @@ class Root:
                                        guest.id,
                                        'Thanks for confirming your studio and game information is up-to-date!')
             else:
-                message = "Something is wrong with your group -- please contact us at {}.".format(c.INDIE_SHOWCASE_EMAIL)
+                message = f"Something is wrong with your group -- please contact us at {c.INDIE_SHOWCASE_EMAIL}."
         return {
             'guest': guest,
             'message': message,
@@ -703,9 +703,9 @@ class Root:
         if guest_merch:
             item = guest_merch.inventory.get(item_id)
             if item:
-                filename = item.get('{}_filename'.format(name))
-                download_filename = item.get('{}_download_filename'.format(name), filename)
-                content_type = item.get('{}_content_type'.format(name))
+                filename = item.get(f'{name}_filename')
+                download_filename = item.get(f'{name}_download_filename', filename)
+                content_type = item.get(f'{name}_content_type')
                 filepath = guest_merch.inventory_path(filename)
                 if filename and download_filename and content_type and os.path.exists(filepath):
                     filesize = os.path.getsize(filepath)
@@ -717,7 +717,7 @@ class Root:
                         download_filename = f"{guest_merch.guest.normalized_group_name}_{' '.join(normalized_name.split()).replace(' ', '_')}.{extension}"
                     cherrypy.response.headers['Accept-Ranges'] = 'bytes'
                     cherrypy.response.headers['Content-Length'] = filesize
-                    cherrypy.response.headers['Content-Range'] = 'bytes 0-{}'.format(filesize)
+                    cherrypy.response.headers['Content-Range'] = f'bytes 0-{filesize}'
                     cherrypy.response.headers['Cache-Control'] = 'no-store'
                     return serve_file(filepath, disposition=disposition, name=download_filename, content_type=content_type)
                 else:

--- a/uber/site_sections/hotel_reports.py
+++ b/uber/site_sections/hotel_reports.py
@@ -186,7 +186,7 @@ class Root:
         for dept in sorted(set(shoulder_nights_missing_shifts.keys()), key=lambda d: d.name):
             dept_heads = sorted(dept.dept_heads, key=lambda a: a.full_name)
             dept_head_emails = ', '.join([
-                a.full_name + (' <{}>'.format(a.email) if a.email else '') for a in dept_heads])
+                a.full_name + (f' <{a.email}>' if a.email else '') for a in dept_heads])
             dept.dept_head_emails = dept_head_emails
             dept.inconsistent_attendees = []
             departments.append(dept)
@@ -365,7 +365,7 @@ class Root:
                 ('Locked-in ' if room.locked_in else '')
                 + 'room created by STOPS for '
                 + room.nights_display
-                + (' ({})'.format(room.notes) if room.notes else '')])
+                + (f' ({room.notes})' if room.notes else '')])
 
             for ra in room.assignments:
                 writerow(ra.attendee, ra.attendee.hotel_requests)
@@ -573,7 +573,7 @@ class Root:
 
         headers = ['First Name', 'Last Name', 'Email Address', 'LoginID']
         for count in range(2, 21):
-            headers.append('LoginID{}'.format(count))
+            headers.append(f'LoginID{count}')
 
         out.writerow(headers)
         added = set()

--- a/uber/site_sections/marketplace_admin.py
+++ b/uber/site_sections/marketplace_admin.py
@@ -51,7 +51,7 @@ class Root:
                                                      Attendee.badge_status != c.WATCHED_STATUS)
 
         attendees = [
-            (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], ' #{}'.format(badge_num) if badge_num else ''))
+            (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], f' #{badge_num}' if badge_num else ''))
             for id, name, badge_type, badge_num in attendee_attrs]
         
         forms_list = ["AdminArtistMarketplaceForm"]
@@ -126,7 +126,7 @@ class Root:
                 c.SQUARE: "SPIn" if c.SPIN_TERMINAL_AUTH_KEY else "Square",
                 c.MANUAL: "Stripe"},
             'changes': session.query(Tracking).filter(
-                or_(Tracking.links.like('%artist_marketplace_application({})%'.format(id)),
+                or_(Tracking.links.like(f'%artist_marketplace_application({id})%'),
                     and_(Tracking.model == 'ArtistMarketplaceApplication',
                          Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'pageviews': session.query(PageViewTracking).filter(PageViewTracking.which == repr(app)

--- a/uber/site_sections/merch_admin.py
+++ b/uber/site_sections/merch_admin.py
@@ -151,7 +151,7 @@ class Root:
                 picker_upper = session.query(Attendee).join(BadgeInfo).filter(BadgeInfo.ident == int(picker_upper)).one()
             except Exception:
                 message = 'Please enter a valid badge number for the person picking up the merch: ' \
-                    '{} is not in the system'.format(picker_upper)
+                    f'{picker_upper} is not in the system'
             else:
                 for badge_num in set(badges):
                     if badge_num:
@@ -165,7 +165,7 @@ class Root:
                                     '{a.name_and_badge_info} already got their merch'.format(a=attendee))
                             else:
                                 attendee.got_merch = True
-                                shirt_key = 'shirt_{}'.format(attendee.badge_num)
+                                shirt_key = f'shirt_{attendee.badge_num}'
                                 if shirt_key in shirt_sizes:
                                     attendee.shirt = int(listify(shirt_sizes.get(shirt_key, c.SIZE_UNKNOWN))[0])
                                 picked_up.append('{a.name_and_badge_info}: {a.merch}'.format(a=attendee))
@@ -255,7 +255,7 @@ class Root:
         merch = attendee.staff_merch if staff_merch else attendee.merch
         got = attendee.got_staff_merch if staff_merch else attendee.got_merch
         if not merch:
-            message = '{} has no merch.'.format(attendee.name_and_badge_info)
+            message = f'{attendee.name_and_badge_info} has no merch.'
         elif got and give_swadge and not attendee.got_swadge:
             message = '{a.name_and_badge_info} marked as receiving their swadge.'.format(
                 a=attendee)
@@ -331,7 +331,7 @@ class Root:
         discount.uses += 1
         session.add(discount)
         session.commit()
-        return {'success': True, 'message': 'Discount for {} has been marked as redeemed.'.format(attendee.name_and_badge_info)}
+        return {'success': True, 'message': f'Discount for {attendee.name_and_badge_info} has been marked as redeemed.'}
 
     @ajax
     @kiosk_login()
@@ -399,7 +399,7 @@ class Root:
             message = '{sale.what} sold{to} for ${sale.cash}{mpoints}' \
                       .format(sale=sale,
                               to=(' to ' + sale.attendee.name_and_badge_info) if sale.attendee else '',
-                              mpoints=' and {} MPoints.'.format(sale.mpoints) if sale.mpoints else '')
+                              mpoints=f' and {sale.mpoints} MPoints.' if sale.mpoints else '')
             return {'id': sale.id, 'success': True, 'message': message}
 
     @ajax

--- a/uber/site_sections/mits.py
+++ b/uber/site_sections/mits.py
@@ -382,8 +382,8 @@ class Root:
         team = session.mits_team(team_id)
         if cherrypy.request.method == 'POST':
             for applicant in team.applicants:
-                applicant.declined_hotel_space = '{}-declined'.format(applicant.id) in params
-                applicant.requested_room_nights = ','.join(listify(params.get('{}-night'.format(applicant.id), [])))
+                applicant.declined_hotel_space = f'{applicant.id}-declined' in params
+                applicant.requested_room_nights = ','.join(listify(params.get(f'{applicant.id}-night', [])))
                 if not applicant.declined_hotel_space and not applicant.requested_room_nights:
                     message = '{} must either declined hotel space or ' \
                         'indicate which room nights they need'.format(applicant.full_name)

--- a/uber/site_sections/panels_admin.py
+++ b/uber/site_sections/panels_admin.py
@@ -404,7 +404,7 @@ class Root:
     @csv_file
     def panels_by_poc(self, out, session, poc_id):
         attendee = session.attendee(poc_id)
-        out.writerow(['', 'Panels for which {} is the panel staff point-of-contact'.format(attendee.full_name)])
+        out.writerow(['', f'Panels for which {attendee.full_name} is the panel staff point-of-contact'])
         out.writerow(['App status', 'Panel Name', 'Panel Location', 'Panel Time', 'Panelists'])
         for app in attendee.panel_applications:
             out.writerow([

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -187,7 +187,7 @@ class Root:
             attendee = session.query(Attendee).filter(func.lower(Attendee.email) == func.lower(params['email']),
                                                       Attendee.is_valid == True).first()
             message = 'Thank you! You will receive a confirmation email if ' \
-                'you are registered for {}.'.format(c.EVENT_NAME_AND_YEAR)
+                f'you are registered for {c.EVENT_NAME_AND_YEAR}.'
 
             subject = c.EVENT_NAME_AND_YEAR + ' Registration Confirmation'
 
@@ -348,7 +348,7 @@ class Root:
                 raise HTTPRedirect("dealer_registration?message={}s must have an invite code to register."
                                    .format(c.DEALER_TERM.capitalize()))
             elif params.get('invite_code') != c.DEALER_INVITE_CODE:
-                raise HTTPRedirect("dealer_registration?message=Incorrect {} invite code.".format(c.DEALER_REG_TERM))
+                raise HTTPRedirect(f"dealer_registration?message=Incorrect {c.DEALER_REG_TERM} invite code.")
 
         params['id'] = 'None'   # security!
         group = Group(is_dealer=True)
@@ -378,7 +378,7 @@ class Root:
                 Tracking.track(session, track_type, group)
                 if 'go_to_cart' in params:
                     raise HTTPRedirect('additional_info?group_id={}{}'
-                                       .format(group.id, "&editing={}".format(edit_id) if edit_id else ""))
+                                       .format(group.id, f"&editing={edit_id}" if edit_id else ""))
                 raise HTTPRedirect("form?dealer_id={}{}".format(group.id,
                                    "&repurchase=1" if params.get('repurchase', '') else ""))
         else:
@@ -620,7 +620,7 @@ class Root:
                     PreregCart.pending_dealers[group.id] = PreregCart.to_sessionized(group,
                                                                                      badge_count=group.badge_count)
                     Tracking.track(session, track_type, group)
-                    url_string = "group_id={}".format(group.id)
+                    url_string = f"group_id={group.id}"
                 else:
                     if attendee.id in PreregCart.unpaid_preregs:
                         track_type = c.EDITED_PREREG
@@ -632,21 +632,21 @@ class Root:
                                                                                        name=params.get('name'),
                                                                                        badges=params.get('badges'))
                     Tracking.track(session, track_type, attendee)
-                    url_string = "attendee_id={}".format(attendee.id)
+                    url_string = f"attendee_id={attendee.id}"
 
                 if not message:
                     if session.attendees_with_badges().filter_by(
                             first_name=attendee.first_name, last_name=attendee.last_name, email=attendee.email).count():
 
-                        raise HTTPRedirect('duplicate?{}'.format(url_string))
+                        raise HTTPRedirect(f'duplicate?{url_string}')
 
                     if attendee.banned:
-                        raise HTTPRedirect('banned?{}'.format(url_string))
+                        raise HTTPRedirect(f'banned?{url_string}')
 
                     if edit_id and params.get('go_to_cart'):
                         raise HTTPRedirect('index')
                     raise HTTPRedirect('additional_info?{}{}{}'.format(
-                        url_string, "&editing={}".format(edit_id) if edit_id else "",
+                        url_string, f"&editing={edit_id}" if edit_id else "",
                         "&repurchase=1" if params.get('repurchase', '') else ""))
 
         promo_code_group = None
@@ -1252,7 +1252,7 @@ class Root:
             raise HTTPRedirect(
                 'group_promo_codes?id={}&message={}',
                 group.id,
-                'You must add at least {} codes.'.format(group.min_badges_addable))
+                f'You must add at least {group.min_badges_addable} codes.')
 
         receipt = session.get_receipt_by_model(group.buyer)
         if receipt:
@@ -1507,13 +1507,13 @@ class Root:
             raise HTTPRedirect(
                 'group_members?id={}&message={}',
                 group.id,
-                'You cannot add fewer than {} badges to this group.'.format(group.min_badges_addable))
+                f'You cannot add fewer than {group.min_badges_addable} badges to this group.')
         
         if group.is_dealer and count > group.dealer_badges_remaining:
             raise HTTPRedirect(
                 'group_members?id={}&message={}',
                 group.id,
-                'You cannot add more than {} badges'.format(group.dealer_badges_remaining))
+                f'You cannot add more than {group.dealer_badges_remaining} badges')
             
         receipt = session.get_receipt_by_model(group)
         if receipt:
@@ -2153,7 +2153,7 @@ class Root:
             set_up_new_account(session, attendee)
 
         raise HTTPRedirect('homepage?message={}', message or
-                           'An email has been sent to {} to set up their account.'.format(attendee.email))
+                           f'An email has been sent to {attendee.email} to set up their account.')
 
     @id_required(Attendee)
     @requires_account(Attendee)
@@ -2437,7 +2437,7 @@ class Root:
             stripe_intent = txn.get_stripe_intent()
 
         if not stripe_intent:
-            return {'error': "Something went wrong. Please contact us at {}.".format(c.REGDESK_EMAIL)}
+            return {'error': f"Something went wrong. Please contact us at {c.REGDESK_EMAIL}."}
 
         if not c.AUTHORIZENET_LOGIN_ID and stripe_intent.status == "succeeded":
             return {'error': "This payment has already been finalized!"}
@@ -2734,7 +2734,7 @@ class Root:
     # TODO: this may be all now-dead one-time code (attendee.owed_shirt doesn't exist anymore)
     def shirt_reorder(self, session, message='', **params):
         attendee = session.attendee(params, restricted=True)
-        assert attendee.owed_shirt, "There's no record of {} being owed a tshirt".format(attendee.full_name)
+        assert attendee.owed_shirt, f"There's no record of {attendee.full_name} being owed a tshirt"
         if 'address' in params:
             if attendee.shirt in [c.NO_SHIRT, c.SIZE_UNKNOWN]:
                 message = 'Please select a shirt size.'

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -507,7 +507,7 @@ class Root:
         session.commit()
         session.check_receipt_closed(item.receipt)
 
-        return {'message': "Item comped{}".format(message_add)}
+        return {'message': f"Item comped{message_add}"}
 
     @ajax
     def undo_refund_receipt_item(self, session, id='', **params):
@@ -564,7 +564,7 @@ class Root:
         session.commit()
         session.check_receipt_closed(item.receipt)
 
-        return {'message': "Item reverted{}".format(message_add)}
+        return {'message': f"Item reverted{message_add}"}
 
     @ajax
     def add_receipt_txn(self, session, id='', **params):
@@ -1138,13 +1138,13 @@ class Root:
 
         messages = []
         if no_attendee:
-            messages.append("{} attendee(s) could not be found.".format(no_attendee))
+            messages.append(f"{no_attendee} attendee(s) could not be found.")
         if invalid_email:
-            messages.append("{} email(s) entered were invalid.".format(invalid_email))
+            messages.append(f"{invalid_email} email(s) entered were invalid.")
         if new_account:
-            messages.append("{} new account(s) were created.".format(new_account))
+            messages.append(f"{new_account} new account(s) were created.")
         if assigned:
-            messages.append("{} attendee(s) were assigned to existing accounts.".format(assigned))
+            messages.append(f"{assigned} attendee(s) were assigned to existing accounts.")
 
         return " ".join(messages)
 
@@ -1168,9 +1168,9 @@ class Root:
 
         messages = []
         if new_account:
-            messages.append("{} new account(s) were created.".format(new_account))
+            messages.append(f"{new_account} new account(s) were created.")
         if assigned:
-            messages.append("{} attendee(s) were assigned to existing accounts.".format(assigned))
+            messages.append(f"{assigned} attendee(s) were assigned to existing accounts.")
 
         raise HTTPRedirect('orphaned_attendees?show_all={}&message={}', show_all, ' '.join(messages))
 
@@ -1556,7 +1556,7 @@ class Root:
                 s=pluralize(attendee_count),
                 a=pluralize(attendee_count, singular='an ' if badge_label.startswith('a') else 'a ', plural=''),
                 badge_label=badge_label,
-                queued='' if not already_queued else ' {} badges are already queued for import.'.format(already_queued),
+                queued='' if not already_queued else f' {already_queued} badges are already queued for import.',
             )
         )
 
@@ -1610,7 +1610,7 @@ class Root:
             '{count} group{s} queued for import.{queued}'.format(
                 count=attendee_count,
                 s=pluralize(attendee_count),
-                queued='' if not already_queued else ' {} groups are already queued for import.'.format(already_queued),
+                queued='' if not already_queued else f' {already_queued} groups are already queued for import.',
             ),
             'groups',
         )

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -281,7 +281,7 @@ class Root:
             message = save_attendee(session, attendee, params)
 
             if not message:
-                message = '{} has been saved'.format(attendee.full_name)
+                message = f'{attendee.full_name} has been saved'
                 if attendee.is_new and c.ADMIN_BADGES_NEED_APPROVAL and not session.current_admin_account().full_registration_admin:
                     attendee.badge_status = c.PENDING_STATUS
                     message += ' as a pending badge'
@@ -580,7 +580,7 @@ class Root:
             .outerjoin(Attendee.active_badge).filter(Attendee.first_name != '',
                                                      Attendee.badge_status.in_([c.NEW_STATUS, c.COMPLETED_STATUS]))
         attendees = [
-            (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], ' #{}'.format(badge_num) if badge_num else ''))
+            (id, '{} - {}{}'.format(name.title(), c.BADGES[badge_type], f' #{badge_num}' if badge_num else ''))
             for id, name, badge_type, badge_num in attendee_attrs]
 
         if cherrypy.request.method == 'POST':
@@ -678,7 +678,7 @@ class Root:
         return {
             'attendee':  attendee,
             'changes': session.query(Tracking).filter(
-                or_(and_(Tracking.links.like('%attendee({})%'.format(id))),
+                or_(and_(Tracking.links.like(f'%attendee({id})%')),
                     and_(Tracking.model == 'Attendee', Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'pageviews': session.query(PageViewTracking).filter(PageViewTracking.which == repr(attendee)
                                                                 ).order_by(PageViewTracking.when).all(),
@@ -921,7 +921,7 @@ class Root:
             groups = [(
                 group.id,
                 (group.name if len(group.name) < 30 else '{}...'.format(group.name[:27]))
-                + (' ({})'.format(group.leader.full_name) if group.leader else ''))
+                + (f' ({group.leader.full_name})' if group.leader else ''))
                 for group in valid_groups]
         else:
             groups = []
@@ -1160,7 +1160,7 @@ class Root:
                 elif payment_method == c.STRIPE:
                     raise HTTPRedirect('pay?id={}', attendee.id)
                 elif payment_method == c.CASH:
-                    message = c.AT_DOOR_CASH_MSG.format('${}'.format(attendee.total_cost))
+                    message = c.AT_DOOR_CASH_MSG.format(f'${attendee.total_cost}')
                 elif payment_method == c.MANUAL:
                     message = c.AT_DOOR_MANUAL_MSG
                 message = message or "Thanks! Please proceed to the registration desk to pick up your badge."
@@ -1223,7 +1223,7 @@ class Root:
         session.add_all(charge.get_receipt_items_to_add())
         session.commit()
         if cherrypy.session.get('kiosk_mode'):
-            success_url = 'register?message={}'.format(c.AT_DOOR_PREPAID_MSG)
+            success_url = f'register?message={c.AT_DOOR_PREPAID_MSG}'
         else:
             success_url = 'at_door_complete?id={}&message={}'.format(attendee.id, c.AT_DOOR_PREPAID_MSG)
         return {'stripe_intent': charge.intent,
@@ -1495,7 +1495,7 @@ class Root:
                 if model_id:
                     existing_model = session.get(model_class, model_id)
                     if existing_model:
-                        message = '{} has already been undeleted'.format(tracked_delete.which)
+                        message = f'{tracked_delete.which} has already been undeleted'
                     else:
                         model = model_class(id=model_id).apply(params, restricted=False)
                 else:
@@ -1503,9 +1503,9 @@ class Root:
 
                 if not message:
                     session.add(model)
-                    message = 'Successfully undeleted {}'.format(tracked_delete.which)
+                    message = f'Successfully undeleted {tracked_delete.which}'
             else:
-                message = 'Could not resolve {}'.format(tracked_delete.model)
+                message = f'Could not resolve {tracked_delete.model}'
 
         raise HTTPRedirect('feed?page={}&who={}&what={}&action={}&message={}', page, who, what, action, message)
 
@@ -1607,7 +1607,7 @@ class Root:
         return {
             'attendee': attendee,
             'changes': session.query(Tracking).filter(
-                or_(and_(Tracking.links.like('%attendee({})%'.format(id)),
+                or_(and_(Tracking.links.like(f'%attendee({id})%'),
                          Tracking.model == 'Attendee', Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'pageviews': session.query(PageViewTracking).filter(PageViewTracking.which == repr(attendee)
                                                                 ).order_by(PageViewTracking.when).all(),
@@ -1675,7 +1675,7 @@ class Root:
 
         if not message:
             success = True
-            message = '{} has been saved'.format(attendee.full_name)
+            message = f'{attendee.full_name} has been saved'
 
             if attendee.is_new and c.ADMIN_BADGES_NEED_APPROVAL and not session.current_admin_account().full_registration_admin:
                 attendee.badge_status = c.PENDING_STATUS

--- a/uber/site_sections/saml.py
+++ b/uber/site_sections/saml.py
@@ -85,7 +85,7 @@ class Root:
                         for attendee in all_matching_attendees:
                             session.add_attendee_to_account(attendee, account)
                     else:
-                        message = "We could not find any registrations matching the email {}.".format(account_email)
+                        message = f"We could not find any registrations matching the email {account_email}."
 
                 if account:
                     cherrypy.session['attendee_account_id'] = account.id
@@ -122,7 +122,7 @@ class Root:
                         our_netloc = urlparse(c.URL_ROOT).netloc
                         redirect_netloc = urlparse(redirect_url).netloc
                         if not redirect_netloc or redirect_netloc != our_netloc:
-                            log.error("SAML authentication used invalid redirect URL: {}".format(redirect_url))
+                            log.error(f"SAML authentication used invalid redirect URL: {redirect_url}")
                             redirect_url = None
                         if redirect_url and 'accounts' in redirect_url and not admin_account:
                             # Prevents a redirect loop if someone tries to log in as an admin with no admin account

--- a/uber/site_sections/schedule.py
+++ b/uber/site_sections/schedule.py
@@ -72,7 +72,7 @@ class Root:
         cherrypy.response.headers['Content-Type'] = \
             'text/calendar; charset=utf-8'
         cherrypy.response.headers['Content-Disposition'] = \
-            'attachment; filename="{}.ics"'.format(calname)
+            f'attachment; filename="{calname}.ics"'
 
         return icalendar
 
@@ -90,7 +90,7 @@ class Root:
                 out.writerow([
                     event.name,
                     event.start_time_local.strftime('%I%p %a').lstrip('0'),
-                    '{} minutes'.format(event.duration),
+                    f'{event.duration} minutes',
                     event.location_name,
                     event.public_description or event.description,
                     panelist_names])
@@ -454,7 +454,7 @@ class Root:
                     p.event.name,
                     ' / '.join(p.tech_needs_labels),
                     p.other_tech_needs,
-                    'Panelists are bringing themselves: {}'.format(p.panelist_bringing) if p.panelist_bringing else ''
+                    f'Panelists are bringing themselves: {p.panelist_bringing}' if p.panelist_bringing else ''
                 ).strip())
             out.writerow(row)
             curr_time += timedelta(minutes=30)

--- a/uber/site_sections/showcase_admin.py
+++ b/uber/site_sections/showcase_admin.py
@@ -78,7 +78,7 @@ class Root:
         return {
             'studio': studio,
             'changes': session.query(Tracking).filter(or_(
-                Tracking.links.like('%indie_studio({})%'.format(id)),
+                Tracking.links.like(f'%indie_studio({id})%'),
                 and_(Tracking.model == 'IndieStudio', Tracking.fk_id == id))).order_by(Tracking.when).all(),
         }
     
@@ -212,7 +212,7 @@ class Root:
             'nonmatching': nonmatching,
             'matching_genre': matching_genre,
             'changes': session.query(Tracking).filter(or_(
-                Tracking.links.like('%indie_judge({})%'.format(id)),
+                Tracking.links.like(f'%indie_judge({id})%'),
                 and_(Tracking.model == 'IndieJudge', Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'emails': session.query(Email).filter(Email.model == 'IndieJudge',
                                                   Email.fk_id == judge.id).order_by(Email.generated).all(),
@@ -313,7 +313,7 @@ class Root:
             'matching_genre': matching_genre,
             'nonmatching': nonmatching,
             'changes': session.query(Tracking).filter(or_(
-                Tracking.links.like('%indie_game({})%'.format(id)),
+                Tracking.links.like(f'%indie_game({id})%'),
                 and_(Tracking.model == 'IndieGame', Tracking.fk_id == id))).order_by(Tracking.when).all(),
             'emails': session.query(Email).filter(Email.model == 'IndieGame',
                                                   Email.fk_id == game.id).order_by(Email.generated).all(),

--- a/uber/site_sections/staffing.py
+++ b/uber/site_sections/staffing.py
@@ -402,7 +402,7 @@ class Root:
         cherrypy.response.headers['Content-Type'] = \
             'text/calendar; charset=utf-8'
         cherrypy.response.headers['Content-Disposition'] = \
-            'attachment; filename="{}.ics"'.format(calname)
+            f'attachment; filename="{calname}.ics"'
 
         return icalendar
 

--- a/uber/site_sections/staffing_admin.py
+++ b/uber/site_sections/staffing_admin.py
@@ -125,7 +125,7 @@ class Root:
             service, uri = None, ''
         else:
             service, message, target_url = get_api_service_from_server(target_server, api_token)
-            uri = '{}/jsonrpc/'.format(target_url)
+            uri = f'{target_url}/jsonrpc/'
 
         department = {}
         from_departments = []
@@ -176,7 +176,7 @@ class Root:
     @ajax_gettable
     def lookup_departments(self, session, target_server='', api_token='', **kwargs):
         service, message, target_url = get_api_service_from_server(target_server, api_token)
-        uri = '{}/jsonrpc/'.format(target_url)
+        uri = f'{target_url}/jsonrpc/'
 
         if not message:
             try:
@@ -204,7 +204,7 @@ class Root:
             **kwargs):
 
         service, message, target_url = get_api_service_from_server(target_server, api_token)
-        uri = '{}/jsonrpc/'.format(target_url)
+        uri = f'{target_url}/jsonrpc/'
 
         if not message and service and cherrypy.request.method == 'POST':
             from_departments = [(id, name) for id, name in sorted(service.dept.list().items(), key=lambda d: d[1])]
@@ -246,6 +246,6 @@ class Root:
                                 to_dept_attraction.signups_open_time = signups_open_time.replace(year=signups_open_time.year + 1)
                             to_department.attractions.append(to_dept_attraction)
 
-            message = 'Successfully imported all departments, roles, job templates, and department attractions from {}'.format(uri)
+            message = f'Successfully imported all departments, roles, job templates, and department attractions from {uri}'
             raise HTTPRedirect('import_shifts?target_server={}&api_token={}&message={}',
                                target_server, api_token, message)

--- a/uber/site_sections/tabletop_checkins.py
+++ b/uber/site_sections/tabletop_checkins.py
@@ -94,7 +94,7 @@ def _attendees(session):
     attendees = [
         {
             'id': id,
-            'displayText': '{} - {}'.format(name.title(), ' #({})'.format(badge_num) if badge_num else '')
+            'displayText': '{} - {}'.format(name.title(), f' #({badge_num})' if badge_num else '')
         }
         for id, name, badge_num in attendee_attrs
     ]
@@ -104,7 +104,7 @@ def _attendees(session):
 def _attendee(a):
     return a and {
         'id': a.id,
-        'displayText': '{} - {}'.format(a.full_name.title(), ' #({})'.format(a.badge_num) if a.badge_num else '')
+        'displayText': '{} - {}'.format(a.full_name.title(), f' #({a.badge_num})' if a.badge_num else '')
     }
 
 

--- a/uber/tasks/attractions.py
+++ b/uber/tasks/attractions.py
@@ -192,7 +192,7 @@ def attractions_send_notifications():
                 # for "when checkin starts".
                 advance_notice = min(advance_notices)
                 if advance_notice == -1 or advance_notice > 30:
-                    checkin = 'is at {}'.format(event.checkin_start_time_label)
+                    checkin = f'is at {event.checkin_start_time_label}'
                 else:
                     checkin = humanize_timedelta(
                         event.time_remaining_to_checkin,

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -203,7 +203,7 @@ def check_near_cap():
     if c.REPORTS_EMAIL:
         actual_badges_left = c.ATTENDEE_BADGE_STOCK - c.ATTENDEE_BADGE_COUNT
         for badges_left in [int(num) for num in c.BADGES_LEFT_ALERTS]:
-            subject = "BADGES SOLD ALERT: {} BADGES LEFT!".format(badges_left)
+            subject = f"BADGES SOLD ALERT: {badges_left} BADGES LEFT!"
             with Session() as session:
                 if not session.query(Email).filter_by(subject=subject).first() and actual_badges_left <= badges_left:
                     EmailService.queue_email(session, 'badges_sold_alert', to=[c.REGDESK_EMAIL, c.ADMIN_EMAIL],

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -194,7 +194,7 @@ def convert_to_absolute_url(relative_uber_page_url):
     if relative_uber_page_url.startswith(c.URL_BASE):
         return relative_uber_page_url
 
-    raise ValueError("relative url MUST start with '../' or '{}'".format(c.PATH))
+    raise ValueError(f"relative url MUST start with '../' or '{c.PATH}'")
 
 
 def make_url(s):
@@ -835,7 +835,7 @@ class days_after(DateBase):
             days = 0
 
         if days < 0:
-            raise ValueError("'days' parameter must be >= 0. days={}".format(days))
+            raise ValueError(f"'days' parameter must be >= 0. days={days}")
 
         self.starting_date = None if not deadline else deadline + timedelta(days=days)
 
@@ -865,7 +865,7 @@ class days_before(DateBase):
     """
     def __init__(self, days, deadline, until=None):
         if days <= 0:
-            raise ValueError("'days' parameter must be > 0. days={}".format(days))
+            raise ValueError(f"'days' parameter must be > 0. days={days}")
 
         if until and days <= until:
             raise ValueError("'days' parameter must be less than 'until'. days={}, until={}".format(days, until))
@@ -1325,8 +1325,8 @@ def valid_password(password):
         return 'Please enter a password.'
 
     if len(password) < c.MINIMUM_PASSWORD_LENGTH:
-        return 'Password must be at least {} characters long.'.format(c.MINIMUM_PASSWORD_LENGTH)
-    if re.search("[^a-zA-Z0-9{}]".format(c.PASSWORD_SPECIAL_CHARS), password):
+        return f'Password must be at least {c.MINIMUM_PASSWORD_LENGTH} characters long.'
+    if re.search(f"[^a-zA-Z0-9{c.PASSWORD_SPECIAL_CHARS}]", password):
         return 'Password must contain only letters, numbers, and the following symbols: ' + c.PASSWORD_SPECIAL_CHARS
     if 'lowercase_char' in c.PASSWORD_CONDITIONS and not re.search("[a-z]", password):
         return 'Password must contain at least one lowercase letter.'
@@ -1336,8 +1336,8 @@ def valid_password(password):
         return 'Password must contain at least one letter.'
     if 'number' in c.PASSWORD_CONDITIONS and not re.search("[0-9]", password):
         return 'Password must contain at least one number.'
-    if 'special_char' in c.PASSWORD_CONDITIONS and not re.search("[{}]".format(c.PASSWORD_SPECIAL_CHARS), password):
-        return 'Password must contain at least one of the following symbols: {}'.format(c.PASSWORD_SPECIAL_CHARS)
+    if 'special_char' in c.PASSWORD_CONDITIONS and not re.search(f"[{c.PASSWORD_SPECIAL_CHARS}]", password):
+        return f'Password must contain at least one of the following symbols: {c.PASSWORD_SPECIAL_CHARS}'
 
 
 class Order:
@@ -1366,7 +1366,7 @@ class RegistrationCode():
 
     _UNAMBIGUOUS_CHARS = string.digits + string.ascii_uppercase
     for _, s in _AMBIGUOUS_CHARS.items():
-        _UNAMBIGUOUS_CHARS = re.sub('[{}]'.format(s), '', _UNAMBIGUOUS_CHARS)
+        _UNAMBIGUOUS_CHARS = re.sub(f'[{s}]', '', _UNAMBIGUOUS_CHARS)
     
     @classmethod
     def sql_normalized_code(cls, code):
@@ -1692,14 +1692,14 @@ def get_api_service_from_server(target_server, api_token):
     import ssl
 
     target_url, target_host, remote_api_token = _format_import_params(target_server, api_token)
-    uri = '{}/jsonrpc/'.format(target_url)
+    uri = f'{target_url}/jsonrpc/'
 
     message, service = '', None
     if target_server or api_token:
         if not remote_api_token:
-            message = 'No API token given and could not find a token for: {}'.format(target_host)
+            message = f'No API token given and could not find a token for: {target_host}'
         elif not target_url:
-            message = 'Unrecognized hostname: {}'.format(target_server)
+            message = f'Unrecognized hostname: {target_server}'
 
         if not message:
             service = ServerProxy(uri=uri, extra_headers={'X-Auth-Token': remote_api_token},
@@ -2155,7 +2155,7 @@ class TaskUtils:
                 paid = c.NOT_PAID
 
             import_from_url = '{}/registration/form?id={}\n\n'.format(import_job.target_server, attendee['id'])
-            new_admin_notes = '{}\n\n'.format(extra_admin_notes) if extra_admin_notes else ''
+            new_admin_notes = f'{extra_admin_notes}\n\n' if extra_admin_notes else ''
             old_admin_notes = ('Old Admin Notes:\n{}\n'.format(attendee['admin_notes'])
                                if attendee['admin_notes'] else '')
 
@@ -2413,7 +2413,7 @@ class TaskUtils:
                 group_attendees = group_results['attendees']
             except Exception as ex:
                 attendee_warning = "Could not import attendees: {}".format(str(ex))
-                import_job.errors += "; {}".format(attendee_warning) if import_job.errors else attendee_warning
+                import_job.errors += f"; {attendee_warning}" if import_job.errors else attendee_warning
 
             # Remove categories that don't exist this year
             current_categories = group_to_import.get('categories', '')

--- a/uber/validations/attendee.py
+++ b/uber/validations/attendee.py
@@ -257,7 +257,7 @@ def out_of_badge_type(form, field):
         try:
             session.get_next_badge_num(badge_type)
         except AssertionError:
-            raise ValidationError('We are sold out of {} badges.'.format(c.BADGES[badge_type]))
+            raise ValidationError(f'We are sold out of {c.BADGES[badge_type]} badges.')
 
 # =============================
 # OtherInfo


### PR DESCRIPTION
Replaced legacy .format() and % string formatting with modern f-strings across models, views, and helper modules. This makes the code much cleaner and easier to read, and f-strings are slightly faster in Python.

Touched the core models (Attendee, Guest, Attraction), API endpoints, site section views (preregistration, reg_admin, art_show_admin, staffing_admin), and utility files.