### PR TITLE
Pass attendee id in shift signup and drop AJAX calls

### DIFF
--- a/uber/templates/staffing/shifts.html
+++ b/uber/templates/staffing/shifts.html
@@ -251,6 +251,7 @@
               url: 'sign_up',
               dataType: 'json',
               data: {
+                id: '{{ attendee.id }}',
                 job_id: id,
                 csrf_token: csrf_token
               },
@@ -293,6 +294,7 @@
               url: 'drop',
               dataType: 'json',
               data: {
+                id: '{{ attendee.id }}',
                 job_id: id,
                 csrf_token: csrf_token
               },


### PR DESCRIPTION
Commit 295c5777d part of PR4544 made id a required parameter on shift sign_up and drop. AJAX request bodies needed to be updated to support the ids being passed. Signups returned a 500 that the page reported to volunteers as a connection error.

<img width="1247" height="272" alt="image" src="https://github.com/user-attachments/assets/0fb5df2e-2682-4b0f-8473-1e5847605030" />
