### PR TITLE
Update Indies checklist functionality

### DIFF
--- a/alembic/versions/e1bdc27ce73c_make_hotel_checklist_steps_optional.py
+++ b/alembic/versions/e1bdc27ce73c_make_hotel_checklist_steps_optional.py
@@ -1,0 +1,61 @@
+"""Make hotel checklist steps optional
+
+Revision ID: e1bdc27ce73c
+Revises: 1331e94c332e
+Create Date: 2026-09-01 07:44:50.709667
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'e1bdc27ce73c'
+down_revision = '1331e94c332e'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('guest_group', sa.Column('hotel_included', sa.Boolean(), server_default='True', nullable=False))
+    op.add_column('indie_game', sa.Column('hotel_included', sa.Boolean(), server_default='True', nullable=False))
+
+
+def downgrade():
+    op.drop_column('indie_game', 'hotel_included')
+    op.drop_column('guest_group', 'hotel_included')

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -2303,8 +2303,8 @@ __many__ = string
 [mivs_checklist]
 [[__many__]]
 start = string(default="")
-deadline = string
-description = string
+deadline = string(default="")
+description = string(default="")
 name = string(default="")
 editable = boolean(default=False)
 showcases = string_list(default=list("mivs", "indie_arcade", 'indie_retro'))

--- a/uber/forms/group.py
+++ b/uber/forms/group.py
@@ -32,6 +32,7 @@ class GroupInfo(MagForm):
 class AdminGroupInfo(GroupInfo):
     guest_group_type = SelectField('Checklist Type', default=0, choices=[(0, 'N/A')] + c.GROUP_TYPE_OPTS, coerce=int)
     payment = BooleanField('Enable the W9 checklist step for this guest.')
+    hotel_included = BooleanField('Enable the hotel checklist step for this guest.')
     can_add = BooleanField('This group may purchase additional badges.')
     is_dealer = BooleanField(f'This group should be treated as {c.DEALER_INDEFINITE_TERM}.',
                              description=f"{c.DEALER_TERM.title()}s are prevented from paying until they are approved,"

--- a/uber/models/guests.py
+++ b/uber/models/guests.py
@@ -42,6 +42,7 @@ class GuestGroup(MagModel, table=True):
     estimated_performance_minutes: int = Field(default=c.DEFAULT_PERFORMANCE_MINUTES, admin_only=True)
     wants_mc: bool | None = Field(nullable=True)
     needs_rehearsal: int | None = Field(sa_column=Column(Choice(c.GUEST_REHEARSAL_OPTS), nullable=True))
+    hotel_included: bool = True
     badges_assigned: bool = False
 
     info: 'GuestInfo' = Relationship(
@@ -158,6 +159,10 @@ class GuestGroup(MagModel, table=True):
         if self.group.unregistered_badges:
             return str(self.group.unregistered_badges) + " Unclaimed"
         return "Yes"
+    
+    @property
+    def hospitality_status(self):
+        return "No Hotel Space" if not self.hotel_included else self.status('hospitality')
 
     @property
     def taxes_status(self):

--- a/uber/models/guests.py
+++ b/uber/models/guests.py
@@ -108,6 +108,12 @@ class GuestGroup(MagModel, table=True):
         for item in c.GUEST_CHECKLIST_ITEMS:
             if self.deadline_from_model(item['name']):
                 checklist_items.append(item)
+        
+        if self.group_type == c.MIVS:
+            steps_with_deadline = {key: val['deadline'] for key, val in c.MIVS_CHECKLIST.items()}
+            steps_with_deadline.update({val['name']: self.deadline_from_model(val['name']) for val in checklist_items})
+            checklist_item_tuples = [(val['name'], val) for val in checklist_items]
+            return sorted(checklist_item_tuples + c.MIVS_CHECKLIST.items(), key=lambda x: steps_with_deadline[x[0]])
 
         return sorted(checklist_items, key=lambda i: self.deadline_from_model(i['name']))
 

--- a/uber/models/showcase.py
+++ b/uber/models/showcase.py
@@ -241,6 +241,8 @@ class IndieStudio(MagModel, table=True):
 
     @property
     def hotel_space_status(self):
+        if self.group.guest and not self.group.guest.hotel_included:
+            return "Does not receive hotel space"
         if self.needs_hotel_space is not None:
             return "Requested hotel space for {} with email {}".format(self.name_for_hotel, self.email_for_hotel)\
                 if self.needs_hotel_space else "Opted out"
@@ -429,6 +431,7 @@ class IndieGame(MagModel, ReviewMixin, table=True):
     registered: datetime = Field(sa_type=DateTime(timezone=True), default_factory=lambda: datetime.now(UTC))
     waitlisted: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
     accepted: datetime | None = Field(sa_type=DateTime(timezone=True), nullable=True)
+    hotel_included: bool = True
 
     codes: list['IndieGameCode'] = Relationship(
         back_populates="game", sa_relationship_kwargs={'lazy': 'selectin', 'cascade': 'all,delete-orphan', 'passive_deletes': True})

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -204,10 +204,8 @@ class Root:
                 if group.guest_group_type:
                     group.guest = group.guest or GuestGroup()
                     group.guest.group_type = group.guest_group_type
-                    if params.get('payment', None):
-                        group.guest.payment = 1
-                    else:
-                        group.guest.payment = 0
+                    group.guest.payment = 1 if params.get('payment', None) else 0
+                    group.guest.hotel_included = True if params.get('hotel_included', None) else False
                 elif group.guest:
                     session.delete(group.guest)
 

--- a/uber/site_sections/panels.py
+++ b/uber/site_sections/panels.py
@@ -39,6 +39,7 @@ class Root:
         """
         app = PanelApplication()
         is_guest = False
+        attendee = None
         readonly_fields = {}
         attrs = [key for key in PanelApplicant().to_dict().keys() if key not in [
                 'id', 'created', 'last_updated', 'external_id', 'last_synced', 'attendee_id', 'submitter', '_model']]
@@ -130,6 +131,7 @@ class Root:
 
         return {
             'app': app,
+            'attendee': attendee,
             'forms': forms,
             'panelist_forms': panelist_forms,
             'message': message,

--- a/uber/site_sections/showcase.py
+++ b/uber/site_sections/showcase.py
@@ -320,8 +320,8 @@ class Root:
     
     @get_studio_id(IndieGame)
     @requires_account(IndieStudio)
-    def show_info(self, session, message='', **params):
-        game = session.indie_game(params)
+    def show_info(self, session, id, message='', **params):
+        game = session.get(IndieGame, id)
         cherrypy.session['studio_id'] = game.studio.id
         image_form = load_forms({}, File(), ['MivsScreenshot'], field_prefix='new')
 

--- a/uber/site_sections/showcase.py
+++ b/uber/site_sections/showcase.py
@@ -307,6 +307,10 @@ class Root:
                 group.cost = group.calc_default_cost()
                 group.guest = GuestGroup()
                 group.guest.group_type = c.MIVS
+                group.guest.hotel_included = False
+                for game in studio.games:
+                    if game.status == c.ACCEPTED and game.hotel_included:
+                        group.guest.hotel_included = True
                 raise HTTPRedirect('index?id={}&message={}', studio.id, 'Your studio has been registered!')
 
         return {

--- a/uber/site_sections/showcase_admin.py
+++ b/uber/site_sections/showcase_admin.py
@@ -1,4 +1,5 @@
 import cherrypy
+import logging
 from sqlalchemy import func, and_, or_
 from sqlalchemy.orm import joinedload
 
@@ -10,6 +11,9 @@ from uber.files import FileService
 from uber.forms import load_forms
 from uber.models import AdminAccount, Attendee, Email, IndieJudge, IndieGameReview, IndieStudio, IndieGame, PageViewTracking, Tracking
 from uber.utils import check, get_api_service_from_server, normalize_email_legacy, validate_model, listify
+
+
+log = logging.getLogger(__name__)
 
 
 def _process_showcase_type(showcase_type, message=''):
@@ -389,12 +393,13 @@ class Root:
         raise HTTPRedirect(return_to, f'{what_removed} successfully removed.')
 
     @csrf_protected
-    def mark_verdict(self, session, id, status):
+    def mark_verdict(self, session, id, status, hotel_included=False):
         if not status:
             raise HTTPRedirect('edit_game?id={}&message={}#results', id, 'You did not mark a status.')
         else:
             game = session.indie_game(id)
             game.status = int(status)
+            game.hotel_included = bool(hotel_included)
             raise HTTPRedirect('edit_game?id={}&message={}#results', game.id, f"{game.title} has been marked as {game.status_label}.")
 
     @csrf_protected

--- a/uber/site_sections/showcase_admin.py
+++ b/uber/site_sections/showcase_admin.py
@@ -397,10 +397,31 @@ class Root:
         if not status:
             raise HTTPRedirect('edit_game?id={}&message={}#results', id, 'You did not mark a status.')
         else:
-            game = session.indie_game(id)
+            game = session.get(IndieGame, id)
             game.status = int(status)
             game.hotel_included = bool(hotel_included)
             raise HTTPRedirect('edit_game?id={}&message={}#results', game.id, f"{game.title} has been marked as {game.status_label}.")
+        
+    @csrf_protected
+    def mark_verdicts(self, session, game_ids, status, hotel_included=False, showcase_type='all', show_all=False):
+
+        return_to = f"index?showcase_type={showcase_type}"
+        if show_all:
+            return_to += "&show_all=True"
+        if not status:
+            raise HTTPRedirect('{}&message={}', return_to, 'You did not mark a status.')
+
+        if isinstance(game_ids, str):
+            game_ids = [game_ids]
+        status = int(status)
+        hotel_included = bool(hotel_included)
+
+        for id in game_ids:
+            game = session.get(IndieGame, id)
+            game.status = status
+            game.hotel_included = hotel_included
+        raise HTTPRedirect(return_to + '&message={}',
+                           f"Selected games have been marked as {c.MIVS_GAME_STATUS[status]}{' with hotel space included' if hotel_included else ''}.")
 
     @csrf_protected
     def send_reviews(self, session, game_id, review_id=None):

--- a/uber/templates/emails/indie_arcade/checklist_reminder.txt
+++ b/uber/templates/emails/indie_arcade/checklist_reminder.txt
@@ -13,7 +13,7 @@ The following items are overdue:
 {% endfor %}
 {% endif %}
 
-Some items, such as Hotels or Selling, have hard dates and need to be completed by their due date.
+Some items, such as {% if studio.group.guest.hotel_included %}Hotels or {% endif %}Selling, have hard dates and need to be completed by their due date.
 
 If you have any questions, please email {{ c.INDIE_ARCADE_EMAIL|email_only }}
 

--- a/uber/templates/emails/indie_retro/checklist_reminder.txt
+++ b/uber/templates/emails/indie_retro/checklist_reminder.txt
@@ -13,7 +13,7 @@ The following items are overdue:
 {% endfor %}
 {% endif %}
 
-Some items, such as Hotels or Selling, have hard dates and need to be completed by their due date.
+Some items, such as {% if studio.group.guest.hotel_included %}Hotels or {% endif %}Selling, have hard dates and need to be completed by their due date.
 
 If you have any questions, please email {{ c.INDIE_RETRO_EMAIL|email_only }}
 

--- a/uber/templates/emails/mivs/checklist_reminder.txt
+++ b/uber/templates/emails/mivs/checklist_reminder.txt
@@ -13,7 +13,7 @@ The following items are overdue:
 {% endfor %}
 {% endif %}
 
-If you don't finish these items, you may get a friendly personal reminder* from MIVS.  Some items, such as Hotels or Selling, have hard dates and need to be completed by their due date.
+If you don't finish these items, you may get a friendly personal reminder* from MIVS.  Some items, such as {% if studio.group.guest.hotel_included %}Hotels or {% endif %}Selling, have hard dates and need to be completed by their due date.
 
 If you have any questions, please email {{ c.MIVS_EMAIL|email_only }}
 

--- a/uber/templates/forms/group/group_info.html
+++ b/uber/templates/forms/group/group_info.html
@@ -15,6 +15,7 @@ Use these to add or rearrange fields. Remember to use {{ super() }} to print the
 
 <div x-data="{ {% block x_data %}
 payment: {{ 'true' if group.guest and group.guest.payment else 'false' }},
+hotel_included: {{ 'true' if not group.guest else group.guest.hotel_included|tojson }},
 get showW9() { return this.guest_group_type != 0 && this.guest_group_type != {{ c.MIVS|tojson }} },
 get groupFields() { return !this.badge_type || this.badge_type == {{ c.PSEUDO_GROUP_BADGE|tojson }} },
 {% endblock %} }">
@@ -33,6 +34,10 @@ get groupFields() { return !this.badge_type || this.badge_type == {{ c.PSEUDO_GR
     <div class="col-sm pt-1" x-show="showW9">
     <div class="form-text">&nbsp;</div>
         {{ form_macros.input(group_info.payment, alpine_model="payment") }}
+    </div>
+    <div class="col-sm pt-1" x-show="guest_group_type != 0">
+    <div class="form-text">&nbsp;</div>
+        {{ form_macros.input(group_info.hotel_included, alpine_model="hotel_included") }}
     </div>
     {% endif %}
 {% endblock %}

--- a/uber/templates/group_admin/form.html
+++ b/uber/templates/group_admin/form.html
@@ -91,7 +91,7 @@
   {% endif %}
   {{ form_macros.form_validation('group-form', 'validate_group') }}
   <form novalidate method="post" id="group-form" action="form" enctype="multipart/form-data" x-data="{
-    guest_group_type: {{ (group.guest_group_type or 0)|jsonize }},
+    guest_group_type: {{ (group.guest.group_type or 0)|jsonize }},
     is_dealer: {{ group.is_dealer|jsonize }},
     is_new: {{ group.is_new|jsonize }},
     badges: {{ 1 if group.is_new else group.badges }}, 

--- a/uber/templates/guest_checklist/hospitality_deadline.html
+++ b/uber/templates/guest_checklist/hospitality_deadline.html
@@ -1,4 +1,5 @@
 {% if snippet %}
+{% if guest.hotel_included %}
   <tr>
     <td width="25">{{ macros.checklist_image(guest.hospitality_status) }}</td>
     <td><b><a href="hospitality?guest_id={{ guest.id }}">
@@ -37,4 +38,5 @@
     <button type="submit" name="completed" class="btn btn-primary" value="1">I Have Filled Out the Survey Above</button>
   </form>
   {% endif %}
+{% endif %}
 {% endif %}

--- a/uber/templates/guests/index.html
+++ b/uber/templates/guests/index.html
@@ -28,28 +28,53 @@
 
   <table style="width:auto">
     {% if guest.group_type == c.MIVS %}
-      {% for key, val in c.MIVS_CHECKLIST.items()|sort(attribute='1.deadline') %}
-        {% if guest.matches_showcases(val['showcases']) and (guest.hotel_included or key != 'hotel_space') %}
-        <h3>{{ val['name'] }}</h3>
-        <p>{{ val['description'] }}</p>
-        <p>
-          {% if not val['start'] or now_localized() >= val['start'] %}
-            <strong>Deadline</strong>: {{ guest.group.studio.checklist_deadline(key)|datetime_local if guest.group.studio }}</p>
-            <p>
-            {% if not guest.group.studio[key + "_status"] %}
-              <a href="mivs_{{ key }}?guest_id={{ guest.id }}">Complete this checklist step</a>.
-            {% elif val['editable'] and now_localized() <= guest.group.studio.checklist_deadline(key) %}
-              You've <strong>already completed</strong> this step but you can still <a href="mivs_{{ key }}?guest_id={{ guest.id }}">edit your response</a> until the deadline.
+      {% for key, val in guest.sorted_checklist_items %}
+        {% if val['deadline_template'] %}
+          {%- include [
+            val['deadline_template'][0] ~ guest.group_type_label|lower|replace(' ','_') ~ '_' ~ val['deadline_template'][1],
+            val['deadline_template'][0] ~ val['deadline_template'][1]
+          ] -%}
+        {% else %}
+          {% if guest.matches_showcases(val['showcases']) and (guest.hotel_included or key != 'hotel_space') %}
+          <tr>
+            {% if not val['start'] or now_localized() >= val['start'] %}
+            <td width="25">{{ macros.checklist_image(guest.group.studio[key + "_status"]) }}</td>
+            {% if not guest.group.studio[key + "_status"] or val['editable'] and now_localized() <= guest.group.studio.checklist_deadline(key) %}
+            <td><b><a href="mivs_{{ key }}?guest_id={{ guest.id }}">{{ val['name'] }}</a></b></td>
             {% else %}
-              You've <strong>already completed</strong> this step.
+            <td><b>{{ val['name'] }}</b></td>
             {% endif %}
-          {% else %}
-            This step is not available yet. We will email you when it becomes available, so keep an eye on your inbox.
+            <td><i>Deadline:</i> {{ guest.group.studio.checklist_deadline(key)|datetime_local if guest.group.studio }}</td>
+            {% else %}
+            <td colspan="2"><b>{{ val['name'] }}</b></td>
+            <td><i>Coming Soon</i></td>
+            {% endif %}
+          </tr>
+          <tr>
+            <td colspan="3">
+              {{ val['description'] }}
+              <br/>
+              {% if False %}
+              {% if not val['start'] or now_localized() >= val['start'] %}
+                {% if not guest.group.studio[key + "_status"] %}
+                  Use the link above to complete this checklist step.
+                {% elif val['editable'] and now_localized() <= guest.group.studio.checklist_deadline(key) %}
+                  You've <strong>already completed</strong> this step but you can still edit your response using hte link above until the deadline.
+                {% else %}
+                  You've <strong>already completed</strong> this step.
+                {% endif %}
+              {% else %}
+                This step is not available yet. We will email you when it becomes available, so keep an eye on your inbox.
+              {% endif %}
+              {% endif %}
+              <br/>
+            </td>
+          </tr>
           {% endif %}
-          </p>
         {% endif %}
       {% endfor %}
     {% else %}
+    hi
       {% for item in guest.sorted_checklist_items -%}
         {# Try to include the checklist template with a prefix matching the group's type, e.g. band_info_deadline.html #}
         {%- include [

--- a/uber/templates/guests/index.html
+++ b/uber/templates/guests/index.html
@@ -29,7 +29,7 @@
   <table style="width:auto">
     {% if guest.group_type == c.MIVS %}
       {% for key, val in c.MIVS_CHECKLIST.items()|sort(attribute='1.deadline') %}
-        {% if guest.matches_showcases(val['showcases']) %}
+        {% if guest.matches_showcases(val['showcases']) and (guest.hotel_included or key != 'hotel_space') %}
         <h3>{{ val['name'] }}</h3>
         <p>{{ val['description'] }}</p>
         <p>

--- a/uber/templates/showcase/index.html
+++ b/uber/templates/showcase/index.html
@@ -16,12 +16,18 @@
     {% include 'showcase/deadlines.html' %}
 
     {% if studio.group %}
-        <h3>Your Badges</h3>
-
+        <h3>Welcome to the Indie Showcase!</h3>
+        <p>You have been accepted into the showcase and confirmed that you are coming.</p>
+        {% if studio.group.guest %}
         <p>
-            You have been accepted into the showcase and confirmed that you are coming.  You may manage the badges in your
+            Your <a href="../guests/index?id={{ studio.group.guest_id }}">checklist page</a>
+            contains information and tasks to prepare you for {{ c.EVENT_NAME }}.
+            Checklist items must be completed before their deadlines, which you will receive email reminders for.
+        </p>
+        {% endif %}
+        <p>
+            You may manage the badges on your
             <a href="../preregistration/group_members?id={{ studio.group_id }}">group management page</a>.
-            {% if False %}Please remember to fill out show info for each game below.{% endif %}
         </p>
     {% elif studio.comped_badges and (not studio.after_confirm_deadline or c.HAS_SHOWCASE_ADMIN_ACCESS) %}
         <h3>Accept or Decline</h3>

--- a/uber/templates/showcase_admin/edit_game.html
+++ b/uber/templates/showcase_admin/edit_game.html
@@ -65,12 +65,12 @@
             {{ game.title }} has been assigned to {{ game.reviews|length }} judges, of whom {{ game.game_reviews|length }} have reviewed it.
         </p>
 
-        <form id="mark-form" method="post" action="mark_verdict" style="display:none">
+        <form id="mark-form" class="mb-3" method="post" action="mark_verdict" style="display:none" x-data="{ status: '{{ game.status|tojson }}' }">
             {{ csrf_token() }}
             <input type="hidden" name="id" value="{{ game.id }}" />
-            <div class="d-flex gap-3 mb-3">
+            <div class="d-flex gap-3 mb-1">
                 <div>
-                <select name="status" class="form-select">
+                <select name="status" class="form-select" x-model="status">
                     <option value="">Choose whether to accept this game into {{ game.showcase_type_label }}</option>
                     <option value="{{ c.ACCEPTED }}">Accept</option>
                     <option value="{{ c.DECLINED }}">Decline</option>
@@ -80,6 +80,13 @@
                 <div>
                 <button type="submit" class="btn btn-primary">Mark Verdict</button>
                 </div>
+            </div>
+            <div x-show="status == {{ c.ACCEPTED }}">
+                <label for="hotel_included" class="checkbox-label">
+                    <input type="checkbox" id="hotel_included" name="hotel_included"{% if game.hotel_included %} checked="checked"{% endif %} />
+                    This studio should have the hotel space step included on their checklist when they confirm their acceptance.
+                </label>
+                <div class="form-text">Note that the checklist item will be enabled if ANY of this studio's accepted games include hotel space.</div>
             </div>
         </form>
 

--- a/uber/templates/showcase_admin/index.html
+++ b/uber/templates/showcase_admin/index.html
@@ -42,16 +42,40 @@
     <div class="tab-content">
         &nbsp;
         <div role="tabpanel" class="tab-pane" id="games" aria-labelledby="games-tab">
-            <div class="d-flex gap-2 mb-3">
+            <div class="d-flex gap-2 mb-3 align-items-start">
                 {% if show_all %}
                 <a href="index?showcase_type={{ showcase_type }}" class="btn btn-secondary">Hide Unsubmitted Games</a>
                 {% else %}
                 <a href="index?showcase_type={{ showcase_type }}&show_all=True" class="btn btn-outline-secondary">Show Unsubmitted Games</a>
                 {% endif %}
+                <form id="mark-verdicts" class="text-end ms-auto" action="mark_verdicts" x-data="{ status: '' }">
+                    <div class="d-flex gap-2 align-items-start">
+                    <button type="button" class="btn btn-primary" data-bs-toggle="collapse" data-bs-target=".mark-verdicts">Mark Verdicts for Selected Games</button>
+                        {{ csrf_token() }}
+                        <div class="collapse mark-verdicts">
+                            <select name="status" class="form-select" x-model="status">
+                                <option value="">Select a Verdict</option>
+                                <option value="{{ c.ACCEPTED }}">Accept</option>
+                                <option value="{{ c.DECLINED }}">Decline</option>
+                                <option value="{{ c.WAITLISTED }}">Waitlist</option>
+                            </select>
+                            <div x-show="status == {{ c.ACCEPTED }}">
+                            <label for="hotel_included" class="checkbox-label">
+                                <input type="checkbox" id="hotel_included" name="hotel_included" />
+                                Include hotel space
+                            </label>
+                            </div>
+                        </div>
+                        <button class="btn btn-primary collapse mark-verdicts">Mark Verdicts</button>
+                    </div>
+                </form>
             </div>
-            <table class="table table-hover datatable" data-page-length="-1">
+            <table class="table table-hover datatable" data-page-length="-1" data-order="[[ 1, &quot;desc&quot; ]]" x-data="{ selectall: false, }">
             <thead>
                 <tr>
+                    <th data-orderable="false">
+                        <label class="d-block"><input type="checkbox" class="form-check-input" @click="selectall=!selectall"></label>
+                    </th>
                     {% if showcase_label == "All" %}<th>Showcase</th>{% endif %}
                     <th>Game</th>
                     <th>Status</th>
@@ -66,6 +90,11 @@
             <tbody>
             {% for game in games %}
                 <tr>
+                    <td>
+                        <label class="d-block">
+                            <input type="checkbox" form="mark-verdicts" class="form-check-input" name="game_ids" value="{{ game.id }}" x-bind:checked="selectall" />
+                        </label>
+                    </td>
                     {% if showcase_label == "All" %}<td>{{ game.showcase_type_label }}</td>{% endif %}
                     <td><a href="edit_game?id={{ game.id }}">{{ game.title }}</a></td>
                     <td>


### PR DESCRIPTION
Admins can now hide the hotel space step on the MIVS and guest checklists. Also adds the ability to bulk mark game verdicts and allows guest checklist steps to appear on Indies checklists, and updates the style of the Indies checklist to match the guest checklist.